### PR TITLE
Made Quarternion's operator overloads use their respective methods

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Quaternion.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Quaternion.cs
@@ -55,10 +55,10 @@ namespace System.Numerics
         /// <param name="w">The W component of the Quaternion.</param>
         public Quaternion(float x, float y, float z, float w)
         {
-            this.X = x;
-            this.Y = y;
-            this.Z = z;
-            this.W = w;
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
         }
 
         /// <summary>


### PR DESCRIPTION
Operator overloads of Quaternion now utilize their respective methods, and removed redundant "this" qualifiers in Quaternion constructor.
