### PR TITLE
Tests should be aware of the Current Culture Info

### DIFF
--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -533,12 +533,13 @@ namespace System.Numerics.Tests
             T[] values1 = GenerateRandomValuesForVector<T>();
             Vector<T> v1 = new Vector<T>(values1);
             string result = v1.ToString(format, provider);
+            string cultureSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator + " ";
 
             string expected = "<";
             for (int g = 0; g < Vector<T>.Count - 1; g++)
             {
                 expected += ((IFormattable)v1[g]).ToString(format, provider);
-                expected += ", ";
+                expected += cultureSeparator;
             }
             expected += ((IFormattable)v1[Vector<T>.Count - 1]).ToString(format, provider);
             expected += ">";

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -362,12 +362,13 @@ namespace System.Numerics.Tests
             T[] values1 = GenerateRandomValuesForVector<T>();
             Vector<T> v1 = new Vector<T>(values1);
             string result = v1.ToString(format, provider);
+            string cultureSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator + " ";
 
             string expected = "<";
             for (int g = 0; g < Vector<T>.Count - 1; g++)
             {
                 expected += ((IFormattable)v1[g]).ToString(format, provider);
-                expected += ", ";
+                expected += cultureSeparator;
             }
             expected += ((IFormattable)v1[Vector<T>.Count - 1]).ToString(format, provider);
             expected += ">";

--- a/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 using System.Numerics;
+using System.Globalization;
 
 namespace System.Numerics.Tests
 {
@@ -1480,13 +1481,14 @@ namespace System.Numerics.Tests
             a.M43 = 43.0f;
             a.M44 = 44.0f;
 
-            string expected = "{ {M11:11 M12:-12 M13:-13.3 M14:14.4} " +
-                                "{M21:21 M22:22 M23:23 M24:24} " +
-                                "{M31:31 M32:32 M33:33 M34:34} " +
-                                "{M41:41 M42:42 M43:43 M44:44} }";
-            string actual;
-
-            actual = a.ToString();
+            string expected = String.Format(CultureInfo.CurrentCulture,
+                "{{ {{M11:{0} M12:{1} M13:{2} M14:{3}}} {{M21:{4} M22:{5} M23:{6} M24:{7}}} {{M31:{8} M32:{9} M33:{10} M34:{11}}} {{M41:{12} M42:{13} M43:{14} M44:{15}}} }}",
+                    11.0f, -12.0f, -13.3f, 14.4f,
+                    21.0f, 22.0f, 23.0f, 24.0f,
+                    31.0f, 32.0f, 33.0f, 34.0f,
+                    41.0f, 42.0f, 43.0f, 44.0f);
+            
+            string actual = a.ToString();
             Assert.Equal(expected, actual);
         }
 

