### PR TITLE
Issue -

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -39,6 +39,7 @@ namespace System.Collections.Immutable
             /// <param name="capacity">The initial capacity of the internal array.</param>
             internal Builder(int capacity)
             {
+                Requires.Range(capacity >= 0, "capacity");
                 this.elements = new RefAsValueType<T>[capacity];
                 this.Count = 0;
             }

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -21,6 +21,12 @@ namespace System.Collections.Immutable.Test
         }
 
         [Fact]
+        public void CreateBuilderInvalidCapacity()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => ImmutableArray.CreateBuilder<int>(-1));
+        }
+
+        [Fact]
         public void NormalConstructionValueType()
         {
             var builder = ImmutableArray.CreateBuilder<int>(3);


### PR DESCRIPTION
ImmutableArray.CreateBuilder<int>(-1); throws overflow exception but is expected to throw ArgumentOutOfRangeException.
Fix -
This fix checks the argument "capacity" for valid range such that ArgumentOutOfRangeException is thrown instead.
Also, added a testcase for this scenario.
