### PR TITLE
Remove internal package source from NuGet.config

### DIFF
--- a/src/nuget/NuGet.Config
+++ b/src/nuget/NuGet.Config
@@ -4,7 +4,6 @@
     <add key="enabled" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="ms-nuget" value="https://ms-nuget.cloudapp.net/api/v2/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <activePackageSource>


### PR DESCRIPTION
In preparation for making our repositories public, I've uploaded
Microsoft.DotNet.BuildTools to NuGet.org.  This change removes
our internal NuGet feed, leaving the public feed.  With this change
the CoreFx repository should now build outside of Microsoft.
