### PR TITLE
Add Jenkins CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Core
 
-[![Build status][build-status-image]][build-status]  [![Issue Stats][pull-requests-image]][pull-requests]  [![Issue Stats][issues-closed-image]][issues-closed] 
+[![Build status][build-status-image]][build-status]  [![Issue Stats][pull-requests-image]][pull-requests]  [![Issue Stats][issues-closed-image]][issues-closed]
 
 Beta Jenkins-CI
 


### PR DESCRIPTION
Add badges for Jenkins CI

The Jenkins CI currently does the Windows hosted Unix build and the regular Windows build and performs a build automatically on a Github push.  In order to avoid collisions with the current appveyor system, the Jenkins PR testing is turned off.
