### PR TITLE
Add directory links for SR.cs files so they appear under the Resources folder in VS

### DIFF
--- a/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
@@ -63,6 +63,9 @@
     <Reference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\SR.cs">
+      <Link>Resources\SR.cs</Link>
+    </Compile>
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -98,9 +101,6 @@
     <Compile Include="System\Xml\Linq\XStreamingElement.cs" />
     <Compile Include="System\Xml\Linq\XText.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="$(CommonPath)\System\SR.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Strings.resx">

--- a/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
+++ b/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
@@ -50,6 +50,9 @@
     <Reference Include="System.Runtime.Extensions" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\SR.cs">
+      <Link>Resources\SR.cs</Link>
+    </Compile>
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -62,7 +65,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\SR.cs" />
     <Compile Include="$(CommonPath)\System\ArrayT.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -69,6 +69,9 @@
     <Compile Include="$(CommonPath)\System\Xml\XmlConst.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\SR.cs">
+      <Link>Resources\SR.cs</Link>
+    </Compile>
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -86,7 +89,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\SR.cs" />
     <Compile Include="$(CommonPath)\System\ArrayT.cs" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
   </ItemGroup>

--- a/src/System.Xml.XPath/src/System.Xml.XPath.csproj
+++ b/src/System.Xml.XPath/src/System.Xml.XPath.csproj
@@ -72,6 +72,9 @@
     <Compile Include="$(CommonPath)\System\Xml\XPathNavigatorEx.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\SR.cs">
+      <Link>Resources\SR.cs</Link>
+    </Compile>
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -165,7 +168,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\SR.cs" />
     <Compile Include="$(CommonPath)\System\ArrayT.cs" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
   </ItemGroup>

--- a/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
+++ b/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
@@ -69,6 +69,9 @@
     <Compile Include="$(CommonPath)\System\Xml\XmlNameHelper.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\SR.cs">
+      <Link>Resources\SR.cs</Link>
+    </Compile>
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -112,7 +115,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\SR.cs" />
     <Compile Include="$(CommonPath)\System\ArrayT.cs" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
   </ItemGroup>


### PR DESCRIPTION
A simple clean-up to group SR.cs under the resources folder in VS. 

We may want to consider adding appropriate links for other commonly linked files so they don't all show up in the root folder of the project in VS. I will file an issue for that.
