### PR TITLE
Fix AppVeyor build script to correctly return error code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,4 @@
-build_script: "\"%VS120COMNTOOLS%VsDevCmd.bat\" && build.cmd"
+build_script:
+  - '"%VS120COMNTOOLS%VsDevCmd.bat"'
+  - build.cmd
 test: off  # disable automatic test discovery, xUnit already runs as part of build.cmd


### PR DESCRIPTION
The script chained the execution of VsDevCmd.bat (aka the "Developer
Command Prompt") with build.cmd which seems to confuse AppVeyor
into not recognizing a non-zero exit code (i.e. when a test fails)
and incorrectly marking the build as green.

Invoking VsDevCmd.bat and build.cmd in two separate steps fixes this.

Fixes #214
