### PR TITLE
Microsoft.Win32.Primitives.csproj: Set AllowUnsafeBlocks to true

### DIFF
--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -11,6 +11,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
When building this project on Unix, the Interop.strerror.Unix.cs file
is included which contains p/invoke calls. We need to enable the
AllowUnsafeBlocks property to allow this.
