### PR TITLE
Fix to build correctly if the repository root has spaces. 

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -83,7 +83,7 @@
 
     <!-- Copy build tools to tools directory -->
     <Exec
-      Command="xcopy /e /y &quot;$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\*&quot; &quot;$(ToolsDir)&quot; > $(ToolsDir)BuildTools.xcopy.log" />
+      Command="xcopy /e /y &quot;$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\*&quot; &quot;$(ToolsDir)&quot; > &quot;$(ToolsDir)BuildTools.xcopy.log&quot;" />
   </Target>
   
 </Project>


### PR DESCRIPTION
For example: "C:\Program Files (x86)\repos\corefx\build.cmd" was broken before this fix.
