### PR TITLE
Implement Microsoft.Win32.Primitives support on Linux

### DIFF
--- a/src/Common/src/Interop/Interop.Errors.Unix.cs
+++ b/src/Common/src/Interop/Interop.Errors.Unix.cs
@@ -7,14 +7,6 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    [DllImport(LIBC, EntryPoint = "strerror")]
-    private static extern IntPtr strerror_core(int errno);
-
-    internal static string strerror(int errno)
-    {
-        return Marshal.PtrToStringAnsi(strerror_core(errno));
-    }
-
     /// <summary>
     /// Validates the result of system call that returns greater than or equal to 0 on success
     /// and less than 0 on failure, with errno set to the error code.
@@ -64,6 +56,8 @@ internal static partial class Interop
         EACCES = 13,
         EEXIST = 17,
         EXDEV = 18,
+        EISDIR = 21,
+        EINVAL = 22,
         EFBIG = 27,
         ENAMETOOLONG = 36,
         ECANCELED = 125,
@@ -80,6 +74,13 @@ internal static partial class Interop
     {
         switch ((Errors)errno)
         {
+            case Errors.EINVAL:
+                throw new ArgumentException();
+
+            case Errors.EISDIR:
+                isDirectory = true;
+                goto case Errors.ENOENT;
+
             case Errors.ENOENT:
                 if (isDirectory)
                 {

--- a/src/Common/src/Interop/Interop.strerror.Unix.cs
+++ b/src/Common/src/Interop/Interop.strerror.Unix.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    [DllImport(LIBC)]
+    private static extern unsafe byte* strerror_r(int errnum, byte* buf, size_t buflen); // GNU-specific
+
+    internal unsafe static string strerror(int errno) // thread-safe version of strerror that internally uses strerror_r, which is thread-safe
+    {
+        const int bufferLength = 1024;  // length long enough for most any Unix error messages
+        byte* buffer = stackalloc byte[bufferLength];
+        IntPtr errorPtr = (IntPtr)strerror_r(errno, buffer, (IntPtr)bufferLength);
+        return Marshal.PtrToStringAnsi(errorPtr); // TODO: Use the proper Encoding
+    }
+}

--- a/src/Microsoft.Win32.Primitives/src/Interop/Interop.Unix.cs
+++ b/src/Microsoft.Win32.Primitives/src/Interop/Interop.Unix.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+internal partial class Interop
+{
+    internal const string LIBC = "libc";
+}

--- a/src/Microsoft.Win32.Primitives/src/Interop/Interop.Windows.cs
+++ b/src/Microsoft.Win32.Primitives/src/Interop/Interop.Windows.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Text;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
+        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode,  EntryPoint="FormatMessageW", SetLastError = true, BestFitMapping = true)]
         public static extern int FormatMessage(int dwFlags, IntPtr lpSource_mustBeNull, uint dwMessageId,
             int dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr[] arguments);
 
@@ -19,11 +18,5 @@ internal partial class Interop
         public const int FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
 
         public const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
-
-        public const int E_FAIL = unchecked((int)0x80004005);
     }
 }
-
-
-
-

--- a/src/Microsoft.Win32.Primitives/src/Interop/Interop.cs
+++ b/src/Microsoft.Win32.Primitives/src/Interop/Interop.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+internal partial class Interop
+{
+    public const int E_FAIL = unchecked((int)0x80004005);
+}

--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -24,8 +24,9 @@
     <RootNamespace>Microsoft.Win32.Primitives</RootNamespace>
     <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <FileAlignment>512</FileAlignment>
-	  <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)bin\$(Configuration)\$(AssemblyName)\</OutputPath>
+	<OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">obj\$(TargetFrameworkVersion)\</BaseIntermediateOutputPath>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
@@ -49,9 +50,21 @@
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>
+  <PropertyGroup>
+    <CommonPath>..\..\Common\src</CommonPath>
+  </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Interop\Interop.manual.cs" />
+    <Compile Include="Interop\Interop.cs" />
     <Compile Include="System\ComponentModel\Win32Exception.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <Compile Include="Interop\Interop.Windows.cs" />
