### PR TITLE
Adding warning for running from bare cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -13,6 +13,8 @@ if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/blob/master/docs/Developers.md for build instructions. && goto :eof
 
+if NOT DEFINED VSINSTALLDIR echo Error: Build should be run from visual studio command prompt. Please see https://github.com/dotnet/corefx/blob/master/docs/Developers.md for build instructions. && goto :eof
+
 :: Log build command line
 set _buildprefix=echo
 set _buildpostfix=^> "%~dp0msbuild.log"


### PR DESCRIPTION
Fixes issue #60  

Launching the vs command prompt appears to set VSINSTALLDIR so using that to detect if running from correct context.
