### PR TITLE
Remove dead code that could slow down enumeration.

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -1049,11 +1049,8 @@ namespace System.Collections.Immutable
                 this.current = null;
                 if (this.stack != null && this.stack.Owner == this.poolUserId)
                 {
-                    using (var stack = this.stack.Use(this))
-                    {
-                        stack.Value.Clear();
-                    }
-
+                    var stack = this.stack.Use(this);
+                    stack.Clear();
                     enumeratingStacks.TryAdd(this, this.stack);
                 }
 
@@ -1071,15 +1068,13 @@ namespace System.Collections.Immutable
 
                 if (this.stack != null)
                 {
-                    using (var stack = this.stack.Use(this))
+                    var stack = this.stack.Use(this);
+                    if (stack.Count > 0)
                     {
-                        if (stack.Value.Count > 0)
-                        {
-                            IBinaryTree<KeyValuePair<TKey, TValue>> n = stack.Value.Pop().Value;
-                            this.current = n;
-                            this.PushLeft(n.Right);
-                            return true;
-                        }
+                        IBinaryTree<KeyValuePair<TKey, TValue>> n = stack.Pop().Value;
+                        this.current = n;
+                        this.PushLeft(n.Right);
+                        return true;
                     }
                 }
 
@@ -1098,11 +1093,8 @@ namespace System.Collections.Immutable
                 this.current = null;
                 if (this.stack != null)
                 {
-                    using (var stack = this.stack.Use(this))
-                    {
-                        stack.Value.Clear();
-                    }
-
+                    var stack = this.stack.Use(this);
+                    stack.Clear();
                     this.PushLeft(this.root);
                 }
             }
@@ -1150,13 +1142,11 @@ namespace System.Collections.Immutable
             private void PushLeft(IBinaryTree<KeyValuePair<TKey, TValue>> node)
             {
                 Requires.NotNull(node, "node");
-                using (var stack = this.stack.Use(this))
+                var stack = this.stack.Use(this);
+                while (!node.IsEmpty)
                 {
-                    while (!node.IsEmpty)
-                    {
-                        stack.Value.Push(new RefAsValueType<IBinaryTree<KeyValuePair<TKey, TValue>>>(node));
-                        node = node.Left;
-                    }
+                    stack.Push(new RefAsValueType<IBinaryTree<KeyValuePair<TKey, TValue>>>(node));
+                    node = node.Left;
                 }
             }
         }
@@ -2026,7 +2016,7 @@ namespace System.Collections.Immutable
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    internal class ImmutableSortedDictionaryDebuggerProxy<TKey,TValue>
+    internal class ImmutableSortedDictionaryDebuggerProxy<TKey, TValue>
     {
         /// <summary>
         /// The collection to be enumerated.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1242,11 +1242,8 @@ namespace System.Collections.Immutable
                 this.current = null;
                 if (this.stack != null && this.stack.Owner == this.poolUserId)
                 {
-                    using (var stack = this.stack.Use(this))
-                    {
-                        stack.Value.Clear();
-                    }
-
+                    var stack = this.stack.Use(this);
+                    stack.Clear();
                     enumeratingStacks.TryAdd(this, this.stack);
                     this.stack = null;
                 }
@@ -1261,20 +1258,18 @@ namespace System.Collections.Immutable
                 this.ThrowIfDisposed();
                 this.ThrowIfChanged();
 
-                using (var stack = this.stack.Use(this))
+                var stack = this.stack.Use(this);
+                if (stack.Count > 0)
                 {
-                    if (stack.Value.Count > 0)
-                    {
-                        IBinaryTree<T> n = stack.Value.Pop().Value;
-                        this.current = n;
-                        this.PushNext(this.reverse ? n.Left : n.Right);
-                        return true;
-                    }
-                    else
-                    {
-                        this.current = null;
-                        return false;
-                    }
+                    IBinaryTree<T> n = stack.Pop().Value;
+                    this.current = n;
+                    this.PushNext(this.reverse ? n.Left : n.Right);
+                    return true;
+                }
+                else
+                {
+                    this.current = null;
+                    return false;
                 }
             }
 
@@ -1287,11 +1282,8 @@ namespace System.Collections.Immutable
 
                 this.enumeratingBuilderVersion = builder != null ? builder.Version : -1;
                 this.current = null;
-                using (var stack = this.stack.Use(this))
-                {
-                    stack.Value.Clear();
-                }
-
+                var stack = this.stack.Use(this);
+                stack.Clear();
                 this.PushNext(this.root);
             }
 
@@ -1338,13 +1330,11 @@ namespace System.Collections.Immutable
             private void PushNext(IBinaryTree<T> node)
             {
                 Requires.NotNull(node, "node");
-                using (var stack = this.stack.Use(this))
+                var stack = this.stack.Use(this);
+                while (!node.IsEmpty)
                 {
-                    while (!node.IsEmpty)
-                    {
-                        stack.Value.Push(new RefAsValueType<IBinaryTree<T>>(node));
-                        node = this.reverse ? node.Right : node.Left;
-                    }
+                    stack.Push(new RefAsValueType<IBinaryTree<T>>(node));
+                    node = this.reverse ? node.Right : node.Left;
                 }
             }
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SecureObjectPool.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SecureObjectPool.cs
@@ -98,11 +98,18 @@ namespace System.Collections.Immutable
             set { this.owner = value; }
         }
 
-        internal SecurePooledObjectUser Use<TCaller>(TCaller caller)
+        /// <summary>
+        /// Returns the recyclable value if it hasn't been reclaimed already.
+        /// </summary>
+        /// <typeparam name="TCaller">The type of renter of the object.</typeparam>
+        /// <param name="caller">The renter of the object.</param>
+        /// <returns>The rented object.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown if <paramref name="caller"/> is no longer the renter of the value.</exception>
+        internal T Use<TCaller>(TCaller caller)
             where TCaller : ISecurePooledObjectUser
         {
             this.ThrowDisposedIfNotOwned(caller);
-            return new SecurePooledObjectUser(this);
+            return this.value;
         }
 
         internal void ThrowDisposedIfNotOwned<TCaller>(TCaller caller)
@@ -111,25 +118,6 @@ namespace System.Collections.Immutable
             if (caller.PoolUserId != this.owner)
             {
                 throw new ObjectDisposedException(caller.GetType().FullName);
-            }
-        }
-
-        internal struct SecurePooledObjectUser : IDisposable
-        {
-            private readonly SecurePooledObject<T> value;
-
-            internal SecurePooledObjectUser(SecurePooledObject<T> value)
-            {
-                this.value = value;
-            }
-
-            internal T Value
-            {
-                get { return this.value.value; }
-            }
-
-            public void Dispose()
-            {
             }
         }
     }


### PR DESCRIPTION
The SecurePooledObjectUser struct was previously used as part of a 'thread safe' design for recycling stacks used for enumeration of tree-based collections. But the thread-safety effort was imperfect and removed a while back. The empty struct remained as a simple way to avoid having to make several changes to callers.

Stephen Toub recently was looking over the code and pointed out that this leftover code causes the C# compiler to emit try/finally blocks and call no-op code which may be slowing down enumeration, which is a hot path in many scenarios. So taking time to remove it now seems prudent.
