### PR TITLE
Intorduced a new auto-property DOSHeader to file System/Reflection/PortableExecutable/PEHeaders.cs

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -175,8 +175,8 @@
     <Compile Include="System\Reflection\PortableExecutable\Machine.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEBinaryReader.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEFileConstants.cs" />
-    <Compile Include="System\Reflection\PortableExecutable\PEFileFlags.cs" />
-	<Compile Include="System\Reflection\PortableExecutable\DosHeader.cs" />
+    <Compile Include="System\Reflection\PortableExecutable\PEFileFlags.cs" />    
+    <Compile Include="System\Reflection\PortableExecutable\DosHeader.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEHeader.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEHeaders.cs" />
     <Compile Include="System\Reflection\PortableExecutable\PEMemoryBlock.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaders.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaders.cs
@@ -75,7 +75,7 @@ namespace System.Reflection.PortableExecutable
 
             if (!isCoffOnly)
             {	
-                // Get DOS header 			
+                // Get DOS header and DOS stub 			
 				int currentOffset = reader.CurrentOffset;
 				reader.Seek(0);
 				this.dosHeader = new DosHeader(ref reader);


### PR DESCRIPTION
We've PEHeader and CoffHeader properties in class PEHeaders(namespace System.Reflection.PortableExecutable), which return the instances of their respective classes, I propose a new property by the name of DOSHeader which will return the DOS header and DOS stub
