### PR TITLE
Fix file name casing in System.Diagnostics.FileVersionInfo.csproj

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\FileVersionInfo.cs" />
-    <Compile Include="Interop\Interop.Manual.cs" />
+    <Compile Include="Interop\Interop.manual.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections">


### PR DESCRIPTION
The file on disk is called Interop.manual.cs, not Interop.Manual.cs.
This fixes compilation with Mono on Linux (or other case-sensitive FS).
