### PR TITLE
Fix System.Collections.Immutable!ImmutableArray<T>.Builder.Sort() to not generate Comparer wrapper each time

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -590,7 +590,7 @@ namespace System.Collections.Immutable
             /// </summary>
             public void Sort()
             {
-                Array.Sort(this.elements, 0, this.Count, new Comparer(Comparer<T>.Default));
+                Array.Sort(this.elements, 0, this.Count, Comparer.Default);
             }
 
             /// <summary>
@@ -701,6 +701,8 @@ namespace System.Collections.Immutable
             private sealed class Comparer : IComparer<RefAsValueType<T>>
             {
                 private readonly IComparer<T> comparer;
+
+                public static readonly Comparer Default = new Comparer(Comparer<T>.Default);
 
                 internal Comparer(IComparer<T> comparer = null)
                 {


### PR DESCRIPTION
System.Collections.Immutable!ImmutableArray<T>.Builder.Sort (3 overloads)
creates a new Comparer wrapper each time. This can get expensive if you call Sort a lot.

Fix- This fix optmizes method Sort() alone among the 3 overloads. Sort() uses the default comparer which through this fix is getting cached into a static field in type Comparer such that the Comparer wrapper is not created each time Sort() is called.

Existing testcase Sort(), covers this case.
