### PR TITLE
Add async document/element loading for XLinq.

### DIFF
--- a/src/System.Xml.XDocument/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/System.Xml.XDocument.csproj
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  
-  
+
+
   <PropertyGroup>
     <!-- Work around known Dev14 bug - see
          https://connect.microsoft.com/VisualStudio/feedback/details/1000796/connect-file-uap-props-not-found-cant-build-a-portable-lib-on-vs14
-    --> 
-     
+    -->
+
     <_WindowsKitBinPath>$(MSBuildProgramFiles32)\Windows Kits\8.1\bin\x86</_WindowsKitBinPath>
     <_WindowsPhoneKitBinPath>$(MSBuildProgramFiles32)\Windows Phone Kits\8.1\bin</_WindowsPhoneKitBinPath>
     <MakePriExeFullPath>$(_WindowsKitBinPath)\makepri.exe</MakePriExeFullPath>
@@ -16,8 +16,8 @@
     <MakePriExtensionPath>$(_WindowsPhoneKitBinPath)\x86\MrmEnvironmentExtDl.dll</MakePriExtensionPath>
     <MakePriExtensionPath_x64>$(_WindowsPhoneKitBinPath)\x64\MrmEnvironmentExtDl.dll</MakePriExtensionPath_x64>
   </PropertyGroup>
-  
-  
+
+
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>

--- a/src/System.Xml.XDocument/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/System.Xml.XDocument.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   
@@ -61,6 +61,7 @@
     <Reference Include="System.Runtime.Extensions" />
     <!--System.Environment.get_CurrentManagedThreadId-->
     <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
     <!--For locking-->
     <Reference Include="System.Reflection" />
     <!--Need to reimplement Type.IsInstanceOfType-->

--- a/src/System.Xml.XDocument/System/Xml/Linq/XComment.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XComment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -90,6 +92,21 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteComment(value);
+        }
+
+        /// <summary>
+        /// Write this <see cref="XComment"/> to the passed in <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XComment"/> to.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteCommentAsync(value).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XContainer.cs
@@ -1163,6 +1163,41 @@ namespace System.Xml.Linq
             }
         }
 
+        internal async Task WriteContentToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (content != null)
+            {
+                string sContent = content as string;
+
+                if (sContent != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    Task tWrite;
+
+                    if (this is XDocument)
+                    {
+                        tWrite = writer.WriteWhitespaceAsync(sContent);
+                    }
+                    else
+                    {
+                        tWrite = writer.WriteStringAsync(sContent);
+                    }
+
+                    await tWrite.ConfigureAwait(false);
+                }
+                else
+                {
+                    XNode n = (XNode)content;
+                    do
+                    {
+                        n = n.next;
+                        await n.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+                    } while (n != content);
+                }
+            }
+        }
+
         static void AddContentToList(List<object> list, object content)
         {
             IEnumerable e = content is string ? null : content as IEnumerable;

--- a/src/System.Xml.XDocument/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XContainer.cs
@@ -871,29 +871,27 @@ namespace System.Xml.Linq
             while (cr.ReadContentFrom(this, r, o) && r.Read()) ;
         }
 
-        internal async Task ReadContentFromAsync(XmlReader r, CancellationToken token)
+        internal async Task ReadContentFromAsync(XmlReader r, CancellationToken cancellationToken)
         {
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
 
             ContentReader cr = new ContentReader(this);
-            while (!token.IsCancellationRequested && cr.ReadContentFrom(this, r) && await r.ReadAsync().ConfigureAwait(false)) ;
-
-            token.ThrowIfCancellationRequested();
+            while (!cancellationToken.IsCancellationRequested && cr.ReadContentFrom(this, r) && await r.ReadAsync().ConfigureAwait(false)) ;
         }
 
-        internal async Task ReadContentFromAsync(XmlReader r, LoadOptions o, CancellationToken token)
+        internal async Task ReadContentFromAsync(XmlReader r, LoadOptions o, CancellationToken cancellationToken)
         {
             if ((o & (LoadOptions.SetBaseUri | LoadOptions.SetLineInfo)) == 0)
             {
-                await ReadContentFromAsync(r, token).ConfigureAwait(false);
+                await ReadContentFromAsync(r, cancellationToken).ConfigureAwait(false);
                 return;
             }
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
 
             ContentReader cr = new ContentReader(this);
-            while (!token.IsCancellationRequested && cr.ReadContentFrom(this, r, o) && await r.ReadAsync().ConfigureAwait(false)) ;
+            while (!cancellationToken.IsCancellationRequested && cr.ReadContentFrom(this, r, o) && await r.ReadAsync().ConfigureAwait(false)) ;
 
-            token.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
         }
         
         /// <summary>

