### PR TITLE
allocation optimizations for immutable collections

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -47,6 +47,16 @@ namespace System.Collections.Immutable
         private readonly Comparers comparers;
 
         /// <summary>
+        /// the collection of keys, lazily computed and then cached.
+        /// </summary>
+        private IEnumerable<TKey> m_keysCollection;
+
+        /// <summary>
+        /// the collection of values, lazily computed and then cached.
+        /// </summary>
+        private IEnumerable<TValue> m_valuesCollection;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableDictionary&lt;TKey, TValue&gt;"/> class.
         /// </summary>
         /// <param name="root">The root.</param>
@@ -70,6 +80,34 @@ namespace System.Collections.Immutable
         {
             this.comparers = comparers ?? Comparers.Get(EqualityComparer<TKey>.Default, EqualityComparer<TValue>.Default);
             this.root = ImmutableSortedDictionary<int, HashBucket>.Node.EmptyNode;
+        }
+
+        /// <summary>
+        /// Generates the enumeration of keys
+        /// </summary>
+        IEnumerable<TKey> GenerateKeysEnumeration()
+        {
+            foreach (var bucket in this.root)
+            {
+                foreach (var item in bucket.Value)
+                {
+                    yield return item.Key;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates the enumeration of values
+        /// </summary>
+        IEnumerable<TValue> GenerateValuesEnumeration()
+        {
+            foreach (var bucket in this.root)
+            {
+                foreach (var item in bucket.Value)
+                {
+                    yield return item.Value;
+                }
+            }
         }
 
         /// <summary>
@@ -171,13 +209,11 @@ namespace System.Collections.Immutable
         {
             get
             {
-                foreach (var bucket in this.root)
+                if (m_keysCollection == null)
                 {
-                    foreach (var item in bucket.Value)
-                    {
-                        yield return item.Key;
-                    }
+                    m_keysCollection = Count == 0 ? Enumerable.Empty<TKey>() : GenerateKeysEnumeration();
                 }
+                return m_keysCollection;
             }
         }
 
@@ -188,13 +224,11 @@ namespace System.Collections.Immutable
         {
             get
             {
-                foreach (var bucket in this.root)
+                if (m_valuesCollection == null)
                 {
-                    foreach (var item in bucket.Value)
-                    {
-                        yield return item.Value;
-                    }
+                    m_valuesCollection = Count == 0 ? Enumerable.Empty<TValue>() : GenerateValuesEnumeration();
                 }
+                return m_valuesCollection;
             }
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -47,12 +47,12 @@ namespace System.Collections.Immutable
         private readonly Comparers comparers;
 
         /// <summary>
-        /// the collection of keys, lazily computed and then cached.
+        /// The collection of keys, lazily computed and then cached.
         /// </summary>
         private IEnumerable<TKey> keysCollection;
 
         /// <summary>
-        /// the collection of values, lazily computed and then cached.
+        /// The collection of values, lazily computed and then cached.
         /// </summary>
         private IEnumerable<TValue> valuesCollection;
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -49,12 +49,12 @@ namespace System.Collections.Immutable
         /// <summary>
         /// the collection of keys, lazily computed and then cached.
         /// </summary>
-        private IEnumerable<TKey> m_keysCollection;
+        private IEnumerable<TKey> keysCollection;
 
         /// <summary>
         /// the collection of values, lazily computed and then cached.
         /// </summary>
-        private IEnumerable<TValue> m_valuesCollection;
+        private IEnumerable<TValue> valuesCollection;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableDictionary&lt;TKey, TValue&gt;"/> class.
@@ -85,7 +85,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Generates the enumeration of keys
         /// </summary>
-        IEnumerable<TKey> GenerateKeysEnumeration()
+        private IEnumerable<TKey> GenerateKeysEnumeration()
         {
             foreach (var bucket in this.root)
             {
@@ -99,7 +99,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Generates the enumeration of values
         /// </summary>
-        IEnumerable<TValue> GenerateValuesEnumeration()
+        private IEnumerable<TValue> GenerateValuesEnumeration()
         {
             foreach (var bucket in this.root)
             {
@@ -209,11 +209,12 @@ namespace System.Collections.Immutable
         {
             get
             {
-                if (m_keysCollection == null)
+                if (keysCollection == null)
                 {
-                    m_keysCollection = Count == 0 ? Enumerable.Empty<TKey>() : GenerateKeysEnumeration();
+                    keysCollection = Count == 0 ? Enumerable.Empty<TKey>() : GenerateKeysEnumeration();
                 }
-                return m_keysCollection;
+                
+                return keysCollection;
             }
         }
 
@@ -224,11 +225,12 @@ namespace System.Collections.Immutable
         {
             get
             {
-                if (m_valuesCollection == null)
+                if (valuesCollection == null)
                 {
-                    m_valuesCollection = Count == 0 ? Enumerable.Empty<TValue>() : GenerateValuesEnumeration();
+                    valuesCollection = Count == 0 ? Enumerable.Empty<TValue>() : GenerateValuesEnumeration();
                 }
-                return m_valuesCollection;
+                
+                return valuesCollection;
             }
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -47,12 +47,12 @@ namespace System.Collections.Immutable
         private readonly IEqualityComparer<TValue> valueComparer;
 
         /// <summary>
-        /// the collection of keys, lazily computed and then cached.
+        /// The collection of keys, lazily computed and then cached.
         /// </summary>
         private IEnumerable<TKey> keysCollection;
 
         /// <summary>
-        /// the collection of values, lazily computed and then cached.
+        /// The collection of values, lazily computed and then cached.
         /// </summary>
         private IEnumerable<TValue> valuesCollection;
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -49,12 +49,12 @@ namespace System.Collections.Immutable
         /// <summary>
         /// the collection of keys, lazily computed and then cached.
         /// </summary>
-        private IEnumerable<TKey> m_keysCollection;
+        private IEnumerable<TKey> keysCollection;
 
         /// <summary>
         /// the collection of values, lazily computed and then cached.
         /// </summary>
-        private IEnumerable<TValue> m_valuesCollection;
+        private IEnumerable<TValue> valuesCollection;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableSortedDictionary&lt;TKey, TValue&gt;"/> class.
@@ -133,11 +133,12 @@ namespace System.Collections.Immutable
         {
             get 
             {
-                if (m_keysCollection == null)
+                if (keysCollection == null)
                 {
-                    m_keysCollection = Count == 0 ? Enumerable.Empty<TKey>() : this.root.Keys;
+                    keysCollection = Count == 0 ? Enumerable.Empty<TKey>() : this.root.Keys;
                 }
-                return m_keysCollection;
+                
+                return keysCollection;
             }
         }
 
@@ -148,11 +149,12 @@ namespace System.Collections.Immutable
         {
             get
             {
-                if (m_valuesCollection == null)
+                if (valuesCollection == null)
                 {
-                    m_valuesCollection = Count == 0 ? Enumerable.Empty<TValue>() : this.root.Values;
+                    valuesCollection = Count == 0 ? Enumerable.Empty<TValue>() : this.root.Values;
                 }
-                return m_valuesCollection;
+                
+                return valuesCollection;
             }
 
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -47,6 +47,16 @@ namespace System.Collections.Immutable
         private readonly IEqualityComparer<TValue> valueComparer;
 
         /// <summary>
+        /// the collection of keys, lazily computed and then cached.
+        /// </summary>
+        private IEnumerable<TKey> m_keysCollection;
+
+        /// <summary>
+        /// the collection of values, lazily computed and then cached.
+        /// </summary>
+        private IEnumerable<TValue> m_valuesCollection;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableSortedDictionary&lt;TKey, TValue&gt;"/> class.
         /// </summary>
         /// <param name="keyComparer">The key comparer.</param>
@@ -121,7 +131,14 @@ namespace System.Collections.Immutable
         /// </summary>
         public IEnumerable<TKey> Keys
         {
-            get { return this.root.Keys; }
+            get 
+            {
+                if (m_keysCollection == null)
+                {
+                    m_keysCollection = Count == 0 ? Enumerable.Empty<TKey>() : this.root.Keys;
+                }
+                return m_keysCollection;
+            }
         }
 
         /// <summary>
@@ -129,7 +146,15 @@ namespace System.Collections.Immutable
         /// </summary>
         public IEnumerable<TValue> Values
         {
-            get { return this.root.Values; }
+            get
+            {
+                if (m_valuesCollection == null)
+                {
+                    m_valuesCollection = Count == 0 ? Enumerable.Empty<TValue>() : this.root.Values;
+                }
+                return m_valuesCollection;
+            }
+
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -10,6 +10,30 @@ namespace System.Collections.Immutable.Test
     public class ImmutableDictionaryTest : ImmutableDictionaryTestBase
     {
         [Fact]
+        public void KeyAndValuesCollectionsAreRecycled()
+        {
+            var empty = Empty<int, string>();
+            var empty2 = Empty<int, string>();
+            var k1 = empty.Keys;            
+            var v1 = empty.Values;
+            Assert.Same(k1, empty.Keys);
+            Assert.Same(v1, empty.Values);
+
+            // for the empty case, we actually use the same (empty) collection
+            Assert.Same(empty.Keys, empty2.Keys);
+            Assert.Same(empty.Values, empty2.Values);
+
+            var withOneElement = empty.Add(1, "one");
+            var k2 = withOneElement.Keys;
+            var v2 = withOneElement.Values;
+
+            Assert.Same(k2, withOneElement.Keys);
+            Assert.Same(v2, withOneElement.Values);
+            Assert.NotSame(k1, k2);
+            Assert.NotSame(v1, v2);
+        }
+
+        [Fact]
         public void AddExistingKeySameValueTest()
         {
             AddExistingKeySameValueTestHelper(Empty(StringComparer.Ordinal, StringComparer.Ordinal), "Company", "Microsoft", "Microsoft");

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -20,6 +20,30 @@ namespace System.Collections.Immutable.Test
         }
 
         [Fact]
+        public void KeyAndValuesCollectionsAreRecycled()
+        {
+            var empty = Empty<int, string>();
+            var empty2 = Empty<int, string>();
+            var k1 = empty.Keys;
+            var v1 = empty.Values;
+            Assert.Same(k1, empty.Keys);
+            Assert.Same(v1, empty.Values);
+
+            // for the empty case, we actually use the same (empty) collection
+            Assert.Same(empty.Keys, empty2.Keys);
+            Assert.Same(empty.Values, empty2.Values);
+
+            var withOneElement = empty.Add(1, "one");
+            var k2 = withOneElement.Keys;
+            var v2 = withOneElement.Values;
+
+            Assert.Same(k2, withOneElement.Keys);
+            Assert.Same(v2, withOneElement.Values);
+            Assert.NotSame(k1, k2);
+            Assert.NotSame(v1, v2);
+        }
+
+        [Fact]
         public void RandomOperationsTest()
         {
             int operationCount = this.RandomOperationsCount;


### PR DESCRIPTION
requesting the Keys or Values of an immutable (sorted) dictionary allocates every time. In scenarios where a dictionary is setup and then used repeatedly, this is inefficient.