### PR TITLE
Fixed wrong typo Automatically -> Atomically

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -422,7 +422,7 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
-        /// Automatically enqueues an element to the tail of a queue.
+        /// Atomically enqueues an element to the tail of a queue.
         /// </summary>
         /// <typeparam name="T">The type of element stored in the queue.</typeparam>
         /// <param name="location">The variable or field to atomically update.</param>


### PR DESCRIPTION
According to [this comment](https://github.com/dotnet/corefx/commit/2c4cafbe7eeb4db70277b74650c9019e4d70a013#commitcomment-8817725) I accidentally 'fixed' a typo I made in the earlier pull request #150. 

This PR is intended to undo to error, unless there are other methods in GIT to undo it. 
