### PR TITLE
Fix thread-safety vulnerability in ImmutableArray<T>

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -15,6 +15,22 @@ namespace System.Collections.Immutable
     /// A readonly array with O(1) indexable lookup time.
     /// </summary>
     /// <typeparam name="T">The type of element stored by the array.</typeparam>
+    /// <devremarks>
+    /// This type has a documented contract of being exactly one reference-type field in size.
+    /// Our own ImmutableInterlocked class depends on it, as well as others externally.
+    /// IMPORTANT NOTICE FOR MAINTAINERS AND REVIEWERS:
+    /// This type should be thread-safe. As a struct, it cannot protect its own fields
+    /// from being changed from one thread while its members are executing on other threads
+    /// because structs can change *in place* simply by reassigning the field containing
+    /// this struct. Therefore it is extremely important that
+    /// ** Every member should only dereference <c>this</c> ONCE. **
+    /// If a member needs to reference the array field, that counts as a dereference of <c>this</c>.
+    /// Calling other instance members (properties or methods) also counts as dereferencing <c>this</c>.
+    /// Any member that needs to use <c>this</c> more than once must instead
+    /// assign <c>this</c> to a local variable and use that for the rest of the code instead.
+    /// This effectively copies the one field in the struct to a local variable so that
+    /// it is insulated from other threads.
+    /// </devremarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IImmutableList<T>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable
     {

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1172,7 +1172,13 @@ namespace System.Collections.Immutable.Test
             // Also noteworthy: this method only tests the thread-safety of the Add method.
             // While it proves the general point, any method that reads 'this' more than once is vulnerable.
             var array = ImmutableArray.Create<int>();
-            Action mutator = () => { for (int i = 0; i < 100; i++) ImmutableInterlocked.InterlockedExchange(ref array, array.Add(1)); };
+            Action mutator = () =>
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    ImmutableInterlocked.InterlockedExchange(ref array, array.Add(1));
+                }
+            };
             Task.WaitAll(Task.Run(mutator), Task.Run(mutator));
         }
 


### PR DESCRIPTION
Any member that references 'this' more than once is vulnerable to in-place replacements of the value of the struct from another thread. That pretty much defeats the thread-safety guarantee of ImmutableArray<T>. So the fix is to make sure we dereference this (to get the array) exactly once per public entrypoint so that the array instance we access is the same every time.

An example of the problem is we can capture the length of the array, and then copy from the array. But in between those two steps another thread updated the field that contained this struct, so while our method is still running, the instance of the array actually _changed_, so the length of the array changed with it, and we throw an exception because we tried to read beyond the bounds of the array.

It turns out this demonstrates a very compelling reason to prefix _all_ instance member access with "this." (not only fields, but properties and methods too!) because it made auditing and fixing this class much easier since I just had to look for any member that referenced 'this' more than once and could use search and replace to change them all to 'self'.

Fixes #191
