### PR TITLE
System.Reflection.Metadata.Tests: reference System.Threading contract assembly

### DIFF
--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -114,6 +114,10 @@
       <HintPath>..\..\packages\System.Text.Encoding.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Text.Encoding.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Threading">
+      <HintPath>..\..\packages\System.Threading.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Threading.Tasks">
       <HintPath>..\..\packages\System.Threading.Tasks.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.Tasks.dll</HintPath>
       <Private>False</Private>

--- a/src/System.Reflection.Metadata/tests/packages.config
+++ b/src/System.Reflection.Metadata/tests/packages.config
@@ -21,6 +21,7 @@
   <package id="System.Runtime.Handles" version="4.0.0-beta-22412" targetFramework="portable-net45+win" />
   <package id="System.Runtime.InteropServices" version="4.0.20-beta-22412" targetFramework="portable-net45+win" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Threading" version="4.0.0-beta-22412" targetFramework="portable-net45+win" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
   <package id="System.Threading.Tasks.Parallel" version="4.0.0-beta-22412" targetFramework="portable-net45+win" />
 </packages>


### PR DESCRIPTION
This allows the test project to be built with Mono's xbuild.

Otherwise I get an error: `CSC: error CS0518: The predefined type 'System.Threading.Interlocked' is not defined or imported` from the Mono compiler.

I suspect this is because the [test project](https://github.com/dotnet/corefx/blob/532860a8912d7ede2106e2d8d40e202c1be35f8a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj#L117-L124) builds against the contract assemblies from the NuGet packages, while the referenced [library project](https://github.com/dotnet/corefx/blob/532860a8912d7ede2106e2d8d40e202c1be35f8a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj#L13-L14) builds against the PCL profile and there is a mismatch somewhere.

Would love to get some feedback if this makes sense :)
