### PR TITLE
Re-enable some Vector tests which were flaky on CI machines

### DIFF
--- a/src/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
@@ -1006,20 +1006,21 @@ namespace System.Numerics.Tests
             private Matrix3x2PlusFloat _a;
             private Matrix3x2PlusFloat _b;
         }
-        //// A test to make sure the fields are laid out how we expect
-        //[Fact]
-        //public unsafe void Matrix3x2FieldOffsetTest()
-        //{
-        //    Matrix3x2* ptr = (Matrix3x2*)0;
 
-        //    Assert.Equal(new IntPtr(0), new IntPtr(&ptr->M11));
-        //    Assert.Equal(new IntPtr(4), new IntPtr(&ptr->M12));
+        // A test to make sure the fields are laid out how we expect
+        [Fact]
+        public unsafe void Matrix3x2FieldOffsetTest()
+        {
+            Matrix3x2* ptr = (Matrix3x2*)0;
 
-        //    Assert.Equal(new IntPtr(8), new IntPtr(&ptr->M21));
-        //    Assert.Equal(new IntPtr(12), new IntPtr(&ptr->M22));
+            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->M11));
+            Assert.Equal(new IntPtr(4), new IntPtr(&ptr->M12));
 
-        //    Assert.Equal(new IntPtr(16), new IntPtr(&ptr->M31));
-        //    Assert.Equal(new IntPtr(20), new IntPtr(&ptr->M32));
-        //}
+            Assert.Equal(new IntPtr(8), new IntPtr(&ptr->M21));
+            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->M22));
+
+            Assert.Equal(new IntPtr(16), new IntPtr(&ptr->M31));
+            Assert.Equal(new IntPtr(20), new IntPtr(&ptr->M32));
+        }
     }
 }

--- a/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -2480,31 +2480,32 @@ namespace System.Numerics.Tests
             private Matrix4x4PlusFloat _a;
             private Matrix4x4PlusFloat _b;
         }
-        //// A test to make sure the fields are laid out how we expect
-        //[Fact]
-        //public unsafe void Matrix4x4FieldOffsetTest()
-        //{
-        //    Matrix4x4* ptr = (Matrix4x4*)0;
 
-        //    Assert.Equal(new IntPtr(0), new IntPtr(&ptr->M11));
-        //    Assert.Equal(new IntPtr(4), new IntPtr(&ptr->M12));
-        //    Assert.Equal(new IntPtr(8), new IntPtr(&ptr->M13));
-        //    Assert.Equal(new IntPtr(12), new IntPtr(&ptr->M14));
+        // A test to make sure the fields are laid out how we expect
+        [Fact]
+        public unsafe void Matrix4x4FieldOffsetTest()
+        {
+            Matrix4x4* ptr = (Matrix4x4*)0;
 
-        //    Assert.Equal(new IntPtr(16), new IntPtr(&ptr->M21));
-        //    Assert.Equal(new IntPtr(20), new IntPtr(&ptr->M22));
-        //    Assert.Equal(new IntPtr(24), new IntPtr(&ptr->M23));
-        //    Assert.Equal(new IntPtr(28), new IntPtr(&ptr->M24));
+            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->M11));
+            Assert.Equal(new IntPtr(4), new IntPtr(&ptr->M12));
+            Assert.Equal(new IntPtr(8), new IntPtr(&ptr->M13));
+            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->M14));
 
-        //    Assert.Equal(new IntPtr(32), new IntPtr(&ptr->M31));
-        //    Assert.Equal(new IntPtr(36), new IntPtr(&ptr->M32));
-        //    Assert.Equal(new IntPtr(40), new IntPtr(&ptr->M33));
-        //    Assert.Equal(new IntPtr(44), new IntPtr(&ptr->M34));
+            Assert.Equal(new IntPtr(16), new IntPtr(&ptr->M21));
+            Assert.Equal(new IntPtr(20), new IntPtr(&ptr->M22));
+            Assert.Equal(new IntPtr(24), new IntPtr(&ptr->M23));
+            Assert.Equal(new IntPtr(28), new IntPtr(&ptr->M24));
 
