### PR TITLE
Enumerate over dictionary keys and values without allocations

### DIFF
--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -84,8 +84,10 @@
     <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+DebuggerProxy.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+Enumerator.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+HashBucket.cs" />
+    <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+KeyCollection.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+MutationInput.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+MutationResult.cs" />
+    <Compile Include="System\Collections\Immutable\ImmutableDictionary`2+ValueCollection.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableDictionary`2.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableExtensions.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableHashSet.cs" />

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+KeyCollection.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+KeyCollection.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.Collections.Immutable
+{
+    /// <content>
+    /// Contains the inner KeyCollection struct.
+    /// </content>
+    partial class ImmutableDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// This structure represents a collection of keys in a dictionary.
+        /// </summary>
+        public struct KeyCollection : IEnumerable<TKey>
+        {
+            /// <summary>
+            /// The underlying dictionary.
+            /// </summary>
+            private readonly ImmutableDictionary<TKey, TValue> _dictionary;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="KeyCollection"/> structure.
+            /// </summary>
+            /// <param name="dictionary">The dictionary.</param>
+            internal KeyCollection(ImmutableDictionary<TKey, TValue> dictionary)
+            {
+                _dictionary = dictionary;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="Enumerator"/> that can be used to iterate through the collection.
+            /// </returns>
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(_dictionary.GetEnumerator());
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
+            /// </returns>
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="IEnumerator"/> that can be used to iterate through the collection.
+            /// </returns>
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            /// <summary>
+            /// Enumerates the contents of the collection in an allocation-free manner.
+            /// </summary>
+            public struct Enumerator : IEnumerator<TKey>
+            {
+                /// <summary>
+                /// The enumerator over key/value pairs in the dictionary.
+                /// </summary>
+                private ImmutableDictionary<TKey, TValue>.Enumerator _dictionaryEnumerator;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Enumerator"/> structure.
+                /// </summary>
+                /// <param name="dictionaryEnumerator">The dictionary enumerator.</param>
+                internal Enumerator(ImmutableDictionary<TKey, TValue>.Enumerator dictionaryEnumerator)
+                    : this()
+                {
+                    _dictionaryEnumerator = dictionaryEnumerator;
+                }
+
+                /// <summary>
+                /// Gets the current element.
+                /// </summary>
+                public TKey Current
+                {
+                    get
+                    {
+                        return _dictionaryEnumerator.Current.Key;
+                    }
+                }
+
+                /// <summary>
+                /// Gets the current element.
+                /// </summary>
+                object IEnumerator.Current
+                {
+                    get
+                    {
+                        return Current;
+                    }
+                }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the collection.
+                /// </summary>
+                /// <returns>
+                /// true if the enumerator was successfully advanced to the next element; false if the enumerator has
+                /// passed the end of the collection.
+                /// </returns>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public bool MoveNext()
+                {
+                    return _dictionaryEnumerator.MoveNext();
+                }
+
+                /// <summary>
+                /// Sets the enumerator to its initial position, which is before the first element in the collection.
+                /// </summary>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public void Reset()
+                {
+                    _dictionaryEnumerator.Reset();
+                }
+
+                /// <summary>
+                /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+                /// </summary>
+                public void Dispose()
+                {
+                    _dictionaryEnumerator.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+ValueCollection.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+ValueCollection.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.Collections.Immutable
+{
+    /// <content>
+    /// Contains the inner ValueCollection struct.
+    /// </content>
+    partial class ImmutableDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// This structure represents a collection of values in a dictionary.
+        /// </summary>
+        public struct ValueCollection : IEnumerable<TValue>
+        {
+            /// <summary>
+            /// The underlying dictionary.
+            /// </summary>
+            private readonly ImmutableDictionary<TKey, TValue> _dictionary;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ValueCollection"/> structure.
+            /// </summary>
+            /// <param name="dictionary">The dictionary.</param>
+            internal ValueCollection(ImmutableDictionary<TKey, TValue> dictionary)
+            {
+                _dictionary = dictionary;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="Enumerator"/> that can be used to iterate through the collection.
+            /// </returns>
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(_dictionary.GetEnumerator());
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
+            /// </returns>
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="IEnumerator"/> that can be used to iterate through the collection.
+            /// </returns>
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            /// <summary>
+            /// Enumerates the contents of the collection in an allocation-free manner.
+            /// </summary>
+            public struct Enumerator : IEnumerator<TValue>
+            {
+                /// <summary>
+                /// The enumerator over key/value pairs in the dictionary.
+                /// </summary>
+                private ImmutableDictionary<TKey, TValue>.Enumerator _dictionaryEnumerator;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Enumerator"/> structure.
+                /// </summary>
+                /// <param name="dictionaryEnumerator">The dictionary enumerator.</param>
+                internal Enumerator(ImmutableDictionary<TKey, TValue>.Enumerator dictionaryEnumerator)
+                    : this()
+                {
+                    _dictionaryEnumerator = dictionaryEnumerator;
+                }
+
+                /// <summary>
+                /// Gets the current element.
+                /// </summary>
+                public TValue Current
+                {
+                    get
+                    {
+                        return _dictionaryEnumerator.Current.Value;
+                    }
+                }
+
+                /// <summary>
+                /// Gets the current element.
+                /// </summary>
+                object IEnumerator.Current
+                {
+                    get
+                    {
+                        return Current;
+                    }
+                }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the collection.
+                /// </summary>
+                /// <returns>
+                /// true if the enumerator was successfully advanced to the next element; false if the enumerator has
+                /// passed the end of the collection.
+                /// </returns>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public bool MoveNext()
+                {
+                    return _dictionaryEnumerator.MoveNext();
+                }
+
+                /// <summary>
+                /// Sets the enumerator to its initial position, which is before the first element in the collection.
+                /// </summary>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public void Reset()
+                {
+                    _dictionaryEnumerator.Reset();
+                }
+
+                /// <summary>
+                /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+                /// </summary>
+                public void Dispose()
+                {
+                    _dictionaryEnumerator.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -166,34 +166,44 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Gets the keys in the map.
         /// </summary>
-        public IEnumerable<TKey> Keys
+        public KeyCollection Keys
         {
             get
             {
-                foreach (var bucket in this.root)
-                {
-                    foreach (var item in bucket.Value)
-                    {
-                        yield return item.Key;
-                    }
-                }
+                return new KeyCollection(this);
+            }
+        }
+
+        /// <summary>
+        /// Gets the keys in the map.
+        /// </summary>
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+        {
+            get
+            {
+                return Keys;
             }
         }
 
         /// <summary>
         /// Gets the values in the map.
         /// </summary>
-        public IEnumerable<TValue> Values
+        public ValueCollection Values
         {
             get
             {
-                foreach (var bucket in this.root)
-                {
-                    foreach (var item in bucket.Value)
-                    {
-                        yield return item.Value;
-                    }
-                }
+                return new ValueCollection(this);
+            }
+        }
+
+        /// <summary>
+        /// Gets the values in the map.
+        /// </summary>
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+        {
+            get
+            {
+                return Values;
             }
         }
 


### PR DESCRIPTION
This pull request offers an alternative to #147. It eliminates the allocations when evaluating the `Keys` and `Values` properties of `ImmutableDictionary<TKey, TValue>`, but does so without increasing the allocated size of an `ImmutableDictionary<TKey, TValue>` instance.

The documentation associated with the members created by this pull request do not currently meet my own quality standards, but I sent the pull request before going through that part in detail in order to get early feedback. If the community believes this approach is the desired implementation for this functionality, I will go back through the documentation in detail.
