### PR TITLE
Fix bug in Matrix4x4.Decompose.

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1638,14 +1638,14 @@ namespace System.Numerics
                         }
                         #endregion
 
-                        *(pCanonicalBasis + cc) = Vector3.Cross(*pVectorBasis[b], *pVectorBasis[a]);
+                        *pVectorBasis[b] = Vector3.Cross(*pVectorBasis[a], *(pCanonicalBasis + cc));
                     }
 
                     *pVectorBasis[b] = Vector3.Normalize(*pVectorBasis[b]);
 
                     if (pfScales[c] < EPSILON)
                     {
-                        *pVectorBasis[b] = Vector3.Cross(*pVectorBasis[c], *pVectorBasis[a]);
+                        *pVectorBasis[c] = Vector3.Cross(*pVectorBasis[a], *pVectorBasis[b]);
                     }
 
                     *pVectorBasis[c] = Vector3.Normalize(*pVectorBasis[c]);


### PR DESCRIPTION
While working on the Win2D numerics implementation, I discovered this longstanding issue
which was inherited from XNA. In some corner cases where one axis of a matrix transform
has degenerate (zero) scale factor, the Decompose method tries to compensate by filling
in an artificially generated orthogonal coordinate system, but was doing this wrong and
generating nonsense results.

Also updated unit tests to properly validate decompose of matrices with zero and negative
scale factors.
