### PR TITLE
Add ImmutableArrayExtensions.SelectMany extension method

### DIFF
--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -38,6 +38,63 @@ namespace System.Linq
         }
 
         /// <summary>
+        /// Projects each element of a sequence to an <see cref="IEnumerable{T}"/>,
+        /// flattens the resulting sequences into one sequence, and invokes a result
+        /// selector function on each element therein.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="immutableArray"/>.</typeparam>
+        /// <typeparam name="TCollection">The type of the intermediate elements collected by collectionSelector.</typeparam>
+        /// <typeparam name="TResult">The type of the elements of the resulting sequence.</typeparam>
+        /// <param name="immutableArray">The immutable array.</param>
+        /// <param name="collectionSelector">A transform function to apply to each element of the input sequence.</param>
+        /// <param name="resultSelector">A transform function to apply to each element of the intermediate sequence.</param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> whose elements are the result
+        /// of invoking the one-to-many transform function collectionSelector on each
+        /// element of source and then mapping each of those sequence elements and their
+        /// corresponding source element to a result element.
+        /// </returns>
+        [Pure]
+        public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(
+            this ImmutableArray<TSource> immutableArray,
+            Func<TSource, IEnumerable<TCollection>> collectionSelector,
+            Func<TSource, TCollection, TResult> resultSelector)
+        {
+            immutableArray.ThrowNullRefIfNotInitialized();
+            if (collectionSelector == null || resultSelector == null)
+            {
+                // throw the same exception as would LINQ
+                return Enumerable.SelectMany(immutableArray, collectionSelector, resultSelector);
+            }
+
+            // This SelectMany overload is used by the C# compiler for a query of the form:
+            //     from i in immutableArray
+            //     from j in anotherCollection
+            //     select Something(i, j);
+            // SelectMany accepts an IEnumerable<TSource>, and ImmutableArray<TSource> is a struct.
+            // By having a special implementation of SelectMany that operates on the ImmutableArray's
+            // underlying array, we can avoid a few allocations, in particular for the boxed
+            // immutable array object that would be allocated when it's passed as an IEnumerable<T>, 
+            // and for the EnumeratorObject that would be allocated when enumerating the boxed array.
+            return SelectManyIterator(immutableArray, collectionSelector, resultSelector);
+        }
+
+        /// <summary>Provides the core iterator implementation of SelectMany.</summary>
+        private static IEnumerable<TResult> SelectManyIterator<TSource, TCollection, TResult>(
+            this ImmutableArray<TSource> immutableArray,
+            Func<TSource, IEnumerable<TCollection>> collectionSelector,
+            Func<TSource, TCollection, TResult> resultSelector)
+        {
+            foreach (TSource item in immutableArray.array)
+            {
+                foreach (TCollection result in collectionSelector(item))
+                {
+                    yield return resultSelector(item, result);
+                }
+            }
+        }
+
+        /// <summary>
         /// Filters a sequence of values based on a predicate.
         /// </summary>
         /// <typeparam name="T">The type of element contained by the collection.</typeparam>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayExtensionsTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayExtensionsTest.cs
@@ -42,6 +42,25 @@ namespace System.Collections.Immutable.Test
         }
 
         [Fact]
+        public void SelectMany()
+        {
+            Func<int, IEnumerable<int>> collectionSelector = i => Enumerable.Range(i, 10);
+            Func<int, int, int> resultSelector = (i, e) => e * 2;
+            foreach (var arr in new[] { empty, oneElement, manyElements })
+            {
+                Assert.Equal(
+                    Enumerable.SelectMany(arr, collectionSelector, resultSelector),
+                    ImmutableArrayExtensions.SelectMany(arr, collectionSelector, resultSelector));
+            }
+
+            Assert.Throws<NullReferenceException>(() => ImmutableArrayExtensions.SelectMany<int, int, int>(emptyDefault, null, null));
+            Assert.Throws<ArgumentNullException>(() => 
+                ImmutableArrayExtensions.SelectMany<int, int, int>(manyElements, null, (i, e) => e));
+            Assert.Throws<ArgumentNullException>(() =>
+                ImmutableArrayExtensions.SelectMany<int, int, int>(manyElements, i => new[] { i }, null));
+        }
+
+        [Fact]
         public void Where()
         {
             Assert.Equal(new[] { 2, 3 }, ImmutableArrayExtensions.Where(manyElements, n => n > 1));


### PR DESCRIPTION
For C# query comprehensions of the form:

from i in immutableArray
from j in someOtherCollection
select Something(i, j)

the compiler requires a particular signature of SelectMany.  This method isn't provided today by ImmutableArrayExtensions for ImmutableArray<T>, and thus the compiler binds to Enumerable's corresponding SelectMany implementation.  This results in a few more allocations than are truly needed: first, the ImmutableArray<T> needs to be boxed when passed as an IEnumerable<T>, and second, when SelectMany's iterator then enumerates this IEnumerable<T>, ImmutableArray<T>'s IEnumerable<T>.GetEnumerator allocates an EnumeratorObject to server as the enumerator.

This PR provides an ImmutableArrayExtensions.SelectMany method that avoids these two allocations.  It includes tests as well.
