### PR TITLE
System.Numerics.Vectors.sln: use correct configuration for Debug

### DIFF
--- a/src/System.Numerics.Vectors.sln
+++ b/src/System.Numerics.Vectors.sln
@@ -14,12 +14,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{53134B0C-0D57-481B-B84E-D1991E8D54FF}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{53134B0C-0D57-481B-B84E-D1991E8D54FF}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{53134B0C-0D57-481B-B84E-D1991E8D54FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53134B0C-0D57-481B-B84E-D1991E8D54FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53134B0C-0D57-481B-B84E-D1991E8D54FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53134B0C-0D57-481B-B84E-D1991E8D54FF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A7074928-82C3-4739-88FE-9B528977950C}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{A7074928-82C3-4739-88FE-9B528977950C}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{A7074928-82C3-4739-88FE-9B528977950C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7074928-82C3-4739-88FE-9B528977950C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7074928-82C3-4739-88FE-9B528977950C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7074928-82C3-4739-88FE-9B528977950C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Before, the Release target got incorrectly assigned to the Debug configuration
for the library and test projects. This results in the library being compiled
into the Release dir when the solution is compiled on the command line
via msbuild.exe, while it should be compiled into the Debug dir.
