### PR TITLE
Implement simple console foreground/background color scoping via IDisposable

### DIFF
--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -50,7 +50,7 @@
     <Reference Include="System.Diagnostics.Contracts">
       <HintPath>..\..\packages\System.Diagnostics.Contracts.4.0.0-beta-22405\lib\portable-wpa80+win80+net45+aspnetcore50\System.Diagnostics.Contracts.dll</HintPath>
       <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>     
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Diagnostics.Debug">
       <HintPath>..\..\packages\System.Diagnostics.Debug.4.0.10-beta-22405\lib\portable-wpa80+win80+net45+aspnetcore50\System.Diagnostics.Debug.dll</HintPath>
@@ -143,6 +143,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="System\Console.cs" />
     <Compile Include="System\ConsoleColor.cs" />
+    <Compile Include="System\DisposableConsoleColor.cs" />
     <Compile Include="System\IO\ConsoleStream.cs" />
     <Compile Include="System\IO\SyncTextReader.cs" />
     <Compile Include="System\IO\SyncTextWriter.cs" />

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -84,6 +84,22 @@ namespace System
             set { ConsolePal.ForegroundColor = value; }
         }
 
+        public static IDisposable UseBackgroundColor(ConsoleColor backgroundColor)
+        {
+            var previousColor = BackgroundColor;
+            BackgroundColor = backgroundColor;
+
+            return new DisposableConsoleColor(() => BackgroundColor = previousColor);
+        }
+
+        public static IDisposable UseForegroundColor(ConsoleColor foregroundColor)
+        {
+            var previousColor = ForegroundColor;
+            ForegroundColor = foregroundColor;
+
+            return new DisposableConsoleColor(() => ForegroundColor = previousColor);
+        }
+
         public static void ResetColor()
         {
             ConsolePal.ResetColor();

--- a/src/System.Console/src/System/DisposableConsoleColor.cs
+++ b/src/System.Console/src/System/DisposableConsoleColor.cs
@@ -1,0 +1,17 @@
+﻿namespace System
+{
+    internal class DisposableConsoleColor : IDisposable
+    {
+        private readonly Action _resetPreviousConsoleSettings;
+
+        public DisposableConsoleColor(Action resetPreviousConsoleSettings )
+        {
+            _resetPreviousConsoleSettings = resetPreviousConsoleSettings;
+        }
+
+        public void Dispose()
+        {
+            _resetPreviousConsoleSettings();
+        }
+    }
+}


### PR DESCRIPTION
Just a simple API evolution that allows the developer to "scope" his color updates. Can be used like that :

``` csharp
static void Main(string[] args)
{
    Console.WriteLine("Default");
    using (Console.UseBackgroundColor(ConsoleColor.Red))
    {
        Console.WriteLine("Background red");
        using (Console.UseForegroundColor(ConsoleColor.Green))
        {
            Console.WriteLine("Foreground green");
            using (Console.UseForegroundColor(ConsoleColor.Yellow))
            {
                Console.WriteLine("Foreground yellow");
            }
            Console.WriteLine("Foreground green");

            using (Console.UseBackgroundColor(ConsoleColor.Blue))
            {
                Console.WriteLine("Background blue");
            }

            Console.WriteLine("Background red");
        }
    }

    Console.WriteLine("Default");
}
```

And outputs like that :
![image](https://cloud.githubusercontent.com/assets/1341236/5394321/69d6a080-813c-11e4-95e9-98856de8555a.png)
