### PR TITLE
[Closes #44] Fix spelling error in ImmutableStack

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
@@ -37,7 +37,7 @@ namespace System.Collections.Immutable
         private readonly T head;
 
         /// <summary>
-        /// A stack that constaints the rest of the elements (under the top element).
+        /// A stack that contains the rest of the elements (under the top element).
         /// </summary>
         private readonly ImmutableStack<T> tail;
 


### PR DESCRIPTION
- [Closes #44] Fix spelling error in `System.Collections.Immutable.ImmutableStack`1` on Line 40
