### PR TITLE
Update the Appveyor Status Badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Core
 
-[![Build status](https://ci.appveyor.com/api/projects/status/xje8bkekyu130e9y?svg=true)](https://ci.appveyor.com/project/dotnet-bot/corefx)
+[![Build status](https://ci.appveyor.com/api/projects/status/xje8bkekyu130e9y/branch/master?svg=true)](https://ci.appveyor.com/project/dotnet-bot/corefx/branch/master)
 
 This repository contains the class libraries for .NET Core. This is currently a
 work in progress, and does not currently contain the entire set of libraries


### PR DESCRIPTION
Currently the status badge points to all the builds triggered in the Appveyor including the Pull Request builds. So if a PR build fails the build status on readme.md will show failure. This change will make the status badge in readme.md to point to the latest build on the dotnet/corefx master branch (excluding the PR builds).
