### PR TITLE
Enable open-source signing product and test binaries.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <PropertyGroup>
-    <BuildToolsVersion>1.0.11-prerelease</BuildToolsVersion>
+    <BuildToolsVersion>1.0.12-prerelease</BuildToolsVersion>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/System.Collections.Immutable/src/Properties/AssemblyInfo.cs
+++ b/src/System.Collections.Immutable/src/Properties/AssemblyInfo.cs
@@ -28,6 +28,8 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 
+#if SIGNED
+[assembly: InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+#else
 [assembly: InternalsVisibleTo("System.Collections.Immutable.Tests")]
-
-
+#endif

--- a/src/System.Reflection.Metadata/src/Properties/AssemblyInfo.cs
+++ b/src/System.Reflection.Metadata/src/Properties/AssemblyInfo.cs
@@ -13,4 +13,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 
+#if SIGNED
+[assembly: InternalsVisibleTo("System.Reflection.Metadata.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+#else
 [assembly: InternalsVisibleTo("System.Reflection.Metadata.Tests")]
+#endif


### PR DESCRIPTION
Update our dependency on dotnet/buildtools to Microsoft.DotNet
.BuildTools 1.0.13-prerelease, which includes support for open-source
signing.  Update InternalsVisibleTo to test assemblies to reference
by strong name.

NOTE - the build tools this change depends on is in PR.  You can view it here:
https://github.com/dotnet/buildtools/pull/11

To test these changes locally, pull and build the above pull request as a NuGet package version "1.0.13-prerelease", and consume that NuGet package in this build.  You can do that by:

Producing the NuGet package:
1) pull changes
2) add a tag with the version number to the latest commit:
     `git tag Microsoft.DotNet.BuildTools-1.0.13-prerelease`
3) building the package with "build.cmd"

Consuming the NuGet package:
1) Create a location for local packages on your hard drive
2) Copy the built buildtools package to this location
ie. copy "D:\oss\buildtools\bin\Release\Packages\Microsoft.DotNet.BuildTools.1.0.13-prerelease.nupkg" "D:\Packages\"
3) Update corefx NuGet.config to consume your local package source

```
diff --git a/src/nuget/NuGet.Config b/src/nuget/NuGet.Config
index fb44517..c9aea8d 100644
--- a/src/nuget/NuGet.Config
+++ b/src/nuget/NuGet.Config
@@ -4,6 +4,7 @@
     <add key="enabled" value="True" />
   </packageRestore>
   <packageSources>
+    <add key="test-local" value="D:\Packages\" /> <!-- DO NOT COMMIT!  IF YOU SEE THIS IN A CR/PR, SAY SOMETHING! -->
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <activePackageSource>
```

4) Build corefx using "build.cmd"