-        //    Assert.Equal(new IntPtr(48), new IntPtr(&ptr->M41));
-        //    Assert.Equal(new IntPtr(52), new IntPtr(&ptr->M42));
-        //    Assert.Equal(new IntPtr(56), new IntPtr(&ptr->M43));
-        //    Assert.Equal(new IntPtr(60), new IntPtr(&ptr->M44));
-        //}
+            Assert.Equal(new IntPtr(32), new IntPtr(&ptr->M31));
+            Assert.Equal(new IntPtr(36), new IntPtr(&ptr->M32));
+            Assert.Equal(new IntPtr(40), new IntPtr(&ptr->M33));
+            Assert.Equal(new IntPtr(44), new IntPtr(&ptr->M34));
+
+            Assert.Equal(new IntPtr(48), new IntPtr(&ptr->M41));
+            Assert.Equal(new IntPtr(52), new IntPtr(&ptr->M42));
+            Assert.Equal(new IntPtr(56), new IntPtr(&ptr->M43));
+            Assert.Equal(new IntPtr(60), new IntPtr(&ptr->M44));
+        }
     }
 }

--- a/src/System.Numerics.Vectors/tests/PlaneTests.cs
+++ b/src/System.Numerics.Vectors/tests/PlaneTests.cs
@@ -346,14 +346,15 @@ namespace System.Numerics.Tests
             private PlanePlusFloat _a;
             private PlanePlusFloat _b;
         }
-        //// A test to make sure the fields are laid out how we expect
-        //[Fact]
-        //public unsafe void PlaneFieldOffsetTest()
-        //{
-        //    Plane* ptr = (Plane*)0;
 
-        //    Assert.Equal(new IntPtr(0), new IntPtr(&ptr->Normal));
-        //    Assert.Equal(new IntPtr(12), new IntPtr(&ptr->D));
-        //}
+        // A test to make sure the fields are laid out how we expect
+        [Fact]
+        public unsafe void PlaneFieldOffsetTest()
+        {
+            Plane* ptr = (Plane*)0;
+
+            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->Normal));
+            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->D));
+        }
     }
 }

--- a/src/System.Numerics.Vectors/tests/QuaternionTests.cs
+++ b/src/System.Numerics.Vectors/tests/QuaternionTests.cs
@@ -964,16 +964,17 @@ namespace System.Numerics.Tests
             private QuaternionPlusFloat _a;
             private QuaternionPlusFloat _b;
         }
-        //// A test to make sure the fields are laid out how we expect
-        //[Fact]
-        //public unsafe void QuaternionFieldOffsetTest()
-        //{
-        //    Quaternion* ptr = (Quaternion*)0;
 
-        //    Assert.Equal(new IntPtr(0), new IntPtr(&ptr->X));
-        //    Assert.Equal(new IntPtr(4), new IntPtr(&ptr->Y));
-        //    Assert.Equal(new IntPtr(8), new IntPtr(&ptr->Z));
-        //    Assert.Equal(new IntPtr(12), new IntPtr(&ptr->W));
-        //}
+        // A test to make sure the fields are laid out how we expect
+        [Fact]
+        public unsafe void QuaternionFieldOffsetTest()
+        {
+            Quaternion* ptr = (Quaternion*)0;
+
+            Assert.Equal(new IntPtr(0), new IntPtr(&ptr->X));
+            Assert.Equal(new IntPtr(4), new IntPtr(&ptr->Y));
+            Assert.Equal(new IntPtr(8), new IntPtr(&ptr->Z));
+            Assert.Equal(new IntPtr(12), new IntPtr(&ptr->W));
+        }
     }
 }

--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -559,7 +559,7 @@ namespace System.Numerics.Tests
 
         // A test for Normalize (Vector2f)
         // Normalize zero length vector
-        //[Fact(Skip="GitHub Issue #22")]
+        [Fact]
         public void Vector2NormalizeTest1()
         {
             Vector2 a = new Vector2(); // no parameter, default to 0.0f

--- a/src/System.Numerics.Vectors/tests/Vector4Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector4Tests.cs
@@ -799,7 +799,7 @@ namespace System.Numerics.Tests
 
         // A test for Normalize (Vector4f)
         // Normalize vector of length zero
-        //[Fact(Skip="GitHub Issue #22")]
+        [Fact]
         public void Vector4NormalizeTest2()
         {
             Vector4 a = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
This should resolve issue #234 and #22. Given that they only fail on the CI server, I will monitor this PR and see if there is still any issue, or whether it was a temporary problem at the time we started using AppVeyor.