--- a/src/System.Numerics.Vectors/tests/QuaternionTests.cs
+++ b/src/System.Numerics.Vectors/tests/QuaternionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 using System.Numerics;
+using System.Globalization;
 
 namespace System.Numerics.Tests
 {
@@ -522,10 +523,12 @@ namespace System.Numerics.Tests
         public void QuaternionToStringTest()
         {
             Quaternion target = new Quaternion(-1.0f, 2.2f, 3.3f, -4.4f);
-            string expected = "{X:-1 Y:2.2 Z:3.3 W:-4.4}";
-            string actual;
 
-            actual = target.ToString();
+            string expected = string.Format(CultureInfo.CurrentCulture
+                , "{{X:{0} Y:{1} Z:{2} W:{3}}}"
+                , -1.0f, 2.2f, 3.3f, -4.4f);
+
+            string actual = target.ToString();
             Assert.Equal(expected, actual);
         }
 

--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -58,16 +58,34 @@ namespace System.Numerics.Tests
         [Fact]
         public void Vector2ToStringTest()
         {
+            string separator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
+            CultureInfo enUsCultureInfo = new CultureInfo("en-US");
+
             Vector2 v1 = new Vector2(2.0f, 3.0f);
 
             string v1str = v1.ToString();
-            Assert.Equal("<2, 3>", v1str);
+            string expectedv1 = string.Format(CultureInfo.CurrentCulture
+                , "<{1:G}{0} {2:G}>"
+                , separator, 2, 3);
+            Assert.Equal(expectedv1, v1str);
 
-            string v1strformatted = v1.ToString("c", new CultureInfo("en-US"));
-            Assert.Equal("<$2.00, $3.00>", v1strformatted);
+            string v1strformatted = v1.ToString("c", CultureInfo.CurrentCulture);
+            string expectedv1formatted = string.Format(CultureInfo.CurrentCulture
+                , "<{1:c}{0} {2:c}>"
+                , separator, 2, 3);
+            Assert.Equal(expectedv1formatted, v1strformatted);
 
-            string v2strformatted = v1.ToString("c");
-            Assert.Equal(string.Format("<{0:C}, {1:C}>", 2, 3), v2strformatted);
+            string v2strformatted = v1.ToString("c", enUsCultureInfo);
+            string expectedv2formatted = string.Format(enUsCultureInfo
+                , "<{1:c}{0} {2:c}>"
+                , enUsCultureInfo.NumberFormat.NumberGroupSeparator, 2, 3);
+            Assert.Equal(expectedv2formatted, v2strformatted);
+
+            string v3strformatted = v1.ToString("c");
+            string expectedv3formatted = string.Format(CultureInfo.CurrentCulture
+                , "<{1:c}{0} {2:c}>"
+                , separator, 2, 3);
+            Assert.Equal(expectedv3formatted, v3strformatted);
         }
 
         // A test for Distance (Vector2f, Vector2f)

--- a/src/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -62,16 +62,33 @@ namespace System.Numerics.Tests
         [Fact]
         public void Vector3ToStringTest()
         {
+            string separator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
+            CultureInfo enUsCultureInfo = new CultureInfo("en-US");
+
             Vector3 v1 = new Vector3(2.0f, 3.0f, 3.3f);
             string v1str = v1.ToString();
-            Assert.Equal("<2, 3, 3.3>", v1str);
+            string expectedv1 = string.Format(CultureInfo.CurrentCulture
+                , "<{1:G}{0} {2:G}{0} {3:G}>"
+                , separator, 2, 3, 3.3);
+            Assert.Equal(expectedv1, v1str);
 
-            string v1strformatted = v1.ToString("c", new CultureInfo("en-US"));
-            Assert.Equal("<$2.00, $3.00, $3.30>", v1strformatted);
+            string v1strformatted = v1.ToString("c", CultureInfo.CurrentCulture);
+            string expectedv1formatted = string.Format(CultureInfo.CurrentCulture
+                , "<{1:c}{0} {2:c}{0} {3:c}>"
+                , separator, 2, 3, 3.3);
+            Assert.Equal(expectedv1formatted, v1strformatted);
 
-            string v2strformatted = v1.ToString("c");
+            string v2strformatted = v1.ToString("c", enUsCultureInfo);
+            string expectedv2formatted = string.Format(enUsCultureInfo
+                , "<{1:c}{0} {2:c}{0} {3:c}>"
+                , enUsCultureInfo.NumberFormat.NumberGroupSeparator, 2, 3, 3.3);
+            Assert.Equal(expectedv2formatted, v2strformatted);
 
-            Assert.Equal(string.Format("<{0:C}, {1:C}, {2:C}>", 2, 3, 3.3), v2strformatted);
+            string v3strformatted = v1.ToString("c");
+            string expectedv3formatted = string.Format(CultureInfo.CurrentCulture
+                , "<{1:c}{0} {2:c}{0} {3:c}>"
+                , separator, 2, 3, 3.3);
+            Assert.Equal(expectedv3formatted, v3strformatted);
         }
 
         // A test for Cross (Vector3f, Vector3f)

--- a/src/System.Numerics.Vectors/tests/Vector4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector4Tests.cs
@@ -63,16 +63,34 @@ namespace System.Numerics.Tests
         [Fact]
         public void Vector4ToStringTest()
         {
+            string separator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
+            CultureInfo enUsCultureInfo = new CultureInfo("en-US");
+
             Vector4 v1 = new Vector4(2.5f, 2.0f, 3.0f, 3.3f);
 
             string v1str = v1.ToString();
-            Assert.Equal("<2.5, 2, 3, 3.3>", v1str);
+            string expectedv1 = string.Format(CultureInfo.CurrentCulture
+                , "<{1:G}{0} {2:G}{0} {3:G}{0} {4:G}>"
+                , separator, 2.5, 2, 3, 3.3);
+            Assert.Equal(expectedv1, v1str);
 
-            string v1strformatted = v1.ToString("c", new CultureInfo("en-US"));
-            Assert.Equal("<$2.50, $2.00, $3.00, $3.30>", v1strformatted);
+            string v1strformatted = v1.ToString("c", CultureInfo.CurrentCulture);
+            string expectedv1formatted = string.Format(CultureInfo.CurrentCulture
+                , "<{1:c}{0} {2:c}{0} {3:c}{0} {4:c}>"
+                , separator, 2.5, 2, 3, 3.3);
+            Assert.Equal(expectedv1formatted, v1strformatted);
 
-            string v2strformatted = v1.ToString("c");
-            Assert.Equal("<$2.50, $2.00, $3.00, $3.30>", v1strformatted);
+            string v2strformatted = v1.ToString("c", enUsCultureInfo);
+            string expectedv2formatted = string.Format(enUsCultureInfo
+                , "<{1:c}{0} {2:c}{0} {3:c}{0} {4:c}>"
+                , enUsCultureInfo.NumberFormat.NumberGroupSeparator, 2.5, 2, 3, 3.3);
+            Assert.Equal(expectedv2formatted, v2strformatted);
+
+            string v3strformatted = v1.ToString("c");
+            string expectedv3formatted = string.Format(CultureInfo.CurrentCulture
+                , "<{1:c}{0} {2:c}{0} {3:c}{0} {4:c}>"
+                , separator, 2.5, 2, 3, 3.3);
+            Assert.Equal(expectedv3formatted, v3strformatted);
         }
 
         // A test for DistanceSquared (Vector4f, Vector4f)


### PR DESCRIPTION
Hello,

As i'm French, my CultureInfo.CurrentCulture is set to "fr-FR" while running tests.
But for some tests, especially for the ToString() methods, tests are write to check "en-US" Culture.
