### PR TITLE
Fix build script to use default web proxy to download remote files.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -34,7 +34,10 @@
         <![CDATA[
            var directory = System.IO.Path.GetDirectoryName(FileName);
            System.IO.Directory.CreateDirectory(directory);
-           new System.Net.WebClient().DownloadFile(Address, FileName);
+           var client = new System.Net.WebClient();
+           client.Proxy = System.Net.WebRequest.DefaultWebProxy;
+           client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+           client.DownloadFile(Address, FileName);
         ]]>
       </Code>
     </Task>


### PR DESCRIPTION
The build fails when behind a firewall.  This PR should address that issue.

Tested on corporate network and also at home
