### PR TITLE
Fix vector tests warnings about obsolete Marshal.SizeOf

### DIFF
--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -12,8 +12,8 @@ namespace System.Numerics.Tests
         [Fact]
         public void Vector2MarshalSizeTest()
         {
-            Assert.Equal(8, Marshal.SizeOf(typeof(Vector2)));
-            Assert.Equal(8, Marshal.SizeOf(new Vector2()));
+            Assert.Equal(8, Marshal.SizeOf<Vector2>());
+            Assert.Equal(8, Marshal.SizeOf<Vector2>(new Vector2()));
         }
 
         [Fact]

--- a/src/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -12,8 +12,8 @@ namespace System.Numerics.Tests
         [Fact]
         public void Vector3MarshalSizeTest()
         {
-            Assert.Equal(12, Marshal.SizeOf(typeof(Vector3)));
-            Assert.Equal(12, Marshal.SizeOf(new Vector3()));
+            Assert.Equal(12, Marshal.SizeOf<Vector3>());
+            Assert.Equal(12, Marshal.SizeOf<Vector3>(new Vector3()));
         }
 
         [Fact]

--- a/src/System.Numerics.Vectors/tests/Vector4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector4Tests.cs
@@ -12,8 +12,8 @@ namespace System.Numerics.Tests
         [Fact]
         public void Vector4MarshalSizeTest()
         {
-            Assert.Equal(16, Marshal.SizeOf(typeof(Vector4)));
-            Assert.Equal(16, Marshal.SizeOf(new Vector4()));
+            Assert.Equal(16, Marshal.SizeOf<Vector4>());
+            Assert.Equal(16, Marshal.SizeOf<Vector4>(new Vector4()));
         }
 
         [Fact]


### PR DESCRIPTION
The System.Numerics.Vectors tests were causing build warnings like the following:

``` C#
Vector2Tests.cs(15,29): warning CS0618: 'System.Runtime.InteropServices.Marshal.SizeOf(System.Type)' is obsolete: 'SizeOf(Type) may be unavailable in future releases. Instead, use SizeOf<T>().
```

This changes does exactly that.
