### PR TITLE
ImmutableArray<T>.Builder.Sort should not create Comparer instance

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -621,7 +621,7 @@ namespace System.Collections.Immutable
                 Requires.Range(index >= 0, "index");
                 Requires.Range(count >= 0 && index + count <= this.Count, "count");
 
-                if (Count > 1)
+                if (count > 1)
                 {
                     Array.Sort(this.elements, index, count, Comparer.Create(comparer));
                 }


### PR DESCRIPTION
ImmutableArray<T>.Builder.Sort should not create Comparer instance if count<=1

Tweaking Sort(int index, int count, IComparer<T> comparer) to check for count instead of Count. Checking for count > 1 will ensure both of these
i. The no. of elements intended to be sorted is > 1
ii. The underlying array contains > 1 elements
