### PR TITLE
Remove or cache some unnecessary allocations

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -345,9 +345,11 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var item in this)
                 {
-                    array.SetValue(new DictionaryEntry(item.Key, item.Value), arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(new DictionaryEntry(item.Key, item.Value), indices);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -780,9 +780,11 @@ namespace System.Collections.Immutable
             Requires.Range(arrayIndex >= 0, "arrayIndex");
             Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             foreach (var item in this)
             {
-                array.SetValue(new DictionaryEntry(item.Key, item.Value), arrayIndex++);
+                indices[0] = arrayIndex++;
+                array.SetValue(new DictionaryEntry(item.Key, item.Value), indices);
             }
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
@@ -562,9 +562,11 @@ namespace System.Collections.Immutable
             Requires.Range(arrayIndex >= 0, "arrayIndex");
             Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             foreach (T item in this)
             {
-                array.SetValue(item, arrayIndex++);
+                indices[0] = arrayIndex++;
+                array.SetValue(item, indices);
             }
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -2590,9 +2590,11 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var element in this)
                 {
-                    array.SetValue(element, arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(element, indices);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -1381,9 +1381,11 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + dictionarySize, "arrayIndex");
 
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var item in this)
                 {
-                    array.SetValue(new DictionaryEntry(item.Key, item.Value), arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(new DictionaryEntry(item.Key, item.Value), indices);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1689,9 +1689,11 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var item in this)
                 {
-                    array.SetValue(item, arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(item, indices);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
@@ -139,9 +139,11 @@ namespace System.Collections.Immutable
             Requires.Range(arrayIndex >= 0, "arrayIndex");
             Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             foreach (T item in this)
             {
-                array.SetValue(item, arrayIndex++);
+                indices[0] = arrayIndex++;
+                array.SetValue(item, indices);
             }
         }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
@@ -14,6 +14,9 @@ namespace System.Reflection.Metadata
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public unsafe struct BlobReader
     {
+        /// <summary>An array containing the '\0' character.</summary>
+        private static readonly char[] _nullCharArray = new char[1] { '\0' };
+        
         internal const int InvalidCompressedInteger = Int32.MaxValue;
 
         private readonly MemoryBlock block;
@@ -482,7 +485,7 @@ namespace System.Reflection.Metadata
             {
                 // Removal of trailing '\0' is a departure from the spec, but required
                 // for compatibility with legacy compilers.
-                return ReadUTF8(length).TrimEnd('\0');
+                return ReadUTF8(length).TrimEnd(_nullCharArray);
             }
 
             if (ReadByte() != 0xFF)

--- a/src/System.Xml.Common/System/Xml/XmlRawWriter.cs
+++ b/src/System.Xml.Common/System/Xml/XmlRawWriter.cs
@@ -148,7 +148,7 @@ namespace System.Xml
         // Forward call to WriteString(string).
         public override void WriteCharEntity(char ch)
         {
-            WriteString(new string(new char[] { ch }));
+            WriteString(new string(ch, 1));
         }
 
         // Forward call to WriteString(string).

--- a/src/System.Xml.XDocument/System/Xml/Linq/XLinq.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XLinq.cs
@@ -8779,6 +8779,8 @@ namespace System.Xml.Linq
 
     internal class XNodeReader : XmlReader, IXmlLineInfo
     {
+        private static readonly char[] WhitespaceChars = new char[] { ' ', '\t', '\n', '\r' };
+
         // The reader position is encoded by the tuple (source, parent).
         // Lazy text uses (instance, parent element). Attribute value
         // uses (instance, parent attribute). End element uses (instance, 
@@ -9200,7 +9202,7 @@ namespace System.Xml.Linq
                         XAttribute a = e.Attribute(name);
                         if (a != null)
                         {
-                            switch (a.Value.Trim(new char[] { ' ', '\t', '\n', '\r' }))
+                            switch (a.Value.Trim(WhitespaceChars))
                             {
                                 case "preserve":
                                     return XmlSpace.Preserve;

--- a/src/System.Xml.XPath/System/Xml/Cache/XPathDocumentBuilder.cs
+++ b/src/System.Xml.XPath/System/Xml/Cache/XPathDocumentBuilder.cs
@@ -384,8 +384,7 @@ namespace MS.Internal.Xml.Cache
         /// </summary>
         public override void WriteCharEntity(char ch)
         {
-            char[] chars = { ch };
-            WriteString(new string(chars), TextBlockType.Text);
+            WriteString(new string(ch, 1), TextBlockType.Text);
         }
 
         /// <summary>

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs
@@ -246,8 +246,12 @@ namespace System.Xml
 
         void ICollection.CopyTo(Array array, int index)
         {
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             for (int i = 0, max = Count; i < max; i++, index++)
-                array.SetValue(nodes[i], index);
+            {
+                indices[0] = index;
+                array.SetValue(nodes[i], indices);
+            }
         }
 
         bool ICollection.IsSynchronized


### PR DESCRIPTION
I noticed a few places where allocations were occurring unnecessary:
- Across several of the immutable and XML collection types, the ICollection.CopyTo implementations were calling Array.SetValue in a loop; the second parameter to SetValue is a params array, so each iteration of the loop was resulting in allocating a new array... I've lifted that implicit allocation out to be an explicit one before the loop.
- In a couple of places in the XML library and the metadata reader, string.Trim\* was being used, either with an array of the same characters unnecessarily being allocated each time, or an implicitly allocated array of constant chars to fill a params array parameter.  I've replaced those with statically cached arrays.
- In a couple of places in the XML library, a string was being constructed around a single character via creating a new char array; I've replaced that with usage of string's ctor that takes a character and a count, avoiding the unnecessary char[] allocation.
