### PR TITLE
Reenable PLINQ tests on command line build, keep disabled in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
 build_script:
   - '"%VS120COMNTOOLS%VsDevCmd.bat"'
-  - build.cmd
+  - build.cmd /p:SkipTestAssemblies=System.Threading.Tasks.Dataflow.Tests;System.Linq.Parallel.Tests
 test: off  # disable automatic test discovery, xUnit already runs as part of build.cmd

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -30,11 +30,12 @@
   <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets')" />
   <Target Name="BuidDirPackages" AfterTargets="Build" DependsOnTargets="BuildPackages" />
 
-  <ItemGroup>
-    <DisabledTestAssembly Include="System.Threading.Tasks.Dataflow.Tests" />
-    <DisabledTestAssembly Include="System.Linq.Parallel.Tests" />
+  <PropertyGroup>
+    <SkipTestAssemblies Condition="'$(SkipTestAssemblies)'==''">System.Threading.Tasks.Dataflow.Tests</SkipTestAssemblies>
+  </PropertyGroup>
 
-    <_SkipTestAssemblies Include="@(DisabledTestAssembly)" />
+  <ItemGroup>
+    <_SkipTestAssemblies Include="@(SkipTestAssemblies)" />
   </ItemGroup>
   
   <Import Project="$(ToolsDir)tests.targets" Condition="Exists('$(ToolsDir)tests.targets')" />


### PR DESCRIPTION
Change SkipTestAssemblies from an ItemGroup to a PropertyGroup so it
can be overridden on the command line, and modify AppVeyor's build
invocation to disable PLINQ tests as we investigate GH corefx/283
