### PR TITLE
Add Regex Tests

### DIFF
--- a/src/System.Text.RegularExpressions.sln
+++ b/src/System.Text.RegularExpressions.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Text.RegularExpressions", "System.Text.RegularExpressions\src\System.Text.RegularExpressions.csproj", "{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Text.RegularExpressions.Tests", "System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj", "{94B106C2-D574-4392-80AB-3EE308A078DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94B106C2-D574-4392-80AB-3EE308A078DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94B106C2-D574-4392-80AB-3EE308A078DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94B106C2-D574-4392-80AB-3EE308A078DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94B106C2-D574-4392-80AB-3EE308A078DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Text.RegularExpressions/src/Properties/AssemblyInfo.cs
+++ b/src/System.Text.RegularExpressions/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Resources;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyCopyright("\x00a9 Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyFileVersion("999.999.999.0")]
+[assembly: AssemblyInformationalVersion("999.999.999.0")]
+[assembly: AssemblyVersion("999.999.999.0")]
+
+[assembly: AssemblyTitle("System.Text.RegularExpressions")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("System.Text.RegularExpressions")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguageAttribute("en-US")]
+
+
+
+[assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
+

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Text.RegularExpressions;
+using System.Collections;
+
+namespace Test
+{
+    /// <summary>
+    /// Tests the CaptureCollection class.
+    /// </summary>
+    public class CaptureCollectionTests
+    {
+        [Fact]
+        public static void CaptureCollection_GetEnumeratorTest_Negative()
+        {
+            Regex rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
+            String strInput = "aaabbccccccccccaaaabc";
+            Match mtch1 = rgx1.Match(strInput);
+            CaptureCollection captrc1 = mtch1.Captures;
+
+            IEnumerator enmtr1 = captrc1.GetEnumerator();
+
+            Capture currentCapture;
+
+            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
+
+
+            for (int i = 0; i < captrc1.Count; i++)
+            {
+                enmtr1.MoveNext();
+            }
+
+            enmtr1.MoveNext();
+
+            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
+            enmtr1.Reset();
+
+            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
+        }
+
+        [Fact]
+        public static void CaptureCollection_GetEnumeratorTest()
+        {
+            Regex rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
+            String strInput = "aaabbccccccccccaaaabc";
+            Match mtch1 = rgx1.Match(strInput);
+            CaptureCollection captrc1 = mtch1.Captures;
+
+            IEnumerator enmtr1 = captrc1.GetEnumerator();
+
+            for (int i = 0; i < captrc1.Count; i++)
+            {
+                enmtr1.MoveNext();
+
+                Assert.Equal(enmtr1.Current, captrc1[i]);
+            }
+
+            Assert.False(enmtr1.MoveNext(), "Err_5! enmtr1.MoveNext returned true");
+
+            enmtr1.Reset();
+
+            for (int i = 0; i < captrc1.Count; i++)
+            {
+                enmtr1.MoveNext();
+
+                Assert.Equal(enmtr1.Current, captrc1[i]);
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/CaptureTests.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Text.RegularExpressions;
+using System.Collections;
+
+namespace Test
+{
+    /// <summary>
+    /// Tests the Capture class.
+    /// </summary>
+    public class CaptureTests
+    {
+        [Fact]
+        public static void Capture_Test()
+        {
+            Match match = Regex.Match("adfadsfSUCCESSadsfadsf", @".*\B(SUCCESS)\B.*");
+            Int32[] iMatch1 = { 0, 22 };
+            String strMatch1 = "adfadsfSUCCESSadsfadsf";
+
+            String[] strGroup1 = { "adfadsfSUCCESSadsfadsf", "SUCCESS" };
+            Int32[] iGroup1 = { 7, 7 };
+            String[] strGrpCap1 = { "SUCCESS" };
+
+            Assert.True(match.Success, "Fail Do not found a match");
+
+            Assert.True(match.Value.Equals(strMatch1), "Expected to return TRUE");
+            Assert.Equal(match.Index, iMatch1[0]);
+            Assert.Equal(match.Length, iMatch1[1]);
+            Assert.Equal(match.Captures.Count, 1);
+
+            Assert.True(match.Captures[0].Value.Equals(strMatch1), "Expected to return TRUE");
+            Assert.Equal(match.Captures[0].Index, iMatch1[0]);
+            Assert.Equal(match.Captures[0].Length, iMatch1[1]);
+
+            Console.WriteLine(match.Captures[0].ToString());
+
+            Assert.Equal(match.Groups.Count, 2);
+
+            //Group 0 always is the Match
+            Assert.True(match.Groups[0].Value.Equals(strMatch1), "Expected to return TRUE");
+            Assert.Equal(match.Groups[0].Index, iMatch1[0]);
+            Assert.Equal(match.Groups[0].Length, iMatch1[1]);
+            Assert.Equal(match.Groups[0].Captures.Count, 1);
+
+
+            //Group 0's Capture is always the Match
+            Assert.True(match.Groups[0].Captures[0].Value.Equals(strMatch1), "Expected to return TRUE");
+            Assert.Equal(match.Groups[0].Captures[0].Index, iMatch1[0]);
+            Assert.Equal(match.Groups[0].Captures[0].Length, iMatch1[1]);
+
+            for (int i = 1; i < match.Groups.Count; i++)
+            {
+                Assert.True(match.Groups[i].Value.Equals(strGroup1[i]), "Expected to return TRUE");
+                Assert.Equal(match.Groups[i].Index, iGroup1[0]);
+                Assert.Equal(match.Groups[i].Length, iGroup1[0]);
+                Assert.Equal(match.Groups[i].Captures.Count, 1);
+            }
+
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/CharacterClassSubtractionSimple.cs
+++ b/src/System.Text.RegularExpressions/tests/CharacterClassSubtractionSimple.cs
@@ -1,0 +1,397 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class CharacterClassSubtraction
+{
+    // This tests CharacterClassSubtraction by specifying pattern, input and expected groups
+    [Fact]
+    public static void CharacterClassSubtractionTestCase()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            for (int i = 0; i < s_regexTests.Length; i++)
+            {
+                iCountTestcases++;
+                if (!s_regexTests[i].Run())
+                {
+                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2}\n", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
+                    iCountErrors++;
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private static RegexTestCase[] s_regexTests = new RegexTestCase[] {
+        /****************************************************************************
+        (A - B) B is a subset of A (ie B only contains chars that are in A)
+        *****************************************************************************/
+        new RegexTestCase(@"[abcd-[d]]+", "dddaabbccddd", "aabbcc"),
+
+         new RegexTestCase(@"[\d-[357]]+", "33312468955","124689"),
+         new RegexTestCase(@"[\d-[357]]+", "51246897","124689"),
+         new RegexTestCase(@"[\d-[357]]+", "3312468977","124689"),
+
+         new RegexTestCase(@"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+
+         new RegexTestCase(@"[\w-[\d]]+", "0AZaz9","AZaz"),
+         new RegexTestCase(@"[\w-[\p{Ll}]]+", "a09AZz","09AZ"),
+
+        new RegexTestCase(@"[\d-[13579]]+", RegexOptions.ECMAScript, "1024689", "02468"),
+        new RegexTestCase(@"[\d-[13579]]+", RegexOptions.ECMAScript, "\x066102468\x0660", "02468"),
+        new RegexTestCase(@"[\d-[13579]]+", "\x066102468\x0660", "\x066102468\x0660"),
+
+         new RegexTestCase(@"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+
+        new RegexTestCase(@"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+        new RegexTestCase(@"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+
+        new RegexTestCase(@"[\p{Ll}-[ae-z]]+", "aaabbbcccdddeee","bbbcccddd"),
+        new RegexTestCase(@"[\p{Nd}-[2468]]+", "20135798","013579"),
+
+        new RegexTestCase(@"[\P{Lu}-[ae-z]]+", "aaabbbcccdddeee","bbbcccddd"),
+        new RegexTestCase(@"[\P{Nd}-[\p{Ll}]]+", "az09AZ'[]","AZ'[]"),
+
+        /****************************************************************************
+        (A - B) B is a superset of A (ie B contains chars that are in A plus other chars that are not in A)
+        *****************************************************************************/
+        new RegexTestCase(@"[abcd-[def]]+", "fedddaabbccddd", "aabbcc"),
+
+         new RegexTestCase(@"[\d-[357a-z]]+", "az33312468955","124689"),
+         new RegexTestCase(@"[\d-[de357fgA-Z]]+", "AZ51246897","124689"),
+         new RegexTestCase(@"[\d-[357\p{Ll}]]+", "az3312468977","124689"),
+
+         new RegexTestCase(@"[\w-[b-y\s]]+", " \tbbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+
+         new RegexTestCase(@"[\w-[\d\p{Po}]]+", "!#0AZaz9","AZaz"),
+         new RegexTestCase(@"[\w-[\p{Ll}\s]]+", "a09AZz","09AZ"),
+
+        new RegexTestCase(@"[\d-[13579a-zA-Z]]+", RegexOptions.ECMAScript, "AZ1024689", "02468"),
+        new RegexTestCase(@"[\d-[13579abcd]]+", RegexOptions.ECMAScript, "abcd\x066102468\x0660", "02468"),
+        new RegexTestCase(@"[\d-[13579\s]]+", " \t\x066102468\x0660", "\x066102468\x0660"),
+
+         new RegexTestCase(@"[\w-[b-y\p{Po}]]+", "!#bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+
+        new RegexTestCase(@"[\w-[b-y!.,]]+", "!.,bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+        new RegexTestCase("[\\w-[b-y\x00-\x0F]]+", "\0bbbaaaABCD09zzzyyy","aaaABCD09zzz"),
+
+        new RegexTestCase(@"[\p{Ll}-[ae-z0-9]]+", "09aaabbbcccdddeee","bbbcccddd"),
+        new RegexTestCase(@"[\p{Nd}-[2468az]]+", "az20135798","013579"),
+
+        new RegexTestCase(@"[\P{Lu}-[ae-zA-Z]]+", "AZaaabbbcccdddeee","bbbcccddd"),
+        new RegexTestCase(@"[\P{Nd}-[\p{Ll}0123456789]]+", "09az09AZ'[]","AZ'[]"),
+
+        /****************************************************************************
+        (A - B) B only contains chars that are not in A
+        *****************************************************************************/
+        new RegexTestCase(@"[abc-[defg]]+", "dddaabbccddd", "aabbcc"),
+
+         new RegexTestCase(@"[\d-[abc]]+", "abc09abc","09"),
+         new RegexTestCase(@"[\d-[a-zA-Z]]+", "az09AZ","09"),
+         new RegexTestCase(@"[\d-[\p{Ll}]]+", "az09az","09"),
+
+         new RegexTestCase(@"[\w-[\x00-\x0F]]+", "bbbaaaABYZ09zzzyyy","bbbaaaABYZ09zzzyyy"),
+
+         new RegexTestCase(@"[\w-[\s]]+", "0AZaz9","0AZaz9"),
+         new RegexTestCase(@"[\w-[\W]]+", "0AZaz9","0AZaz9"),
+         new RegexTestCase(@"[\w-[\p{Po}]]+", "#a09AZz!","a09AZz"),
+
+        new RegexTestCase(@"[\d-[\D]]+", RegexOptions.ECMAScript, "azAZ1024689", "1024689"),
+        new RegexTestCase(@"[\d-[a-zA-Z]]+", RegexOptions.ECMAScript, "azAZ\x066102468\x0660", "02468"),
+        new RegexTestCase(@"[\d-[\p{Ll}]]+", "\x066102468\x0660", "\x066102468\x0660"),
+
+         new RegexTestCase(@"[a-zA-Z0-9-[\s]]+", " \tazAZ09","azAZ09"),
+
+        new RegexTestCase(@"[a-zA-Z0-9-[\W]]+", "bbbaaaABCD09zzzyyy","bbbaaaABCD09zzzyyy"),
+        new RegexTestCase(@"[a-zA-Z0-9-[^a-zA-Z0-9]]+", "bbbaaaABCD09zzzyyy","bbbaaaABCD09zzzyyy"),
+
+        new RegexTestCase(@"[\p{Ll}-[A-Z]]+", "AZaz09","az"),
+        new RegexTestCase(@"[\p{Nd}-[a-z]]+", "az09","09"),
+
+        new RegexTestCase(@"[\P{Lu}-[\p{Lu}]]+", "AZazAZ","az"),
+        new RegexTestCase(@"[\P{Lu}-[A-Z]]+", "AZazAZ","az"),
+        new RegexTestCase(@"[\P{Nd}-[\p{Nd}]]+", "azAZ09","azAZ"),
+        new RegexTestCase(@"[\P{Nd}-[2-8]]+", "1234567890azAZ1234567890","azAZ"),
+
+        /****************************************************************************
+        (A - B) A and B are the same sets
+        *****************************************************************************/
+        //No Negation
+        new RegexTestCase(@"[abcd-[abcd]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[1234-[1234]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        //All Negation
+        new RegexTestCase(@"[^abcd-[^abcd]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^1234-[^1234]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+
+        //No Negation        
+        new RegexTestCase(@"[a-z-[a-z]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[0-9-[0-9]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        //All Negation
+        new RegexTestCase(@"[^a-z-[^a-z]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^0-9-[^0-9]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+
+        //No Negation
+        new RegexTestCase(@"[\w-[\w]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\W-[\W]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\s-[\s]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\S-[\S]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\d-[\d]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\D-[\D]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        //All Negation
+        new RegexTestCase(@"[^\w-[^\w]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\W-[^\W]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\s-[^\s]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\S-[^\S]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\d-[^\d]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\D-[^\D]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        //MixedNegation
+        new RegexTestCase(@"[^\w-[\W]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\w-[^\W]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\s-[\S]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\s-[^\S]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\d-[\D]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\d-[^\D]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+
+        //No Negation
+        new RegexTestCase(@"[\p{Ll}-[\p{Ll}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\P{Ll}-[\P{Ll}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\p{Lu}-[\p{Lu}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\P{Lu}-[\P{Lu}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\p{Nd}-[\p{Nd}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\P{Nd}-[\P{Nd}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        //All Negation
+        new RegexTestCase(@"[^\p{Ll}-[^\p{Ll}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\P{Ll}-[^\P{Ll}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\p{Lu}-[^\p{Lu}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\P{Lu}-[^\P{Lu}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\p{Nd}-[^\p{Nd}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\P{Nd}-[^\P{Nd}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        //MixedNegation
+        new RegexTestCase(@"[^\p{Ll}-[\P{Ll}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\p{Ll}-[^\P{Ll}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\p{Lu}-[\P{Lu}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\p{Lu}-[^\P{Lu}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[^\p{Nd}-[\P{Nd}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+        new RegexTestCase(@"[\p{Nd}-[^\P{Nd}]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n"),
+
+        /****************************************************************************
+        Alternating construct
+        *****************************************************************************/
+        new RegexTestCase(@"([ ]|[\w-[0-9]])+", "09az AZ90", "az AZ", "Z"),
+        new RegexTestCase(@"([0-9-[02468]]|[0-9-[13579]])+", "az1234567890za", "1234567890", "0"),
+        new RegexTestCase(@"([^0-9-[a-zAE-Z]]|[\w-[a-zAF-Z]])+", "azBCDE1234567890BCDEFza", "BCDE1234567890BCDE", "E"),
+        new RegexTestCase("([\u0000-\uFFFF-[azAZ09]]|[\u0000-\uFFFF-[^azAZ09]])+", "azAZBCDE1234567890BCDEFAZza", "azAZBCDE1234567890BCDEFAZza", "a"),
+        new RegexTestCase(@"([\p{Ll}-[aeiou]]|[^\w-[\s]])+", "aeiobcdxyz!@#aeio", "bcdxyz!@#", "#"),
+
+        /****************************************************************************
+        Multiple characater classes using character class subtraction
+        *****************************************************************************/
+        new RegexTestCase(@"98[\d-[9]][\d-[8]][\d-[0]]", "98911 98881 98870 98871", "98871"),
+        new RegexTestCase(@"m[\w-[^aeiou]][\w-[^aeiou]]t", "mbbt mect meet", "meet"),
+
+        /****************************************************************************
+        Nested character class subtraction
+        *****************************************************************************/
+        new RegexTestCase("[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]+",
+            "abcxyzABCXYZ123890", "bcxyzABCXYZ123890"),
+        new RegexTestCase("[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]]+",
+            "bcxyzABCXYZ123890a", "a"),
+
+
+        /****************************************************************************
+        Negation with character class subtraction
+        *****************************************************************************/
+        new RegexTestCase("[abcdef-[^bce]]+", "adfbcefda", "bce"),
+        new RegexTestCase("[^cde-[ag]]+", "agbfxyzga", "bfxyz"),
+
+
+        /****************************************************************************
+        Misc The idea here is come up with real world examples of char class subtraction. Things that
+        would be difficult to define without it
+        *****************************************************************************/
+        new RegexTestCase("[\u0000-\uFFFF-[\\p{P}\\p{S}\\p{C}]]+", "!@`';.,$+<>=\x0001\x001FazAZ09", "azAZ09"),
+        new RegexTestCase(@"[\p{L}-[^\p{Lu}]]+", "09',.abcxyzABCXYZ", "ABCXYZ"),
+
+        new RegexTestCase(@"[\p{IsGreek}-[\P{Lu}]]+", "\u0390\u03FE\u0386\u0388\u03EC\u03EE\u0400", "\u03FE\u0386\u0388\u03EC\u03EE"),
+        new RegexTestCase(@"[\p{IsBasicLatin}-[G-L]]+", "GAFMZL", "AFMZ"),
+
+        new RegexTestCase(@"[a-zA-Z-[aeiouAEIOU]]+", "aeiouAEIOUbcdfghjklmnpqrstvwxyz", "bcdfghjklmnpqrstvwxyz"),
+
+        //The following is an overly complex way of matching an ip address using char class subtraction
+        new RegexTestCase(@"^
+        (?<octet>^
+            (
+                (
+                    (?<Octet2xx>[\d-[013-9]])
+                    |
+                    [\d-[2-9]]
+                )
+                (?(Octet2xx)
+                    (
+                        (?<Octet25x>[\d-[01-46-9]])
+                        |
+                        [\d-[5-9]]
+                    )
+                    (
+                        (?(Octet25x)
+                            [\d-[6-9]]
+                            |
+                            [\d]
+                        )
+                    )
+                    |
+                    [\d]{2}
+                )
+            )
+            |
+            ([\d][\d])
+            |
+            [\d]
+        )$"
+        , RegexOptions.IgnorePatternWhitespace, "255",  "255", "255", "2", "5", "5", "", "255", "2", "5"),
+
+        new RegexTestCase(@"^
+        (?<octet>
+            (
+                (
+                    (?<Octet2xx>[\d-[013-9]])
+                    |
+                    [\d-[2-9]]
+                )
+                (?(Octet2xx)
+                    (
+                        (?<Octet25x>[\d-[01-46-9]])
+                        |
+                        [\d-[5-9]]
+                    )
+                    (
+                        (?(Octet25x)
+                            [\d-[6-9]]
+                            |
+                            [\d]
+                        )
+                    )
+                    |
+                    [\d]{2}
+                )
+            )
+            |
+            ([\d][\d])
+            |
+            [\d]
+        )$"
+        , RegexOptions.IgnorePatternWhitespace, "256"),
+
+        new RegexTestCase(@"^
+        (?<octet>
+            (
+                (
+                    (?<Octet2xx>[\d-[013-9]])
+                    |
+                    [\d-[2-9]]
+                )
+                (?(Octet2xx)
+                    (
+                        (?<Octet25x>[\d-[01-46-9]])
+                        |
+                        [\d-[5-9]]
+                    )
+                    (
+                        (?(Octet25x)
+                            [\d-[6-9]]
+                            |
+                            [\d]
+                        )
+                    )
+                    |
+                    [\d]{2}
+                )
+            )
+            |
+            ([\d][\d])
+            |
+            [\d]
+        )$"
+        , RegexOptions.IgnorePatternWhitespace, "261"),
+
+
+        /****************************************************************************
+        Parser Correctness
+        *****************************************************************************/
+        //Character Class Substraction
+        new RegexTestCase(@"[abcd\-d-[bc]]+", "bbbaaa---dddccc", "aaa---ddd"),
+        new RegexTestCase(@"[abcd\-d-[bc]]+", "bbbaaa---dddccc", "aaa---ddd"),
+        new RegexTestCase(@"[^a-f-[\x00-\x60\u007B-\uFFFF]]+", "aaafffgggzzz{{{", "gggzzz"),
+        new RegexTestCase(@"[a-f-[]]+", typeof(ArgumentException)),
+        new RegexTestCase(@"[\[\]a-f-[[]]+", "gggaaafff]]][[[", "aaafff]]]"),
+        new RegexTestCase(@"[\[\]a-f-[]]]+", "gggaaafff[[[]]]", "aaafff[[["),
+
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "a]]", "a]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "b]]", "b]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "c]]", "c]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "d]]", "d]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "[]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "-]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "`]]"),
+        new RegexTestCase(@"[ab\-\[cd-[-[]]]]", "e]]"),
+
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "a]]", "a]]"),
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "b]]", "b]]"),
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "c]]", "c]]"),
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "d]]", "d]]"),
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "-]]", "-]]"),
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "']]"),
+        new RegexTestCase(@"[ab\-\[cd-[[]]]]", "e]]"),
+
+        new RegexTestCase(@"[a-[a-f]]", "abcdefghijklmnopqrstuvwxyz"),
+        new RegexTestCase(@"[a-[c-e]]+", "bbbaaaccc", "aaa"),
+        new RegexTestCase(@"[a-[c-e]]+", "```aaaccc", "aaa"),
+
+        new RegexTestCase(@"[a-d\--[bc]]+", "cccaaa--dddbbb", "aaa--ddd"),
+
+        //NOT Character Class Substraction
+        new RegexTestCase(@"[\0- [bc]+", "!!!\0\0\t\t  [[[[bbbcccaaa", "\0\0\t\t  [[[[bbbccc"),
+        new RegexTestCase(@"[[abcd]-[bc]]+", "a-b]", "a-b]"),
+        new RegexTestCase(@"[-[e-g]+", "ddd[[[---eeefffggghhh", "[[[---eeefffggg"),
+        new RegexTestCase(@"[-e-g]+", "ddd---eeefffggghhh", "---eeefffggg"),
+        new RegexTestCase(@"[-e-g]+", "ddd---eeefffggghhh", "---eeefffggg"),
+        new RegexTestCase(@"[a-e - m-p]+", "---a b c d e m n o p---", "a b c d e m n o p"),
+        new RegexTestCase(@"[^-[bc]]", "b] c] -] aaaddd]", "d]"),
+        new RegexTestCase(@"[^-[bc]]", "b] c] -] aaa]ddd]", "a]"),
+        new RegexTestCase(@"[A-[]+", typeof(ArgumentException)),
+
+        //Make sure we correctly handle \-
+        new RegexTestCase(@"[a\-[bc]+", "```bbbaaa---[[[cccddd", "bbbaaa---[[[ccc"),
+        new RegexTestCase(@"[a\-[\-\-bc]+", "```bbbaaa---[[[cccddd", "bbbaaa---[[[ccc"),
+        new RegexTestCase(@"[a\-\[\-\[\-bc]+", "```bbbaaa---[[[cccddd", "bbbaaa---[[[ccc"),
+        new RegexTestCase(@"[abc\--[b]]+", "[[[```bbbaaa---cccddd", "aaa---ccc"),
+        new RegexTestCase(@"[abc\-z-[b]]+", "```aaaccc---zzzbbb", "aaaccc---zzz"),
+        new RegexTestCase(@"[a-d\-[b]+", "```aaabbbcccddd----[[[[]]]", "aaabbbcccddd----[[[["),
+        new RegexTestCase(@"[abcd\-d\-[bc]+", "bbbaaa---[[[dddccc", "bbbaaa---[[[dddccc"),
+
+        //Everything works correctly with option RegexOptions.IgnorePatternWhitespace
+        new RegexTestCase(@"[a - c - [ b ] ]+", RegexOptions.IgnorePatternWhitespace, "dddaaa   ccc [[[[ bbb ]]]", " ]]]"),
+        new RegexTestCase(@"[a - c - [ b ] +", RegexOptions.IgnorePatternWhitespace, "dddaaa   ccc [[[[ bbb ]]]", "aaa   ccc [[[[ bbb "),
+    };
+}

--- a/src/System.Text.RegularExpressions/tests/EscapeUnescapeTests.cs
+++ b/src/System.Text.RegularExpressions/tests/EscapeUnescapeTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class EscapeUnescapeTests
+{
+    /*
+    Tested Methods:
+    
+        public static String Escape(String str);     round tripping "#$^*+(){}<>\\|. "
+
+        public static String Unescape(string str); 
+
+    */
+
+    [Fact]
+    public static void EscapeUnescape()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String s1;
+        String s2;
+        String s3;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static String Escape(String str);     round tripping "#$^*+(){}<>\\|. "
+            //    public static String Unescape(string str); 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            s1 = "#$^*+(){}<>\\|. ";
+            s2 = Regex.Escape(s1);
+            s3 = Regex.Unescape(s2);
+            if (!s1.Equals(s3))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/GroupNamesAndNumbers.cs
+++ b/src/System.Text.RegularExpressions/tests/GroupNamesAndNumbers.cs
@@ -1,0 +1,698 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class GroupNamesAndNumber
+{
+    /*
+    Tested Methods:
+    
+        public string[] GetGroupNames();
+
+        public int[] GetGroupNumbers();    
+
+        public string GroupNameFromNumber(int i);
+
+        public int GroupNumberFromName(string name);
+
+    */
+
+    [Fact]
+    public static void GroupNamesAndNumberTestCase()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        String s;
+        String[] expectedNames;
+        String[] expectedGroups;
+        int[] expectedNumbers;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            //[]Vanilla
+            s = "Ryan Byington";
+            r = new Regex("(?<first_name>\\S+)\\s(?<last_name>\\S+)");
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "first_name", "last_name"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "Ryan Byington", "Ryan", "Byington"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_79793asdwk! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_12087ahas! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_08712saopz! Unexpected Groups");
+            }
+
+            //[]RegEx from SDK
+            s = "abc208923xyzanqnakl";
+            r = new Regex(@"((?<One>abc)\d+)?(?<Two>xyz)(.*)");
+            strLoc = "Loc_0822aws";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "1", "2", "One", "Two"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2, 3, 4
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "abc208923xyzanqnakl", "abc208923", "anqnakl", "abc", "xyz"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_79793asdwk! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_12087ahas! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_0822klas! Unexpected Groups");
+            }
+
+            //[]RegEx with numeric names
+            s = "0272saasdabc8978xyz][]12_+-";
+            r = new Regex(@"((?<256>abc)\d+)?(?<16>xyz)(.*)");
+            strLoc = "Loc_0982asd";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "1", "2", "16", "256"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2, 16, 256
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "abc8978xyz][]12_+-", "abc8978", "][]12_+-", "xyz", "abc"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_79793asdwk! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_12087ahas! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7072ankla! Unexpected Groups");
+            }
+
+            //[]RegEx with numeric names and string names
+            s = "0272saasdabc8978xyz][]12_+-";
+            r = new Regex(@"((?<4>abc)(?<digits>\d+))?(?<2>xyz)(?<everything_else>.*)");
+            strLoc = "Loc_98968asdf";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "1", "2", "digits", "4", "everything_else"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2, 3, 4, 5
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "abc8978xyz][]12_+-", "abc8978", "xyz", "8978", "abc", "][]12_+-"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9496sad! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6984awsd! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7072ankla! Unexpected Groups");
+            }
+
+            //[]RegEx with 0 numeric names
+            try
+            {
+                r = new Regex(@"foo(?<0>bar)");
+                iCountErrors++;
+                Console.WriteLine("Err_16891 Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9877sawa Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx without closing >
+            try
+            {
+                r = new Regex(@"foo(?<1bar)");
+                iCountErrors++;
+                Console.WriteLine("Err_2389uop Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3298asoia Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[] Duplicate string names
+            s = "Ryan Byington";
+            r = new Regex("(?<first_name>\\S+)\\s(?<first_name>\\S+)");
+            strLoc = "Loc_sdfa9849";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "first_name"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "Ryan Byington", "Byington"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_32189asdd! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7978assd! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_98732soiya! Unexpected Groups");
+            }
+
+            //[] Duplicate numeric names
+            s = "Ryan Byington";
+            r = new Regex("(?<15>\\S+)\\s(?<15>\\S+)");
+            strLoc = "Loc_89198asda";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "15"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 15
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "Ryan Byington", "Byington"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_97654awwa! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6498asde! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_316jkkl! Unexpected Groups");
+            }
+
+            /******************************************************************
+            Repeat the same steps from above but using (?'foo') instead
+            ******************************************************************/
+            //[]Vanilla
+            s = "Ryan Byington";
+            r = new Regex("(?'first_name'\\S+)\\s(?'last_name'\\S+)");
+            strLoc = "Loc_0982aklpas";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "first_name", "last_name"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "Ryan Byington", "Ryan", "Byington"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_464658safsd! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_15689asda! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_31568kjkj! Unexpected Groups");
+            }
+
+            //[]RegEx from SDK
+            s = "abc208923xyzanqnakl";
+            r = new Regex(@"((?'One'abc)\d+)?(?'Two'xyz)(.*)");
+            strLoc = "Loc_98977uouy";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "1", "2", "One", "Two"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2, 3, 4
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "abc208923xyzanqnakl", "abc208923", "anqnakl", "abc", "xyz"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_65498yuiy! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_5698yuiyh! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2168hkjh! Unexpected Groups");
+            }
+
+            //[]RegEx with numeric names
+            s = "0272saasdabc8978xyz][]12_+-";
+            r = new Regex(@"((?'256'abc)\d+)?(?'16'xyz)(.*)");
+            strLoc = "Loc_9879hjly";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "1", "2", "16", "256"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2, 16, 256
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "abc8978xyz][]12_+-", "abc8978", "][]12_+-", "xyz", "abc"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_21689hjkh! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2689juj! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2358adea! Unexpected Groups");
+            }
+
+            //[]RegEx with numeric names and string names
+            s = "0272saasdabc8978xyz][]12_+-";
+            r = new Regex(@"((?'4'abc)(?'digits'\d+))?(?'2'xyz)(?'everything_else'.*)");
+            strLoc = "Loc_23189uioyp";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "1", "2", "digits", "4", "everything_else"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1, 2, 3, 4, 5
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "abc8978xyz][]12_+-", "abc8978", "xyz", "8978", "abc", "][]12_+-"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3219hjkj! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_23189aseq! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2318adew! Unexpected Groups");
+            }
+
+            //[]RegEx with 0 numeric names
+            try
+            {
+                r = new Regex(@"foo(?'0'bar)");
+                iCountErrors++;
+                Console.WriteLine("Err_16891 Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9877sawa Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx without closing >
+            try
+            {
+                r = new Regex(@"foo(?'1bar)");
+                iCountErrors++;
+                Console.WriteLine("Err_979asja Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_16889asdfw Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[] Duplicate string names
+            s = "Ryan Byington";
+            r = new Regex("(?'first_name'\\S+)\\s(?'first_name'\\S+)");
+            strLoc = "Loc_2318opa";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "first_name"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 1
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "Ryan Byington", "Byington"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_28978adfe! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3258adsw! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2198asd! Unexpected Groups");
+            }
+
+            //[] Duplicate numeric names
+            s = "Ryan Byington";
+            r = new Regex("(?'15'\\S+)\\s(?'15'\\S+)");
+            strLoc = "Loc_3289hjaa";
+            iCountTestcases++;
+            expectedNames = new String[]
+            {
+            "0", "15"
+            }
+
+            ;
+            expectedNumbers = new int[]
+            {
+            0, 15
+            }
+
+            ;
+            expectedGroups = new String[]
+            {
+            "Ryan Byington", "Byington"
+            }
+
+            ;
+            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_13289asd! Unexpected GroupNames");
+            }
+
+            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_23198asdf! Unexpected GroupNumbers");
+            }
+
+            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_15689teraku! Unexpected Groups");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static bool VerifyGroupNames(Regex r, String[] expectedNames, int[] expectedNumbers)
+    {
+        string[] names = r.GetGroupNames();
+        if (names.Length != expectedNames.Length)
+        {
+            Console.WriteLine("Err_08722aswa! Expect {0} names actual={1}", expectedNames.Length, names.Length);
+            return false;
+        }
+
+        for (int i = 0; i < expectedNames.Length; i++)
+        {
+            if (!names[i].Equals(expectedNames[i]))
+            {
+                Console.WriteLine("Err_09878asfas! Expected GroupNames[{0}]={1} actual={2}", i, expectedNames[i], names[i]);
+                return false;
+            }
+
+            if (expectedNames[i] != r.GroupNameFromNumber(expectedNumbers[i]))
+            {
+                Console.WriteLine("Err_6589sdafn!GroupNameFromNumber({0})={1} actual={2}", expectedNumbers[i], expectedNames[i], r.GroupNameFromNumber(expectedNumbers[i]));
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool VerifyGroupNumbers(Regex r, String[] expectedNames, int[] expectedNumbers)
+    {
+        int[] numbers = r.GetGroupNumbers();
+        if (numbers.Length != expectedNumbers.Length)
+        {
+            Console.WriteLine("Err_7978awoyp! Expect {0} numbers actual={1}", expectedNumbers.Length, numbers.Length);
+            return false;
+        }
+
+        for (int i = 0; i < expectedNumbers.Length; i++)
+        {
+            if (numbers[i] != expectedNumbers[i])
+            {
+                Console.WriteLine("Err_4342asnmc! Expected GroupNumbers[{0}]={1} actual={2}", i, expectedNumbers[i], numbers[i]);
+                return false;
+            }
+
+            if (expectedNumbers[i] != r.GroupNumberFromName(expectedNames[i]))
+            {
+                Console.WriteLine("Err_98795ajkas!GroupNumberFromName({0})={1} actual={2}", expectedNames[i], expectedNumbers[i], r.GroupNumberFromName(expectedNames[i]));
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool VerifyGroups(Regex r, String s, String[] expectedGroups, String[] expectedNames, int[] expectedNumbers)
+    {
+        Match m = r.Match(s);
+        Group g;
+        if (!m.Success)
+        {
+            Console.WriteLine("Err_08220kha Match not a success");
+            return false;
+        }
+
+        if (m.Groups.Count != expectedGroups.Length)
+        {
+            Console.WriteLine("Err_9722asqa! Expect {0} groups actual={1}", expectedGroups.Length, m.Groups.Count);
+            return false;
+        }
+
+        for (int i = 0; i < expectedNumbers.Length; i++)
+        {
+            if (null == (g = m.Groups[expectedNames[i]]) || expectedGroups[i] != g.Value)
+            {
+                Console.WriteLine("Err_3327nkoo! Expected Groups[{0}]={1} actual={2}", expectedNames[i], expectedGroups[i], g == null ? "<null>" : g.Value);
+                return false;
+            }
+
+            if (null == (g = m.Groups[expectedNumbers[i]]) || expectedGroups[i] != g.Value)
+            {
+                Console.WriteLine("Err_9465sdjh! Expected Groups[{0}]={1} actual={2}", expectedNumbers[i], expectedGroups[i], g == null ? "<null>" : g.Value);
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/IsMatchMatchSplitTests.cs
+++ b/src/System.Text.RegularExpressions/tests/IsMatchMatchSplitTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class IsMatchMatchSplitTests
+{
+    /*
+    Tested Methods:
+    
+
+        public static Boolean IsMatch() variants
+
+        public static Match Match(string input, String pattern, String options);     "abc","[aBc]","i"
+
+        public static String[] Split(string input, String pattern, String options);     "[abc]", "i"
+            "1A2B3C4"
+    */
+
+    [Fact]
+    public static void IsMatchMatchSplit()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String s;
+        String[] sa;
+        String[] saExp1 =
+        {
+        "a", "b", "c"
+        }
+
+        ;
+        String[] saExp2 =
+        {
+        "1", "2", "3", "4"
+        }
+
+        ;
+        int i = 0;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Boolean IsMatch() variants
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            if (!Regex.IsMatch("abc", "abc"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+
+            if (!Regex.IsMatch("abc", "aBc", RegexOptions.IgnoreCase))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7432rwe! doesnot match");
+            }
+
+            if (!Regex.IsMatch("abc", "aBc", RegexOptions.IgnoreCase))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7432rwe! doesnot match");
+            }
+
+            strLoc = "Loc_0003";
+            iCountTestcases++;
+            // [] Scenario 3 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            s = "1A2B3C4";
+            sa = Regex.Split(s, "[abc]", RegexOptions.IgnoreCase);
+            for (i = 0; i < sa.Length; i++)
+            {
+                if (!saExp2[i].Equals(sa[i]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_452wfdf! doesnot match");
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/R2LGetGroupNamesMatchTests.cs
+++ b/src/System.Text.RegularExpressions/tests/R2LGetGroupNamesMatchTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class R2LGetGroupNamesMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Boolean RightToLeft;     
+
+        public static String[] GetGroupNames();     "(?<first_name>\\S+)\\s(?<last_name>\\S+)"
+
+        public static Match Match(string input);     
+            "David Bau"
+
+        public static Boolean IsMatch(string input);     //D+
+            "12321"
+
+    */
+
+    [Fact]
+    public static void R2LGetGroupNamesMatch()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        String s;
+        String[] names;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            s = "David Bau";
+            r = new Regex("(?<first_name>\\S+)\\s(?<last_name>\\S+)");
+            // [] public static String[] GetGroupNames();     "(?<first_name>\\S+)\\s(?<last_name>\\S+)"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            names = r.GetGroupNames();
+            if (!names[0].Equals("0"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! unexpected result");
+            }
+
+            if (!names[1].Equals("first_name"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! unexpected result");
+            }
+
+            if (!names[2].Equals("last_name"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! unexpected result");
+            }
+
+            // [] public static Match Match(string input); 
+            //"David Bau"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563sdfg";
+            iCountTestcases++;
+            m = r.Match(s);
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+
+            // [] public static Match Match(string input); 
+            //"David Bau"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            s = "12321";
+            r = new Regex(@"\D+");
+            if (r.IsMatch(s))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_fsdf! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexComponentsSplitTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexComponentsSplitTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RegexComponentsSplitTests
+{
+    [Fact]
+    public static void RegexComponentsSplit()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            for (int i = 0; i < s_regexTests.Length; i++)
+            {
+                iCountTestcases++;
+                if (!s_regexTests[i].Run())
+                {
+                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2}\n", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
+                    iCountErrors++;
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private static RegexComponentsSplitTestCase[] s_regexTests = new RegexComponentsSplitTestCase[]
+    {
+        /*********************************************************
+            ValidCases
+            *********************************************************/
+    new RegexComponentsSplitTestCase(@"(\s)?(-)", "once -upon-a time", new String[]
+    {
+    "once", " ", "-", "upon", "-", "a time"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"(\s)?(-)", "once upon a time", new String[]
+    {
+    "once upon a time"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"(\s)?(-)", "once - -upon- a- time", new String[]
+    {
+    "once", " ", "-", "", " ", "-", "upon", "-", " a", "-", " time"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", "123abcde456aBCDe789", new String[]
+    {
+    "123", "b", "d", "456aBCDe789"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.IgnoreCase, "123abcde456aBCDe789", new String[]
+    {
+    "123", "b", "d", "456", "B", "D", "789"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", "123abcde456aBCDe789", new String[]
+    {
+    "123", "d", "b", "456aBCDe789"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.IgnoreCase, "123abcde456aBCDe789", new String[]
+    {
+    "123", "d", "b", "456", "D", "B", "789"
+    }
+
+    ), /*********************************************************
+        RightToLeft
+        *********************************************************/
+new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.RightToLeft, "123abcde456aBCDe789", new String[]
+    {
+    "123", "d", "b", "456aBCDe789"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, "123abcde456aBCDe789", new String[]
+    {
+    "123", "d", "b", "456", "D", "B", "789"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.RightToLeft, "123abcde456aBCDe789", new String[]
+    {
+    "123", "b", "d", "456aBCDe789"
+    }
+
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.RightToLeft | RegexOptions.IgnoreCase, "123abcde456aBCDe789", new String[]
+    {
+    "123", "b", "d", "456", "B", "D", "789"
+    }
+
+    ), }
+
+    ;
+    public class RegexComponentsSplitTestCase
+    {
+        private String _pattern;
+        private String _input;
+        private RegexOptions _options;
+        private String[] _expectedResult;
+        public RegexComponentsSplitTestCase(String pattern, String input, String[] expectedResult)
+            : this(pattern, RegexOptions.None, input, expectedResult)
+        {
+        }
+
+        public RegexComponentsSplitTestCase(String pattern, RegexOptions options, String input, String[] expectedResult)
+        {
+            _pattern = pattern;
+            _options = options;
+            _input = input;
+            _expectedResult = expectedResult;
+        }
+
+        public string Pattern
+        {
+            get
+            {
+                return _pattern;
+            }
+        }
+
+        public string Input
+        {
+            get
+            {
+                return _input;
+            }
+        }
+
+        public RegexOptions Options
+        {
+            get
+            {
+                return _options;
+            }
+        }
+
+        public String[] ExpectedResult
+        {
+            get
+            {
+                return _expectedResult;
+            }
+        }
+
+        public bool ExpectSuccess
+        {
+            get
+            {
+                return null != _expectedResult && _expectedResult.Length != 0;
+            }
+        }
+
+        public bool Run()
+        {
+            Regex r;
+            String[] result = null;
+            r = new Regex(_pattern, _options);
+            try
+            {
+                result = r.Split(_input);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Err_78394ayuua! Expected no exception to be thrown and the following was thrown: \n{0}", e);
+                return false;
+            }
+
+            if (result.Length != _expectedResult.Length)
+            {
+                Console.WriteLine("Err_13484pua! Expected string[].Length and actual differ expected={0} actual={1}", _expectedResult.Length, result.Length);
+                return false;
+            }
+
+            for (int i = 0; i < _expectedResult.Length; i++)
+            {
+                if (result[i] != _expectedResult[i])
+                {
+                    Console.WriteLine("Err_6897nzxn! Expected result and actual result differ expected='{0}' actual='{1}' at {2}", _expectedResult[i], result[i], i);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexConstructorTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexConstructorTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RegexConstructorTests
+{
+    [Fact]
+    public static void RegexConstructor()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            //[]RegEx with null expression
+            strLoc = "Loc_sdfa9849";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex(null, RegexOptions.None);
+                iCountErrors++;
+                Console.WriteLine("Err_16891 Expected Regex to throw ArgumentNullException and nothing was thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9877sawa Expected Regex to throw ArgumentNullException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with negative RegexOptions
+            strLoc = "Loc_3198sdf";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", (RegexOptions)(-1));
+                iCountErrors++;
+                Console.WriteLine("Err_2389asfd Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_898asdf Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with to high RegexOptions
+            strLoc = "Loc_23198awd";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", (RegexOptions)0x400);
+                iCountErrors++;
+                Console.WriteLine("Err_1238sadw Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6579asdf Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with ECMA RegexOptions with all other valid options
+            strLoc = "Loc_3198sdf";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_97878dsaw Expected Regex not to throw and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with ECMA RegexOptions with all other valid options plus RirghtToLeft
+            strLoc = "Loc_9875asd";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.RightToLeft);
+                iCountErrors++;
+                Console.WriteLine("Err_9789swd Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9489sdjk Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with ECMA RegexOptions with all other valid options plus ExplicitCapture
+            strLoc = "Loc_54864jhlt";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
+                iCountErrors++;
+                Console.WriteLine("Err_6556jhkj Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2189jhss Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with ECMA RegexOptions with all other valid options plus Singleline
+            strLoc = "Loc_9891asfes";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+                iCountErrors++;
+                Console.WriteLine("Err_3156add Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_456hjhj Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+
+            //[]RegEx with ECMA RegexOptions with all other valid options plus IgnorePatternWhitespace
+            strLoc = "Loc_23889asddf";
+            iCountTestcases++;
+            try
+            {
+                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace);
+                iCountErrors++;
+                Console.WriteLine("Err_3568sdae Expected Regex to throw ArgumentException and nothing was thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4657dsacd Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexLangElementsCoverageTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexLangElementsCoverageTests.cs
@@ -1,0 +1,794 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using System.Globalization;
+using Xunit;
+
+public class RegexLangElementsCoverageTests
+{
+    // This class mainly exists to hit language elements that were missed in other test cases.
+    [Fact]
+    public static void RegexLangElementsCoverage()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        long startWorkingSet = 0, endWorkingSet;
+        double percentDifference;
+        double maxAcceptablePercentDifference = .3;
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            //AppDomain.CurrentDomain.AssemblyLoad += AssemblyLoadEventHandler;
+
+            for (int i = 0; i < s_regexTests.Length; i++)
+            {
+                try
+                {
+                    iCountTestcases++;
+                    if (!s_regexTests[i].Run())
+                    {
+                        Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2}\n", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
+                        iCountErrors++;
+                    }
+
+                    if (i == 0)
+                    {
+                        startWorkingSet = GC.GetTotalMemory(true);
+                        Console.WriteLine("GC.GetTotalMemory={0}", startWorkingSet);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2} threw the following exception:", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
+                    Console.WriteLine(e);
+                    iCountErrors++;
+                }
+            }
+
+            endWorkingSet = GC.GetTotalMemory(true);
+            Console.WriteLine("GC.GetTotalMemory={0}", endWorkingSet);//This should be relatively close to the previous value printed out.
+            //On my machine in Whidbey the difference was of about 3%
+            //In Everett the difference was over 100%
+
+            percentDifference = ((double)Math.Abs(startWorkingSet - endWorkingSet)) / startWorkingSet;
+
+            if (maxAcceptablePercentDifference < percentDifference)
+            {
+                Console.WriteLine("Err_004888anied Total memory increased significantly there may be a memory leak");
+                Console.WriteLine("Percent Difference={0}, Max Acceptable Percent Difference={1}, Start Working Set={2}, End Working Set={3}",
+                    percentDifference, maxAcceptablePercentDifference, startWorkingSet, endWorkingSet);
+                iCountErrors++;
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+
+    //private const int GERMAN_PHONEBOOK = 0x10407;
+    //private const int ENGLISH_US = 0x0409;
+    //private const int INVARIANT = 0x007F;
+    //private const int CZECH = 0x0405;
+    //private const int DANISH = 0x0406;
+    //private const int TURKISH = 0x041F;
+    //private const int LATIN_AZERI = 0x042C;
+    private static CultureInfo _GERMAN_PHONEBOOK = new CultureInfo("de-DE");
+    private static CultureInfo _ENGLISH_US = new CultureInfo("en-US");
+    private static CultureInfo _INVARIANT = new CultureInfo("");
+    private static CultureInfo _CZECH = new CultureInfo("cs-CZ");
+    private static CultureInfo _DANISH = new CultureInfo("da-DK");
+    private static CultureInfo _TURKISH = new CultureInfo("tr-TR");
+    private static CultureInfo _LATIN_AZERI = new CultureInfo("az-Latn-AZ");
+
+    private static RegexTestCase[] s_regexTests = new RegexTestCase[] {
+
+        /*********************************************************
+        Unicode Char Classes
+        *********************************************************/
+        new RegexTestCase(@"(\p{Lu}\w*)\s(\p{Lu}\w*)", "Hello World", new string[] {"Hello World", "Hello", "World"}),
+        new RegexTestCase(@"(\p{Lu}\p{Ll}*)\s(\p{Lu}\p{Ll}*)", "Hello World", new string[] {"Hello World", "Hello", "World"}),
+        new RegexTestCase(@"(\P{Ll}\p{Ll}*)\s(\P{Ll}\p{Ll}*)", "Hello World", new string[] {"Hello World", "Hello", "World"}),
+        new RegexTestCase(@"(\P{Lu}+\p{Lu})\s(\P{Lu}+\p{Lu})", "hellO worlD", new string[] {"hellO worlD", "hellO", "worlD"}),
+        new RegexTestCase(@"(\p{Lt}\w*)\s(\p{Lt}*\w*)", "\u01C5ello \u01C5orld", new string[] {"\u01C5ello \u01C5orld", "\u01C5ello", "\u01C5orld"}),
+        new RegexTestCase(@"(\P{Lt}\w*)\s(\P{Lt}*\w*)", "Hello World", new string[] {"Hello World", "Hello", "World"}),
+
+
+        /*********************************************************
+            Character ranges IgnoreCase
+        *********************************************************/
+        new RegexTestCase(@"[@-D]+", RegexOptions.IgnoreCase, "eE?@ABCDabcdeE", new string[] {"@ABCDabcd"}),
+        new RegexTestCase(@"[>-D]+", RegexOptions.IgnoreCase, "eE=>?@ABCDabcdeE", new string[] {">?@ABCDabcd"}),
+        new RegexTestCase(@"[\u0554-\u0557]+", RegexOptions.IgnoreCase, "\u0583\u0553\u0554\u0555\u0556\u0584\u0585\u0586\u0557\u0558", new string[] {"\u0554\u0555\u0556\u0584\u0585\u0586\u0557"}),
+        new RegexTestCase(@"[X-\]]+", RegexOptions.IgnoreCase, "wWXYZxyz[\\]^", new string[] {"XYZxyz[\\]"}),
+        new RegexTestCase(@"[X-\u0533]+", RegexOptions.IgnoreCase, "\u0551\u0554\u0560AXYZaxyz\u0531\u0532\u0533\u0561\u0562\u0563\u0564", new string[] {"AXYZaxyz\u0531\u0532\u0533\u0561\u0562\u0563"}),
+        new RegexTestCase(@"[X-a]+", RegexOptions.IgnoreCase, "wWAXYZaxyz", new string[] {"AXYZaxyz"}),
+        new RegexTestCase(@"[X-c]+", RegexOptions.IgnoreCase, "wWABCXYZabcxyz", new string[] {"ABCXYZabcxyz"}),
+        new RegexTestCase(@"[X-\u00C0]+", RegexOptions.IgnoreCase, "\u00C1\u00E1\u00C0\u00E0wWABCXYZabcxyz", new string[] {"\u00C0\u00E0wWABCXYZabcxyz"}),
+        new RegexTestCase(@"[\u0100\u0102\u0104]+", RegexOptions.IgnoreCase, "\u00FF \u0100\u0102\u0104\u0101\u0103\u0105\u0106", new string[] {"\u0100\u0102\u0104\u0101\u0103\u0105"}),
+        new RegexTestCase(@"[B-D\u0130]+", RegexOptions.IgnoreCase, "aAeE\u0129\u0131\u0068 BCDbcD\u0130\u0069\u0070", new string[] {"BCDbcD\u0130\u0069"}),
+        new RegexTestCase(@"[\u013B\u013D\u013F]+", RegexOptions.IgnoreCase, "\u013A\u013B\u013D\u013F\u013C\u013E\u0140\u0141", new string[] {"\u013B\u013D\u013F\u013C\u013E\u0140"}),
+        new RegexTestCase(@"[\uFFFD-\uFFFF]+", RegexOptions.IgnoreCase, "\uFFFC\uFFFD\uFFFE\uFFFF", new string[] {"\uFFFD\uFFFE\uFFFF"}),
+        new RegexTestCase(@"[\uFFFC-\uFFFE]+", RegexOptions.IgnoreCase, "\uFFFB\uFFFC\uFFFD\uFFFE\uFFFF", new string[] {"\uFFFC\uFFFD\uFFFE"}),
+
+
+
+        /*********************************************************
+            Escape Chars
+            *********************************************************/
+        new RegexTestCase("(Cat)\r(Dog)", "Cat\rDog", new string[] {"Cat\rDog", "Cat", "Dog"}),
+        new RegexTestCase("(Cat)\t(Dog)", "Cat\tDog", new string[] {"Cat\tDog", "Cat", "Dog"}),
+        new RegexTestCase("(Cat)\f(Dog)", "Cat\fDog", new string[] {"Cat\fDog", "Cat", "Dog"}),
+
+
+        /*********************************************************
+            Miscelaneous { witout matching }
+            *********************************************************/
+        new RegexTestCase(@"\p{klsak", typeof(ArgumentException)),
+        new RegexTestCase(@"{5", "hello {5 world", new string[] {"{5"}),
+        new RegexTestCase(@"{5,", "hello {5, world", new string[] {"{5,"}),
+        new RegexTestCase(@"{5,6", "hello {5,6 world", new string[] {"{5,6"}),
+
+
+        /*********************************************************
+            Miscelaneous inline options
+            *********************************************************/
+        new RegexTestCase(@"(?r:cat)", typeof(ArgumentException)),
+        new RegexTestCase(@"(?c:cat)", typeof(ArgumentException)),
+        new RegexTestCase(@"(?n:(?<cat>cat)(\s+)(?<dog>dog))", "cat   dog", new string[] {"cat   dog", "cat", "dog"}),
+        new RegexTestCase(@"(?n:(cat)(\s+)(dog))", "cat   dog", new string[] {"cat   dog"}),
+        new RegexTestCase(@"(?n:(cat)(?<SpaceChars>\s+)(dog))", "cat   dog", new string[] {"cat   dog", "   "}),
+        new RegexTestCase(@"(?x:
+                            (?<cat>cat) # Cat statement
+                            (\s+) # Whitespace chars
+                            (?<dog>dog # Dog statement
+                            ))", "cat   dog", new string[] {"cat   dog", "   ",  "cat", "dog"}),
+        new RegexTestCase(@"(?e:cat)", typeof(ArgumentException)),
+        new RegexTestCase(@"(?+i:cat)", "CAT", new string[] {"CAT"}),
+
+
+        /*********************************************************
+            \d, \D, \s, \S, \w, \W, \P, \p inside character range 
+            *********************************************************/
+        new RegexTestCase(@"cat([\d]*)dog", "hello123cat230927dog1412d", new string[] {"cat230927dog", "230927"}),
+        new RegexTestCase(@"([\D]*)dog", "65498catdog58719", new string[] {"catdog", "cat"}),
+        new RegexTestCase(@"cat([\s]*)dog", "wiocat   dog3270", new string[] {"cat   dog", "   "}),
+        new RegexTestCase(@"cat([\S]*)", "sfdcatdog    3270", new string[] {"catdog", "dog"}),
+        new RegexTestCase(@"cat([\w]*)", "sfdcatdog    3270", new string[] {"catdog", "dog"}),
+        new RegexTestCase(@"cat([\W]*)dog", "wiocat   dog3270", new string[] {"cat   dog", "   "}),
+        new RegexTestCase(@"([\p{Lu}]\w*)\s([\p{Lu}]\w*)", "Hello World", new string[] {"Hello World", "Hello", "World"}),
+        new RegexTestCase(@"([\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", "Hello World", new string[] {"Hello World", "Hello", "World"}),
+
+        new RegexTestCase(@"cat([a-\d]*)dog", typeof(ArgumentException)),
+        new RegexTestCase(@"([5-\D]*)dog", typeof(ArgumentException)),
+        new RegexTestCase(@"cat([6-\s]*)dog", typeof(ArgumentException)),
+        new RegexTestCase(@"cat([c-\S]*)", typeof(ArgumentException)),
+        new RegexTestCase(@"cat([7-\w]*)", typeof(ArgumentException)),
+        new RegexTestCase(@"cat([a-\W]*)dog", typeof(ArgumentException)),
+        new RegexTestCase(@"([f-\p{Lu}]\w*)\s([\p{Lu}]\w*)", typeof(ArgumentException)),
+        new RegexTestCase(@"([1-\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", typeof(ArgumentException)),
+        new RegexTestCase(@"[\p]", typeof(ArgumentException)),
+        new RegexTestCase(@"[\P]", typeof(ArgumentException)),
+        new RegexTestCase(@"([\pcat])", typeof(ArgumentException)),
+        new RegexTestCase(@"([\Pcat])", typeof(ArgumentException)),
+        new RegexTestCase(@"(\p{", typeof(ArgumentException)),
+        new RegexTestCase(@"(\p{Ll", typeof(ArgumentException)),
+
+
+
+        /*********************************************************
+            \x, \u, \a, \b, \e, \f, \n, \r, \t, \v, \c, inside character range 
+            *********************************************************/
+       new RegexTestCase(@"(cat)([\x41]*)(dog)", "catAAAdog", new String[] {"catAAAdog", "cat", "AAA", "dog"}),
+       new RegexTestCase(@"(cat)([\u0041]*)(dog)", "catAAAdog", new String[] {"catAAAdog", "cat", "AAA", "dog"}),
+       new RegexTestCase(@"(cat)([\a]*)(dog)", "cat\a\a\adog", new String[] {"cat\a\a\adog", "cat", "\a\a\a", "dog"}),
+       new RegexTestCase(@"(cat)([\b]*)(dog)", "cat\b\b\bdog", new String[] {"cat\b\b\bdog", "cat", "\b\b\b", "dog"}),
+       new RegexTestCase(@"(cat)([\e]*)(dog)", "cat\u001B\u001B\u001Bdog", new String[] {"cat\u001B\u001B\u001Bdog", "cat", "\u001B\u001B\u001B", "dog"}),
+       new RegexTestCase(@"(cat)([\f]*)(dog)", "cat\f\f\fdog", new String[] {"cat\f\f\fdog", "cat", "\f\f\f", "dog"}),
+       new RegexTestCase(@"(cat)([\r]*)(dog)", "cat\r\r\rdog", new String[] {"cat\r\r\rdog", "cat", "\r\r\r", "dog"}),
+       new RegexTestCase(@"(cat)([\v]*)(dog)", "cat\v\v\vdog", new String[] {"cat\v\v\vdog", "cat", "\v\v\v", "dog"}),
+       new RegexTestCase(@"(cat)([\o]*)(dog)", typeof(ArgumentException)),
+
+
+        /*********************************************************
+        \d, \D, \s, \S, \w, \W, \P, \p inside character range ([0-5]) with ECMA Option
+        *********************************************************/
+       new RegexTestCase(@"cat([\d]*)dog", RegexOptions.ECMAScript, "hello123cat230927dog1412d", new string[] {"cat230927dog", "230927"}),
+       new RegexTestCase(@"([\D]*)dog", RegexOptions.ECMAScript, "65498catdog58719", new string[] {"catdog", "cat"}),
+       new RegexTestCase(@"cat([\s]*)dog", RegexOptions.ECMAScript, "wiocat   dog3270", new string[] {"cat   dog", "   "}),
+       new RegexTestCase(@"cat([\S]*)", RegexOptions.ECMAScript, "sfdcatdog    3270", new string[] {"catdog", "dog"}),
+       new RegexTestCase(@"cat([\w]*)", RegexOptions.ECMAScript, "sfdcatdog    3270", new string[] {"catdog", "dog"}),
+       new RegexTestCase(@"cat([\W]*)dog", RegexOptions.ECMAScript, "wiocat   dog3270", new string[] {"cat   dog", "   "}),
+       new RegexTestCase(@"([\p{Lu}]\w*)\s([\p{Lu}]\w*)", RegexOptions.ECMAScript, "Hello World", new string[] {"Hello World", "Hello", "World"}),
+       new RegexTestCase(@"([\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", RegexOptions.ECMAScript, "Hello World", new string[] {"Hello World", "Hello", "World"}),
+
+        /*********************************************************
+        \d, \D, \s, \S, \w, \W, \P, \p outside character range ([0-5]) with ECMA Option
+        *********************************************************/
+       new RegexTestCase(@"(cat)\d*dog", RegexOptions.ECMAScript, "hello123cat230927dog1412d", new string[] {"cat230927dog", "cat"}),
+       new RegexTestCase(@"\D*(dog)", RegexOptions.ECMAScript, "65498catdog58719", new string[] {"catdog", "dog"}),
+       new RegexTestCase(@"(cat)\s*(dog)", RegexOptions.ECMAScript, "wiocat   dog3270", new string[] {"cat   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\S*", RegexOptions.ECMAScript, "sfdcatdog    3270", new string[] {"catdog", "cat"}),
+       new RegexTestCase(@"(cat)\w*", RegexOptions.ECMAScript, "sfdcatdog    3270", new string[] {"catdog", "cat"}),
+       new RegexTestCase(@"(cat)\W*(dog)", RegexOptions.ECMAScript, "wiocat   dog3270", new string[] {"cat   dog", "cat", "dog"}),
+       new RegexTestCase(@"\p{Lu}(\w*)\s\p{Lu}(\w*)", RegexOptions.ECMAScript, "Hello World", new string[] {"Hello World", "ello", "orld"}),
+       new RegexTestCase(@"\P{Ll}\p{Ll}*\s\P{Ll}\p{Ll}*", RegexOptions.ECMAScript, "Hello World", new string[] {"Hello World"}),
+
+        /*********************************************************
+        Use < in a group
+        *********************************************************/
+       new RegexTestCase(@"cat(?<0>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<1dog>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<dog)_*>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<dog!>)_*>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<dog >)_*>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<dog<>)_*>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<->dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?<dog121>dog)", "catcatdogdogcat", new string[] {"catdog", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s*(?<cat>dog)", "catcat    dogdogcat", new string[] {"cat    dog", "dog"}),
+       new RegexTestCase(@"(?<1>cat)\s*(?<1>dog)", "catcat    dogdogcat", new string[] {"cat    dog", "dog"}),
+       new RegexTestCase(@"(?<2048>cat)\s*(?<2048>dog)", "catcat    dogdogcat", new string[] {"cat    dog", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<dog-cat>dog)", "cat_Hello_World_dog", new string[] {"cat_Hello_World_dog", "", "_Hello_World_"}),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<-cat>dog)", "cat_Hello_World_dog", new string[] {"cat_Hello_World_dog", ""}),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<cat-cat>dog)", "cat_Hello_World_dog", new string[] {"cat_Hello_World_dog", "_Hello_World_"}),
+       new RegexTestCase(@"(?<1>cat)\w+(?<dog-1>dog)", "cat_Hello_World_dog", new string[] {"cat_Hello_World_dog", "", "_Hello_World_"}),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<2-cat>dog)", "cat_Hello_World_dog", new string[] {"cat_Hello_World_dog", "", "_Hello_World_"}),
+       new RegexTestCase(@"(?<1>cat)\w+(?<2-1>dog)", "cat_Hello_World_dog", new string[] {"cat_Hello_World_dog", "", "_Hello_World_"}),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<dog-16>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<dog-1uosn>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<dog-catdog>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<dog-()*!@>dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\w+(?<dog-0>dog)", "cat_Hello_World_dog", null),
+
+        /*********************************************************
+        Quantifiers
+        *********************************************************/
+       new RegexTestCase(@"(?<cat>cat){", "STARTcat{", new string[] {"cat{", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){fdsa", "STARTcat{fdsa", new string[] {"cat{fdsa", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){1", "STARTcat{1", new string[] {"cat{1", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){1END", "STARTcat{1END", new string[] {"cat{1END", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){1,", "STARTcat{1,", new string[] {"cat{1,", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){1,END", "STARTcat{1,END", new string[] {"cat{1,END", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){1,2", "STARTcat{1,2", new string[] {"cat{1,2", "cat"}),
+       new RegexTestCase(@"(?<cat>cat){1,2END", "STARTcat{1,2END", new string[] {"cat{1,2END", "cat"}),
+
+        /*********************************************************
+        Use (? in a group
+        *********************************************************/
+       new RegexTestCase(@"cat(?(?#COMMENT)cat)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?(?'cat'cat)dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?(?<cat>cat)dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"cat(?(?afdcat)dog)", typeof(ArgumentException)),
+
+        /*********************************************************
+        Use IgnorePatternWhitespace 
+        *********************************************************/
+       new RegexTestCase(@"(cat) #cat
+                            \s+ #followed by 1 or more whitespace
+                            (dog)  #followed by dog
+                            ", RegexOptions.IgnorePatternWhitespace, "cat    dog", new String[] {"cat    dog", "cat", "dog" }),
+       new RegexTestCase(@"(cat) #cat
+                            \s+ #followed by 1 or more whitespace
+                            (dog)  #followed by dog", RegexOptions.IgnorePatternWhitespace, "cat    dog", new String[] {"cat    dog", "cat", "dog" }),
+       new RegexTestCase(@"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace) (dog)  (?#followed by dog)",
+           RegexOptions.IgnorePatternWhitespace, "cat    dog", new String[] {"cat    dog", "cat", "dog" }),
+       new RegexTestCase(@"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace",
+           RegexOptions.IgnorePatternWhitespace, typeof(ArgumentException)),
+
+        /*********************************************************
+        Without IgnorePatternWhitespace 
+        *********************************************************/
+       new RegexTestCase(@"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace", typeof(ArgumentException)),
+
+        /*********************************************************
+        Back Reference
+        *********************************************************/
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k<cat>", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k'cat'", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\<cat>", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\'cat'", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k<1>", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k'1'", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\<1>", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\'1'", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\1", "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\1", RegexOptions.ECMAScript, "asdfcat   dogcat   dog", new string[] {"cat   dogcat", "cat", "dog"}),
+
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k<dog>", "asdfcat   dogdog   dog", new string[] {"cat   dogdog", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\2", "asdfcat   dogdog   dog", new string[] {"cat   dogdog", "cat", "dog"}),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\2", RegexOptions.ECMAScript, "asdfcat   dogdog   dog", new string[] {"cat   dogdog", "cat", "dog"}),
+
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\kcat", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k<cat2>", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k<8>cat", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k<8>cat", RegexOptions.ECMAScript, typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k8", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\k8", RegexOptions.ECMAScript, typeof(ArgumentException)),
+
+        /*********************************************************
+        Octal
+        *********************************************************/
+       new RegexTestCase(@"(cat)(\077)", "hellocat?dogworld", new string[] {"cat?", "cat", "?"}),
+       new RegexTestCase(@"(cat)(\77)", "hellocat?dogworld", new string[] {"cat?", "cat", "?"}),
+       new RegexTestCase(@"(cat)(\176)", "hellocat~dogworld", new string[] {"cat~", "cat", "~"}),
+       new RegexTestCase(@"(cat)(\400)", "hellocat\0dogworld", new string[] {"cat\0", "cat", "\0"}),
+       new RegexTestCase(@"(cat)(\300)", "hellocat\u00C0dogworld", new string[] {"cat\u00C0", "cat", "\u00C0"}),
+       new RegexTestCase(@"(cat)(\300)", "hellocat\u00C0dogworld", new string[] {"cat\u00C0", "cat", "\u00C0"}),
+       new RegexTestCase(@"(cat)(\477)", "hellocat\u003Fdogworld", new string[] {"cat\u003F", "cat", "\u003F"}),
+       new RegexTestCase(@"(cat)(\777)", "hellocat\u00FFdogworld", new string[] {"cat\u00FF", "cat", "\u00FF"}),
+       new RegexTestCase(@"(cat)(\7770)", "hellocat\u00FF0dogworld", new string[] {"cat\u00FF0", "cat", "\u00FF0"}),
+       new RegexTestCase(@"(cat)(\7)", typeof(ArgumentException)),
+
+       new RegexTestCase(@"(cat)(\077)", RegexOptions.ECMAScript, "hellocat?dogworld", new string[] {"cat?", "cat", "?"}),
+       new RegexTestCase(@"(cat)(\77)", RegexOptions.ECMAScript, "hellocat?dogworld", new string[] {"cat?", "cat", "?"}),
+       new RegexTestCase(@"(cat)(\7)", RegexOptions.ECMAScript, "hellocat\adogworld", new string[] {"cat\a", "cat", "\a"}),
+       new RegexTestCase(@"(cat)(\40)", RegexOptions.ECMAScript, "hellocat dogworld", new string[] {"cat ", "cat", " "}),
+       new RegexTestCase(@"(cat)(\040)", RegexOptions.ECMAScript, "hellocat dogworld", new string[] {"cat ", "cat", " "}),
+       new RegexTestCase(@"(cat)(\176)", RegexOptions.ECMAScript, "hellocatcat76dogworld", new string[] {"catcat76", "cat", "cat76"}),
+       new RegexTestCase(@"(cat)(\377)", RegexOptions.ECMAScript, "hellocat\u00FFdogworld", new string[] {"cat\u00FF", "cat", "\u00FF"}),
+       new RegexTestCase(@"(cat)(\400)", RegexOptions.ECMAScript, "hellocat 0Fdogworld", new string[] {"cat 0", "cat", " 0"}),
+
+        /*********************************************************
+        Decimal
+        *********************************************************/
+       new RegexTestCase(@"(cat)\s+(?<2147483646>dog)", "asdlkcat  dogiwod", new string[] {"cat  dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(?<2147483647>dog)",  "asdlkcat  dogiwod", new string[] {"cat  dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(?<2147483648>dog)", typeof(System.ArgumentException)),
+       new RegexTestCase(@"(cat)\s+(?<21474836481097>dog)", typeof(System.ArgumentException)),
+
+        /*********************************************************
+        Hex
+        *********************************************************/
+       new RegexTestCase(@"(cat)(\x2a*)(dog)", "asdlkcat***dogiwod", new string[] {"cat***dog", "cat", "***", "dog"}),
+       new RegexTestCase(@"(cat)(\x2b*)(dog)", "asdlkcat+++dogiwod", new string[] {"cat+++dog", "cat", "+++", "dog"}),
+       new RegexTestCase(@"(cat)(\x2c*)(dog)", "asdlkcat,,,dogiwod", new string[] {"cat,,,dog", "cat", ",,,", "dog"}),
+       new RegexTestCase(@"(cat)(\x2d*)(dog)", "asdlkcat---dogiwod", new string[] {"cat---dog", "cat", "---", "dog"}),
+       new RegexTestCase(@"(cat)(\x2e*)(dog)", "asdlkcat...dogiwod", new string[] {"cat...dog", "cat", "...", "dog"}),
+       new RegexTestCase(@"(cat)(\x2f*)(dog)", "asdlkcat///dogiwod", new string[] {"cat///dog", "cat", "///", "dog"}),
+
+       new RegexTestCase(@"(cat)(\x2A*)(dog)", "asdlkcat***dogiwod", new string[] {"cat***dog", "cat", "***", "dog"}),
+       new RegexTestCase(@"(cat)(\x2B*)(dog)", "asdlkcat+++dogiwod", new string[] {"cat+++dog", "cat", "+++", "dog"}),
+       new RegexTestCase(@"(cat)(\x2C*)(dog)", "asdlkcat,,,dogiwod", new string[] {"cat,,,dog", "cat", ",,,", "dog"}),
+       new RegexTestCase(@"(cat)(\x2D*)(dog)", "asdlkcat---dogiwod", new string[] {"cat---dog", "cat", "---", "dog"}),
+       new RegexTestCase(@"(cat)(\x2E*)(dog)", "asdlkcat...dogiwod", new string[] {"cat...dog", "cat", "...", "dog"}),
+       new RegexTestCase(@"(cat)(\x2F*)(dog)", "asdlkcat///dogiwod", new string[] {"cat///dog", "cat", "///", "dog"}),
+
+        /*********************************************************
+        ScanControl
+        *********************************************************/
+       new RegexTestCase(@"(cat)(\c*)(dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(cat)\c", typeof(ArgumentException)),
+       new RegexTestCase(@"(cat)(\c *)(dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(cat)(\c?*)(dog)", typeof(ArgumentException)),
+       new RegexTestCase("(cat)(\\c\0*)(dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(cat)(\c`*)(dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(cat)(\c\|*)(dog)", typeof(ArgumentException)),
+       new RegexTestCase(@"(cat)(\c\[*)(dog)", typeof(ArgumentException)),
+
+       new RegexTestCase(@"(cat)(\c@*)(dog)", "asdlkcat\0\0dogiwod", new string[] {"cat\0\0dog", "cat", "\0\0", "dog"}),
+       new RegexTestCase(@"(cat)(\cA*)(dog)", "asdlkcat\u0001dogiwod", new string[] {"cat\u0001dog", "cat", "\u0001", "dog"}),
+       new RegexTestCase(@"(cat)(\ca*)(dog)", "asdlkcat\u0001dogiwod", new string[] {"cat\u0001dog", "cat", "\u0001", "dog"}),
+
+       new RegexTestCase(@"(cat)(\cC*)(dog)", "asdlkcat\u0003dogiwod", new string[] {"cat\u0003dog", "cat", "\u0003", "dog"}),
+       new RegexTestCase(@"(cat)(\cc*)(dog)", "asdlkcat\u0003dogiwod", new string[] {"cat\u0003dog", "cat", "\u0003", "dog"}),
+
+       new RegexTestCase(@"(cat)(\cD*)(dog)", "asdlkcat\u0004dogiwod", new string[] {"cat\u0004dog", "cat", "\u0004", "dog"}),
+       new RegexTestCase(@"(cat)(\cd*)(dog)", "asdlkcat\u0004dogiwod", new string[] {"cat\u0004dog", "cat", "\u0004", "dog"}),
+
+       new RegexTestCase(@"(cat)(\cX*)(dog)", "asdlkcat\u0018dogiwod", new string[] {"cat\u0018dog", "cat", "\u0018", "dog"}),
+       new RegexTestCase(@"(cat)(\cx*)(dog)", "asdlkcat\u0018dogiwod", new string[] {"cat\u0018dog", "cat", "\u0018", "dog"}),
+
+       new RegexTestCase(@"(cat)(\cZ*)(dog)", "asdlkcat\u001adogiwod", new string[] {"cat\u001adog", "cat", "\u001a", "dog"}),
+       new RegexTestCase(@"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", new string[] {"cat\u001adog", "cat", "\u001a", "dog"}),
+
+        /*********************************************************
+        Atomic Zero-Width Assertions \A \Z \z \G \b \B
+        *********************************************************/
+        //\A
+        new RegexTestCase(@"\A(cat)\s+(dog)", "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"\A(cat)\s+(dog)", RegexOptions.Multiline, "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"\A(cat)\s+(dog)", RegexOptions.ECMAScript, "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+
+       new RegexTestCase(@"\A(cat)\s+(dog)", "cat   \n\n\ncat     dog", null),
+       new RegexTestCase(@"\A(cat)\s+(dog)", RegexOptions.Multiline, "cat   \n\n\ncat     dog", null),
+       new RegexTestCase(@"\A(cat)\s+(dog)", RegexOptions.ECMAScript, "cat   \n\n\ncat     dog", null),
+
+        //\Z
+        new RegexTestCase(@"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", RegexOptions.Multiline, "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", RegexOptions.ECMAScript, "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", RegexOptions.Multiline, "cat   \n\n\n   dog\n", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", RegexOptions.ECMAScript, "cat   \n\n\n   dog\n", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+
+       new RegexTestCase(@"(cat)\s+(dog)\Z", "cat   dog\n\n\ncat", null),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", RegexOptions.Multiline, "cat   dog\n\n\ncat     ", null),
+       new RegexTestCase(@"(cat)\s+(dog)\Z", RegexOptions.ECMAScript, "cat   dog\n\n\ncat     ", null),
+
+        //\z
+        new RegexTestCase(@"(cat)\s+(dog)\z", "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\z", RegexOptions.Multiline, "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+       new RegexTestCase(@"(cat)\s+(dog)\z", RegexOptions.ECMAScript, "cat   \n\n\n   dog", new string[] {"cat   \n\n\n   dog", "cat", "dog"}),
+
+       new RegexTestCase(@"(cat)\s+(dog)\z", "cat   dog\n\n\ncat", null),
+       new RegexTestCase(@"(cat)\s+(dog)\z", RegexOptions.Multiline, "cat   dog\n\n\ncat     ", null),
+       new RegexTestCase(@"(cat)\s+(dog)\z", RegexOptions.ECMAScript, "cat   dog\n\n\ncat     ", null),
+       new RegexTestCase(@"(cat)\s+(dog)\z", "cat   \n\n\n   dog\n", null),
+       new RegexTestCase(@"(cat)\s+(dog)\z", RegexOptions.Multiline, "cat   \n\n\n   dog\n", null),
+       new RegexTestCase(@"(cat)\s+(dog)\z", RegexOptions.ECMAScript, "cat   \n\n\n   dog\n", null),
+
+        //\b
+        new RegexTestCase(@"\b@cat", "123START123@catEND", new string[] {"@cat"}),
+       new RegexTestCase(@"\b\<cat", "123START123<catEND", new string[] {"<cat"}),
+       new RegexTestCase(@"\b,cat", "satwe,,,START,catEND", new string[] {",cat"}),
+       new RegexTestCase(@"\b\[cat", "`12START123[catEND", new string[] {"[cat"}),
+
+       new RegexTestCase(@"\b@cat", "123START123;@catEND", null),
+       new RegexTestCase(@"\b\<cat", "123START123'<catEND", null),
+       new RegexTestCase(@"\b,cat", "satwe,,,START',catEND", null),
+       new RegexTestCase(@"\b\[cat", "`12START123'[catEND", null),
+
+        //\B
+        new RegexTestCase(@"\B@cat", "123START123;@catEND", new string[] {"@cat"}),
+       new RegexTestCase(@"\B\<cat", "123START123'<catEND", new string[] {"<cat"}),
+       new RegexTestCase(@"\B,cat", "satwe,,,START',catEND", new string[] {",cat"}),
+       new RegexTestCase(@"\B\[cat", "`12START123'[catEND", new string[] {"[cat"}),
+
+       new RegexTestCase(@"\B@cat", "123START123@catEND", null),
+       new RegexTestCase(@"\B\<cat", "123START123<catEND", null),
+       new RegexTestCase(@"\B,cat", "satwe,,,START,catEND", null),
+       new RegexTestCase(@"\B\[cat", "`12START123[catEND", null),
+
+        /*********************************************************
+        \w matching \p{Lm} (Letter, Modifier)
+        *********************************************************/
+       new RegexTestCase(@"(\w+)\s+(\w+)", "cat\u02b0 dog\u02b1", new string[] {"cat\u02b0 dog\u02b1", "cat\u02b0", "dog\u02b1"}),
+       new RegexTestCase(@"(cat\w+)\s+(dog\w+)", "STARTcat\u30FC dog\u3005END", new string[] {"cat\u30FC dog\u3005END", "cat\u30FC", "dog\u3005END"}),
+       new RegexTestCase(@"(cat\w+)\s+(dog\w+)", "STARTcat\uff9e dog\uff9fEND", new string[] {"cat\uff9e dog\uff9fEND", "cat\uff9e", "dog\uff9fEND"}),
+
+        /*********************************************************
+        positive and negative character classes [a-c]|[^b-c]
+        *********************************************************/
+       new RegexTestCase(@"[^a]|d", "d", new string[] {"d"}),
+       new RegexTestCase(@"([^a]|[d])*", "Hello Worlddf", new string[] {"Hello Worlddf", "f"}),
+       new RegexTestCase(@"([^{}]|\n)+", "{{{{Hello\n World \n}END", new string[] {"Hello\n World \n", "\n"}),
+       new RegexTestCase(@"([a-d]|[^abcd])+", "\tonce\n upon\0 a- ()*&^%#time?", new string[] {"\tonce\n upon\0 a- ()*&^%#time?", "?"}),
+       new RegexTestCase(@"([^a]|[a])*", "once upon a time", new string[] {"once upon a time", "e"}),
+       new RegexTestCase(@"([a-d]|[^abcd]|[x-z]|^wxyz])+", "\tonce\n upon\0 a- ()*&^%#time?", new string[] {"\tonce\n upon\0 a- ()*&^%#time?", "?"}),
+       new RegexTestCase(@"([a-d]|[e-i]|[^e]|wxyz])+", "\tonce\n upon\0 a- ()*&^%#time?", new string[] {"\tonce\n upon\0 a- ()*&^%#time?", "?"}),
+
+        /*********************************************************
+        canonical and non-cannonical char class, where one group is in it's
+        simplist form [a-e] and another is more complex .
+        *********************************************************/
+       new RegexTestCase(@"^(([^b]+ )|(.* ))$", "aaa ", new string[] {"aaa ", "aaa ", "aaa ", ""}),
+       new RegexTestCase(@"^(([^b]+ )|(.*))$", "aaa", new string[] {"aaa", "aaa", "", "aaa"}),
+       new RegexTestCase(@"^(([^b]+ )|(.* ))$", "bbb ", new string[] {"bbb ", "bbb ", "", "bbb "}),
+       new RegexTestCase(@"^(([^b]+ )|(.*))$", "bbb", new string[] {"bbb", "bbb", "", "bbb"}),
+       new RegexTestCase(@"^((a*)|(.*))$", "aaa", new string[] {"aaa", "aaa", "aaa", ""}),
+       new RegexTestCase(@"^((a*)|(.*))$", "aaabbb", new string[] {"aaabbb", "aaabbb", "", "aaabbb"}),
+
+       new RegexTestCase(@"(([0-9])|([a-z])|([A-Z]))*", "{hello 1234567890 world}", new string[] {"", "", "", "", ""}),
+       new RegexTestCase(@"(([0-9])|([a-z])|([A-Z]))+", "{hello 1234567890 world}", new string[] {"hello", "o", "", "o", ""}),
+       new RegexTestCase(@"(([0-9])|([a-z])|([A-Z]))*", "{HELLO 1234567890 world}", new string[] {"", "", "", "", ""}),
+       new RegexTestCase(@"(([0-9])|([a-z])|([A-Z]))+", "{HELLO 1234567890 world}", new string[] {"HELLO", "O", "", "", "O"}),
+       new RegexTestCase(@"(([0-9])|([a-z])|([A-Z]))*", "{1234567890 hello  world}", new string[] {"", "", "", "", ""}),
+       new RegexTestCase(@"(([0-9])|([a-z])|([A-Z]))+", "{1234567890 hello world}", new string[] {"1234567890", "0", "0", "", ""}),
+
+       new RegexTestCase(@"^(([a-d]*)|([a-z]*))$", "aaabbbcccdddeeefff", new string[] {"aaabbbcccdddeeefff", "aaabbbcccdddeeefff", "", "aaabbbcccdddeeefff"}),
+       new RegexTestCase(@"^(([d-f]*)|([c-e]*))$", "dddeeeccceee", new string[] {"dddeeeccceee", "dddeeeccceee", "", "dddeeeccceee"}),
+       new RegexTestCase(@"^(([c-e]*)|([d-f]*))$", "dddeeeccceee", new string[] {"dddeeeccceee", "dddeeeccceee", "dddeeeccceee", ""}),
+
+       new RegexTestCase(@"(([a-d]*)|([a-z]*))", "aaabbbcccdddeeefff", new string[] {"aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", ""}),
+       new RegexTestCase(@"(([d-f]*)|([c-e]*))", "dddeeeccceee", new string[] {"dddeee", "dddeee", "dddeee", ""}),
+       new RegexTestCase(@"(([c-e]*)|([d-f]*))", "dddeeeccceee", new string[] {"dddeeeccceee", "dddeeeccceee", "dddeeeccceee", ""}),
+
+       new RegexTestCase(@"(([a-d]*)|(.*))", "aaabbbcccdddeeefff", new string[] {"aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", ""}),
+       new RegexTestCase(@"(([d-f]*)|(.*))", "dddeeeccceee", new string[] {"dddeee", "dddeee", "dddeee", ""}),
+       new RegexTestCase(@"(([c-e]*)|(.*))", "dddeeeccceee", new string[] {"dddeeeccceee", "dddeeeccceee", "dddeeeccceee", ""}),
+
+        /*********************************************************
+        \p{Pi} (Punctuation Initial quote) \p{Pf} (Punctuation Final quote)
+        *********************************************************/
+       new RegexTestCase(@"\p{Pi}(\w*)\p{Pf}", "\u00ABCat\u00BB   \u00BBDog\u00AB'", new string[] {"\u00ABCat\u00BB", "Cat"}),
+       new RegexTestCase(@"\p{Pi}(\w*)\p{Pf}", "\u2018Cat\u2019   \u2019Dog\u2018'", new string[] {"\u2018Cat\u2019", "Cat"}),
+
+
+
+        /*********************************************************
+Use special unicode characters        
+        *********************************************************/
+        /*        new RegexTest(@"AE", "\u00C4", new string[] {"Hello World", "Hello", "World"}, GERMAN_PHONEBOOK),
+                new RegexTest(@"oe", "\u00F6", new string[] {"Hello World", "Hello", "World"}, GERMAN_PHONEBOOK),
+
+                new RegexTest("\u00D1", "\u004E\u0303", new string[] {"Hello World", "Hello", "World"}, ENGLISH_US),
+                new RegexTest("\u00D1", "\u004E\u0303", new string[] {"Hello World", "Hello", "World"}, INVARIANT),        
+                new RegexTest("\u00D1", RegexOptions.IgnoreCase, "\u006E\u0303", new string[] {"Hello World", "Hello", "World"}, ENGLISH_US),
+                new RegexTest("\u00D1", RegexOptions.IgnoreCase, "\u006E\u0303", new string[] {"Hello World", "Hello", "World"}, INVARIANT),    
+
+                new RegexTest("\u00F1", RegexOptions.IgnoreCase, "\u004E\u0303", new string[] {"Hello World", "Hello", "World"}, ENGLISH_US),
+                new RegexTest("\u00F1", RegexOptions.IgnoreCase, "\u004E\u0303", new string[] {"Hello World", "Hello", "World"}, INVARIANT),        
+                new RegexTest("\u00F1", "\u006E\u0303", new string[] {"Hello World", "Hello", "World"}, ENGLISH_US),
+                new RegexTest("\u00F1", "\u006E\u0303", new string[] {"Hello World", "Hello", "World"}, ENGLISH_US),
+        */
+       new RegexTestCase("CH", RegexOptions.IgnoreCase, "Ch", new string[] {"Ch"}, _ENGLISH_US),
+       new RegexTestCase("CH", RegexOptions.IgnoreCase, "Ch", new string[] {"Ch"}, _CZECH),
+       new RegexTestCase("cH", RegexOptions.IgnoreCase, "Ch", new string[] {"Ch"}, _ENGLISH_US),
+       new RegexTestCase("cH", RegexOptions.IgnoreCase, "Ch", new string[] {"Ch"}, _CZECH),
+
+       new RegexTestCase("AA", RegexOptions.IgnoreCase, "Aa", new string[] {"Aa"}, _ENGLISH_US),
+       new RegexTestCase("AA", RegexOptions.IgnoreCase, "Aa", new string[] {"Aa"}, _DANISH),
+       new RegexTestCase("aA", RegexOptions.IgnoreCase, "Aa", new string[] {"Aa"}, _ENGLISH_US),
+       new RegexTestCase("aA", RegexOptions.IgnoreCase, "Aa", new string[] {"Aa"}, _DANISH),
+
+       new RegexTestCase("\u0131", RegexOptions.IgnoreCase, "\u0049", new string[] {"\u0049"}, _TURKISH),
+       new RegexTestCase("\u0130", RegexOptions.IgnoreCase, "\u0069", new string[] {"\u0069"}, _TURKISH),
+       new RegexTestCase("\u0131", RegexOptions.IgnoreCase, "\u0049", new string[] {"\u0049"}, _LATIN_AZERI),
+       new RegexTestCase("\u0130", RegexOptions.IgnoreCase, "\u0069", new string[] {"\u0069"}, _LATIN_AZERI),
+
+       new RegexTestCase("\u0131", RegexOptions.IgnoreCase, "\u0049", null, _ENGLISH_US),
+       new RegexTestCase("\u0131", RegexOptions.IgnoreCase, "\u0069", null, _ENGLISH_US),
+
+        new RegexTestCase("\u0130", RegexOptions.IgnoreCase, "\u0049", new string[] {"\u0049"}, _ENGLISH_US),
+        new RegexTestCase("\u0130", RegexOptions.IgnoreCase, "\u0069", new string[] {"\u0069"}, _ENGLISH_US),
+
+       new RegexTestCase("\u0131", RegexOptions.IgnoreCase, "\u0049", null, _INVARIANT),
+       new RegexTestCase("\u0131", RegexOptions.IgnoreCase, "\u0069", null, _INVARIANT),
+       new RegexTestCase("\u0130", RegexOptions.IgnoreCase, "\u0049", null, _INVARIANT),
+       new RegexTestCase("\u0130", RegexOptions.IgnoreCase, "\u0069", null, _INVARIANT),
+
+        /*********************************************************
+        ECMAScript
+        *********************************************************/
+       new RegexTestCase(@"(?<cat>cat)\s+(?<dog>dog)\s+\123\s+\234", RegexOptions.ECMAScript, "asdfcat   dog     cat23    dog34eia", new string[] {"cat   dog     cat23    dog34", "cat", "dog"}),
+
+
+        /*********************************************************
+        Balanced Mactching
+        *********************************************************/
+       new RegexTestCase(@"<div> 
+            (?> 
+                <div>(?<DEPTH>) |   
+                </div> (?<-DEPTH>) |  
+                .?
+            )*?
+            (?(DEPTH)(?!)) 
+            </div>", RegexOptions.IgnorePatternWhitespace,
+           "<div>this is some <div>red</div> text</div></div></div>",
+           new string[] {"<div>this is some <div>red</div> text</div>", ""}),
+
+       new RegexTestCase(@"(
+            ((?'open'<+)[^<>]*)+
+            ((?'close-open'>+)[^<>]*)+
+            )+", RegexOptions.IgnorePatternWhitespace,
+           "<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>",
+           new string[] {"<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>", "<02deep_03<03deep_03>>>",
+               "<03deep_03", ">>>", "<", "03deep_03"}),
+
+       new RegexTestCase(@"(
+            (?<start><)?
+            [^<>]?
+            (?<end-start>>)?
+            )*", RegexOptions.IgnorePatternWhitespace,
+           "<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>",
+           new string[] {"<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>", "", "",
+               "01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>"}),
+
+       new RegexTestCase(@"(
+            (?<start><[^/<>]*>)?
+            [^<>]?
+            (?<end-start></[^/<>]*>)?
+            )*", RegexOptions.IgnorePatternWhitespace,
+           "<b><a>Cat</a></b>",
+           new string[] {"<b><a>Cat</a></b>", "", "", "<a>Cat</a>"}),
+
+       new RegexTestCase(@"(
+            (?<start><(?<TagName>[^/<>]*)>)?
+            [^<>]?
+            (?<end-start></\k<TagName>>)?
+            )*", RegexOptions.IgnorePatternWhitespace,
+           "<b>cat</b><a>dog</a>",
+           new string[] {"<b>cat</b><a>dog</a>", "", "", "a", "dog"}),
+
+        /*********************************************************
+        Balanced Mactching With Backtracking
+        *********************************************************/
+       new RegexTestCase(@"(
+            (?<start><[^/<>]*>)?
+            .?
+            (?<end-start></[^/<>]*>)?
+            )*
+            (?(start)(?!)) ", RegexOptions.IgnorePatternWhitespace,
+           "<b><a>Cat</a></b><<<<c>>>><<d><e<f>><g><<<>>>>",
+           new string[] {"<b><a>Cat</a></b><<<<c>>>><<d><e<f>><g><<<>>>>", "", "", "<a>Cat"}),
+
+        /*********************************************************
+        Character Classes and Lazy quantifier
+        *********************************************************/
+       new RegexTestCase(@"([0-9]+?)([\w]+?)", RegexOptions.ECMAScript, "55488aheiaheiad", new string[] {"55", "5", "5"}),
+       new RegexTestCase(@"([0-9]+?)([a-z]+?)", RegexOptions.ECMAScript, "55488aheiaheiad", new string[] {"55488a", "55488", "a"}),
+
+        /*********************************************************
+        Misclaneous/Regression scenarios
+        *********************************************************/
+       new RegexTestCase(@"(?<openingtag>1)(?<content>.*?)(?=2)", RegexOptions.Singleline | RegexOptions.ExplicitCapture,
+           "1\r\n<Projecaa DefaultTargets=\"x\"/>\r\n2", new string[] {"1\r\n<Projecaa DefaultTargets=\"x\"/>\r\n", "1", "\r\n<Projecaa DefaultTargets=\"x\"/>\r\n"}),
+
+       new RegexTestCase(@"\G<%#(?<code>.*?)?%>", RegexOptions.Singleline,
+           @"<%# DataBinder.Eval(this, ""MyNumber"") %>", new string[] {@"<%# DataBinder.Eval(this, ""MyNumber"") %>", @" DataBinder.Eval(this, ""MyNumber"") "}),
+
+        /*********************************************************
+        Nested Quantifiers
+        *********************************************************/
+       new RegexTestCase(@"^[abcd]{0,0x10}*$", "a{0,0x10}}}", new string[] {"a{0,0x10}}}"}),
+       new RegexTestCase(@"^[abcd]{0,16}*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]{1,}*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]{1}*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]{0,16}?*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]{1,}?*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]{1}?*$", typeof(ArgumentException)),
+
+       new RegexTestCase(@"^[abcd]*+$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]+*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]?*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]*?+$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]+?*$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]??*$", typeof(ArgumentException)),
+
+       new RegexTestCase(@"^[abcd]*{0,5}$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]+{0,5}$", typeof(ArgumentException)),
+       new RegexTestCase(@"^[abcd]?{0,5}$", typeof(ArgumentException)),
+
+        /*********************************************************
+        Lazy operator Backtracking
+        *********************************************************/
+       new RegexTestCase(@"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/",  RegexOptions.IgnoreCase, "http://www.msn.com", null),
+       new RegexTestCase(@"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/",  RegexOptions.IgnoreCase, "http://www.msn.com/", new string[] {"http://www.msn.com/", "com", String.Empty}),
+       new RegexTestCase(@"http://([a-zA-Z0-9\-]*\.?)*?/", RegexOptions.IgnoreCase, @"http://www.google.com/", new string[] {"http://www.google.com/", "com"}),
+
+       new RegexTestCase(@"([a-z]*?)([\w])",  RegexOptions.IgnoreCase, "cat", new string[] {"c", String.Empty, "c"}),
+       new RegexTestCase(@"^([a-z]*?)([\w])$",  RegexOptions.IgnoreCase, "cat", new string[] {"cat", "ca", "t"}),
+
+        // TODO: Come up with more scenarios here
+
+        /*********************************************************
+        Backtracking
+        *********************************************************/
+       new RegexTestCase(@"([a-z]*)([\w])",  RegexOptions.IgnoreCase, "cat", new string[] {"cat", "ca", "t"}),
+       new RegexTestCase(@"^([a-z]*)([\w])$",  RegexOptions.IgnoreCase, "cat", new string[] {"cat", "ca", "t"}),
+
+        // TODO: Come up with more scenarios here
+
+        /*********************************************************
+        Character Escapes Invalid Regular Expressions
+        *********************************************************/
+       new RegexTestCase(@"\u", typeof(ArgumentException)),
+       new RegexTestCase(@"\ua", typeof(ArgumentException)),
+       new RegexTestCase(@"\u0", typeof(ArgumentException)),
+       new RegexTestCase(@"\x", typeof(ArgumentException)),
+       new RegexTestCase(@"\x2", typeof(ArgumentException)),
+
+
+        /*********************************************************
+        Character class Invalid Regular Expressions
+        *********************************************************/
+       new RegexTestCase(@"[", typeof(ArgumentException)),
+       new RegexTestCase(@"[]", typeof(ArgumentException)),
+       new RegexTestCase(@"[a", typeof(ArgumentException)),
+       new RegexTestCase(@"[^", typeof(ArgumentException)),
+       new RegexTestCase(@"[cat", typeof(ArgumentException)),
+       new RegexTestCase(@"[^cat", typeof(ArgumentException)),
+       new RegexTestCase(@"[a-", typeof(ArgumentException)),
+       new RegexTestCase(@"[a-]+", "ba-b", new string[] {"a-"}),
+       new RegexTestCase(@"\p{", typeof(ArgumentException)),
+       new RegexTestCase(@"\p{cat", typeof(ArgumentException)),
+       new RegexTestCase(@"\p{cat}", typeof(ArgumentException)),
+       new RegexTestCase(@"\P{", typeof(ArgumentException)),
+       new RegexTestCase(@"\P{cat", typeof(ArgumentException)),
+       new RegexTestCase(@"\P{cat}", typeof(ArgumentException)),
+
+        /*********************************************************
+        Quantifiers
+        *********************************************************/
+       new RegexTestCase(@"(cat){", "cat{", new string[] {"cat{", "cat"}),
+       new RegexTestCase(@"(cat){}", "cat{}", new string[] {"cat{}", "cat"}),
+       new RegexTestCase(@"(cat){,", "cat{,", new string[] {"cat{,", "cat"}),
+       new RegexTestCase(@"(cat){,}", "cat{,}", new string[] {"cat{,}", "cat"}),
+       new RegexTestCase(@"(cat){cat}", "cat{cat}", new string[] {"cat{cat}", "cat"}),
+       new RegexTestCase(@"(cat){cat,5}", "cat{cat,5}", new string[] {"cat{cat,5}", "cat"}),
+       new RegexTestCase(@"(cat){5,dog}", "cat{5,dog}", new string[] {"cat{5,dog}", "cat"}),
+       new RegexTestCase(@"(cat){cat,dog}", "cat{cat,dog}", new string[] {"cat{cat,dog}", "cat"}),
+       new RegexTestCase(@"(cat){,}?", "cat{,}?", new string[] {"cat{,}", "cat"}),
+       new RegexTestCase(@"(cat){cat}?", "cat{cat}?", new string[] {"cat{cat}", "cat"}),
+       new RegexTestCase(@"(cat){cat,5}?", "cat{cat,5}?", new string[] {"cat{cat,5}", "cat"}),
+       new RegexTestCase(@"(cat){5,dog}?", "cat{5,dog}?", new string[] {"cat{5,dog}", "cat"}),
+       new RegexTestCase(@"(cat){cat,dog}?", "cat{cat,dog}?", new string[] {"cat{cat,dog}", "cat"}),
+
+        /*********************************************************
+        Grouping Constructs Invalid Regular Expressions
+        *********************************************************/
+       new RegexTestCase(@"(", typeof(ArgumentException)),
+       new RegexTestCase(@"(?", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>", typeof(ArgumentException)),
+       new RegexTestCase(@"(?'", typeof(ArgumentException)),
+       new RegexTestCase(@"(?'cat'", typeof(ArgumentException)),
+       new RegexTestCase(@"(?:", typeof(ArgumentException)),
+       new RegexTestCase(@"(?imn", typeof(ArgumentException)),
+       new RegexTestCase(@"(?imn )", typeof(ArgumentException)),
+       new RegexTestCase(@"(?=", typeof(ArgumentException)),
+       new RegexTestCase(@"(?!", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<=", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<!", typeof(ArgumentException)),
+       new RegexTestCase(@"(?>", typeof(ArgumentException)),
+
+       new RegexTestCase(@"()", "cat", new string[] {String.Empty, String.Empty}),
+       new RegexTestCase(@"(?)", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<)", typeof(ArgumentException)),
+       new RegexTestCase(@"(?<cat>)", "cat", new string[] {String.Empty, String.Empty}),
+       new RegexTestCase(@"(?')", typeof(ArgumentException)),
+       new RegexTestCase(@"(?'cat')", "cat", new string[] {String.Empty, String.Empty}),
+       new RegexTestCase(@"(?:)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?imn)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?imn)cat", "(?imn)cat", new string[] {"cat"}),
+       new RegexTestCase(@"(?=)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?!)", "(?!)cat"),
+       new RegexTestCase(@"(?<=)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?<!)", "(?<!)cat"),
+       new RegexTestCase(@"(?>)", "cat", new string[] {String.Empty}),
+
+        /*********************************************************
+        Grouping Constructs Invalid Regular Expressions
+        *********************************************************/
+       new RegexTestCase(@"\1", typeof(ArgumentException)),
+       new RegexTestCase(@"\1", typeof(ArgumentException)),
+       new RegexTestCase(@"\k", typeof(ArgumentException)),
+       new RegexTestCase(@"\k<", typeof(ArgumentException)),
+       new RegexTestCase(@"\k<1", typeof(ArgumentException)),
+       new RegexTestCase(@"\k<cat", typeof(ArgumentException)),
+       new RegexTestCase(@"\k<>", typeof(ArgumentException)),
+
+        /*********************************************************
+        Alternation construct Invalid Regular Expressions
+        *********************************************************/
+       new RegexTestCase(@"(?(", typeof(ArgumentException)),
+       new RegexTestCase(@"(?()|", typeof(ArgumentException)),
+       new RegexTestCase(@"(?()|)", "(?()|)", new string[] {""}),
+
+       new RegexTestCase(@"(?(cat", typeof(ArgumentException)),
+       new RegexTestCase(@"(?(cat)|", typeof(ArgumentException)),
+
+       new RegexTestCase(@"(?(cat)|)", "cat", new string[] {""}),
+       new RegexTestCase(@"(?(cat)|)", "dog", new string[] {""}),
+
+       new RegexTestCase(@"(?(cat)catdog|)", "catdog", new string[] {"catdog"}),
+       new RegexTestCase(@"(?(cat)catdog|)", "dog", new string[] {""}),
+       new RegexTestCase(@"(?(cat)dog|)", "dog", new string[] {""}),
+       new RegexTestCase(@"(?(cat)dog|)", "cat", new string[] {""}),
+
+       new RegexTestCase(@"(?(cat)|catdog)", "cat", new string[] {""}),
+       new RegexTestCase(@"(?(cat)|catdog)", "catdog", new string[] {""}),
+       new RegexTestCase(@"(?(cat)|dog)", "dog", new string[] {"dog"}),
+       new RegexTestCase(@"(?(cat)|dog)", "oof"),
+
+        /*********************************************************
+        Empty Match
+        *********************************************************/
+       new RegexTestCase(@"([a*]*)+?$", "ab", new string[] {"", ""}),
+       new RegexTestCase(@"(a*)+?$", "b", new string[] {"", ""}),
+    };
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests0.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests0.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input, string pattern);     Testing \B special character escape
+            "adfadsfSUCCESSadsfadsf", ".*\\B(SUCCESS)\\B.*"
+
+        public static Match Match(string input, string pattern);     Testing octal sequence matches
+            "011", "\\060(\\061)?\\061" 
+
+        public static Match Match(string input, string pattern);     Testing hexadecimal sequence matches
+            "012", "(\\x30\\x31\\x32)"
+
+        public static Match Match(string input, string pattern);     Testing control character escapes???
+            "2", "(\u0032)"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase0()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Match match;
+        String s;
+        String strMatch1 = "adfadsfSUCCESSadsfadsf";
+        Int32[] iMatch1 =
+        {
+        0, 22
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "adfadsfSUCCESSadsfadsf", "SUCCESS"
+        }
+
+        ;
+        Int32[] iGroup1 =
+        {
+        7, 7
+        }
+
+        ;
+        String[] strGrpCap1 =
+        {
+        "SUCCESS"
+        }
+
+        ;
+        Int32[,] iGrpCap1 =
+        {
+        {
+        7, 7
+        }
+        }
+
+        ;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input, string pattern);     Testing \B special character escape
+            //"adfadsfSUCCESSadsfadsf", ".*\\B(SUCCESS)\\B.*"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            match = Regex.Match("adfadsfSUCCESSadsfadsf", @".*\B(SUCCESS)\B.*");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7356wgd! Fail Do not found a match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[0]) || (match.Groups[i].Length != iGroup1[1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[0], iGroup1[1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[j, 0]) || (match.Groups[i].Captures[j].Length != iGrpCap1[j, 1]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "!! unexpected return result, Value = {0}, Index = {1}, Length = {2}", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input, string pattern);     Testing octal sequence matches
+            //"011", "\\060(\\061)?\\061"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            //Octal \061 is ASCII 49
+            match = Regex.Match("011", @"\060(\061)?\061");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_576trffg! Do not found octal sequence match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input, string pattern);     Testing hexadecimal sequence matches
+            //"012", "(\\x30\\x31\\x32)"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            //Hex \x31 is ASCII 49
+            match = Regex.Match("012", @"(\x30\x31\x32)");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_674tgdg! Do not found hexadecimal sequence match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input, string pattern);     Testing control character escapes???
+            //"2", "(\u0032)"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_743gf";
+            iCountTestcases++;
+            s = "4"; // or "\u0034"
+            match = Regex.Match(s, "(\u0034)");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4532gvfs! Do not found unicode character match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error: Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests1.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests1.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+
+        public static Match Match(string input);     Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
+            "ab.cc"
+
+        public static Match Match(string input);     Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
+            "aaabb.cc"
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase1()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strMatch1 = "aaabb.cc";
+        Int32[] iMatch1 =
+        {
+        0, 8
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "aaabb.cc", "bb.c", "c"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 8
+        }
+
+        , {
+        3, 4
+        }
+
+        , {
+        7, 1
+        }
+        }
+
+        ;
+        //This could be a rectangular array
+        String[,] strGrpCap1 =
+        {
+        {
+        "aaabb.cc"
+        }
+
+        , {
+        "bb.c"
+        }
+
+        , {
+        "c"
+        }
+        }
+
+        ;
+        Int32[,,] iGrpCap1 =
+        {
+        {
+        {
+        0, 8
+        }
+        }
+
+        , {
+        {
+        3, 4
+        }
+        }
+
+        , {
+        {
+        7, 1
+        }
+        }
+        }
+
+        ;
+        Regex r;
+        Match match;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
+            //"ab.cc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex(@"a+\.?b*\.+c{2}");
+            match = r.Match("ab.cc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4532gvfs! 1 do not match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
+            //"aaabb.cc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("^aaa(bb.+)(d|c)$");
+            match = r.Match("aaabb.cc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7563rfsgf! 2 do not match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 3)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i, j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i, j, 0]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i, j, 1]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i, j], iGrpCap1[i, j, 0], iGrpCap1[i, j, 1]);
+                        }
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests10.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests10.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input); First testing pattern "abcabc" : Actual    "(abc){2}"
+            " !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas &  100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?"
+
+        public static Match Match(string input); Searching for numeric characters : Actual    "[0-9]"
+            "12345asdfasdfasdfljkhsda67890"
+
+        public static Match Match(string input); Different pattern specification. This time range of symbols is allowed. : Actual    "[a-z0-9]+"
+            "[token1]? GARBAGEtoken2GARBAGE ;token3!"
+
+        public static Match Match(string input); Trying empty string. : Actual    "[a-z0-9]+"
+            ""
+
+    */
+
+    [Fact]
+    public static void MatchTestCase10()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        String s;
+        Int32 i;
+        Int32[] iaExp1 =
+        {
+        0, 1, 2, 3, 4, 24, 25, 26, 27, 28
+        }
+
+        ;
+        String[] saExp2 =
+        {
+        "token1", "token2", "token3"
+        }
+
+        ;
+        Int32[] iaExp2 =
+        {
+        1, 17, 32
+        }
+
+        ;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input); First testing pattern "abcabc" : Actual    "(abc){2}"
+            //" !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas & 100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex("(abc){2}");
+            s = " !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas & 100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?";
+            for (m = r.Match(s); m.Success; m = m.NextMatch())
+            {
+                if (!m.Groups[0].ToString().Equals("abcabc") && ((m.Groups[0].Index != 2) || (m.Groups[0].Index != 125)))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_234fsadg! doesnot match");
+                }
+            }
+
+            // [] public static Match Match(string input); Searching for numeric characters : Actual    "[0-9]"
+            //"12345asdfasdfasdfljkhsda67890"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("[0-9]");
+            s = "12345asdfasdfasdfljkhsda67890";
+            i = 0;
+            for (m = r.Match(s); m.Success; m = m.NextMatch(), i++)
+            {
+                if (!Char.IsDigit(m.Groups[0].Value[0]) || m.Groups[0].Index != iaExp1[i])
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_234fsadg! doesnot match " + m.Groups[0].Index);
+                }
+            }
+
+            // [] public static Match Match(string input); Different pattern specification. This time range of symbols is allowed. : Actual    "[a-z0-9]+"
+            //"[token1]? GARBAGEtoken2GARBAGE ;token3!"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex("[a-z0-9]+");
+            s = "[token1]? GARBAGEtoken2GARBAGE ;token3!";
+            i = 0;
+            for (m = r.Match(s); m.Success; m = m.NextMatch(), i++)
+            {
+                if (!m.Groups[0].ToString().Equals(saExp2[i]) || m.Groups[0].Index != iaExp2[i])
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_452wfdf! doesnot match " + m.Groups[0].ToString() + " " + m.Groups[0].Index);
+                }
+            }
+
+            // [] Scenario 4 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex("[a-z0-9]+");
+            m = r.Match("");
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_865rfsg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests11.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests11.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Numbering pattern slots: "(?< 1>\\d{3})(?< 2>\\d{3})(?< 3>\\d{4})"
+            "8885551111"
+
+        public static Match Match(string input);     Not naming pattern slots at all: "^(cat|chat)"
+            "cats are bad"
+
+        public static Match Match(string input);      "([0-9]+(\\.[0-9]+){3})"
+            "209.25.0.111"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase11()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        Match match;
+        String s;
+        String strMatch1 = "209.25.0.111";
+        Int32[] iMatch1 =
+        {
+        0, 12
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "209.25.0.111", "209.25.0.111", ".111"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 12
+        }
+
+        , {
+        0, 12
+        }
+
+        , {
+        8, 4
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[3][];
+        strGrpCap1[0] = new String[]
+        {
+        "209.25.0.111"
+        }
+
+        ;
+        strGrpCap1[1] = new String[]
+        {
+        "209.25.0.111"
+        }
+
+        ;
+        strGrpCap1[2] = new String[]
+        {
+        ".25", ".0", ".111"
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[3][];
+        iGrpCap1[0] = new Int32[]
+        {
+        0, 12
+        }
+
+        ; //This is ignored
+        iGrpCap1[1] = new Int32[]
+        {
+        0, 12
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        iGrpCap1[2] = new Int32[]
+        {
+        3, 6, 8, 3, 2, 4
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        Int32[] iGrpCapCnt1 =
+        {
+        1, 1, 3
+        }
+
+        ; //0 is ignored
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Numbering pattern slots: "(?<1>\\d{3})(?<2>\\d{3})(?<3>\\d{4})"
+            //"8885551111"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            s = "8885551111";
+            r = new Regex(@"(?<1>\d{3})(?<2>\d{3})(?<3>\d{4})");
+            m = r.Match(s);
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+
+            s = "Invalid string";
+            m = r.Match(s);
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_764efdg! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     Not naming pattern slots at all: "^(cat|chat)"
+            //"cats are bad"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("^(cat|chat)");
+            m = r.Match("cats are bad");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+
+            // [] public static Match Match(string input);      "([0-9]+(\\.[0-9]+){3})"
+            //"209.25.0.111"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            s = "209.25.0.111";
+            r = new Regex(@"([0-9]+(\.[0-9]+){3})");
+            match = r.Match(s);
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 3)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt1[i]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt1[i]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests2.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests2.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Using [a-z], \s, \w : Actual - "([a-zA-Z]+)\\s(\\w+)"
+            "David Bau"
+
+        public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)"
+            "Price: 5 dollars"
+
+        public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "[^0-9]+(\\d+)"
+            "Price: 30 dollars"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase2()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        Match match;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Using [a-z], \s, \w : Actual - "([a-zA-Z]+)\\s(\\w+)"
+            //"David Bau"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex(@"([a-zA-Z]+)\s(\w+)");
+            match = r.Match("David Bau");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7563rfsgf! doesnot match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)"
+            //"Price: 5 dollars"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex(@"(\S+):\W(\d+)\s(\D+)");
+            m = r.Match("Price: 5 dollars");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_75erfdg! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "[^0-9]+(\\d+)"
+            //"Price: 30 dollars"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex(@"[^0-9]+(\d+)");
+            m = r.Match("Price: 30 dollars");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_5743rfsfg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests3.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests3.cs
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Using greedy quantifiers : Actual - "(a+)(b*)(c?)"
+            "aaabbbccc"
+
+        public static Match Match(string input);     Using lazy quantifiers: Actual - "(d+?)(e*?)(f??)"
+            "dddeeefff"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase3()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match match;
+        String strMatch1 = "aaabbbc";
+        Int32[] iMatch1 =
+        {
+        0, 7
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "aaabbbc", "aaa", "bbb", "c"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 7
+        }
+
+        , {
+        0, 3
+        }
+
+        , {
+        3, 3
+        }
+
+        , {
+        6, 1
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[4][];
+        strGrpCap1[0] = new String[]
+        {
+        "aaabbbc"
+        }
+
+        ;
+        strGrpCap1[1] = new String[]
+        {
+        "aaa"
+        }
+
+        ;
+        strGrpCap1[2] = new String[]
+        {
+        "bbb"
+        }
+
+        ;
+        strGrpCap1[3] = new String[]
+        {
+        "c"
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[4][];
+        iGrpCap1[0] = new Int32[]
+        {
+        5, 9, 3, 3
+        }
+
+        ; //This is ignored
+        iGrpCap1[1] = new Int32[]
+        {
+        0, 3
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        iGrpCap1[2] = new Int32[]
+        {
+        3, 3
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        iGrpCap1[3] = new Int32[]
+        {
+        6, 1
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        String strMatch2 = "d";
+        Int32[] iMatch2 =
+        {
+        0, 1
+        }
+
+        ;
+        String[] strGroup2 =
+        {
+        "d", "d", String.Empty, String.Empty
+        }
+
+        ;
+        Int32[,] iGroup2 =
+        {
+        {
+        0, 1
+        }
+
+        , {
+        0, 1
+        }
+
+        , {
+        1, 0
+        }
+
+        , {
+        1, 0
+        }
+        }
+
+        ;
+        String[][] strGrpCap2 = new String[4][];
+        strGrpCap2[0] = new String[]
+        {
+        "d"
+        }
+
+        ;
+        strGrpCap2[1] = new String[]
+        {
+        "d"
+        }
+
+        ;
+        strGrpCap2[2] = new String[]
+        {
+        String.Empty
+        }
+
+        ;
+        strGrpCap2[3] = new String[]
+        {
+        String.Empty
+        }
+
+        ;
+        Int32[][] iGrpCap2 = new Int32[4][];
+        iGrpCap2[0] = new Int32[]
+        {
+        0, 1
+        }
+
+        ; //This is ignored
+        iGrpCap2[1] = new Int32[]
+        {
+        0, 1
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        iGrpCap2[2] = new Int32[]
+        {
+        1, 0
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        iGrpCap2[3] = new Int32[]
+        {
+        1, 0
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Using greedy quantifiers : Actual - "(a+)(b*)(c?)"
+            //"aaabbbccc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex("(a+)(b*)(c?)");
+            match = r.Match("aaabbbccc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_5743rfsfg! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 4)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Using lazy quantifiers: Actual - "(d+?)(e*?)(f??)"
+            //"dddeeefff"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            //Interesting match from this pattern and input. If needed to go to the end of the string change the ? to + in the last lazy quantifier
+            r = new Regex("(d+?)(e*?)(f??)");
+            match = r.Match("dddeeefff");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_78653refgs! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 4)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_873gfsg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_845sgds_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_2075egg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests4.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests4.cs
@@ -1,0 +1,384 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Noncapturing group : Actual - "(a+)(?:b*)(ccc)"
+            "aaabbbccc"
+
+        public static Match Match(string input);     Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+"
+            "abcXXXdef"
+
+        public static Match Match(string input);     Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+"
+            "abcXXXdef" - Negative
+
+        public static Match Match(string input);     Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<  =  XXX ) def "
+            " abcXXXdef "
+        public  static  Match  Match ( string  input ) ; Zero-width  negative  lookbehind  assertion :  Actual - " ( \ \ w ) { 6 } ( ? < ! XXX ) def "
+            " XXXabcdef "
+        public  static  Match  Match ( string  input ) ; Nonbacktracking  subexpression :  Actual - " [ ^ 0 - 9 ] + ( ?>[0-9]+)3"
+            "abc123"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase4()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match match;
+        String strMatch1 = "aaabbbccc";
+        Int32[] iMatch1 =
+        {
+        0, 9
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "aaabbbccc", "aaa", "ccc"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 9
+        }
+
+        , {
+        0, 3
+        }
+
+        , {
+        6, 3
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[3][];
+        strGrpCap1[0] = new String[]
+        {
+        "aaabbbccc"
+        }
+
+        ;
+        strGrpCap1[1] = new String[]
+        {
+        "aaa"
+        }
+
+        ;
+        strGrpCap1[2] = new String[]
+        {
+        "ccc"
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[3][];
+        iGrpCap1[0] = new Int32[]
+        {
+        5, 9
+        }
+
+        ; //This is ignored
+        iGrpCap1[1] = new Int32[]
+        {
+        0, 3
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        iGrpCap1[2] = new Int32[]
+        {
+        6, 3
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        String strMatch2 = "abcXXXdef";
+        Int32[] iMatch2 =
+        {
+        0, 9
+        }
+
+        ;
+        String[] strGroup2 =
+        {
+        "abcXXXdef"
+        }
+
+        ;
+        Int32[,] iGroup2 =
+        {
+        {
+        0, 9
+        }
+        }
+
+        ;
+        String[][] strGrpCap2 = new String[1][];
+        strGrpCap2[0] = new String[]
+        {
+        "abcXXXdef"
+        }
+
+        ;
+        Int32[][] iGrpCap2 = new Int32[1][];
+        iGrpCap2[0] = new Int32[]
+        {
+        0, 9
+        }
+
+        ; //This is ignored
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Noncapturing group : Actual - "(a+)(?:b*)(ccc)"
+            //"aaabbbccc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex("(a+)(?:b*)(ccc)");
+            match = r.Match("aaabbbccc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_78653refgs! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 3)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+"
+            //"abcXXXdef"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex(@"abc(?=XXX)\w+");
+            match = r.Match("abcXXXdef");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7453efg! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_827345sdf! unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_1074sf! unexpected return result");
+                }
+
+                if (match.Groups.Count != 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2175sgg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_68217fdgs! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_139wn!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_107vxg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_745dsgg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+"
+            //"abcXXXdef" - Negative
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex(@"abc(?!XXX)\w+");
+            match = r.Match("abcXXXdef");
+            if (match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_756tdfg! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<=XXX)def"
+            //"abcXXXdef"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex(@"(\w){6}(?<=XXX)def");
+            match = r.Match("abcXXXdef");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_1072gdg! doesnot match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
+            //"XXXabcdef"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex(@"(\w){6}(?<!XXX)def");
+            match = r.Match("XXXabcdef");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_532resgf! doesnot match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Nonbacktracking subexpression: Actual - "[^0-9]+(?>[0-9]+)3"
+            //"abc123"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex("[^0-9]+(?>[0-9]+)3");
+            //The last 3 causes the match to fail, since the non backtracking subexpression does not give up the last digit it matched
+            //for it to be a success. For a correct match, remove the last character, '3' from the pattern
+            match = r.Match("abc123");
+            if (match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests5.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests5.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Aaaa\\w+zzz\\Z"
+            "aaaasdfajsdlfjzzz"
+
+        public static Match Match(string input);     Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Aaaa\\w+zzz\\Z"
+            "aaaasdfajsdlfjzzza"
+
+        public static Match Match(string input, Int32 startat);     Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Gbbb"
+            "aaabbb", 3
+
+        public static Match Match(string input, Int32 startat);     Using beginning/end of string chars \A, \Z, ^ : Actual - "^b"
+            "ab", 1
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase5()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
+            //"aaaasdfajsdlfjzzz"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex(@"\Aaaa\w+zzz\Z");
+            m = r.Match("aaaasdfajsdlfjzzz");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
+            //"aaaasdfajsdlfjzzza"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex(@"\Aaaa\w+zzz\Z");
+            m = r.Match("aaaasdfajsdlfjzzza");
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
+            //"line2\nline3\n"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex(@"\A(line2\n)line3\Z", RegexOptions.Multiline);
+            m = r.Match("line2\nline3\n");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_872nj! doesnot match");
+            }
+
+            // [] public static Match Match(string input, Int32 startat);     Using beginning/end of string chars ^ : Actual - "^b"
+            //"ab", 1
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex("^b");
+            m = r.Match("ab");
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_865rfsg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests6.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests6.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Backreferences : Actual - "(\\w)\\1"
+            "aa"
+
+        public static Match Match(string input);      : Actual - "(?<char>\\w)\\<char>"
+            "aa"
+
+        public static Match Match(string input);      : Actual - "(?< 4 3>\\w)\\43"
+            "aa"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase6()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        Match match;
+        String strMatch1 = "aa";
+        Int32[] iMatch1 =
+        {
+        0, 2
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "aa", "a"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 2
+        }
+
+        , {
+        0, 1
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[2][];
+        strGrpCap1[0] = new String[]
+        {
+        "aa"
+        }
+
+        ;
+        strGrpCap1[1] = new String[]
+        {
+        "a"
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[2][];
+        iGrpCap1[0] = new Int32[]
+        {
+        0, 2
+        }
+
+        ; //This is ignored
+        iGrpCap1[1] = new Int32[]
+        {
+        0, 1
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Backreferences : Actual - "(\\w)\\1"
+            //"aa"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex(@"(\w)\1");
+            match = r.Match("aa");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);      : Actual - "(?<char>\\w)\\<char>"
+            //"aa"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex(@"(?<char>\w)\<char>");
+            m = r.Match("aa");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+
+            // [] public static Match Match(string input);      : Actual - "(?<43>\\w)\\43"
+            //"aa"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex(@"(?<43>\w)\43");
+            m = r.Match("aa");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_452wfdf! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests7.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests7.cs
@@ -1,0 +1,298 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Alternation constructs : Actual - "(111|aaa)"
+            "aaa"
+
+        public static Match Match(string input);      : Actual - "abc(?(1)111|222)"
+            "abc222"
+
+        public static Match Match(string input);      : Actual - "(?< 1>\\d+)abc(?(1)222|111)"
+            "111abc222"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase7()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        Match match;
+        String strMatch1 = "abc222";
+        Int32[] iMatch1 =
+        {
+        0, 6
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "abc222", String.Empty
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 6
+        }
+
+        , {
+        0, 0
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[2][];
+        strGrpCap1[0] = new String[]
+        {
+        "abc222"
+        }
+
+        ;
+        strGrpCap1[1] = new String[]
+        {
+        String.Empty
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[2][];
+        iGrpCap1[0] = new Int32[]
+        {
+        0, 6
+        }
+
+        ; //This is ignored
+        iGrpCap1[1] = new Int32[]
+        {
+        0, 0
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        String strMatch2 = "111abc222";
+        Int32[] iMatch2 =
+        {
+        0, 9
+        }
+
+        ;
+        String[] strGroup2 =
+        {
+        "111abc222", "111"
+        }
+
+        ;
+        Int32[,] iGroup2 =
+        {
+        {
+        0, 9
+        }
+
+        , {
+        0, 3
+        }
+        }
+
+        ;
+        String[][] strGrpCap2 = new String[2][];
+        strGrpCap2[0] = new String[]
+        {
+        "111abc222"
+        }
+
+        ;
+        strGrpCap2[1] = new String[]
+        {
+        "111"
+        }
+
+        ;
+        Int32[][] iGrpCap2 = new Int32[2][];
+        iGrpCap2[0] = new Int32[]
+        {
+        0, 9
+        }
+
+        ; //This is ignored
+        iGrpCap2[1] = new Int32[]
+        {
+        0, 3
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        Int32[] iGrpCapCnt2 =
+        {
+        1, 1
+        }
+
+        ;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Alternation constructs : Actual - "(111|aaa)"
+            //"aaa"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex("(111|aaa)");
+            m = r.Match("aaa");
+            if (!m.Success || !m.Groups[1].Value.Equals("aaa"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+
+            // [] public static Match Match(string input);      : Actual - "abc(?(1)111|222)"
+            //"abc222"    
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("(abbc)(?(1)111|222)");
+            match = r.Match("abc222");
+            if (match.Success)
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 0))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount={6}", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);      : Actual - "(?<1>\\d+)abc(?(1)222|111)"
+            //"111abc222"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex(@"(?<MyDigits>\d+)abc(?(MyDigits)222|111)");
+            match = r.Match("111abc222");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_452wfdf! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_827345sdf! unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_1074sf! unexpected return result");
+                }
+
+                if (match.Groups.Count != 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2175sgg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_68217fdgs! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_139wn!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt2[i]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_107vxg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = {6}", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1], match.Groups[i].Captures.Count);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_745dsgg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests8.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests8.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Using "n" Regex option. Only explicitly named groups should be captured : Actual - "([0-9]*)\\s(?<s>[a-z_A-Z]+)", "n"
+            "200 dollars"
+
+        public static Match Match(string input);     Single line mode "s". Includes new line character. : Actual - "([^/]+)","s"
+            "abc\n"
+
+        public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - " ([^/]+) ","x"
+            "abc"
+
+        public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - "\x20([^/]+)\x20","x"
+            "abc"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase8()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        Match match;
+        String strMatch1 = "200 dollars";
+        Int32[] iMatch1 =
+        {
+        0, 11
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "200 dollars", "dollars"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 11
+        }
+
+        , {
+        4, 7
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[2][];
+        strGrpCap1[0] = new String[]
+        {
+        "200 dollars"
+        }
+
+        ;
+        strGrpCap1[1] = new String[]
+        {
+        "dollars"
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[2][];
+        iGrpCap1[0] = new Int32[]
+        {
+        0, 11
+        }
+
+        ; //This is ignored
+        iGrpCap1[1] = new Int32[]
+        {
+        4, 7
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        Int32[] iGrpCapCnt1 =
+        {
+        1, 1
+        }
+
+        ; //0 is ignored
+        String strMatch2 = "abc\nsfc";
+        Int32[] iMatch2 =
+        {
+        0, 7
+        }
+
+        ;
+        String[] strGroup2 =
+        {
+        "abc\nsfc", "abc\nsfc"
+        }
+
+        ;
+        Int32[,] iGroup2 =
+        {
+        {
+        0, 7
+        }
+
+        , {
+        0, 7
+        }
+        }
+
+        ;
+        String[][] strGrpCap2 = new String[2][];
+        strGrpCap2[0] = new String[]
+        {
+        "abc\nsfc"
+        }
+
+        ;
+        strGrpCap2[1] = new String[]
+        {
+        "abc\nsfc"
+        }
+
+        ;
+        Int32[][] iGrpCap2 = new Int32[2][];
+        iGrpCap2[0] = new Int32[]
+        {
+        0, 11
+        }
+
+        ; //This is ignored
+        iGrpCap2[1] = new Int32[]
+        {
+        0, 7
+        }
+
+        ; //The first half contains the Index and the latter half the Lengths
+        Int32[] iGrpCapCnt2 =
+        {
+        1, 1
+        }
+
+        ; //0 is ignored
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Using "n" Regex option. Only explicitly named groups should be captured : Actual - "([0-9]*)\\s(?<s>[a-z_A-Z]+)", "n"
+            //"200 dollars"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex(@"([0-9]*)\s(?<s>[a-z_A-Z]+)", RegexOptions.ExplicitCapture);
+            match = r.Match("200 dollars");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt1[i]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt1[i]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Single line mode "s". Includes new line character. : Actual - "([^/]+)","s"
+            //"abc\n" 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("(.*)", RegexOptions.Singleline);
+            match = r.Match("abc\nsfc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_827345sdf! unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_1074sf! unexpected return result");
+                }
+
+                if (match.Groups.Count != 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2175sgg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_68217fdgs! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_139wn!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt2[i]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_107vxg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt2[i]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_745dsgg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - " ([^/]+) ","x"
+            //"abc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex("            ((.)+)      ", RegexOptions.IgnorePatternWhitespace);
+            m = r.Match("abc");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_452wfdf! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - "\x20([^/]+)\x20","x"
+            //"abc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex("\x20([^/]+)\x20\x20\x20\x20\x20\x20\x20", RegexOptions.IgnorePatternWhitespace);
+            m = r.Match(" abc       ");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_865rfsg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests9.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests9.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexMatchTests
+{
+    /*
+    Tested Methods:
+    
+        public static Match Match(string input);     Turning on case insensitive option in mid-pattern : Actual - "aaa(?i:match this)bbb"
+            "aaaMaTcH ThIsbbb"
+
+        public static Match Match(string input);     Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i"
+            "AaAmatch thisBBb"
+
+        public static Match Match(string input);     Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
+            "AaAmatch thisBBb"
+
+        public static Match Match(string input);     Comments : Actual - "aaa(?#ignore this completely)bbb"
+            "aaabbb"
+
+    */
+
+    [Fact]
+    public static void RegexMatchTestCase9()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        Match m;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Turning on case insensitive option in mid-pattern : Actual - "aaa(?i:match this)bbb"
+            //"aaaMaTcH ThIsbbb" 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            if ("i".ToUpper() == "I")
+            {
+                r = new Regex("aaa(?i:match this)bbb");
+                m = r.Match("aaaMaTcH ThIsbbb");
+                if (!m.Success)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_234fsadg! doesnot match");
+                }
+            }
+
+            // [] public static Match Match(string input);     Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i"
+            //"AaAmatch thisBBb"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("aaa(?-i:match this)bbb", RegexOptions.IgnoreCase);
+            m = r.Match("AaAmatch thisBBb");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
+            //"AaAmatch thisBBb"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex("aaa(?-i:match this)bbb", RegexOptions.IgnoreCase);
+            m = r.Match("AaAmatcH thisBBb");
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_452wfdf! doesnot match");
+            }
+
+            // [] public static Match Match(string input);     Comments : Actual - "aaa(?#ignore this completely)bbb"
+            //"aaabbb"    
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex("aaa(?#ignore this completely)bbb");
+            m = r.Match("aaabbb");
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_865rfsg! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexMatchValueTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchValueTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RegexMatchValueTests
+{
+    [Fact]
+    public static void MatchValue()
+    {
+        //////////// Global Variables used for all tests
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        Regex rgx1;
+        Match mtch1;
+        String strInput;
+        String strExpected;
+        GroupCollection grpc1;
+        CaptureCollection capc1;
+        String[] arrGroupExp =
+        {
+        "aaabbcccccccccc", "aaa", "bb", "cccccccccc"
+        }
+
+        ;
+        String[] arrGroupExp1 =
+        {
+        "abracadabra", "abra", "cad"
+        }
+
+        ;
+        String[] arrCaptureExp =
+        {
+        "aaabbcccccccccc", "aaa", "bb", "cccccccccc"
+        }
+
+        ;
+        String[] arrCaptureExp1 =
+        {
+        "abracad", "abra"
+        }
+
+        ;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            //[] We are testing the Value property of Match, Group and Capture here. Value is the more semantic equivalent of 
+            //the current ToString
+            //trim leading and trailing white spaces
+            //my answer to the csharp alias, Regex.Replace(strInput, @"\s*(.*?)\s*$", "${1}") works fine, Even Freidl gives it 
+            //a solution, albeit not a very fast one
+            iCountTestcases++;
+            rgx1 = new Regex(@"\s*(.*?)\s*$");
+            strInput = " Hello World ";
+            mtch1 = rgx1.Match(strInput);
+            if (mtch1.Success)
+            {
+                strExpected = strInput;
+                if (!strExpected.Equals(mtch1.Value))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_759ed! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, mtch1.Value);
+                }
+            }
+
+            //[]for Groups and Captures
+            iCountTestcases++;
+            rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
+            strInput = "aaabbccccccccccaaaabc";
+            mtch1 = rgx1.Match(strInput);
+            if (mtch1.Success)
+            {
+                strExpected = "aaabbcccccccccc";
+                if (!strExpected.Equals(mtch1.Value))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_745fg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, mtch1.Value);
+                }
+
+                grpc1 = mtch1.Groups;
+                if (grpc1.Count != 4)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_67fdaq! The expected value was not returned, Expected - 4 Returned - {0}", grpc1.Count);
+                }
+
+                for (int i = 0; i < grpc1.Count; i++)
+                {
+                    if (!arrGroupExp[i].Equals(grpc1[i].Value))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_00213534_{2}! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp[i], grpc1[i].Value, i);
+                    }
+
+                    //Group has a Captures property too
+                    capc1 = grpc1[i].Captures;
+                    if (capc1.Count != 1)
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_0834esfd! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
+                    }
+
+                    if (!arrGroupExp[i].Equals(capc1[0].Value))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_974535! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp[i], capc1[0].Value);
+                    }
+                }
+
+                capc1 = mtch1.Captures;
+                if (capc1.Count != 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_863trfg! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
+                }
+
+                strExpected = "aaabbcccccccccc";
+                if (!strExpected.Equals(capc1[0].Value))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_97463dfsg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, capc1[0].Value);
+                }
+            }
+
+            //Another example - given by Brad Merril in an article on RegularExpressions
+            iCountTestcases++;
+            rgx1 = new Regex(@"(abra(cad)?)+");
+            strInput = "abracadabra1abracadabra2abracadabra3";
+            mtch1 = rgx1.Match(strInput);
+            while (mtch1.Success)
+            {
+                strExpected = "abracadabra";
+                if (!strExpected.Equals(mtch1.Value))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_7342wsdg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, mtch1.Value);
+                }
+
+                grpc1 = mtch1.Groups;
+                if (grpc1.Count != 3)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_9745fgg! The expected value was not returned, Expected - 4 Returned - {0}", grpc1.Count);
+                }
+
+                for (int i = 0; i < grpc1.Count; i++)
+                {
+                    if (!arrGroupExp1[i].Equals(grpc1[i].Value))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_8756fdg! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp1[i], grpc1[i].Value, i);
+                    }
+
+                    //Group has a Captures property too
+                    capc1 = grpc1[i].Captures;
+                    switch (i)
+                    {
+                        case 1:
+                            if (capc1.Count != 2)
+                            {
+                                iCountErrors++;
+                                Console.WriteLine("Err_9745fgs! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
+                            }
+
+                            for (int j = 0; j < capc1.Count; j++)
+                            {
+                                if (!arrCaptureExp1[j].Equals(capc1[j].Value))
+                                {
+                                    iCountErrors++;
+                                    Console.WriteLine("Err_97453sdf! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp[j], capc1[j].Value);
+                                }
+                            }
+
+                            break;
+                        case 2:
+                            if (capc1.Count != 1)
+                            {
+                                iCountErrors++;
+                                Console.WriteLine("Err_8473rsg! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
+                            }
+
+                            strExpected = "cad";
+                            if (!strExpected.Equals(capc1[0].Value))
+                            {
+                                iCountErrors++;
+                                Console.WriteLine("Err_9743rfsfg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, capc1[0].Value);
+                            }
+
+                            break;
+                    }
+                }
+
+                capc1 = mtch1.Captures;
+                if (capc1.Count != 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_7453fgds! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
+                }
+
+                strExpected = "abracadabra";
+                if (!strExpected.Equals(capc1[0].Value))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_0753rdg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, capc1[0].Value);
+                }
+
+                mtch1 = mtch1.NextMatch();
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==\n" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests0.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests0.cs
@@ -1,0 +1,327 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexReplaceStringTests
+{
+    [Fact]
+    public static void RegexReplaceStringTestCase0()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        String s;
+        String sResult;
+        Int32 i;
+        String pattern;
+        String sExp;
+        Match match;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] Group name checks
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            s = "08/10/99 16:00";
+            r = new Regex(@"(?<1>\d{1,2})/(?<2>\d{1,2})/(?<3>\d{2,4})\s(?<time>\S+)");
+            match = r.Match(s);
+            sResult = r.Match(s).Result("${time}");
+            if (!sResult.Equals("16:00"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
+            }
+
+            sResult = r.Match(s).Result("$1");
+            if (!sResult.Equals("08"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
+            }
+
+            sResult = r.Match(s).Result("$2");
+            if (!sResult.Equals("10"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
+            }
+
+            sResult = r.Match(s).Result("$3");
+            if (!sResult.Equals("99"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
+            }
+
+            // [] Regex.Replace()
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            s = "08/10/99 16:00";
+            sResult = Regex.Replace(s, @"[^ ]+\s(?<time>)", "${time}");
+            if (!sResult.Equals("16:00") || !s.Equals("08/10/99 16:00"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_0723gsg! doesnot match, " + sResult + " " + s);
+            }
+
+            s = "MiCrOsOfT";
+            sResult = Regex.Replace(s, "icrosoft", "icrosoft", RegexOptions.IgnoreCase);
+            if (!sResult.Equals("Microsoft"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_174ds! doesnot match, " + sResult + " " + s);
+            }
+
+            s = "my dog has fleas";
+            sResult = Regex.Replace(s, "dog", "CAT", RegexOptions.IgnoreCase);
+            if (!sResult.Equals("my CAT has fleas"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_174ds! doesnot match, " + sResult + " " + s);
+            }
+
+            s = "D.Bau";
+            r = new Regex(@"D\.(.+)");
+            sResult = r.Replace(s, "David $1");
+            if (!sResult.Equals("David Bau"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_5734s! doesnot match, " + sResult + " " + s);
+            }
+
+            s = "aaaaa";
+            r = new Regex("a");
+            sResult = r.Replace(s, "b", 2);
+            if (!sResult.Equals("bbaaa"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_78453fgs! doesnot match, " + sResult + " " + s);
+            }
+
+            sResult = r.Replace(s, "b", 2, 3);
+            if (!sResult.Equals("aaabb"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_712ff! doesnot match, " + sResult + " " + s);
+            }
+
+            // [] Replace with MatchEvaluators - relevant fn's for this are defined below 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            sResult = Regex.Replace("Big mountain", "(Big|Small)", new MatchEvaluator(Rep1));
+            iCountTestcases++;
+            if (!sResult.Equals("Huge mountain"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_452wfdf! doesnot match, " + sResult);
+            }
+
+            sResult = Regex.Replace("Small village", "(Big|Small)", new MatchEvaluator(Rep1));
+            if (!sResult.Equals("Tiny village"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_8420sgf! doesnot match, " + sResult);
+            }
+
+            if ("i".ToUpper() == "I")
+            {
+                sResult = Regex.Replace("bIG horse", "(Big|Small)", new MatchEvaluator(Rep1), RegexOptions.IgnoreCase);
+                if (!sResult.Equals("Huge horse"))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_232fg! doesnot match, " + sResult);
+                }
+            }
+
+            sResult = Regex.Replace("sMaLl dog", "(Big|Small)", new MatchEvaluator(Rep1), RegexOptions.IgnoreCase);
+            if (!sResult.Equals("Tiny dog"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_073235rdfa! doesnot match, " + sResult);
+            }
+
+            r = new Regex(".+");
+            sResult = r.Replace("XSP_TEST_FAILURE", new MatchEvaluator(Rep2));
+            if (!sResult.Equals("SUCCESS"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_246egsd! doesnot match, " + sResult);
+            }
+
+            r = new Regex("[abcabc]");
+            sResult = r.Replace("abcabc", new MatchEvaluator(Rep3));
+            if (!sResult.Equals("ABCABC"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_75432sg! doesnot match, " + sResult);
+            }
+
+            r = new Regex("[abcabc]");
+            sResult = r.Replace("abcabc", new MatchEvaluator(Rep3), 3);
+            if (!sResult.Equals("ABCabc"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_75432sg! doesnot match, " + sResult);
+            }
+
+            r = new Regex("[abcabc]");
+            sResult = r.Replace("abcabc", new MatchEvaluator(Rep3), 3, 2);
+            if (!sResult.Equals("abCABc"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_75432sg! doesnot match, " + sResult);
+            }
+
+            // [] Replace with group numbers
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            r = new Regex("([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z])))))))))))))))");
+            sResult = r.Replace("abcdefghiklmnop", "$15");
+            if (!sResult.Equals("p"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_865rfsg! doesnot match, " + sResult);
+            }
+
+            sResult = r.Replace("abcdefghiklmnop", "$3");
+            if (!sResult.Equals("cdefghiklmnop"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9752fsf! doesnot match, " + sResult);
+            }
+
+            //Stress
+            pattern = String.Empty;
+            for (i = 0; i < 1000; i++)
+                pattern += "([a-z]";
+            for (i = 0; i < 1000; i++)
+                pattern += ")";
+            s = String.Empty;
+            for (i = 0; i < 200; i++)
+                s += "abcde";
+            r = new Regex(pattern);
+            sResult = r.Replace(s, "$1000");
+            if (!sResult.Equals("e"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_98725rdfsg! doesnot match, " + sResult);
+            }
+
+            sResult = r.Replace(s, "$1");
+            sExp = String.Empty;
+            for (i = 0; i < 200; i++)
+                sExp += "abcde";
+            if (!sResult.Equals(sExp))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_1074wf! doesnot match, " + sResult);
+            }
+
+            //undefined group
+            sResult = Regex.Replace("abc", "([a_z])(.+)", "$3");
+            if (!sResult.Equals("$3"))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_1074wf! doesnot match, " + sResult);
+            }
+
+            // Regression test:
+            // Regex treating Devanagari matra characters as matching "\b"
+            // Unicode characters in the "Mark, NonSpacing" Category, U+0902=Devanagari sign anusvara, U+0947=Devanagri vowel sign E
+            try
+            {
+                iCountTestcases++;
+                Regex regexRendering = new Regex(@"\u0915\u0930.*?\b", RegexOptions.CultureInvariant | RegexOptions.Singleline);
+                String strBoldedText = regexRendering.Replace("\u092f\u0939 \u0915\u0930 \u0935\u0939 \u0915\u0930\u0947\u0902 \u0939\u0948\u0964", RepBold);
+                String expectedBoldedText = "\u092f\u0939 <b>\u0915\u0930</b> \u0935\u0939 <b>\u0915\u0930\u0947\u0902</b> \u0939\u0948\u0964";
+                if (strBoldedText != expectedBoldedText)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_788921gh! Devanagari matra characters are threated as \"\b\"");
+                    Console.WriteLine("Expected string: {0}\nActual string: {1}", GetUnicodeString(expectedBoldedText), GetUnicodeString(strBoldedText));
+                }
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_788921! Unexpected Exception: " + e);
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static String Rep1(Match input)
+    {
+        String s = String.Empty;
+        if (String.Compare(input.ToString(), "Big", StringComparison.CurrentCultureIgnoreCase) == 0)
+            s = "Huge";
+        else
+            s = "Tiny";
+        return s;
+    }
+
+    public static String Rep2(Match input)
+    {
+        return "SUCCESS";
+    }
+
+    public static String Rep3(Match input)
+    {
+        String s = String.Empty;
+        if (input.ToString().Equals("a"))
+            s = "A";
+        if (input.ToString().Equals("b"))
+            s = "B";
+        if (input.ToString().Equals("c"))
+            s = "C";
+        return s;
+    }
+
+    public static String RepBold(Match m)
+    {
+        string str = m.ToString();
+        return String.Format("<b>{0}</b>", str);
+    }
+
+    static String GetUnicodeString(String str)
+    {
+        StringBuilder buffer = new StringBuilder();
+        for (int i = 0; i < str.Length; i++)
+        {
+            if (str[i] < 0x20)
+            {
+                buffer.Append("\\u" + ((int)str[i]).ToString("x4"));
+            }
+            else if (str[i] < 0x7f)
+            {
+                buffer.Append(str[i]);
+            }
+            else
+            {
+                buffer.Append("\\u" + ((int)str[i]).ToString("x4"));
+            }
+        }
+
+        return (buffer.ToString());
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests1.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests1.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public partial class RegexReplaceStringTests
+{
+    [Fact]
+    public static void RegexReplaceStringTestCase1()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            for (int i = 0; i < _regexTests.Length; i++)
+            {
+                iCountTestcases++;
+                if (!_regexTests[i].Run())
+                {
+                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2} ReplaceString={3}\n", i, _regexTests[i].Pattern, _regexTests[i].Input, _regexTests[i].ReplaceString);
+                    iCountErrors++;
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private static RegexReplaceStringTest[] _regexTests = new RegexReplaceStringTest[]
+    {
+        /*********************************************************
+        ValidCases
+        *********************************************************/
+    new RegexReplaceStringTest(@"(?<cat>cat)\s*(?<dog>dog)", "cat dog", "${cat}est ${dog}est", "catest dogest"), new RegexReplaceStringTest(@"(?<cat>cat)\s*(?<dog>dog)", "slkfjsdcat dogkljeah", "START${cat}dogcat${dog}END", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<512>cat)\s*(?<256>dog)", "slkfjsdcat dogkljeah", "START${512}dogcat${256}END", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<256>cat)\s*(?<512>dog)", "slkfjsdcat dogkljeah", "START${256}dogcat${512}END", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<512>cat)\s*(?<256>dog)", "slkfjsdcat dogkljeah", "STARTcat$256$512dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<256>cat)\s*(?<512>dog)", "slkfjsdcat dogkljeah", "STARTcat$512$256dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(hello)cat\s+dog(world)", "hellocat dogworld", "$1$$$2", "hello$world"), new RegexReplaceStringTest(@"(hello)\s+(world)", "What the hello world goodby", "$&, how are you?", "What the hello world, how are you? goodby"), new RegexReplaceStringTest(@"(hello)\s+(world)", "What the hello world goodby", "$`cookie are you doing", "What the What the cookie are you doing goodby"), new RegexReplaceStringTest(@"(cat)\s+(dog)", "before textcat dogafter text", ". This is the $' and ", "before text. This is the after text and after text"), new RegexReplaceStringTest(@"(cat)\s+(dog)", "before textcat dogafter text", ". The following should be dog and it is $+. ", "before text. The following should be dog and it is dog. after text"), new RegexReplaceStringTest(@"(cat)\s+(dog)", "before textcat dogafter text", ". The following should be the entire string '$_'. ", "before text. The following should be the entire string 'before textcat dogafter text'. after text"), new RegexReplaceStringTest(@"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $3$4", "START world hello hello world $3$4 END"), new RegexReplaceStringTest(@"(hello)\s+(world)", "START hello    world END", "$2 $1 $1 $2 $123$234", "START world hello hello world $123$234 END"), new RegexReplaceStringTest(@"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", "My dog cat has fleas."), new RegexReplaceStringTest(@"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline, "My dog cat has fleas.", "$05$06$07$04$01$02$03$08$09$10$11", "My cat dog has fleas."), /*********************************************************
+        ValidCases with ECMAScript option
+        *********************************************************/
+    new RegexReplaceStringTest(@"(?<512>cat)\s*(?<256>dog)", RegexOptions.ECMAScript, "slkfjsdcat dogkljeah", "STARTcat${256}${512}dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<256>cat)\s*(?<512>dog)", RegexOptions.ECMAScript, "slkfjsdcat dogkljeah", "STARTcat${512}${256}dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<1>cat)\s*(?<2>dog)", RegexOptions.ECMAScript, "slkfjsdcat dogkljeah", "STARTcat$2$1dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<2>cat)\s*(?<1>dog)", RegexOptions.ECMAScript, "slkfjsdcat dogkljeah", "STARTcat$1$2dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<512>cat)\s*(?<256>dog)", RegexOptions.ECMAScript, "slkfjsdcat dogkljeah", "STARTcat$256$512dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(?<256>cat)\s*(?<512>dog)", RegexOptions.ECMAScript, "slkfjsdcat dogkljeah", "STARTcat$512$256dogEND", "slkfjsdSTARTcatdogcatdogENDkljeah"), new RegexReplaceStringTest(@"(hello)\s+world", RegexOptions.ECMAScript, "START hello    world END", "$234 $1 $1 $234 $3$4", "START $234 hello hello $234 $3$4 END"), new RegexReplaceStringTest(@"(hello)\s+(world)", RegexOptions.ECMAScript, "START hello    world END", "$2 $1 $1 $2 $3$4", "START world hello hello world $3$4 END"), new RegexReplaceStringTest(@"(hello)\s+(world)", RegexOptions.ECMAScript, "START hello    world END", "$2 $1 $1 $2 $123$234", "START world hello hello world hello23world34 END"), new RegexReplaceStringTest(@"(?<12>hello)\s+(world)", RegexOptions.ECMAScript, "START hello    world END", "$1 $12 $12 $1 $123$134", "START world hello hello world hello3world34 END"), new RegexReplaceStringTest(@"(?<123>hello)\s+(?<23>world)", RegexOptions.ECMAScript, "START hello    world END", "$23 $123 $123 $23 $123$234", "START world hello hello world helloworld4 END"), new RegexReplaceStringTest(@"(?<123>hello)\s+(?<234>world)", RegexOptions.ECMAScript, "START hello    world END", "$234 $123 $123 $234 $123456$234567", "START world hello hello world hello456world567 END"), new RegexReplaceStringTest(@"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", RegexOptions.CultureInvariant | RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline, "My dog cat has fleas.", "$01$02$03$04$05$06$07$08$09$10$11", "My dog cat has fleas."), new RegexReplaceStringTest(@"(d)(o)(g)(\s)(c)(a)(t)(\s)(h)(a)(s)", RegexOptions.CultureInvariant | RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline, "My dog cat has fleas.", "$05$06$07$04$01$02$03$08$09$10$11", "My cat dog has fleas."), /*********************************************************
+        Error cases
+        *********************************************************/
+    new RegexReplaceStringTest(@"(?<256>cat)\s*(?<512>dog)", "slkfjsdcat dogkljeah", "STARTcat$512$", "slkfjsdSTARTcatdog$kljeah"), new RegexReplaceStringTest(@"(?<256>cat)\s*(?<512>dog)", "slkfjsdcat dogkljeah", "STARTcat$2048$1024dogEND", "slkfjsdSTARTcat$2048$1024dogENDkljeah"), new RegexReplaceStringTest(@"(?<cat>cat)\s*(?<dog>dog)", "slkfjsdcat dogkljeah", "START${catTWO}dogcat${dogTWO}END", "slkfjsdSTART${catTWO}dogcat${dogTWO}ENDkljeah"), }
+
+    ;
+    public class RegexReplaceStringTest
+    {
+        private String _pattern;
+        private String _input;
+        private RegexOptions _options;
+        private String _replaceString;
+        private String _expectedResult;
+        private Type _expectedExceptionType;
+        public RegexReplaceStringTest(String pattern, String input, String replaceString, String expectedResult)
+            : this(pattern, RegexOptions.None, input, replaceString, expectedResult)
+        {
+        }
+
+        public RegexReplaceStringTest(String pattern, RegexOptions options, String input, String replaceString, String expectedResult)
+        {
+            _pattern = pattern;
+            _options = options;
+            _input = input;
+            _replaceString = replaceString;
+            _expectedResult = expectedResult;
+        }
+
+        public RegexReplaceStringTest(String pattern, String input, String replaceString, Type expectedExceptionType)
+            : this(pattern, RegexOptions.None, input, replaceString, expectedExceptionType)
+        {
+        }
+
+        public RegexReplaceStringTest(String pattern, RegexOptions options, String input, String replaceString, Type expectedExceptionType)
+        {
+            _pattern = pattern;
+            _options = options;
+            _input = input;
+            _replaceString = replaceString;
+            _expectedExceptionType = expectedExceptionType;
+        }
+
+        public string Pattern
+        {
+            get
+            {
+                return _pattern;
+            }
+        }
+
+        public string Input
+        {
+            get
+            {
+                return _input;
+            }
+        }
+
+        public RegexOptions Options
+        {
+            get
+            {
+                return _options;
+            }
+        }
+
+        public String ReplaceString
+        {
+            get
+            {
+                return _replaceString;
+            }
+        }
+
+        public String ExpectedResult
+        {
+            get
+            {
+                return _expectedResult;
+            }
+        }
+
+        public Type ExpectedExceptionType
+        {
+            get
+            {
+                return _expectedExceptionType;
+            }
+        }
+
+        public bool ExpectException
+        {
+            get
+            {
+                return null != _expectedExceptionType;
+            }
+        }
+
+        public bool ExpectSuccess
+        {
+            get
+            {
+                return null != _expectedResult && _expectedResult.Length != 0;
+            }
+        }
+
+        public bool Run()
+        {
+            Regex r;
+            String result = null;
+            r = new Regex(_pattern, _options);
+            try
+            {
+                result = r.Replace(_input, _replaceString);
+                if (ExpectException)
+                {
+                    Console.WriteLine("Err_09872anba! Expected Regex to throw {0} exception and none was thrown", _expectedExceptionType);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                if (ExpectException && e.GetType() == _expectedExceptionType)
+                {
+                    return true;
+                }
+                else
+                {
+                    Console.WriteLine("Err_78394ayuua! Expected no exception to be thrown and the following was thrown: \n{0}", e);
+                    return false;
+                }
+            }
+
+            if (!ExpectSuccess)
+            {
+                if (result != _input)
+                {
+                    Console.WriteLine("Err_2270awanm! Did not expect anything to be replaced result='{0}'", result);
+                    return false;
+                }
+
+                return true;
+            }
+
+            if (result != _expectedResult)
+            {
+                Console.WriteLine("Err_68997asnzxn! Expected result and actual result differ\n expected={0} actual={1}", _expectedResult, result);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexSplitTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexSplitTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RegexSplitTests
+{
+    /*
+    Tested Methods:
+    
+        public static String[] Split(string input);     ":"
+            "kkk:lll:mmm:nnn:ooo"
+
+        public static String[] Split(string input, Int32 count);     ":"
+            "kkk:lll:mmm:nnn:ooo", 2
+
+        public static String[] Split(string input, Int32 count, Int32 startat);     ":"
+            "kkk:lll:mmm:nnn:ooo", 3, 6
+
+    */
+
+    [Fact]
+    public static void RegexSplit()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        String s;
+        String[] sa;
+        String[] saExp = new String[]
+        {
+        "kkk", "lll", "mmm", "nnn", "ooo"
+        }
+
+        ;
+        String[] saExp1 = new String[]
+        {
+        "kkk", "lll:mmm:nnn:ooo"
+        }
+
+        ;
+        String[] saExp2 = new String[]
+        {
+        "kkk:lll", "mmm", "nnn:ooo"
+        }
+
+        ;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            s = "kkk:lll:mmm:nnn:ooo";
+            r = new Regex(":");
+            // [] Scenario 1 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            sa = r.Split(s);
+            if (sa.Length != 5)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_8452esgf! doesnot match");
+            }
+
+            for (int i = 0; i < sa.Length; i++)
+            {
+                if (!sa[i].Equals(saExp[i]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_234fsadg! doesnot match {0} Expected - {1} Returned - {2}", i, saExp[i], sa[i]);
+                }
+            }
+
+            //a count of 0 means split all
+            sa = r.Split(s, 0);
+            if (sa.Length != 5)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_765wgdd! doesnot match");
+            }
+
+            for (int i = 0; i < sa.Length; i++)
+            {
+                if (!sa[i].Equals(saExp[i]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_0174wfg! doesnot match {0} Expected - {1} Returned - {2}", i, saExp[i], sa[i]);
+                }
+            }
+
+            // [] public static String[] Split(string input, Int32 count);     ":"
+            //"kkk:lll:mmm:nnn:ooo", 2
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            sa = r.Split(s, 2);
+            if (sa.Length != 2)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2435fsd! doesnot match");
+            }
+
+            for (int i = 0; i < sa.Length; i++)
+            {
+                if (!sa[i].Equals(saExp1[i]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_s2345fs! doesnot match {0} Expected - {1} Returned - {2}", i, saExp1[i], sa[i]);
+                }
+            }
+
+            // [] public static String[] Split(string input, Int32 count, Int32 startat);     ":"
+            //"kkk:lll:mmm:nnn:ooo", 3, 6
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            sa = r.Split(s, 3, 6);
+            if (sa.Length != 3)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4532gdg! does not match");
+            }
+
+            for (int i = 0; i < sa.Length; i++)
+            {
+                if (!sa[i].Equals(saExp2[i]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_845fd! doesnot match {0} Expected - {1} Returned - {2}", i, saExp2[i], sa[i]);
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RegexUnicodeCharTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexUnicodeCharTests.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RegexUnicodeCharTests
+{
+    // This test case checks the unicode-aware features in theregex engine.
+
+    private const Int32 MaxUnicodeRange = 2 << 15;//we are adding 0's here?
+
+    [Fact]
+    public static void RegexUnicodeChar()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        Char ch1;
+        List<Char> alstValidChars;
+        List<Char> alstInvalidChars;
+        Int32 iCharCount;
+        Int32 iNonCharCount;
+
+        String pattern;
+        String input;
+        Regex regex;
+        Match match;
+
+        Int32 iNumLoop;
+        Int32 iWordCharLength;
+        Int32 iNonWordCharLength;
+        StringBuilder sbldr1;
+        StringBuilder sbldr2;
+        Random random;
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            //[]Regex engine is Unicode aware now for the \w and \d character classes
+            // \s is not - i.e. it still only recognizes the ASCII space separators, not Unicode ones
+            // The new character classes for this:
+            //[\p{L1}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]
+            iCountTestcases++;
+
+
+            Console.WriteLine("MaxUnicodeRange, " + MaxUnicodeRange);
+
+            alstValidChars = new List<Char>();
+            alstInvalidChars = new List<Char>();
+            for (int i = 0; i < MaxUnicodeRange; i++)
+            {
+                ch1 = (Char)i;
+                switch (CharUnicodeInfo.GetUnicodeCategory(ch1))
+                {
+                    case UnicodeCategory.UppercaseLetter:        //Lu
+                    case UnicodeCategory.LowercaseLetter:        //Li
+                    case UnicodeCategory.TitlecaseLetter:        // Lt
+                    case UnicodeCategory.ModifierLetter:         // Lm
+                    case UnicodeCategory.OtherLetter:            // Lo
+                    case UnicodeCategory.DecimalDigitNumber:     // Nd
+                    //                    case UnicodeCategory.LetterNumber:           // ??
+                    //                    case UnicodeCategory.OtherNumber:            // ??
+                    case UnicodeCategory.NonSpacingMark:
+                    //                    case UnicodeCategory.SpacingCombiningMark:   // Mc
+                    case UnicodeCategory.ConnectorPunctuation:   // Pc
+                        alstValidChars.Add(ch1);
+                        break;
+                    default:
+                        alstInvalidChars.Add(ch1);
+                        break;
+                }
+            }
+
+
+
+            //[]\w - we will create strings from valid characters that form \w and make sure that the regex engine catches this.
+            //Build a random string with valid characters followed by invalid characters
+            iCountTestcases++;
+
+            random = new Random(-55);
+
+            pattern = @"\w*";
+            regex = new Regex(pattern);
+
+            iNumLoop = 100;
+            iWordCharLength = 10;
+            iCharCount = alstValidChars.Count;
+            iNonCharCount = alstInvalidChars.Count;
+            iNonWordCharLength = 15;
+
+            for (int i = 0; i < iNumLoop; i++)
+            {
+                sbldr1 = new StringBuilder();
+                sbldr2 = new StringBuilder();
+                for (int j = 0; j < iWordCharLength; j++)
+                {
+                    ch1 = alstValidChars[random.Next(iCharCount)];
+                    sbldr1.Append(ch1);
+                    sbldr2.Append(ch1);
+                }
+                for (int j = 0; j < iNonWordCharLength; j++)
+                    sbldr1.Append(alstInvalidChars[random.Next(iNonCharCount)]);
+                input = sbldr1.ToString();
+                match = regex.Match(input);
+                if (!match.Success
+                    || (match.Index != 0)
+                    || (match.Length != iWordCharLength)
+                    || !(match.Value.Equals(sbldr2.ToString()))
+                )
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_753wfgg_" + i + "! Error detected: input-{0}", input);
+                    Console.WriteLine("Match index={0}, length={1}, value={2}, match.Value.Equals(expected)={3}\n",
+                        match.Index, match.Length, match.Value, match.Value.Equals(sbldr2.ToString()));
+
+                    if (match.Length > iWordCharLength)
+                    {
+                        Console.WriteLine("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n{0}={1}",
+                            (int)match.Value[iWordCharLength], CharUnicodeInfo.GetUnicodeCategory(match.Value[iWordCharLength]));
+                    }
+                }
+
+                match = match.NextMatch();
+                do
+                {
+                    //This is tedious. But we report empty Matches for each of the non-matching characters!!!
+                    //duh!!! because we say so on the pattern - remember what * stands for :-)
+                    if (!match.Value.Equals(String.Empty)
+                        || (match.Length != 0)
+                    )
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_2975sg_" + i + "! Error detected: input-{0}", input);
+                        Console.WriteLine("Match index={0}, length={1}, value={2}\n",
+                            match.Index, match.Length, match.Value);
+                    }
+                    match = match.NextMatch();
+                } while (match.Success);
+            }
+
+            //[]Build a random string with invalid characters followed by valid characters and then again invalid
+            iCountTestcases++;
+
+            random = new Random(-55);
+
+            pattern = @"\w+";
+            regex = new Regex(pattern);
+
+            iNumLoop = 500;
+            iWordCharLength = 10;
+            iCharCount = alstValidChars.Count;
+            iNonCharCount = alstInvalidChars.Count;
+            iNonWordCharLength = 15;
+
+            for (int i = 0; i < iNumLoop; i++)
+            {
+                sbldr1 = new StringBuilder();
+                sbldr2 = new StringBuilder();
+                for (int j = 0; j < iNonWordCharLength; j++)
+                    sbldr1.Append(alstInvalidChars[random.Next(iNonCharCount)]);
+                for (int j = 0; j < iWordCharLength; j++)
+                {
+                    ch1 = alstValidChars[random.Next(iCharCount)];
+                    sbldr1.Append(ch1);
+                    sbldr2.Append(ch1);
+                }
+                for (int j = 0; j < iNonWordCharLength; j++)
+                    sbldr1.Append(alstInvalidChars[random.Next(iNonCharCount)]);
+                input = sbldr1.ToString();
+                match = regex.Match(input);
+
+                if (!match.Success
+                    || (match.Index != iNonWordCharLength)
+                    || (match.Length != iWordCharLength)
+                    || !(match.Value.Equals(sbldr2.ToString()))
+                )
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975sgf_" + i + "! Error detected: input-{0}", input);
+                }
+
+                match = match.NextMatch();
+                if (match.Success)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_246sdg_" + i + "! Error detected: input-{0}", input);
+                }
+            }
+
+            alstValidChars = new List<Char>();
+            alstInvalidChars = new List<Char>();
+            for (int i = 0; i < MaxUnicodeRange; i++)
+            {
+                ch1 = (Char)i;
+                switch (CharUnicodeInfo.GetUnicodeCategory(ch1))
+                {
+                    case UnicodeCategory.DecimalDigitNumber:     // Nd
+                        alstValidChars.Add(ch1);
+                        break;
+                    default:
+                        alstInvalidChars.Add(ch1);
+                        break;
+                }
+            }
+
+            //[]\d - we will create strings from valid characters that form \d and make sure that the regex engine catches this.            
+            //[]Build a random string with valid characters and then again invalid
+            iCountTestcases++;
+
+            pattern = @"\d+";
+            regex = new Regex(pattern);
+
+            iNumLoop = 100;
+            iWordCharLength = 10;
+            iNonWordCharLength = 15;
+            iCharCount = alstValidChars.Count;
+            iNonCharCount = alstInvalidChars.Count;
+
+            for (int i = 0; i < iNumLoop; i++)
+            {
+                sbldr1 = new StringBuilder();
+                sbldr2 = new StringBuilder();
+                for (int j = 0; j < iWordCharLength; j++)
+                {
+                    ch1 = alstValidChars[random.Next(iCharCount)];
+                    sbldr1.Append(ch1);
+                    sbldr2.Append(ch1);
+                }
+                for (int j = 0; j < iNonWordCharLength; j++)
+                    sbldr1.Append(alstInvalidChars[random.Next(iNonCharCount)]);
+                input = sbldr1.ToString();
+                match = regex.Match(input);
+                if (!match.Success
+                    || (match.Index != 0)
+                    || (match.Length != iWordCharLength)
+                    || !(match.Value.Equals(sbldr2.ToString()))
+                )
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_245sfg_" + i + "! Error detected: input-{0}", input);
+                }
+
+                match = match.NextMatch();
+                if (match.Success)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_29765sg_" + i + "! Error detected: input-{0}", input);
+                }
+            }
+
+            //[]Build a random string with invalid characters, valid and then again invalid
+            iCountTestcases++;
+
+            pattern = @"\d+";
+            regex = new Regex(pattern);
+
+            iNumLoop = 100;
+            iWordCharLength = 10;
+            iNonWordCharLength = 15;
+            iCharCount = alstValidChars.Count;
+            iNonCharCount = alstInvalidChars.Count;
+
+            for (int i = 0; i < iNumLoop; i++)
+            {
+                sbldr1 = new StringBuilder();
+                sbldr2 = new StringBuilder();
+                for (int j = 0; j < iNonWordCharLength; j++)
+                    sbldr1.Append(alstInvalidChars[random.Next(iNonCharCount)]);
+                for (int j = 0; j < iWordCharLength; j++)
+                {
+                    ch1 = alstValidChars[random.Next(iCharCount)];
+                    sbldr1.Append(ch1);
+                    sbldr2.Append(ch1);
+                }
+                for (int j = 0; j < iNonWordCharLength; j++)
+                    sbldr1.Append(alstInvalidChars[random.Next(iNonCharCount)]);
+                input = sbldr1.ToString();
+                match = regex.Match(input);
+                if (!match.Success
+                    || (match.Index != iNonWordCharLength)
+                    || (match.Length != iWordCharLength)
+                    || !(match.Value.Equals(sbldr2.ToString()))
+                )
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_29756tsg_" + i + "! Error detected: input-{0}", input);
+                }
+
+                match = match.NextMatch();
+                if (match.Success)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_27sjhr_" + i + "! Error detected: input-{0}", input);
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}
+
+

--- a/src/System.Text.RegularExpressions/tests/ReturnValueChecks.cs
+++ b/src/System.Text.RegularExpressions/tests/ReturnValueChecks.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class ReturnValueChecks
+{
+    // All the work on Return value checks are spread throughout the test bed.
+    [Fact]
+    public static void ReturnValueChecksTests()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strMatch1 = "aaabb.cc";
+        Int32[] iMatch1 =
+        {
+        0, 8
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "aaabb.cc", "bb.c", "c"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 8
+        }
+
+        , {
+        3, 4
+        }
+
+        , {
+        7, 1
+        }
+        }
+
+        ;
+        //This could be a rectangular array
+        String[,] strGrpCap1 =
+        {
+        {
+        "aaabb.cc"
+        }
+
+        , {
+        "bb.c"
+        }
+
+        , {
+        "c"
+        }
+        }
+
+        ;
+        Int32[,,] iGrpCap1 =
+        {
+        {
+        {
+        0, 8
+        }
+        }
+
+        , {
+        {
+        3, 4
+        }
+        }
+
+        , {
+        {
+        7, 1
+        }
+        }
+        }
+
+        ;
+        Regex r;
+        Match match;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Match Match(string input);     Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
+            //"ab.cc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex(@"a+\.?b*\.+c{2}");
+            match = r.Match("ab.cc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4532gvfs! 1 do not match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+            }
+
+            // [] public static Match Match(string input);     Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
+            //"aaabb.cc"
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            r = new Regex("^aaa(bb.+)(d|c)$");
+            match = r.Match("aaabb.cc");
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_7563rfsgf! 2 do not match");
+            }
+            else
+            {
+                Console.WriteLine("\r\nmatch.Value =  " + match.Value + ", Index = " + match.Index + ", Length = " + match.Length);
+                Console.WriteLine("\r\nmatch.Captures.Count =  " + match.Captures.Count);
+                for (int i = 0; i < match.Captures.Count; i++)
+                {
+                    Console.WriteLine("\tmatch.Captures[" + i + "].Value =  " + match.Captures[i].Value + ", Index = " + match.Captures[i].Index + ", Length = " + match.Captures[i].Length);
+                }
+
+                Console.WriteLine("\r\nmatch.Groups.Count =  " + match.Groups.Count);
+                for (int i = 0; i < match.Groups.Count; i++)
+                {
+                    Console.WriteLine("\r\n\tmatch.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                    Console.WriteLine("\tmatch.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Console.WriteLine("\t\tmatch.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                    }
+                }
+
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 3)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i, j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i, j, 0]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i, j, 1]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i, j], iGrpCap1[i, j, 0], iGrpCap1[i, j, 1]);
+                        }
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RightToLeft.cs
+++ b/src/System.Text.RegularExpressions/tests/RightToLeft.cs
@@ -1,0 +1,374 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RightToLeft
+{
+    // This test case was added to improve code coverage on methods that have a different code path with the RightToLeft option
+    [Fact]
+    public static void RightToLeftTests()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo"; // 000ooOooo spooky
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        Regex r;
+        String s;
+        Match m;
+        MatchCollection mCollection;
+        string replace, actualResult, expectedResult;
+        string[] splitResult, expectedSplitResult;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            //[]IsMatch(string) with RightToLeft
+            strLoc = "Loc_sdfa9849";
+            r = new Regex(@"\s+\d+", RegexOptions.RightToLeft);
+            s = @"sdf 12sad";
+            if (!r.IsMatch(s))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_16891dfa Expected match");
+            }
+
+            s = @" asdf12 ";
+            if (r.IsMatch(s))
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_16891dafes Did not expect match");
+            }
+
+            //[]Match(string, int, int) with RightToLeft
+            strLoc = "Loc_6589aead";
+            r = new Regex(@"foo\d+", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo         ";
+            m = r.Match(s, 0, s.Length);
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_86847sdae Expected match");
+            }
+
+            if (m.Value != "foo4567890")
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4988awea Expected Value={0} actual={1}", "foo4567890", m.Value);
+            }
+
+            m = r.Match(s, 10, s.Length - 10);
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_658asea Expected match");
+            }
+
+            if (m.Value != "foo4567890")
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6488ead Expected Value={0} actual={1}", "foo4567890", m.Value);
+            }
+
+            m = r.Match(s, 10, 4);
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2389eads Expected match");
+            }
+
+            if (m.Value != "foo4")
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_65489asdead Expected Value={0} actual={1}", "foo4", m.Value);
+            }
+
+            m = r.Match(s, 10, 3);
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6489sdfwa Did not expect match");
+            }
+
+            m = r.Match(s, 11, s.Length - 11);
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_64542adesa Did not expect match");
+            }
+
+            //[]Matches(string) with RightToLeft
+            strLoc = "Loc_49487depmz";
+            r = new Regex(@"foo\d+", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo1foo  0987";
+            mCollection = r.Matches(s);
+            if (mCollection.Count != 2)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_49889eadf Expected match");
+            }
+            else
+            {
+                if (mCollection[0].Value != "foo1")
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_8977eade Expected Value={0} actual={1}", "foo1", mCollection[0].Value);
+                }
+
+                if (mCollection[1].Value != "foo4567890")
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_97884dsae Expected Value={0} actual={1}", "foo4567890", mCollection[0].Value);
+                }
+            }
+
+            //[]Replace(string, string) with RightToLeft
+            strLoc = "Loc_3215dsfg";
+            r = new Regex(@"foo\s+", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo         ";
+            replace = "bar";
+            actualResult = r.Replace(s, replace);
+            expectedResult = "0123456789foo4567890bar";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_65489asdead Expected Result={0} actual={1}", expectedResult, actualResult);
+            }
+
+            //[]Replace(string, string, int count) with RightToLeft
+            strLoc = "Loc_90822safwe";
+            r = new Regex(@"\d", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo         ";
+            replace = "#";
+            actualResult = r.Replace(s, replace, 17);
+            expectedResult = "##########foo#######foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_1658asead Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            actualResult = r.Replace(s, replace, 7);
+            expectedResult = "0123456789foo#######foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_1238jhioa Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            actualResult = r.Replace(s, replace, 0);
+            expectedResult = "0123456789foo4567890foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_56498dafe Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            actualResult = r.Replace(s, replace, -1);
+            expectedResult = "##########foo#######foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_80972jnklase Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            //[]Replace(string, MatchEvaluator) with RightToLeft
+            strLoc = "Loc_5645eade";
+            r = new Regex(@"foo\s+", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo         ";
+            replace = "bar";
+            actualResult = r.Replace(s, new MatchEvaluator(MyBarMatchEvaluator));
+            expectedResult = "0123456789foo4567890bar";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_489894sead Expected Result={0} actual={1}", expectedResult, actualResult);
+            }
+
+            //[]Replace(string, string, int count) with RightToLeft
+            strLoc = "Loc_6548eada";
+            r = new Regex(@"\d", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo         ";
+            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), 17);
+            expectedResult = "##########foo#######foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6589adsfe Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), 7);
+            expectedResult = "0123456789foo#######foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_65489eadea Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), 0);
+            expectedResult = "0123456789foo4567890foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_56489eafd Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), -1);
+            expectedResult = "##########foo#######foo         ";
+            if (actualResult != expectedResult)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_6487eafd Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
+            }
+
+            //[]Split(string) with RightToLeft
+            strLoc = "Loc_5645eade";
+            r = new Regex(@"foo", RegexOptions.RightToLeft);
+            s = @"0123456789foo4567890foo         ";
+            splitResult = r.Split(s);
+            expectedSplitResult = new string[]
+            {
+            "0123456789", "4567890", "         "
+            }
+
+            ;
+            if (splitResult.Length != expectedSplitResult.Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_65489aeee Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
+            }
+            else
+            {
+                for (int i = 0; i < expectedSplitResult.Length; i++)
+                {
+                    if (splitResult[i] != expectedSplitResult[i])
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_0232jkoas Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
+                    }
+                }
+            }
+
+            //[]Split(string, int) with RightToLeft
+            strLoc = "Loc_5645eade";
+            r = new Regex(@"\d", RegexOptions.RightToLeft);
+            s = @"1a2b3c4d5e6f7g8h9i0k";
+            splitResult = r.Split(s, 11);
+            expectedSplitResult = new string[]
+            {
+            "", "a", "b", "c", "d", "e", "f", "g", "h", "i", "k"
+            }
+
+            ;
+            if (splitResult.Length != expectedSplitResult.Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_68ead Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
+            }
+            else
+            {
+                for (int i = 0; i < expectedSplitResult.Length; i++)
+                {
+                    if (splitResult[i] != expectedSplitResult[i])
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1235eas Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
+                    }
+                }
+            }
+
+            splitResult = r.Split(s, 10);
+            expectedSplitResult = new string[]
+            {
+            "1a", "b", "c", "d", "e", "f", "g", "h", "i", "k"
+            }
+
+            ;
+            if (splitResult.Length != expectedSplitResult.Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_66898adejl Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
+            }
+            else
+            {
+                for (int i = 0; i < expectedSplitResult.Length; i++)
+                {
+                    if (splitResult[i] != expectedSplitResult[i])
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_9648kojk Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
+                    }
+                }
+            }
+
+            splitResult = r.Split(s, 2);
+            expectedSplitResult = new string[]
+            {
+            "1a2b3c4d5e6f7g8h9i", "k"
+            }
+
+            ;
+            if (splitResult.Length != expectedSplitResult.Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_66898adejl Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
+            }
+            else
+            {
+                for (int i = 0; i < expectedSplitResult.Length; i++)
+                {
+                    if (splitResult[i] != expectedSplitResult[i])
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_9648kojk Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
+                    }
+                }
+            }
+
+            splitResult = r.Split(s, 1);
+            expectedSplitResult = new string[]
+            {
+            "1a2b3c4d5e6f7g8h9i0k"
+            }
+
+            ;
+            if (splitResult.Length != expectedSplitResult.Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_56987dellp Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
+            }
+            else
+            {
+                for (int i = 0; i < expectedSplitResult.Length; i++)
+                {
+                    if (splitResult[i] != expectedSplitResult[i])
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_13678jhuy Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
+                    }
+                }
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private static string MyBarMatchEvaluator(Match m)
+    {
+        return "bar";
+    }
+
+    private static string MyPoundMatchEvaluator(Match m)
+    {
+        return "#";
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/RightToLeftMatchStartAtTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RightToLeftMatchStartAtTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class RightToLeftMatchStartAtTests
+{
+    /*
+    Tested Methods:
+    
+        public static Boolean RightToLeft;     
+
+        public static Match Match(string input, Int32 startat);     "aaa"
+            "aaabbb", 3
+
+        public static Match Match(string input, Int32 startat);     "aaa", "r"
+            "aaabbb", 3
+
+        public static Match Match(string input, Int32 startat);     "AAA", "i"
+            "aaabbb", 3
+    */
+
+    [Fact]
+    public static void RightToLeftMatchStartAt()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Regex r;
+        String s;
+        Match m;
+        Match match;
+        String strMatch1 = "aaa";
+        Int32[] iMatch1 =
+        {
+        0, 3
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        "aaa"
+        }
+
+        ;
+        Int32[,] iGroup1 =
+        {
+        {
+        0, 3
+        }
+        }
+
+        ;
+        String[][] strGrpCap1 = new String[1][];
+        strGrpCap1[0] = new String[]
+        {
+        "aaa"
+        }
+
+        ;
+        Int32[][] iGrpCap1 = new Int32[1][];
+        iGrpCap1[0] = new Int32[]
+        {
+        5, 9, 3, 3
+        }
+
+        ; //This is ignored
+        Int32[] iGrpCapCnt1 =
+        {
+        1, 1
+        }
+
+        ; //0 is ignored
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            // [] public static Boolean RightToLeft;     
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yg";
+            iCountTestcases++;
+            r = new Regex("aaa");
+            if (r.RightToLeft)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234fsadg! doesnot match");
+            }
+
+            // [] public static Boolean RightToLeft
+            //-----------------------------------------------------------------
+            strLoc = "Loc_746tegd";
+            iCountTestcases++;
+            r = new Regex("aaa", RegexOptions.RightToLeft);
+            if (!r.RightToLeft)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_452wfdf! doesnot match");
+            }
+
+            // [] public static Match Match(string input, Int32 startat);     "aaa"
+            //"aaabbb", 3
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298vy";
+            iCountTestcases++;
+            s = "aaabbb";
+            r = new Regex("aaa");
+            m = r.Match(s, 3);
+            if (m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_87543! doesnot match");
+            }
+
+            // [] public static Match Match(string input, Int32 startat);     "aaa", "r"
+            //"aaabbb", 3
+            //-----------------------------------------------------------------
+            strLoc = "Loc_563rfg";
+            iCountTestcases++;
+            s = "aaabbb";
+            r = new Regex("aaa", RegexOptions.RightToLeft);
+            match = r.Match(s, 3);
+            if (!match.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_865rfsg! doesnot match");
+            }
+            else
+            {
+                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_98275dsg: unexpected return result");
+                }
+
+                //Match.Captures always is Match
+                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                if (match.Groups.Count != 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_75324sg! unexpected return result");
+                }
+
+                //Group 0 always is the Match
+                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2046gsg! unexpected return result");
+                }
+
+                //Group 0's Capture is always the Match
+                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_2975edg!! unexpected return result");
+                }
+
+                for (int i = 1; i < match.Groups.Count; i++)
+                {
+                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt1[i]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt1[i]);
+                    }
+
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
+                        }
+                    }
+                }
+            }
+
+            // []     public static Match Match(string input);     "AAA", "i"
+            //"aaabbb", 3
+            //-----------------------------------------------------------------
+            strLoc = "Loc_3452sdg";
+            iCountTestcases++;
+            s = "aaabbb";
+            r = new Regex("AAA", RegexOptions.IgnoreCase);
+            m = r.Match(s);
+            if (!m.Success)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_fsdfxcvz! doesnot match");
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/SplitMatchIsMatchTests.cs
+++ b/src/System.Text.RegularExpressions/tests/SplitMatchIsMatchTests.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class SplitMatchIsMatchTests
+{
+    /*
+        Class: Regex
+        Tested Methods:
+
+            public static string[] Split(string input, string pattern); 
+                very simple
+    
+            public static bool IsMatch(string input, string pattern, string options); 
+                "m" option with 5 patterns
+
+            public static bool IsMatch(string input, string pattern); 
+                "abc", "^b"
+
+            public static Match Match(string input, string pattern);     ???
+                "XSP_TEST_FAILURE SUCCESS", ".*\\b(\\w+)\\b"
+    */
+
+    [Fact]
+    public static void SplitMatchIsMatch()
+    {
+        //////////// Global Variables used for all tests
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        Match match;
+        String[] sa;
+        String[] strMatch1 =
+        {
+        "line2\nline3", "line2\nline3", "line3\n\nline4", "line3\n\nline4", "line2\nline3"
+        }
+
+        ;
+        Int32[,] iMatch1 =
+        {
+        {
+        6, 11
+        }
+
+        , {
+        6, 11
+        }
+
+        , {
+        12, 12
+        }
+
+        , {
+        12, 12
+        }
+
+        , {
+        6, 11
+        }
+        }
+
+        ;
+        String[] strGroup1 =
+        {
+        }
+
+        ;
+        String[] strGrpCap1 =
+        {
+        }
+
+        ;
+        String strMatch2 = "XSP_TEST_FAILURE SUCCESS";
+        Int32[] iMatch2 =
+        {
+        0, 24
+        }
+
+        ;
+        String[] strGroup2 =
+        {
+        "XSP_TEST_FAILURE SUCCESS", "SUCCESS"
+        }
+
+        ;
+        Int32[] iGroup2 =
+        {
+        17, 7
+        }
+
+        ;
+        String[] strGrpCap2 =
+        {
+        "SUCCESS"
+        }
+
+        ;
+        Int32[] iGrpCap2 =
+        {
+        17, 7
+        }
+
+        ;
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+            try
+            {
+                // []     public static string[] Split(string input, string pattern); 
+                //    very simple
+                //-----------------------------------------------------------------
+                strLoc = "Loc_498yg";
+                iCountTestcases++;
+                sa = Regex.Split("word0    word1    word2    word3", "    ");
+                for (int i = 0; i < sa.Length; i++)
+                {
+                    String s = "word" + i;
+                    if (String.Compare(sa[i], s) != 0)
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_7654fdgd! Fail : [" + s + "] not equal [" + sa[i] + "]");
+                    }
+                }
+                //-----------------------------------------------------------------
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                // [] public static bool IsMatch(string input, string pattern, string options); 
+                //"m" option with 5 patterns
+                //-----------------------------------------------------------------
+                strLoc = "Loc_298vy";
+                iCountTestcases++;
+                sa = new String[5];
+                sa[0] = "(line2$\n)line3";
+                sa[1] = "(line2\n^)line3";
+                sa[2] = "(line3\n$\n)line4";
+                sa[3] = "(line3\n^\n)line4";
+                sa[4] = "(line2$\n^)line3";
+                for (int ii = 0; ii < sa.Length; ii++)
+                {
+                    strLoc = "Loc_0002." + ii.ToString();
+                    if (!Regex.IsMatch("line1\nline2\nline3\n\nline4", sa[ii], RegexOptions.Multiline))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Fail : " + strLoc + " : Pattern not match");
+                    }
+                    else
+                    {
+                        match = Regex.Match("line1\nline2\nline3\n\nline4", sa[ii], RegexOptions.Multiline);
+                        if (!match.Value.Equals(strMatch1[ii]) || (match.Index != iMatch1[ii, 0]) || (match.Length != iMatch1[ii, 1]) || (match.Captures.Count != 1))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_75234_" + ii + " : unexpected return result");
+                        }
+
+                        for (int i = 0; i < match.Captures.Count; i++)
+                        {
+                            if (!match.Captures[i].Value.Equals(strMatch1[ii]) || (match.Captures[i].Index != iMatch1[ii, 0]) || (match.Captures[i].Length != iMatch1[ii, 1]))
+                            {
+                                iCountErrors++;
+                                Console.WriteLine("Err_8743fsgd_" + ii + "_" + i + " : unexpected return result");
+                            }
+                        }
+
+                        if (match.Groups.Count != 2)
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_3976dffd! unexpected return result");
+                        }
+
+                        for (int i = 0; i < match.Groups.Count; i++)
+                        {
+                            Console.WriteLine("\r\n    match.Groups[" + i + "].Value =  " + match.Groups[i].Value + ", Index = " + match.Groups[i].Index + ", Length = " + match.Groups[i].Length);
+                            Console.WriteLine("    match.Groups[" + i + "].Captures.Count =  " + match.Groups[i].Captures.Count);
+                            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                            {
+                                Console.WriteLine("        match.Groups[" + i + "].Captures[" + j + "].Value =  " + match.Groups[i].Captures[j].Value + ", Index = " + match.Groups[i].Captures[j].Index + ", Length = " + match.Groups[i].Captures[j].Length);
+                            }
+                        }
+                    }
+                }
+                //-----------------------------------------------------------------
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            try
+            {
+                // [] public static bool IsMatch(string input, string pattern); 
+                //"abc", "^b"
+                //-----------------------------------------------------------------
+                strLoc = "Loc_75rfds";
+                iCountTestcases++;
+                if (Regex.IsMatch("abc", "^b"))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_7356wgd! Fail : " + strLoc + " : unexpected match");
+                }
+                //-----------------------------------------------------------------
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            try
+            {
+                // [] public static Match Match(string input, string pattern);     ???
+                //"XSP_TEST_FAILURE SUCCESS", ".*\\b(\\w+)\\b"
+                //-----------------------------------------------------------------
+                strLoc = "Loc_87423fs";
+                iCountTestcases++;
+                match = Regex.Match("XSP_TEST_FAILURE SUCCESS", @".*\b(\w+)\b");
+                if (!match.Success)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_753rwef! Unexpected results returned");
+                }
+                else
+                {
+                    if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_98275dsg: unexpected return result");
+                    }
+
+                    //Match.Captures always is Match
+                    if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_2046gsg! unexpected return result");
+                    }
+
+                    if (match.Groups.Count != 2)
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_75324sg! unexpected return result");
+                    }
+
+                    //Group 0 always is the Match
+                    if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_2046gsg! unexpected return result");
+                    }
+
+                    //Group 0's Capture is always the Match
+                    if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
+                    {
+                        iCountErrors++;
+                        Console.WriteLine("Err_2975edg!! unexpected return result");
+                    }
+
+                    for (int i = 1; i < match.Groups.Count; i++)
+                    {
+                        if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[0]) || (match.Groups[i].Length != iGroup2[1]) || (match.Groups[i].Captures.Count != 1))
+                        {
+                            iCountErrors++;
+                            Console.WriteLine("Err_1954eg_" + i + "! unexpected return result");
+                        }
+
+                        for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                        {
+                            if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[0]) || (match.Groups[i].Captures[j].Length != iGrpCap2[1]))
+                            {
+                                iCountErrors++;
+                                Console.WriteLine("Err_5072dn_" + i + "_" + j + "!! unexpected return result");
+                            }
+                        }
+                    }
+                }
+                //-----------------------------------------------------------------
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+        Assert.Equal(0, iCountErrors);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/Support.cs
+++ b/src/System.Text.RegularExpressions/tests/Support.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+public class RegexTestCase
+{
+    private String _pattern;
+    private String _input;
+    private RegexOptions _options;
+    private String[] _expectedGroups;
+    private Type _expectedExceptionType;
+    private System.Globalization.CultureInfo _cultureInfo;
+
+    public RegexTestCase(String pattern, String input, params String[] expectedGroups) : this(pattern, RegexOptions.None, input, expectedGroups) { }
+
+    public RegexTestCase(String pattern, String input, String[] expectedGroups, CultureInfo culture) : this(pattern, RegexOptions.None, input, expectedGroups, culture) { }
+
+    public RegexTestCase(String pattern, RegexOptions options, String input, params String[] expectedGroups)
+    {
+        _pattern = pattern;
+        _options = options;
+        _input = input;
+        _expectedGroups = expectedGroups;
+        _cultureInfo = null;
+    }
+
+    public RegexTestCase(String pattern, RegexOptions options, String input, String[] expectedGroups, CultureInfo culture)
+    {
+        _pattern = pattern;
+        _options = options;
+        _input = input;
+        _expectedGroups = expectedGroups;
+        _cultureInfo = culture;
+    }
+
+    public RegexTestCase(String pattern, Type expectedExceptionType) : this(pattern, RegexOptions.None, expectedExceptionType) { }
+
+    public RegexTestCase(String pattern, RegexOptions options, Type expectedExceptionType)
+    {
+        _pattern = pattern;
+        _options = options;
+        _expectedExceptionType = expectedExceptionType;
+    }
+
+    public string Pattern { get { return _pattern; } }
+
+    public string Input { get { return _input; } }
+
+    public RegexOptions Options { get { return _options; } }
+
+    public String[] ExpectedGroups { get { return _expectedGroups; } }
+
+    public Type ExpectedExceptionType { get { return _expectedExceptionType; } }
+
+    public bool ExpectException { get { return null != _expectedExceptionType; } }
+
+    public bool ExpectSuccess { get { return null != _expectedGroups && _expectedGroups.Length != 0; } }
+
+    public bool Run()
+    {
+        Regex r;
+        Match m;
+        System.Globalization.CultureInfo originalCulture = null;
+
+        try
+        {
+            if (null != _cultureInfo)
+            {
+                originalCulture = CultureInfo.CurrentCulture;
+                CultureInfo.CurrentCulture = _cultureInfo;
+            }
+
+
+            try
+            {
+                r = new Regex(_pattern, _options);
+
+                if (ExpectException)
+                {
+                    Console.WriteLine("Err_09872anba! Expected Regex to throw {0} exception and none was thrown", _expectedExceptionType);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                if (ExpectException && e.GetType() == _expectedExceptionType)
+                {
+                    return true;
+                }
+                else if (ExpectException)
+                {
+                    Console.WriteLine("Err_4980asu! Expected exception of type {0} and instead the following was thrown: \n{1}", _expectedExceptionType, e);
+                    return false;
+                }
+                else
+                {
+                    Console.WriteLine("Err_78394ayuua! Expected no exception to be thrown and the following was thrown: \n{0}", e);
+                    return false;
+                }
+            }
+
+            m = r.Match(_input);
+        }
+        finally
+        {
+            if (null != _cultureInfo)
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        if (m.Success && !ExpectSuccess)
+        {
+            Console.WriteLine("Err_2270awanm! Did not expect the match to succeed");
+            return false;
+        }
+        else if (!m.Success && ExpectSuccess)
+        {
+            Console.WriteLine("Err_68997asnzxn! Did not expect the match to fail");
+            return false;
+        }
+
+        if (!ExpectSuccess)
+        {
+            //The match was not suppose to suceed and it failed. There is no more checking to do
+            //so the test was a sucess
+            return true;
+        }
+
+        if (m.Groups.Count != _expectedGroups.Length)
+        {
+            Console.WriteLine("Err_0234jah!Expected {0} groups and got {1} groups", _expectedGroups.Length, m.Groups.Count);
+            return false;
+        }
+
+        if (m.Value != _expectedGroups[0])
+        {
+            Console.WriteLine("Err_611074ahhar Expected Value='{0}' Actual='{1}'", _expectedGroups[0], m.Value);
+            return false;
+        }
+
+        int[] groupNumbers = r.GetGroupNumbers();
+        string[] groupNames = r.GetGroupNames();
+
+        for (int i = 0; i < _expectedGroups.Length; i++)
+        {
+            //Verify Group.Value
+            if (m.Groups[groupNumbers[i]].Value != _expectedGroups[i])
+            {
+                Console.WriteLine("Err_07823nhhl Expected Group[{0}]='{1}' actual='{2}' Name={3}",
+                    groupNumbers[i], _expectedGroups[i], m.Groups[groupNumbers[i]], r.GroupNameFromNumber(groupNumbers[i]));
+                return false;
+            }
+
+            //Verify the same thing is returned from groups when using either an int or string index
+            if (m.Groups[groupNumbers[i]] != m.Groups[groupNames[i]])
+            {
+                Console.WriteLine("Err_08712saklj Expected Groups[{0}]='{1}' Groups[{2}]='{3}'",
+                    groupNumbers[i], m.Groups[groupNumbers[i]], groupNames[i], m.Groups[groupNames[i]]);
+                return false;
+            }
+
+            //Verify GetGroupNumberFromName
+            if (groupNumbers[i] != r.GroupNumberFromName(groupNames[i]))
+            {
+                Console.WriteLine("Err_68974aehui Expected GroupNumberFromName({0})={1} actual{2}",
+                    groupNames[i], groupNumbers[i], r.GroupNumberFromName(groupNames[i]));
+                return false;
+            }
+
+            //Verify GetGroupNameFromNumber
+            if (groupNames[i] != r.GroupNameFromNumber(groupNumbers[i]))
+            {
+                Console.WriteLine("Err_3468plhmy Expected GroupNameFromNumber({0})={1} actual{2}",
+                    groupNumbers[i], groupNames[i], r.GroupNameFromNumber(groupNumbers[i]));
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="..\..\packages\xunit.core.2.0.0-beta5-build2785\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0-beta5-build2785\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{94B106C2-D574-4392-80AB-3EE308A078DF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <AssemblyName>System.Text.RegularExpressions.Tests</AssemblyName>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <!-- Compiled Source Files -->
+  <ItemGroup>
+    <Compile Include="CaptureCollectionTests.cs" />
+    <Compile Include="CaptureTests.cs" />
+    <Compile Include="EscapeUnescapeTests.cs" />
+    <Compile Include="GroupNamesAndNumbers.cs" />
+    <Compile Include="IsMatchMatchSplitTests.cs" />
+    <Compile Include="R2LGetGroupNamesMatchTests.cs" />
+    <Compile Include="RegexComponentsSplitTests.cs" />
+    <Compile Include="RegexConstructorTests.cs" />
+    <Compile Include="RegexMatchTests0.cs" />
+    <Compile Include="RegexMatchTests1.cs" />
+    <Compile Include="RegexMatchTests2.cs" />
+    <Compile Include="RegexMatchTests3.cs" />
+    <Compile Include="RegexMatchTests4.cs" />
+    <Compile Include="RegexMatchTests5.cs" />
+    <Compile Include="RegexMatchTests6.cs" />
+    <Compile Include="RegexMatchTests7.cs" />
+    <Compile Include="RegexMatchTests8.cs" />
+    <Compile Include="RegexMatchTests9.cs" />
+    <Compile Include="RegexMatchTests10.cs" />
+    <Compile Include="RegexMatchTests11.cs" />
+    <Compile Include="RegexMatchValueTests.cs" />
+    <Compile Include="RegexReplaceStringTests0.cs" />
+    <Compile Include="RegexReplaceStringTests1.cs" />
+    <Compile Include="RegexSplitTests.cs" />
+    <Compile Include="ReturnValueChecks.cs" />
+    <Compile Include="RightToLeft.cs" />
+    <Compile Include="RightToLeftMatchStartAtTests.cs" />
+    <Compile Include="SplitMatchIsMatchTests.cs" />
+    <Compile Include="RegexUnicodeCharTests.cs" />
+    <Compile Include="RegexLangElementsCoverageTests.cs" />
+    <Compile Include="CharacterClassSubtractionSimple.cs" />
+    <Compile Include="Support.cs" />
+  </ItemGroup>
+  <!-- References used -->
+  <ItemGroup>
+    <Reference Include="System.Collections">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Collections.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Console">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Console.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Globalization">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Globalization.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Globalization.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.IO.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Runtime.4.0.20-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Runtime.Extensions.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Text.Encoding.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Text.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Threading.Tasks.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0-beta5-build2785\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert">
+      <HintPath>..\..\packages\xunit.assert.2.0.0-beta5-build2785\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\packages\xunit.core.2.0.0-beta5-build2785\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">
+      <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
+      <Name>XunitTraitsDiscoverers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Text.RegularExpressions.csproj">
+      <Project>{be28323e-327a-4e0f-b7f9-16ab7eab59dd}</Project>
+      <Name>System.Text.RegularExpressions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- Automatically added by VS -->
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.RegularExpressions/tests/packages.config
+++ b/src/System.Text.RegularExpressions/tests/packages.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Collections" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Console" version="4.0.0-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Globalization" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.IO" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Runtime" version="4.0.20-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
+  <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+  <package id="xunit.abstractions" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+  <package id="xunit.assert" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+  <package id="xunit.core" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+</packages>


### PR DESCRIPTION
This adds our tests for the System.Text.RegularExpressions library.

Currently, these tests (and almost all of the tests that we will be bringing out from our internal sources) are going to print a lot of things to the console, as that is the testing paradigm we follow internally. We will be coming up with a way to either redirect the test output, or make it configurable.
