### PR TITLE
Changed math helper class to use its own Pi property

### DIFF
--- a/src/System.Numerics.Vectors/tests/MathHelper.cs
+++ b/src/System.Numerics.Vectors/tests/MathHelper.cs
@@ -6,14 +6,14 @@ namespace System.Numerics
     static class MathHelper
     {
         public const float Pi = (float)Math.PI;
-        public const float PiOver2 = (float)Math.PI / 2f;
-        public const float PiOver4 = (float)Math.PI / 4f;
+        public const float PiOver2 = Pi / 2f;
+        public const float PiOver4 = Pi / 4f;
 
 
         // Angle conversion helper.
         public static float ToRadians(float degrees)
         {
-            return degrees * (float)Math.PI / 180f;
+            return degrees * Pi / 180f;
         }
 
 


### PR DESCRIPTION
Maybe nitpicking, but I just wanted to say I contributed to the .NET core :)

The math helper class was re evaluating `(float)Math.PI` instead of using its own public property.
Also fixed the grammar on a comment while I was oggling the code.
