### PR TITLE
Move NuGet.config up one level where VS can see it

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageRestore>
+    <add key="enabled" value="True" />
+  </packageRestore>
+  <packageSources>
+    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
NuGet.config files can be found by VS package restore so long as they're
in a parent directory of the sln.

Copy the file one level higher to align with that. Once the buildtools
are updated, the old copy can be deleted.
