### PR TITLE
Reduce Node sizes by shrinking "height" from Int32 to Byte

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -1792,7 +1792,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The depth of the tree beneath this node.
             /// </summary>
-            private int height;
+            private byte height; // AVL tree max height <= ~1.44 * log2(maxNodes + 2)
 
             /// <summary>
             /// The number of elements contained by this subtree starting at this node.
@@ -1843,7 +1843,7 @@ namespace System.Collections.Immutable
                 this.key = key;
                 this.left = left;
                 this.right = right;
-                this.height = 1 + Math.Max(left.height, right.height);
+                this.height = (byte)(1 + Math.Max(left.height, right.height));
                 this.count = 1 + left.count + right.count;
                 this.frozen = frozen;
             }
@@ -3215,7 +3215,7 @@ namespace System.Collections.Immutable
                         this.right = right;
                     }
 
-                    this.height = 1 + Math.Max(this.left.height, this.right.height);
+                    this.height = (byte)(1 + Math.Max(this.left.height, this.right.height));
                     this.count = 1 + this.left.count + this.right.count;
                     return this;
                 }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -1182,7 +1182,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The depth of the tree beneath this node.
             /// </summary>
-            private int height;
+            private byte height; // AVL tree max height <= ~1.44 * log2(maxNodes + 2)
 
             /// <summary>
             /// The left tree.
@@ -1228,7 +1228,7 @@ namespace System.Collections.Immutable
                 this.value = value;
                 this.left = left;
                 this.right = right;
-                this.height = 1 + Math.Max(left.height, right.height);
+                this.height = (byte)(1 + Math.Max(left.height, right.height));
                 this.frozen = frozen;
             }
 
@@ -1974,7 +1974,7 @@ namespace System.Collections.Immutable
                         this.right = right;
                     }
 
-                    this.height = 1 + Math.Max(this.left.height, this.right.height);
+                    this.height = (byte)(1 + Math.Max(this.left.height, this.right.height));
                     return this;
                 }
             }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1407,7 +1407,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The depth of the tree beneath this node.
             /// </summary>
-            private int height;
+            private byte height; // AVL tree max height <= ~1.44 * log2(maxNodes + 2)
 
             /// <summary>
             /// The number of elements contained by this subtree starting at this node.
@@ -1458,7 +1458,7 @@ namespace System.Collections.Immutable
                 this.key = key;
                 this.left = left;
                 this.right = right;
-                this.height = 1 + Math.Max(left.height, right.height);
+                this.height = (byte)(1 + Math.Max(left.height, right.height));
                 this.count = 1 + left.count + right.count;
                 this.frozen = frozen;
             }
@@ -2178,7 +2178,7 @@ namespace System.Collections.Immutable
                         this.right = right;
                     }
 
-                    this.height = 1 + Math.Max(this.left.height, this.right.height);
+                    this.height = (byte)(1 + Math.Max(this.left.height, this.right.height));
                     this.count = 1 + this.left.count + this.right.count;
                     return this;
                 }


### PR DESCRIPTION
As pointed out by @pgavlin in another PR (https://github.com/dotnet/corefx/pull/164), using a Byte instead of an Int32 to store an AVL tree node's height is sufficient for any possible tree we could care about.  This change switches the three existing AVL tree node types to use a Byte for height.  With the other fields currently on these nodes, for 32-bit this allows for better packing (the "frozen" field can be in the same word now as "height"), shaving a word off the size of each allocated node object.
