### PR TITLE
Fix DEBUG constant name

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -982,7 +982,6 @@ namespace System.Text.RegularExpressions
             return (_roptions & RegexOptions.CultureInvariant) != 0;
         }
 
-
 #if DEBUG
         /*
          * True if the regex has debugging enabled

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -385,7 +385,8 @@ namespace System.Text.RegularExpressions
         {
             return _pattern;
         }
-#if DBG
+
+#if DEBUG
         public String Dump(String indent)
         {
             StringBuilder sb = new StringBuilder();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCapture.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCapture.cs
@@ -99,7 +99,8 @@ namespace System.Text.RegularExpressions
         {
             return _text.Substring(_index + _length, _text.Length - _index - _length);
         }
-#if DBG
+
+#if DEBUG
         internal virtual String Description()
         {
             StringBuilder Sb = new StringBuilder();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -489,7 +489,7 @@ namespace System.Text.RegularExpressions
             DigitClass = "\x00\x00\x01" + (char)((int)UnicodeCategory.DecimalDigitNumber + 1);
             NotDigitClass = "\x00\x00\x01" + unchecked((char)(-((int)UnicodeCategory.DecimalDigitNumber + 1)));
 
-#if DBG
+#if DEBUG
             // make sure the _propTable is correctly ordered
             int len = _propTable.Length;
             for (int i = 0; i < len - 1; i++)
@@ -1252,7 +1252,7 @@ namespace System.Text.RegularExpressions
             throw new ArgumentException(SR.Format(SR.MakeException, pattern, SR.Format(SR.UnknownProperty, capname)));
         }
 
-#if DBG
+#if DEBUG
 
         /*
          * SetDescription()

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -231,9 +231,8 @@ namespace System.Text.RegularExpressions
         {
             return new ArgumentException(message);
         }
-        // Debug only code below
 
-#if DBG
+#if DEBUG
         internal static String[] CodeStr = new String[]
         {
             "Onerep", "Notonerep", "Setrep",

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -201,7 +201,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-#if DBG
+#if DEBUG
         internal static String AnchorDescription(int anchors)
         {
             StringBuilder sb = new StringBuilder();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -130,7 +130,7 @@ namespace System.Text.RegularExpressions
         private void Backtrack()
         {
             int newpos = _runtrack[_runtrackpos++];
-#if DBG
+#if DEBUG
             if (_runmatch.Debug)
             {
                 if (newpos < 0)
@@ -466,7 +466,7 @@ namespace System.Text.RegularExpressions
 
             for (; ;)
             {
-#if DBG
+#if DEBUG
                 if (_runmatch.Debug)
                 {
                     DumpState();
@@ -1181,7 +1181,8 @@ namespace System.Text.RegularExpressions
                 Backtrack();
             }
         }
-#if DBG
+
+#if DEBUG
         internal override void DumpState()
         {
             base.DumpState();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -616,7 +616,8 @@ namespace System.Text.RegularExpressions
         {
             return _type;
         }
-#if DBG
+
+#if DEBUG
         internal static String[] TypeStr = new String[] {
             "Onerep", "Notonerep", "Setrep",
             "Oneloop", "Notoneloop", "Setloop",

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1610,7 +1610,7 @@ namespace System.Text.RegularExpressions
                     return RegexOptions.Singleline;
                 case 'x':
                     return RegexOptions.IgnorePatternWhitespace;
-#if DBG
+#if DEBUG
                 case 'd':
                     return RegexOptions.Debug;
 #endif

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -130,7 +130,7 @@ namespace System.Text.RegularExpressions
 
             for (; ;)
             {
-#if DBG
+#if DEBUG
                 if (_runregex.Debug)
                 {
                     Debug.WriteLine("");
@@ -147,7 +147,7 @@ namespace System.Text.RegularExpressions
                         InitMatch();
                         initted = true;
                     }
-#if DBG
+#if DEBUG
                     if (_runregex.Debug)
                     {
                         Debug.WriteLine("Executing engine starting at " + _runtextpos.ToString(CultureInfo.InvariantCulture));
@@ -227,7 +227,7 @@ namespace System.Text.RegularExpressions
             if (0 > _timeoutOccursAt && 0 < currentMillis)
                 return;
 
-#if DBG
+#if DEBUG
             if (_runregex.Debug)
             {
                 Debug.WriteLine("");
@@ -555,7 +555,8 @@ namespace System.Text.RegularExpressions
         {
             return _runmatch.MatchLength(cap);
         }
-#if DBG
+
+#if DEBUG
         /*
          * Dump the current state
          */

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -30,7 +30,8 @@ namespace System.Text.RegularExpressions
         internal String[] _capslist;
         internal RegexOptions _options;
         internal int _captop;
-#if DBG
+
+#if DEBUG
         internal void Dump()
         {
             _root.Dump();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -42,7 +42,7 @@ namespace System.Text.RegularExpressions
         {
             RegexWriter w = new RegexWriter();
             RegexCode retval = w.RegexCodeFromRegexTree(t);
-#if DBG
+#if DEBUG
             if (t.Debug)
             {
                 t.Dump();


### PR DESCRIPTION
It looks like DBG was being used instead of DEBUG at System.Text.RegularExpressions.

Was this on purpose?