--- a/src/System.Xml.XDocument/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XContainer.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Debug = System.Diagnostics.Debug;
 using IEnumerable = System.Collections.IEnumerable;
 using StringBuilder = System.Text.StringBuilder;
 using Interlocked = System.Threading.Interlocked;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace System.Xml.Linq
 {

--- a/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
@@ -223,45 +223,6 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
-        /// Create a new <see cref="XDocument"/> based on the contents of the file 
-        /// referenced by the URI parameter passed in.  Optionally, whitespace can be preserved.  
-        /// <see cref="XmlReader.Create(string)"/>
-        /// </summary>
-        /// <remarks>
-        /// This method uses the <see cref="XmlReader.Create(string)"/> method to create
-        /// an <see cref="XmlReader"/> to read the raw XML into an underlying
-        /// XML tree.  If LoadOptions.PreserveWhitespace is enabled then
-        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
-        /// is set to false.
-        /// </remarks>
-        /// <param name="uri">
-        /// A string representing the URI of the file to be loaded into a new <see cref="XDocument"/>.
-        /// </param>
-        /// <param name="options">
-        /// A set of <see cref="LoadOptions"/>.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token.
-        /// </param>
-        /// <returns>
-        /// An <see cref="XDocument"/> initialized with the contents of the file referenced
-        /// in the passed uri parameter.  If LoadOptions.PreserveWhitespace is enabled then
-        /// all whitespace will be preserved.
-        /// </returns>
-        [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "0#", Justification = "Back-compat with System.Xml.")]
-        public static async Task<XDocument> LoadAsync(string uri, LoadOptions options, CancellationToken cancellationToken)
-        {
-            XmlReaderSettings rs = GetXmlReaderSettings(options);
-
-            rs.Async = true;
-
-            using (XmlReader r = XmlReader.Create(uri, rs))
-            {
-                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
         /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
         /// the passed <see cref="Stream"/> parameter.  
         /// </summary>

--- a/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
@@ -240,7 +240,7 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
         /// <returns>
@@ -249,12 +249,12 @@ namespace System.Xml.Linq
         /// all whitespace will be preserved.
         /// </returns>
         [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "0#", Justification = "Back-compat with System.Xml.")]
-        public static async Task<XDocument> LoadAsync(string uri, LoadOptions options, CancellationToken token)
+        public static async Task<XDocument> LoadAsync(string uri, LoadOptions options, CancellationToken cancellationToken)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(uri, rs))
             {
-                return await LoadAsync(r, options, token).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -322,19 +322,19 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
         /// <returns>
         /// A new <see cref="XDocument"/> containing the contents of the passed in
         /// <see cref="Stream"/>.
         /// </returns>
-        public static async Task<XDocument> LoadAsync(Stream stream, LoadOptions options, CancellationToken token)
+        public static async Task<XDocument> LoadAsync(Stream stream, LoadOptions options, CancellationToken cancellationToken)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(stream, rs))
             {
-                return await LoadAsync(r, options, token).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -402,19 +402,19 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
         /// <returns>
         /// A new <see cref="XDocument"/> containing the contents of the passed in
         /// <see cref="TextReader"/>.
         /// </returns>
-        public static async Task<XDocument> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken token)
+        public static async Task<XDocument> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken cancellationToken)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(textReader, rs))
             {
-                return await LoadAsync(r, options, token).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -474,24 +474,24 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
         /// <returns>
         /// A new <see cref="XDocument"/> containing the contents of the passed
         /// in <see cref="XmlReader"/>.
         /// </returns>
-        public static async Task<XDocument> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken token)
+        public static async Task<XDocument> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
         {
             if (reader == null) throw new ArgumentNullException("reader");
             if (reader.ReadState == ReadState.Initial)
             {
-                token.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 await reader.ReadAsync().ConfigureAwait(false);
             }
 
             XDocument d = InitLoad(reader, options);
-            await d.ReadContentFromAsync(reader, options, token);
+            await d.ReadContentFromAsync(reader, options, cancellationToken);
 
             if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
             if (d.Root == null) throw new InvalidOperationException(SR.InvalidOperation_MissingRoot);

--- a/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 using Encoding = System.Text.Encoding;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Xml.Linq
 {

--- a/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XDocument.cs
@@ -223,6 +223,42 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Create a new <see cref="XDocument"/> based on the contents of the file 
+        /// referenced by the URI parameter passed in.  Optionally, whitespace can be preserved.  
+        /// <see cref="XmlReader.Create(string)"/>
+        /// </summary>
+        /// <remarks>
+        /// This method uses the <see cref="XmlReader.Create(string)"/> method to create
+        /// an <see cref="XmlReader"/> to read the raw XML into an underlying
+        /// XML tree.  If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="uri">
+        /// A string representing the URI of the file to be loaded into a new <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="token">
+        /// A cancellation token.
+        /// </param>
+        /// <returns>
+        /// An <see cref="XDocument"/> initialized with the contents of the file referenced
+        /// in the passed uri parameter.  If LoadOptions.PreserveWhitespace is enabled then
+        /// all whitespace will be preserved.
+        /// </returns>
+        [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "0#", Justification = "Back-compat with System.Xml.")]
+        public static async Task<XDocument> LoadAsync(string uri, LoadOptions options, CancellationToken token)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+            using (XmlReader r = XmlReader.Create(uri, rs))
+            {
+                return await LoadAsync(r, options, token).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
         /// the passed <see cref="Stream"/> parameter.  
         /// </summary>
@@ -271,6 +307,39 @@ namespace System.Xml.Linq
 
         /// <summary>
         /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
+        /// the passed <see cref="Stream"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the underlying <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> containing the raw XML to read into the newly
+        /// created <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="token">
+        /// A cancellation token.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="XDocument"/> containing the contents of the passed in
+        /// <see cref="Stream"/>.
+        /// </returns>
+        public static async Task<XDocument> LoadAsync(Stream stream, LoadOptions options, CancellationToken token)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+            using (XmlReader r = XmlReader.Create(stream, rs))
+            {
+                return await LoadAsync(r, options, token).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
         /// the passed <see cref="TextReader"/> parameter.  
         /// </summary>
         /// <param name="textReader">
@@ -313,6 +382,39 @@ namespace System.Xml.Linq
             using (XmlReader r = XmlReader.Create(textReader, rs))
             {
                 return Load(r, options);
+            }
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XDocument"/> and initialize its underlying XML tree using
+        /// the passed <see cref="TextReader"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="textReader">
+        /// A <see cref="TextReader"/> containing the raw XML to read into the newly
+        /// created <see cref="XDocument"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="token">
+        /// A cancellation token.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="XDocument"/> containing the contents of the passed in
+        /// <see cref="TextReader"/>.
+        /// </returns>
+        public static async Task<XDocument> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken token)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+            using (XmlReader r = XmlReader.Create(textReader, rs))
+            {
+                return await LoadAsync(r, options, token).ConfigureAwait(false);
             }
         }
 

--- a/src/System.Xml.XDocument/System/Xml/Linq/XDocumentType.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XDocumentType.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -140,6 +142,23 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteDocType(name, publicId, systemId, internalSubset);
+        }
+
+        /// <summary>
+        /// Write this <see cref="XDocumentType"/> to the passed in <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XDocumentType"/> to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteDocTypeAsync(name, publicId, systemId, internalSubset).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -138,9 +138,17 @@ namespace System.Xml.Linq
         {
         }
 
