### PR TITLE
Removes some string-related allocations from XML libraries

### DIFF
--- a/src/Common/src/System/Xml/XmlTextWriter.cs
+++ b/src/Common/src/System/Xml/XmlTextWriter.cs
@@ -408,23 +408,27 @@ namespace System.Xml
                 textWriter.Write(name);
                 if (pubid != null)
                 {
-                    textWriter.Write(" PUBLIC " + quoteChar);
+                    textWriter.Write(" PUBLIC ");
+                    textWriter.Write(quoteChar);
                     textWriter.Write(pubid);
-                    textWriter.Write(quoteChar + " " + quoteChar);
+                    textWriter.Write(quoteChar);
+                    textWriter.Write(' ');
+                    textWriter.Write(quoteChar);
                     textWriter.Write(sysid);
                     textWriter.Write(quoteChar);
                 }
                 else if (sysid != null)
                 {
-                    textWriter.Write(" SYSTEM " + quoteChar);
+                    textWriter.Write(" SYSTEM ");
+                    textWriter.Write(quoteChar);
                     textWriter.Write(sysid);
                     textWriter.Write(quoteChar);
                 }
                 if (subset != null)
                 {
-                    textWriter.Write("[");
+                    textWriter.Write('[');
                     textWriter.Write(subset);
-                    textWriter.Write("]");
+                    textWriter.Write(']');
                 }
                 textWriter.Write('>');
             }
@@ -1122,7 +1126,10 @@ namespace System.Xml
                 this.currentState = State.Prolog;
 
                 StringBuilder bufBld = new StringBuilder(128);
-                bufBld.Append("version=" + quoteChar + "1.0" + quoteChar);
+                bufBld.Append("version=");
+                bufBld.Append(quoteChar);
+                bufBld.Append("1.0");
+                bufBld.Append(quoteChar);
                 if (this.encoding != null)
                 {
                     bufBld.Append(" encoding=");

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlDeclaration.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlDeclaration.cs
@@ -72,18 +72,20 @@ namespace System.Xml
         {
             get
             {
-                StringBuilder strb = new StringBuilder("version=\"" + Version + "\"");
+                StringBuilder strb = new StringBuilder("version=\"");
+                strb.Append(Version);
+                strb.Append('"');
                 if (Encoding.Length > 0)
                 {
                     strb.Append(" encoding=\"");
                     strb.Append(Encoding);
-                    strb.Append("\"");
+                    strb.Append('"');
                 }
                 if (Standalone.Length > 0)
                 {
                     strb.Append(" standalone=\"");
                     strb.Append(Standalone);
-                    strb.Append("\"");
+                    strb.Append('"');
                 }
                 return strb.ToString();
             }


### PR DESCRIPTION
While looking at string allocations in our code base, I noticed a couple that can be trivially avoided in the XML libraries.
