### PR TITLE
Disable 2 SIMD Tests because of CI build break

### DIFF
--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -541,8 +541,7 @@ namespace System.Numerics.Tests
 
         // A test for Normalize (Vector2f)
         // Normalize zero length vector
-        //[Fact(Skip="Build Machine Issue")]
-        // GitHub Issue #22
+        //[Fact(Skip="GitHub Issue #22")]
         public void Vector2NormalizeTest1()
         {
             Vector2 a = new Vector2(); // no parameter, default to 0.0f

--- a/src/System.Numerics.Vectors/tests/Vector4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector4Tests.cs
@@ -781,8 +781,7 @@ namespace System.Numerics.Tests
 
         // A test for Normalize (Vector4f)
         // Normalize vector of length zero
-        //[Fact(Skip="Build Machine Issue")]
-        // GitHub Issue #22
+        //[Fact(Skip="GitHub Issue #22")]
         public void Vector4NormalizeTest2()
         {
             Vector4 a = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
These two tests failed previously on the CI build server. This disables them until I'm able to investigate the issue on the build machine directly.
