### PR TITLE
Developer doc update to indicate VS cmd prompt usage

### DIFF
--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -7,7 +7,7 @@ We currently only support building and running on Windows. Other platforms will
 come later.
 
 The command line build is invoked in  
-[Visual Studio Command Prompt](http://msdn.microsoft.com/en-us/library/ms229859(v=vs.110).aspx) 
+[Visual Studio Command Prompt](http://msdn.microsoft.com/en-us/library/ms229859(v=vs.110).aspx)
 via
 
 ```


### PR DESCRIPTION
This is related to #60. The main developer document does not call out that build should happen
in a VS command prompt.