+    <Compile Include="System\ComponentModel\Win32Exception.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Unix' ">
+    <Compile Include="$(CommonPath)\Interop\Interop.strerror.Unix.cs" />
+    <Compile Include="Interop\Interop.Unix.cs" />
+    <Compile Include="System\ComponentModel\Win32Exception.Unix.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Unix.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Unix.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace System.ComponentModel
+{
+    public partial class Win32Exception : Exception
+    {
+        private static string GetErrorMessage(int error)
+        {
+            return Interop.strerror(error);
+        }
+    }
+}

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Windows.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.Windows.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace System.ComponentModel
+{
+    public partial class Win32Exception : Exception
+    {
+        private static string GetErrorMessage(int error)
+        {
+            string errorMsg;
+
+            StringBuilder sb = new StringBuilder(256);
+            do
+            {
+                if (TryGetErrorMessage(error, sb, out errorMsg))
+                    return errorMsg;
+                else
+                {
+                    // increase the capacity of the StringBuilder by 4.
+                    sb.Capacity *= 4;
+                }
+            }
+            while (sb.Capacity < MaxAllowedBufferSize);
+
+            // If you come here then a size as large as 65K is also not sufficient and so we give the generic errorMsg.
+            return String.Format("Unknown error (0x{0:x})", error);
+        }
+
+        private static bool TryGetErrorMessage(int error, StringBuilder sb, out string errorMsg) 
+        {
+            errorMsg = "";
+
+            int result = Interop.mincore.FormatMessage(
+                                        Interop.mincore.FORMAT_MESSAGE_IGNORE_INSERTS |
+                                        Interop.mincore.FORMAT_MESSAGE_FROM_SYSTEM |
+                                        Interop.mincore.FORMAT_MESSAGE_ARGUMENT_ARRAY,
+                                        IntPtr.Zero, (uint)error, 0, sb, sb.Capacity + 1,
+                                        null);
+            if (result != 0)
+            {
+                int i = sb.Length;
+                while (i > 0)
+                {
+                    char ch = sb[i - 1];
+                    if (ch > 32 && ch != '.') break;
+                    i--;
+                }
+                errorMsg = sb.ToString(0, i);
+            }
+            else if (Marshal.GetLastWin32Error() == Interop.mincore.ERROR_INSUFFICIENT_BUFFER) 
+            {
+                return false;
+            }
+            else {
+                errorMsg = String.Format("Unknown error (0x{0:x})", error);
+            }
+
+            return true;
+        }
+
+        // Windows API FormatMessage lets you format a message string given an errocode.
+        // Unlike other APIs this API does not support a way to query it for the total message size.
+        //
+        // So the API can only be used in one of these two ways.
+        // a. You pass a buffer of appropriate size and get the resource.
+        // b. Windows creates a buffer and passes the address back and the onus of releasing the bugffer lies on the caller.
+        //
+        // Since the error code is coming from the user, it is not possible to know the size in advance.
+        // Unfortunately we can't use option b. since the buffer can only be freed using LocalFree and it is a private API on onecore.
+        // Also, using option b is ugly for the manged code and could cause memory leak in situations where freeing is unsuccessful.
+        // 
+        // As a result we use the following approach.
+        // We initially call the API with a buffer size of 256 and then gradually increase the size in case of failure until we reach the maxiumum allowed limit of 65K.
+        private const int MaxAllowedBufferSize = 65 * 1024;
+    }
+}

--- a/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel
     /// <devdoc>
     ///    <para>The exception that is thrown for a Win32 error code.</para>
     /// </devdoc>
-    public class Win32Exception : Exception
+    public partial class Win32Exception : Exception
     {
         /// <devdoc>
         ///    <para>Represents the Win32 error code associated with this exception. This 
@@ -41,7 +41,7 @@ namespace System.ComponentModel
             nativeErrorCode = error;
             // Win32Exception is not inheriting from ExternalException anymore, 
             // so we set the HResult manually to have the exact behavior we used to have when inherited from ExternalException
-            HResult = Interop.mincore.E_FAIL;
+            HResult = Interop.E_FAIL;
         }
 
         /// <devdoc>
