### PR TITLE
dir.props: correctly enclose 'Exists' condition in single quotes

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -19,7 +19,7 @@
     <NuGetToolPath>$(ToolsDir)NuGet.exe</NuGetToolPath>
     <NuGetConfigFile>$(SourceDir)nuget\NuGet.Config</NuGetConfigFile>
     <NuGetConfigCommandLine
-      Condition="Exists($(NuGetConfigFile))">-ConfigFile &quot;$(NuGetConfigFile)&quot;</NuGetConfigCommandLine>
+      Condition="Exists('$(NuGetConfigFile)')">-ConfigFile &quot;$(NuGetConfigFile)&quot;</NuGetConfigCommandLine>
   </PropertyGroup>
 
   <!-- Common build tool properties -->


### PR DESCRIPTION
According to MSDN (http://msdn.microsoft.com/en-us/library/7szfhaft.aspx), the
single quotes can be left off for "simple alphanumeric strings or boolean values".
This is not the case here (it is a property), so we should use single quotes.

Note that MSBuild ignores this, but it results in a parser error on Mono's xbuild.
