### PR TITLE
Use a generic list for capsList

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -53,7 +53,7 @@ namespace System.Text.RegularExpressions
         internal Dictionary<Int32, Int32> _caps;            // if captures are sparse, this is the hashtable capnum->index
         internal Dictionary<String, Int32> _capnames;       // if named captures are used, this maps names->index
 
-        internal String[] _capslist;                        // if captures are sparse or named captures are used, this is the sorted list of names
+        internal List<String> _capslist;                    // if captures are sparse or named captures are used, this is the sorted list of names
         internal int _capsize;                              // the size of the capture array
 
         internal ExclusiveReference _runnerref;             // cached runner
@@ -298,9 +298,7 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                result = new String[_capslist.Length];
-
-                System.Array.Copy(_capslist, 0, result, 0, _capslist.Length);
+                result = _capslist.ToArray();
             }
 
             return result;
@@ -372,7 +370,7 @@ namespace System.Text.RegularExpressions
                     i = _caps[i];
                 }
 
-                if (i >= 0 && i < _capslist.Length)
+                if (i >= 0 && i < _capslist.Count)
                     return _capslist[i];
 
                 return String.Empty;
@@ -1054,12 +1052,12 @@ namespace System.Text.RegularExpressions
         internal RegexCode _code;
         internal Dictionary<Int32, Int32> _caps;
         internal Dictionary<String, Int32> _capnames;
-        internal String[] _capslist;
+        internal List<String> _capslist;
         internal int _capsize;
         internal ExclusiveReference _runnerref;
         internal SharedReference _replref;
 
-        internal CachedCodeEntry(CachedCodeEntryKey key, Dictionary<String, Int32> capnames, String[] capslist, RegexCode code, Dictionary<Int32, Int32> caps, int capsize, ExclusiveReference runner, SharedReference repl)
+        internal CachedCodeEntry(CachedCodeEntryKey key, Dictionary<String, Int32> capnames, List<String> capslist, RegexCode code, Dictionary<Int32, Int32> caps, int capsize, ExclusiveReference runner, SharedReference repl)
         {
             _key = key;
             _capnames = capnames;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -56,7 +56,6 @@ namespace System.Text.RegularExpressions
         {
             RegexParser p;
             RegexNode root;
-            String[] capnamelist;
 
             p = new RegexParser((op & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
 
@@ -67,12 +66,7 @@ namespace System.Text.RegularExpressions
             p.Reset(op);
             root = p.ScanRegex();
 
-            if (p._capnamelist == null)
-                capnamelist = null;
-            else
-                capnamelist = p._capnamelist.ToArray();
-
-            return new RegexTree(root, p._caps, p._capnumlist, p._captop, p._capnames, capnamelist, op);
+            return new RegexTree(root, p._caps, p._capnumlist, p._captop, p._capnames, p._capnamelist, op);
         }
 
         /*

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// RegexTree is just a wrapper for a node tree with some
-// global information attached.
-
-using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>
+    /// RegexTree is just a wrapper for a node tree with some global information attached.
+    /// </summary>
     internal sealed class RegexTree
     {
-        internal RegexTree(RegexNode root, Dictionary<Int32, Int32> caps, Int32[] capnumlist, int captop, Dictionary<String, Int32> capnames, String[] capslist, RegexOptions opts)
-
+        internal RegexTree(RegexNode root, Dictionary<Int32, Int32> caps, Int32[] capnumlist, int captop, Dictionary<String, Int32> capnames, List<String> capslist, RegexOptions opts)
         {
             _root = root;
             _caps = caps;
@@ -27,7 +25,7 @@ namespace System.Text.RegularExpressions
         internal Dictionary<Int32, Int32> _caps;
         internal Int32[] _capnumlist;
         internal Dictionary<String, Int32> _capnames;
-        internal String[] _capslist;
+        internal List<String> _capslist;
         internal RegexOptions _options;
         internal int _captop;
 #if DBG


### PR DESCRIPTION
The list created for capsList is being copied to an array on every
RegexTree created, and there is no point in that when we only need an
array for Regex.GetGroupNames

This is just a small performance improvement, but one I believe merits the effort. (:
