### PR TITLE
Use invariant culture for converting XPath objects in tests

### DIFF
--- a/src/Common/tests/System.Xml.XPath/Common/Utils.cs
+++ b/src/Common/tests/System.Xml.XPath/Common/Utils.cs
@@ -3,6 +3,7 @@
 
 using Xunit;
 using System;
+using System.Globalization;
 using System.Xml;
 using System.Xml.XPath;
 
@@ -82,7 +83,7 @@ namespace XPathTests.Common
 
             var evaluated = xPathNavigator.Evaluate(xPathExpression);
 
-            return (T)Convert.ChangeType(evaluated, typeof(T));
+            return (T)Convert.ChangeType(evaluated, typeof(T), CultureInfo.InvariantCulture);
         }
 
         internal static void XPathStringTest(string xml, string testExpression, object expected, XmlNamespaceManager namespaceManager = null, string startingNodePath = null)

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Globalization" />
     <Reference Include="System.IO" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Runtime" />

--- a/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Globalization" />
     <Reference Include="System.IO" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Runtime" />

--- a/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
+++ b/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Globalization" />
     <Reference Include="System.IO" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Runtime" />


### PR DESCRIPTION
Before, a call to Convert.ChangeType() in the XPath tests used the current culture,
which resulted in test failures on cultures like de-AT and on Windows 10.
Instead, we now use the invariant culture when converting objects to fix this.

Fixes #136
