### PR TITLE
Remove allocations in ImmutableArray.RemoveAll/ImmutableList.FindAll

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -860,16 +860,23 @@ namespace System.Collections.Immutable
                 return new ImmutableArray<T>(self.array);
             }
 
-            var removeIndexes = new List<int>();
+            List<int> removeIndexes = null;
             for (int i = 0; i < self.array.Length; i++)
             {
                 if (match(self.array[i]))
                 {
+                    if (removeIndexes == null)
+                    {
+                        removeIndexes = new List<int>();
+                    }
+
                     removeIndexes.Add(i);
                 }
             }
 
-            return self.RemoveAtRange(removeIndexes);
+            return removeIndexes != null ?
+                self.RemoveAtRange(removeIndexes) :
+                self;
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -2788,16 +2788,23 @@ namespace System.Collections.Immutable
                 Requires.NotNull(match, "match");
                 Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
-                var builder = ImmutableList<T>.Empty.ToBuilder();
+                ImmutableList<T>.Builder builder = null;
                 foreach (var item in this)
                 {
                     if (match(item))
                     {
+                        if (builder == null)
+                        {
+                            builder = ImmutableList<T>.Empty.ToBuilder();
+                        }
+
                         builder.Add(item);
                     }
                 }
 
-                return builder.ToImmutable();
+                return builder != null ?
+                    builder.ToImmutable() :
+                    ImmutableList<T>.Empty;
             }
 
             /// <summary>


### PR DESCRIPTION
ImmutableArray<T>.RemoveAll and ImmutableList<T>.FindAll both unconditionally allocate an object (a list or a builder) to store the results of iterating over the collection and running the supplied predicate.  However, if the predicate never returns true, these objects aren't needed.  This PR simply changes the allocation of that object to be lazy such that it's only allocated if needed, making both FindAll and RemoveAll allocation-free if no elements are found to match the predicate.
