### PR TITLE
Array.Empty<int>() to new int[] {}

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroup.cs
@@ -15,7 +15,7 @@ namespace System.Text.RegularExpressions
     public class Group : Capture
     {
         // the empty group object
-        internal static Group _emptygroup = new Group(String.Empty, Array.Empty<int>(), 0);
+        internal static Group _emptygroup = new Group(String.Empty, new int[] {}, 0);
 
         internal int[] _caps;
         internal int _capcount;


### PR DESCRIPTION
`Array.Empty<int>()` wouldn't compile for me. Am I missing something?  The only GoogBingHoo I could find was something in `Microsoft.FSharp.Collections.Array`