@@ -62,7 +62,7 @@ namespace System.ComponentModel
             nativeErrorCode = Marshal.GetLastWin32Error();
             // Win32Exception is not inheriting from ExternalException anymore, 
             // so we set the HResult manually to have the exact behavior we used to have when inherited from ExternalException
-            HResult = Interop.mincore.E_FAIL;
+            HResult = Interop.E_FAIL;
         }
 
         /// <devdoc>
@@ -75,74 +75,6 @@ namespace System.ComponentModel
             {
                 return nativeErrorCode;
             }
-        }
-
-        private static bool TryGetErrorMessage(int error, StringBuilder sb, out string errorMsg) 
-        {
-            errorMsg = "";
-
-            int result = Interop.mincore.FormatMessage(
-                                        Interop.mincore.FORMAT_MESSAGE_IGNORE_INSERTS |
-                                        Interop.mincore.FORMAT_MESSAGE_FROM_SYSTEM |
-                                        Interop.mincore.FORMAT_MESSAGE_ARGUMENT_ARRAY,
-                                        IntPtr.Zero, (uint)error, 0, sb, sb.Capacity + 1,
-                                        null);
-            if (result != 0)
-            {
-                int i = sb.Length;
-                while (i > 0)
-                {
-                    char ch = sb[i - 1];
-                    if (ch > 32 && ch != '.') break;
-                    i--;
-                }
-                errorMsg = sb.ToString(0, i);
-            }
-            else if (Marshal.GetLastWin32Error() == Interop.mincore.ERROR_INSUFFICIENT_BUFFER) 
-            {
-                return false;
-            }
-            else {
-                errorMsg = String.Format("Unknown error (0x{0:x})", error);
-            }
-
-            return true;
-        }
-
-        // Windows API FormatMessage lets you format a message string given an errocode.
-        // Unlike other APIs this API does not support a way to query it for the total message size.
-        //
-        // So the API can only be used in one of these two ways.
-        // a. You pass a buffer of appropriate size and get the resource.
-        // b. Windows creates a buffer and passes the address back and the onus of releasing the bugffer lies on the caller.
-        //
-        // Since the error code is coming from the user, it is not possible to know the size in advance.
-        // Unfortunately we can't use option b. since the buffer can only be freed using LocalFree and it is a private API on onecore.
-        // Also, using option b is ugly for the manged code and could cause memory leak in situations where freeing is unsuccessful.
-        // 
-        // As a result we use the following approach.
-        // We initially call the API with a buffer size of 256 and then gradually increase the size in case of failure until we reach the maxiumum allowed limit of 65K.
-        private const int MaxAllowedBufferSize = 65 * 1024;
-
-        private static string GetErrorMessage(int error) 
-        {
-            string errorMsg;
-
-            StringBuilder sb = new StringBuilder(256);
-            do 
-            {
-                if (TryGetErrorMessage(error, sb, out errorMsg))
-                    return errorMsg;
-                else 
-                {
-                    // increase the capacity of the StringBuilder by 4.
-                    sb.Capacity *= 4;
-                }
-            }
-            while (sb.Capacity < MaxAllowedBufferSize);
-
-            // If you come here then a size as large as 65K is also not sufficient and so we give the generic errorMsg.
-            return String.Format("Unknown error (0x{0:x})", error);
         }
     }
 }

--- a/src/Microsoft.Win32.Primitives/tests/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/tests/Win32Exception.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.Primitives.Tests
     public static class Win32ExceptionTestType
     {
         [Fact]
-        public static void InstentiateException()
+        public static void InstantiateException()
         {
             Win32Exception ex = new Win32Exception(5);
             Assert.True(ex.HResult == E_FAIL);

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Interop\Interop.manual.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Interop.CoreFileIO.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\Interop.Errors.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.strerror.Unix.cs" />
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />


### PR DESCRIPTION
Separates out the Windows interop code from the main Win32Exception type, and then adds a basic Linux implementation, based on strerror_r. (There are a few other minor, unrelated changes, e.g. some additional enum values in an interop file, in order to keep these files in sync with additional .NET Core projects not yet shared.)
