### PR TITLE
Limit application of the JitIntrinsicAttribute

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/JitIntrinsicAttribute.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/JitIntrinsicAttribute.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>
     /// An attribute that can be attached to JIT Intrinsic methods/properties
     /// </summary>
-    [AttributeUsage(AttributeTargets.All)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property)]
     internal class JitIntrinsicAttribute : Attribute
     {
     }


### PR DESCRIPTION
This attribute should limit where it can be placed to something that the JIT will respect.
