### PR TITLE
Remove allocations from Keys/Values/ContainsValue members

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using Validation;
 
 namespace System.Collections.Immutable
@@ -162,7 +161,13 @@ namespace System.Collections.Immutable
             /// </summary>
             public IEnumerable<TKey> Keys
             {
-                get { return this.root.Values.SelectMany(b => b).Select(kv => kv.Key); }
+                get 
+                {
+                    foreach (KeyValuePair<TKey, TValue> item in this)
+                    {
+                        yield return item.Key;
+                    }
+                }
             }
 
             /// <summary>
@@ -179,7 +184,13 @@ namespace System.Collections.Immutable
             /// </summary>
             public IEnumerable<TValue> Values
             {
-                get { return this.root.Values.SelectMany(b => b).Select(kv => kv.Value).ToArray(this.Count); }
+                get
+                {
+                    foreach (KeyValuePair<TKey, TValue> item in this)
+                    {
+                        yield return item.Value;
+                    }
+                }
             }
 
             /// <summary>
@@ -564,7 +575,14 @@ namespace System.Collections.Immutable
             [Pure]
             public bool ContainsValue(TValue value)
             {
-                return this.Values.Contains(value, this.ValueComparer);
+                foreach (KeyValuePair<TKey, TValue> item in this)
+                {
+                    if (this.ValueComparer.Equals(value, item.Value))
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using Validation;
 using BCL = System.Collections.Generic;
 
@@ -504,7 +503,14 @@ namespace System.Collections.Immutable
         [Pure]
         public bool ContainsValue(TValue value)
         {
-            return this.Values.Contains(value, this.ValueComparer);
+            foreach (KeyValuePair<TKey, TValue> item in this) 
+            {
+                if (this.ValueComparer.Equals(value, item.Value)) 
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -1585,7 +1585,14 @@ namespace System.Collections.Immutable
             internal bool ContainsValue(TValue value, IEqualityComparer<TValue> valueComparer)
             {
                 Requires.NotNull(valueComparer, "valueComparer");
-                return this.Values.Contains(value, valueComparer);
+                foreach (KeyValuePair<TKey, TValue> item in this)
+                {
+                    if (valueComparer.Equals(value, item.Value))
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             /// <summary>
@@ -1600,7 +1607,7 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool Contains(KeyValuePair<TKey, TValue> pair, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
             {
-                Requires.NotNullAllowStructs(pair.Key != null, "key");
+                Requires.NotNullAllowStructs(pair.Key, "key");
                 Requires.NotNull(keyComparer, "keyComparer");
                 Requires.NotNull(valueComparer, "valueComparer");
 


### PR DESCRIPTION
Several methods in the immutable collections library use LINQ and incur more allocation than is necessary.  In particular, several types’ Keys and Values properties as well as their ContainsValue methods can be optimized to avoid multiple unnecessary allocations.

For example, ImmutableDictionary<TKey, TValue>.ContainsValue(TValue) is implemented today to get this.Values and then call LINQ’s Contains on that result.  This results in an allocation for the Values enumerable (which, as with all C# iterators, has an optimization to also double as enumerator when possible), but since the dictionary also provides an allocation-free enumerator, we can simply open code the enumeration, making ContainsValue allocation-free as well.

The worst offender this PR fixes is ImmutableDictionary<TKey, TValue>.Builder.Values, which is implemented with the code “return this.root.Values.SelectMany(b => b).Select(kv => kv.Value).ToArray(this.Count)”.  This results in upwards of five allocations plus two allocations per HashBucket in the dictionary (so a dictionary with 100 items could very well incur over 200 allocations to enumerate via the builder’s Keys/Values)!  A similar fix brings it down to just one allocation, for the enumerable. (The removal of the ToArray method does change the semantics slightly, so it could be put back if really desired, but it’s unclear why those semantics were desired, and the corresponding Keys property doesn’t have such a ToArray call, so it appears to not be by design.)

The decrease in allocation and LINQ usage also has a measurable impact on throughput, e.g. perf of ImmutableDictionary<TKey, TValue>.ContainsValue improves by ~10%, perf of enumerating ImmutableDictionary<TKey, TValue>.Builder.Values improves by ~20%, etc.

(This PR is orthogonal to #147 and can be merged independently.)
