### PR TITLE
ImmutableCollections: include the key in the "duplicate key" exception message

### DIFF
--- a/src/System.Collections.Immutable/src/Strings.Designer.cs
+++ b/src/System.Collections.Immutable/src/Strings.Designer.cs
@@ -97,7 +97,7 @@ namespace System.Collections.Immutable {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An element with the same key '{0}' but a different value already exists..
+        ///   Looks up a localized string similar to An element with the same key but a different value already exists. Key: {0}.
         /// </summary>
         internal static string DuplicateKey {
             get {

--- a/src/System.Collections.Immutable/src/Strings.resx
+++ b/src/System.Collections.Immutable/src/Strings.resx
@@ -130,7 +130,7 @@
     <value>Collection was modified; enumeration operation may not execute.</value>
   </data>
   <data name="DuplicateKey" xml:space="preserve">
-    <value>An element with the same key '{0}' but a different value already exists.</value>
+    <value>An element with the same key but a different value already exists. Key: {0}</value>
   </data>
   <data name="InvalidEmptyOperation" xml:space="preserve">
     <value>This operation does not apply to an empty instance.</value>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+HashBucket.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace System.Collections.Immutable
 {
@@ -146,13 +147,13 @@ namespace System.Collections.Immutable
                         case KeyCollisionBehavior.ThrowIfValueDifferent:
                             if (!valueComparer.Equals(this.firstValue.Value, value))
                             {
-                                throw new ArgumentException(String.Format(Strings.DuplicateKey, key));
+                                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, key));
                             }
 
                             result = OperationResult.NoChangeRequired;
                             return this;
                         case KeyCollisionBehavior.ThrowAlways:
-                            throw new ArgumentException(String.Format(Strings.DuplicateKey, key));
+                            throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, key));
                         default:
                             throw new InvalidOperationException(); // unreachable
                     }
@@ -178,13 +179,13 @@ namespace System.Collections.Immutable
                             var existingEntry = this.additionalElements[keyCollisionIndex];
                             if (!valueComparer.Equals(existingEntry.Value, value))
                             {
-                                throw new ArgumentException(String.Format(Strings.DuplicateKey, key));
+                                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, key));
                             }
 
                             result = OperationResult.NoChangeRequired;
                             return this;
                         case KeyCollisionBehavior.ThrowAlways:
-                            throw new ArgumentException(String.Format(Strings.DuplicateKey, key));
+                            throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, key));
                         default:
                             throw new InvalidOperationException(); // unreachable
                     }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Linq;
 using Validation;
 
@@ -908,7 +909,7 @@ namespace System.Collections.Immutable
                         {
                             if (!this.valueComparer.Equals(value, item.Value))
                             {
-                                throw new ArgumentException(String.Format(Strings.DuplicateKey, item.Key));
+                                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, item.Key));
                             }
                         }
                         else
@@ -1873,7 +1874,7 @@ namespace System.Collections.Immutable
                         }
                         else
                         {
-                            throw new ArgumentException(String.Format(Strings.DuplicateKey, key));
+                            throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, key));
                         }
                     }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using Validation;
 
 namespace System.Collections.Immutable
@@ -471,7 +472,7 @@ namespace System.Collections.Immutable
                     }
                     else
                     {
-                        throw new ArgumentException(String.Format(Strings.DuplicateKey, key));
+                        throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.DuplicateKey, key));
                     }
                 }
 

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -264,9 +264,9 @@ namespace System.Collections.Immutable.Test
         public void CollisionExceptionMessageContainsKey()
         {
             var map = ImmutableDictionary.Create<string, string>()
-                .Add("a", "1").Add("b", "2");
-            var exception = Assert.Throws<ArgumentException>(() => map.Add("a", "3"));
-            Assert.Contains("'a'", exception.Message);
+                .Add("firstKey", "1").Add("secondKey", "2");
+            var exception = Assert.Throws<ArgumentException>(() => map.Add("firstKey", "3"));
+            Assert.Contains("firstKey", exception.Message);
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -308,9 +308,9 @@ namespace System.Collections.Immutable.Test
         public void CollisionExceptionMessageContainsKey()
         {
             var map = ImmutableSortedDictionary.Create<string, string>()
-                .Add("a", "1").Add("b", "2");
-            var exception = Assert.Throws<ArgumentException>(() => map.Add("a", "3"));
-            Assert.Contains("'a'", exception.Message);
+                .Add("firstKey", "1").Add("secondKey", "2");
+            var exception = Assert.Throws<ArgumentException>(() => map.Add("firstKey", "3"));
+            Assert.Contains("firstKey", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
This makes the exception message much more useful in log files, etc.
E.g. `An element with the same key 'Invoice_413' but a different value already exists`

Based on a twitter [discussion](https://twitter.com/terrajobst/status/540658277562851329) with @terrajobst.
