### PR TITLE
Fix GetGroup never returning EmptyGroup

### DIFF
--- a/src/System.Text.RegularExpressions/src/Properties/AssemblyInfo.cs
+++ b/src/System.Text.RegularExpressions/src/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -29,3 +30,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(true)]
 
+[assembly: InternalsVisibleTo("System.Text.RegularExpressions.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -83,24 +83,18 @@ namespace System.Text.RegularExpressions
         {
             if (_captureMap != null)
             {
-                Object o;
-
-                o = _captureMap[groupnum];
-                if (o == null)
-                    return Group._emptygroup;
-                //throw new ArgumentOutOfRangeException("groupnum");
-
-                return GetGroupImpl((int)o);
+                int groupNumImpl;
+                if (_captureMap.TryGetValue(groupnum, out groupNumImpl))
+                {
+                    return GetGroupImpl(groupNumImpl);
+                }
             }
-            else
+            else if (groupnum < _match._matchcount.Length && groupnum >= 0)
             {
-                //if (groupnum >= _match._regex.CapSize || groupnum < 0)
-                //   throw new ArgumentOutOfRangeException("groupnum");
-                if (groupnum >= _match._matchcount.Length || groupnum < 0)
-                    return Group._emptygroup;
-
                 return GetGroupImpl(groupnum);
             }
+
+            return Group._emptygroup;
         }
 
 

--- a/src/System.Text.RegularExpressions/tests/RegexGroupCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexGroupCollectionTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RegexGroupCollectionTests
+{
+    [Fact]
+    public static void GetGroupTest()
+    {
+        var caps = new Dictionary<int, int>
+        {
+            { 0, 0 }
+        };
+        var groups = new GroupCollection(null, caps);
+        var group = groups.GetGroup(1);
+        Assert.NotEqual(Group._emptygroup, group);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="R2LGetGroupNamesMatchTests.cs" />
     <Compile Include="RegexComponentsSplitTests.cs" />
     <Compile Include="RegexConstructorTests.cs" />
+    <Compile Include="RegexGroupCollectionTests.cs" />
     <Compile Include="RegexMatchTests0.cs" />
     <Compile Include="RegexMatchTests1.cs" />
     <Compile Include="RegexMatchTests2.cs" />


### PR DESCRIPTION
This is a very obvious bug:
_captureMap probably used to be a hashtable and the code was not properly refactored.

I took the opportunity to redo the method using the Dictionary equivalent logic.

Not adding unit tests for this, because the unit test project seems to be missing, and I'm not sure if you guys are going to add it or not, so let me know how to proceed.