### PR TITLE
Add Test Explorer VS package Service guid.

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -67,6 +67,9 @@
       <Name>System.Threading.Tasks.Dataflow</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Every time the Dataflow solution opens (and Test Explorer is used) VS2013 adds this tag to the project. Just concede to the IDE and allow it to be added to the project and check into SCC so that the project doesn't get constantly dirtied by the IDE.

It appears this tag already is in all the other test projects. This recently added test project had not yet been 'tainted', so this takes care of that.
