### PR TITLE
Disable PLinq tests failing on CI Machine

### DIFF
--- a/src/System.Linq.Parallel/test/PlinqModesTests.cs
+++ b/src/System.Linq.Parallel/test/PlinqModesTests.cs
@@ -11,7 +11,9 @@ namespace Test
 {
     public static class PlinqModesTests
     {
-        [Fact]
+        // This test is failing on our CI machines, probably due to the VM's limited CPU.
+        // To-do: Re-enable this test when we resolve the build machine issues.
+        // [Fact(Skip="Issue #176")]
         public static void RunPlinqModesTests()
         {
             // I would assume that this gets the number of processors (ie. Environment.ProcessorCount)

--- a/src/System.Linq.Parallel/test/UnionIntersectDistinctTests.cs
+++ b/src/System.Linq.Parallel/test/UnionIntersectDistinctTests.cs
@@ -82,7 +82,9 @@ namespace Test
             }
         }
 
-        [Fact]
+        // This test is failing on our CI machines, probably due to the VM's limited CPU.
+        // To-do: Re-enable this test when we resolve the build machine issues.
+        // [Fact(Skip="Issue #176")]
         public static void RunOrderedUnionTest1()
         {
             for (int len = 1; len <= 300; len += 3)

--- a/src/System.Linq.Parallel/test/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/test/WithCancellationTests.cs
@@ -90,7 +90,9 @@ namespace Test
             Assert.NotNull(caughtException);
         }
 
-        [Fact]
+        // This test is failing on our CI machines, probably due to the VM's limited CPU.
+        // To-do: Re-enable this test when we resolve the build machine issues.
+        // [Fact(Skip="Issue #176")]
         public static void CTT_Sorting_ToArray()
         {
             int size = 10000;
@@ -128,7 +130,9 @@ namespace Test
             Assert.Equal(tokenSource.Token, caughtException.CancellationToken);
         }
 
-        [Fact]
+        // This test is failing on our CI machines, probably due to the VM's limited CPU.
+        // To-do: Re-enable this test when we resolve the build machine issues.
+        // [Fact(Skip="Issue #176")]
         public static void CTT_NonSorting_AsynchronousMergerEnumeratorDispose()
         {
             int size = 10000;
@@ -214,7 +218,9 @@ namespace Test
             Assert.NotNull(caughtException);
         }
 
-        [Fact]
+        // This test is failing on our CI machines, probably due to the VM's limited CPU.
+        // To-do: Re-enable this test when we resolve the build machine issues.
+        // [Fact(Skip="Issue #176")]
         public static void CTT_NonSorting_ToArray_ExternalCancel()
         {
             int size = 10000;


### PR DESCRIPTION
It seems like some of the new PLinq tests are not working properly on the AppVeyor CI machines, possibly because of their limited CPU or other resources. We should investigate this but for now the tests will be disabled.
