### PR TITLE
Removing redundant comparison with "null"

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
@@ -52,7 +52,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Vector2))
+            if (!(obj is Vector2))
                 return false;
             return Equals((Vector2)obj);
         }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
@@ -57,7 +57,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Vector3))
+            if (!(obj is Vector3))
                 return false;
             return Equals((Vector3)obj);
         }

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
@@ -61,7 +61,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Vector4))
+            if (!(obj is Vector4))
                 return false;
             return Equals((Vector4)obj);
         }


### PR DESCRIPTION
Removing redundant comparison with "null" ((!(obj is Vector)) is superset condition for (obj == null))