+        internal XElement(AsyncConstructionSentry s)
+        {
+        }
+
         internal XElement(XmlReader r, LoadOptions o)
         {
             ReadElementFrom(r, o);
+        }
+
+        internal struct AsyncConstructionSentry
+        {
         }
 
         /// <summary>
@@ -703,7 +711,8 @@ namespace System.Xml.Linq
             token.ThrowIfCancellationRequested();
             if (await reader.MoveToContentAsync().ConfigureAwait(false) != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
 
-            XElement e = new XElement(reader, options);
+            XElement e = new XElement(new AsyncConstructionSentry());
+            await e.ReadElementFromAsync(reader, options, token).ConfigureAwait(false);
 
             token.ThrowIfCancellationRequested();
             await reader.MoveToContentAsync().ConfigureAwait(false);

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -571,18 +571,20 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.</param>
         /// <returns>
         /// An <see cref="XElement"/> initialized with the contents of the file referenced
         /// in the passed uri parameter.  If LoadOptions.PreserveWhitespace is enabled then
         /// significant whitespace will be preserved.
         /// </returns>
         [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", Justification = "Back-compat with System.Xml.")]
-        public static async Task<XElement> LoadAsync(string uri, LoadOptions options, CancellationToken token)
+        public static async Task<XElement> LoadAsync(string uri, LoadOptions options, CancellationToken cancellationToken)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(uri, rs))
             {
-                return await LoadAsync(r, options, token).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -650,18 +652,18 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.</param>
         /// <returns>
         /// A new <see cref="XElement"/> containing the contents of the passed in
         /// <see cref="Stream"/>.
         /// </returns>
-        public static async Task<XElement> LoadAsync(Stream stream, LoadOptions options, CancellationToken token)
+        public static async Task<XElement> LoadAsync(Stream stream, LoadOptions options, CancellationToken cancellationToken)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(stream, rs))
             {
-                return await LoadAsync(r, options, token).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -729,18 +731,18 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.</param>
         /// <returns>
         /// A new <see cref="XElement"/> containing the contents of the passed in
         /// <see cref="TextReader"/>.
         /// </returns>
-        public static async Task<XElement> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken token)
+        public static async Task<XElement> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken cancellationToken)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(textReader, rs))
             {
-                return await LoadAsync(r, options, token).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -797,23 +799,23 @@ namespace System.Xml.Linq
         /// <param name="options">
         /// A set of <see cref="LoadOptions"/>.
         /// </param>
-        /// <param name="token">
+        /// <param name="cancellationToken">
         /// A cancellation token.</param>
         /// <returns>
         /// A new <see cref="XElement"/> containing the contents of the passed
         /// in <see cref="XmlReader"/>.
         /// </returns>
-        public static async Task<XElement> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken token)
+        public static async Task<XElement> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
         {
             if (reader == null) throw new ArgumentNullException("reader");
 
-            token.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             if (await reader.MoveToContentAsync().ConfigureAwait(false) != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
 
             XElement e = new XElement(new AsyncConstructionSentry());
-            await e.ReadElementFromAsync(reader, options, token).ConfigureAwait(false);
+            await e.ReadElementFromAsync(reader, options, cancellationToken).ConfigureAwait(false);
 
-            token.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             await reader.MoveToContentAsync().ConfigureAwait(false);
 
             if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -560,45 +560,6 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
-        /// Create a new <see cref="XElement"/> based on the contents of the file 
-        /// referenced by the URI parameter passed in.  Optionally, whitespace can be preserved.  
-        /// <see cref="XmlReader.Create(string)"/>
-        /// <seealso cref="XDocument.Load(string, LoadOptions)"/> 
-        /// </summary>
-        /// <remarks>
-        /// This method uses the <see cref="XmlReader.Create(string)"/> method to create
-        /// an <see cref="XmlReader"/> to read the raw XML into an underlying
-        /// XML tree. If LoadOptions.PreserveWhitespace is enabled then
-        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
-        /// is set to false.
-        /// </remarks>
-        /// <param name="uri">
-        /// A string representing the URI of the file to be loaded into a new <see cref="XElement"/>.
-        /// </param>
-        /// <param name="options">
-        /// A set of <see cref="LoadOptions"/>.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token.</param>
-        /// <returns>
-        /// An <see cref="XElement"/> initialized with the contents of the file referenced
-        /// in the passed uri parameter.  If LoadOptions.PreserveWhitespace is enabled then
-        /// significant whitespace will be preserved.
-        /// </returns>
-        [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", Justification = "Back-compat with System.Xml.")]
-        public static async Task<XElement> LoadAsync(string uri, LoadOptions options, CancellationToken cancellationToken)
-        {
-            XmlReaderSettings rs = GetXmlReaderSettings(options);
-
-            rs.Async = true;
-
-            using (XmlReader r = XmlReader.Create(uri, rs))
-            {
-                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
         /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
         /// the passed <see cref="Stream"/> parameter.  
         /// </summary>

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -138,7 +138,7 @@ namespace System.Xml.Linq
         {
         }
 
-        internal XElement(AsyncConstructionSentry s)
+        XElement(AsyncConstructionSentry s)
         {
         }
 
@@ -147,7 +147,14 @@ namespace System.Xml.Linq
             ReadElementFrom(r, o);
         }
 
-        internal struct AsyncConstructionSentry
+        internal static async Task<XElement> CreateAsync(XmlReader r, CancellationToken cancellationToken)
+        {
+            XElement xe = new XElement(new AsyncConstructionSentry());
+            await xe.ReadElementFromAsync(r, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+            return xe;
+        }
+
+        struct AsyncConstructionSentry
         {
         }
 

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -8,6 +8,8 @@ using CultureInfo = System.Globalization.CultureInfo;
 using IEnumerable = System.Collections.IEnumerable;
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 using StringBuilder = System.Text.StringBuilder;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace System.Xml.Linq
 {
@@ -673,6 +675,39 @@ namespace System.Xml.Linq
             if (reader.MoveToContent() != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
             XElement e = new XElement(reader, options);
             reader.MoveToContent();
+            if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
+            return e;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XElement"/> containing the contents of the
+        /// passed in <see cref="XmlReader"/>.
+        /// </summary>
+        /// <param name="reader">
+        /// An <see cref="XmlReader"/> containing the XML to be read into the new
+        /// <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="token">
+        /// A cancellation token.</param>
+        /// <returns>
+        /// A new <see cref="XElement"/> containing the contents of the passed
+        /// in <see cref="XmlReader"/>.
+        /// </returns>
+        public static async Task<XElement> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken token)
+        {
+            if (reader == null) throw new ArgumentNullException("reader");
+
+            token.ThrowIfCancellationRequested();
+            if (await reader.MoveToContentAsync().ConfigureAwait(false) != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
+
+            XElement e = new XElement(reader, options);
+
+            token.ThrowIfCancellationRequested();
+            await reader.MoveToContentAsync().ConfigureAwait(false);
+
             if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
             return e;
         }
@@ -1705,6 +1740,38 @@ namespace System.Xml.Linq
 
         void ReadElementFrom(XmlReader r, LoadOptions o)
         {
+            ReadElementFromImpl(r, o);
+
+            if (!r.IsEmptyElement)
+            {
+                r.Read();
+                ReadContentFrom(r, o);
+            }
+
+            r.Read();
+        }
+
+        async Task ReadElementFromAsync(XmlReader r, LoadOptions o, CancellationToken token)
+        {
+            ReadElementFromImpl(r, o);
+
+            if (!r.IsEmptyElement)
+            {
+                token.ThrowIfCancellationRequested();
+                await r.ReadAsync().ConfigureAwait(false);
+
+                await ReadContentFromAsync(r, o, token).ConfigureAwait(false);
+            }
+
+            token.ThrowIfCancellationRequested();
+            await r.ReadAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Shared implementation between ReadElementFrom / ReadElementFromAsync.
+        /// </summary>
+        void ReadElementFromImpl(XmlReader r, LoadOptions o)
+        {
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
             name = XNamespace.Get(r.NamespaceURI).GetName(r.LocalName);
             if ((o & LoadOptions.SetBaseUri) != 0)
@@ -1737,12 +1804,6 @@ namespace System.Xml.Linq
                 } while (r.MoveToNextAttribute());
                 r.MoveToElement();
             }
-            if (!r.IsEmptyElement)
-            {
-                r.Read();
-                ReadContentFrom(r, o);
-            }
-            r.Read();
         }
 
         internal void RemoveAttribute(XAttribute a)

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -553,6 +553,40 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Create a new <see cref="XElement"/> based on the contents of the file 
+        /// referenced by the URI parameter passed in.  Optionally, whitespace can be preserved.  
+        /// <see cref="XmlReader.Create(string)"/>
+        /// <seealso cref="XDocument.Load(string, LoadOptions)"/> 
+        /// </summary>
+        /// <remarks>
+        /// This method uses the <see cref="XmlReader.Create(string)"/> method to create
+        /// an <see cref="XmlReader"/> to read the raw XML into an underlying
+        /// XML tree. If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="uri">
+        /// A string representing the URI of the file to be loaded into a new <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="XElement"/> initialized with the contents of the file referenced
+        /// in the passed uri parameter.  If LoadOptions.PreserveWhitespace is enabled then
+        /// significant whitespace will be preserved.
+        /// </returns>
+        [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", Justification = "Back-compat with System.Xml.")]
+        public static async Task<XElement> Load(string uri, LoadOptions options, CancellationToken token)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+            using (XmlReader r = XmlReader.Create(uri, rs))
+            {
+                return await LoadAsync(r, options, token).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
         /// the passed <see cref="Stream"/> parameter.  
         /// </summary>
@@ -598,6 +632,39 @@ namespace System.Xml.Linq
                 return Load(r, options);
             }
         }
+
+        /// <summary>
+        /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
+        /// the passed <see cref="Stream"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> containing the raw XML to read into the newly
+        /// created <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="token">
+        /// A cancellation token.</param>
+        /// <returns>
+        /// A new <see cref="XElement"/> containing the contents of the passed in
+        /// <see cref="Stream"/>.
+        /// </returns>
+        public static async Task<XElement> Load(Stream stream, LoadOptions options, CancellationToken token)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+            using (XmlReader r = XmlReader.Create(stream, rs))
+            {
+                return await LoadAsync(r, options, token).ConfigureAwait(false);
+            }
+        }
+
         /// <summary>
         /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
         /// the passed <see cref="TextReader"/> parameter.  
@@ -642,6 +709,38 @@ namespace System.Xml.Linq
             using (XmlReader r = XmlReader.Create(textReader, rs))
             {
                 return Load(r, options);
+            }
+        }
+
+        /// <summary>
+        /// Create a new <see cref="XElement"/> and initialize its underlying XML tree using
+        /// the passed <see cref="TextReader"/> parameter.  Optionally whitespace handling
+        /// can be preserved.
+        /// </summary>
+        /// <remarks>
+        /// If LoadOptions.PreserveWhitespace is enabled then
+        /// the <see cref="XmlReaderSettings"/> property <see cref="XmlReaderSettings.IgnoreWhitespace"/>
+        /// is set to false.
+        /// </remarks>
+        /// <param name="textReader">
+        /// A <see cref="TextReader"/> containing the raw XML to read into the newly
+        /// created <see cref="XElement"/>.
+        /// </param>
+        /// <param name="options">
+        /// A set of <see cref="LoadOptions"/>.
+        /// </param>
+        /// <param name="token">
+        /// A cancellation token.</param>
+        /// <returns>
+        /// A new <see cref="XElement"/> containing the contents of the passed in
+        /// <see cref="TextReader"/>.
+        /// </returns>
+        public static async Task<XElement> LoadAsync(TextReader textReader, LoadOptions options, CancellationToken token)
+        {
+            XmlReaderSettings rs = GetXmlReaderSettings(options);
+            using (XmlReader r = XmlReader.Create(textReader, rs))
+            {
+                return await LoadAsync(r, options, token).ConfigureAwait(false);
             }
         }
 

--- a/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XElement.cs
@@ -3,13 +3,13 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 using CultureInfo = System.Globalization.CultureInfo;
 using IEnumerable = System.Collections.IEnumerable;
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 using StringBuilder = System.Text.StringBuilder;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace System.Xml.Linq
 {
@@ -577,7 +577,7 @@ namespace System.Xml.Linq
         /// significant whitespace will be preserved.
         /// </returns>
         [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", Justification = "Back-compat with System.Xml.")]
-        public static async Task<XElement> Load(string uri, LoadOptions options, CancellationToken token)
+        public static async Task<XElement> LoadAsync(string uri, LoadOptions options, CancellationToken token)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(uri, rs))
@@ -656,7 +656,7 @@ namespace System.Xml.Linq
         /// A new <see cref="XElement"/> containing the contents of the passed in
         /// <see cref="Stream"/>.
         /// </returns>
-        public static async Task<XElement> Load(Stream stream, LoadOptions options, CancellationToken token)
+        public static async Task<XElement> LoadAsync(Stream stream, LoadOptions options, CancellationToken token)
         {
             XmlReaderSettings rs = GetXmlReaderSettings(options);
             using (XmlReader r = XmlReader.Create(stream, rs))

--- a/src/System.Xml.XDocument/System/Xml/Linq/XNode.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XNode.cs
@@ -7,6 +7,8 @@ using System.IO;
 using CultureInfo = System.Globalization.CultureInfo;
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 using StringBuilder = System.Text.StringBuilder;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Xml.Linq
 {
@@ -557,6 +559,13 @@ namespace System.Xml.Linq
         /// </summary>
         /// <param name="writer">The <see cref="XmlWriter"/> to write the current node into.</param>
         public abstract void WriteTo(XmlWriter writer);
+
+        /// <summary>
+        /// Write the current node to an <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="XmlWriter"/> to write the current node into.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public abstract Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken);
 
         internal virtual void AppendText(StringBuilder sb)
         {

--- a/src/System.Xml.XDocument/System/Xml/Linq/XNode.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XNode.cs
@@ -463,6 +463,64 @@ namespace System.Xml.Linq
         }
 
         /// <summary>
+        /// Creates an <see cref="XNode"/> from an <see cref="XmlReader"/>.
+        /// The runtime type of the node is determined by the node type
+        /// (<see cref="XObject.NodeType"/>) of the first node encountered
+        /// in the reader.
+        /// </summary>
+        /// <param name="reader">An <see cref="XmlReader"/> positioned at the node to read into this <see cref="XNode"/>.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>An <see cref="XNode"/> that contains the nodes read from the reader.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the <see cref="XmlReader"/> is not positioned on a recognized node type.
+        /// </exception>
+        public static async Task<XNode> ReadFromAsync(XmlReader reader, CancellationToken cancellationToken)
+        {
+            if (reader == null) throw new ArgumentNullException("reader");
+            if (reader.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
+
+            XNode ret;
+
+            switch (reader.NodeType)
+            {
+                case XmlNodeType.Text:
+                case XmlNodeType.SignificantWhitespace:
+                case XmlNodeType.Whitespace:
+                    ret = new XText(reader.Value);
+                    break;
+                case XmlNodeType.CDATA:
+                    ret = new XCData(reader.Value);
+                    break;
+                case XmlNodeType.Comment:
+                    ret = new XComment(reader.Value);
+                    break;
+                case XmlNodeType.DocumentType:
+                    var name = reader.Name;
+                    var publicId = reader.GetAttribute("PUBLIC");
+                    var systemId = reader.GetAttribute("SYSTEM");
+                    var internalSubset = reader.Value;
+
+                    ret = new XDocumentType(name, publicId, systemId, internalSubset);
+                    break;
+                case XmlNodeType.Element:
+                    return await XElement.CreateAsync(reader, cancellationToken).ConfigureAwait(false);
+                case XmlNodeType.ProcessingInstruction:
+                    var target = reader.Name;
+                    var data = reader.Value;
+
+                    ret = new XProcessingInstruction(target, data);
+                    break;
+                default:
+                    throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, reader.NodeType));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await reader.ReadAsync().ConfigureAwait(false);
+
+            return ret;
+        }
+
+        /// <summary>
         /// Removes this XNode from the underlying XML tree.
         /// </summary>
         /// <exception cref="InvalidOperationException">

--- a/src/System.Xml.XDocument/System/Xml/Linq/XProcessingInstruction.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XProcessingInstruction.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 namespace System.Xml.Linq
 {
     /// <summary>
@@ -116,6 +118,21 @@ namespace System.Xml.Linq
         {
             if (writer == null) throw new ArgumentNullException("writer");
             writer.WriteProcessingInstruction(target, data);
+        }
+
+        /// <summary>
+        /// Writes this <see cref="XProcessingInstruction"/> to the passed in <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XProcessingInstruction"/> to.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteProcessingInstructionAsync(target, data).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/System.Xml.XDocument/System/Xml/Linq/XText.cs
+++ b/src/System.Xml.XDocument/System/Xml/Linq/XText.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using StringBuilder = System.Text.StringBuilder;
 
 namespace System.Xml.Linq
@@ -87,6 +89,35 @@ namespace System.Xml.Linq
             {
                 writer.WriteString(text);
             }
+        }
+
+        /// <summary>
+        /// Write this <see cref="XText"/> to the given <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">
+        /// The <see cref="XmlWriter"/> to write this <see cref="XText"/> to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token.
+        /// </param>
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        {
+            if (writer == null) throw new ArgumentNullException("writer");
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Task t;
+
+            if (parent is XDocument)
+            {
+                t = writer.WriteWhitespaceAsync(text);
+            }
+            else
+            {
+                t = writer.WriteStringAsync(text);
+            }
+
+            await t.ConfigureAwait(false);
         }
 
         internal override void AppendText(StringBuilder sb)


### PR DESCRIPTION
Adds XElement.LoadAsync and XDocument.LoadAsync. Code from the sync versions has been largely lifted out so they can share an implementation as much as possible.