### PR TITLE
Update regular expressions collections to implement IReadOnlyList<T>

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -5,6 +5,7 @@
 // contained in a compiled Regex.
 
 using System.Collections;
+using System.Collections.Generic;
 
 namespace System.Text.RegularExpressions
 {
@@ -17,7 +18,7 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
-    public class CaptureCollection : ICollection
+    public class CaptureCollection : ICollection, IReadOnlyList<Capture>
     {
         internal Group _group;
         internal int _capcount;
@@ -93,6 +94,11 @@ namespace System.Text.RegularExpressions
             return new CaptureEnumerator(this);
         }
 
+        IEnumerator<Capture> IEnumerable<Capture>.GetEnumerator()
+        {
+            return new CaptureEnumerator(this);
+        }
+
         /*
          * Nonpublic code to return set of captures for the group
          */
@@ -124,7 +130,7 @@ namespace System.Text.RegularExpressions
      * Should it be public?
      */
 
-    internal class CaptureEnumerator : IEnumerator
+    internal class CaptureEnumerator : IEnumerator<Capture>
     {
         internal CaptureCollection _rcc;
         internal int _curindex;
@@ -161,6 +167,11 @@ namespace System.Text.RegularExpressions
             get { return Capture; }
         }
 
+        Capture IEnumerator<Capture>.Current
+        {
+            get { return Capture; }
+        }
+
         /*
          * Returns the current capture
          */
@@ -181,6 +192,10 @@ namespace System.Text.RegularExpressions
         public void Reset()
         {
             _curindex = -1;
+        }
+
+        void IDisposable.Dispose()
+        {
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -13,7 +13,7 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
-    public class GroupCollection : ICollection
+    public class GroupCollection : ICollection, IReadOnlyList<Group>
     {
         internal Match _match;
         internal Dictionary<Int32, Int32> _captureMap;
@@ -148,6 +148,11 @@ namespace System.Text.RegularExpressions
         {
             return new GroupEnumerator(this);
         }
+
+        IEnumerator<Group> IEnumerable<Group>.GetEnumerator()
+        {
+            return new GroupEnumerator(this);
+        }
     }
 
 
@@ -155,7 +160,7 @@ namespace System.Text.RegularExpressions
      * This non-public enumerator lists all the captures
      * Should it be public?
      */
-    internal class GroupEnumerator : IEnumerator
+    internal class GroupEnumerator : IEnumerator<Group>
     {
         internal GroupCollection _rgc;
         internal int _curindex;
@@ -192,6 +197,11 @@ namespace System.Text.RegularExpressions
             get { return Capture; }
         }
 
+        Group IEnumerator<Group>.Current
+        {
+            get { return (Group)Capture; }
+        }
+
         /*
          * Returns the current capture
          */
@@ -212,6 +222,10 @@ namespace System.Text.RegularExpressions
         public void Reset()
         {
             _curindex = -1;
+        }
+
+        void IDisposable.Dispose()
+        {
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -18,7 +18,7 @@ namespace System.Text.RegularExpressions
     /// Represents the set of names appearing as capturing group
     /// names in a regular expression.
     /// </summary>
-    public class MatchCollection : ICollection
+    public class MatchCollection : ICollection, IReadOnlyList<Match>
     {
         internal Regex _regex;
         internal List<Match> _matches;
@@ -159,13 +159,18 @@ namespace System.Text.RegularExpressions
         {
             return new MatchEnumerator(this);
         }
+
+        IEnumerator<Match> IEnumerable<Match>.GetEnumerator()
+        {
+            return new MatchEnumerator(this);
+        }
     }
 
     /*
      * This non-public enumerator lists all the group matches.
      * Should it be public?
      */
-    internal class MatchEnumerator : IEnumerator
+    internal class MatchEnumerator : IEnumerator<Match>
     {
         internal MatchCollection _matchcoll;
         internal Match _match = null;
@@ -213,6 +218,14 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        Match IEnumerator<Match>.Current
+        {
+            get
+            {
+                return (Match)Current;
+            }
+        }
+
         /*
          * Position before the first item
          */
@@ -221,6 +234,10 @@ namespace System.Text.RegularExpressions
             _curindex = 0;
             _done = false;
             _match = null;
+        }
+
+        void IDisposable.Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
Fixes #271 

I believe this is the least intrusive path to implementing the requested functionality.

I considered the following items but decided to not include them with this pull request.
- `GroupEnumerator` is internal, so it might be possible to change the type of `GroupEnumerator.Capture` from `Capture` to `Group`. This would make the explicit cast in the generic `Current` property unnecessary.
- I did not update `CaptureCollection` to implement `IReadOnlyDictionary<string, Capture>`, primarily because it's a larger change with the addition of the `Keys` and `Values` properties (even if they are explicitly implemented). This should probably be reviewed independently from a straightforward implementation of `IReadOnlyList<T>`.
