### PR TITLE
Disable the NuGet cache when installing Microsoft.DotNet.BuildTools

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -81,7 +81,7 @@
     <!-- Restore build tools -->
     <Exec
       StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; install Microsoft.DotNet.BuildTools -Prerelease -Version $(BuildToolsVersion) -o &quot; $(PackagesDir) &quot; $(NuGetConfigCommandLine)" />
+      Command="&quot;$(NuGetToolPath)&quot; install Microsoft.DotNet.BuildTools -Prerelease -NoCache -Version $(BuildToolsVersion) -o &quot; $(PackagesDir) &quot; $(NuGetConfigCommandLine)" />
 
     <!-- Copy build tools to tools directory -->
     <Exec


### PR DESCRIPTION
Adding -NoCache to the command `ìnstall Microsoft.DotNet.BuildTools` in build.proj fixes issue #206 
