### PR TITLE
Use String.Equals instead of String.Compare for equality checks

### DIFF
--- a/src/Common/src/System/Xml/XmlTextWriter.cs
+++ b/src/Common/src/System/Xml/XmlTextWriter.cs
@@ -736,7 +736,7 @@ namespace System.Xml
                 {
                     throw new ArgumentException(SR.Xml_InvalidPiChars);
                 }
-                if (0 == String.Compare(name, "xml", StringComparison.OrdinalIgnoreCase) && this.stateTable == stateTableDocument)
+                if (String.Equals(name, "xml", StringComparison.OrdinalIgnoreCase) && this.stateTable == stateTableDocument)
                 {
                     throw new ArgumentException(SR.Xml_DupXmlDecl);
                 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/Pipe.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/Pipe.cs
@@ -476,7 +476,7 @@ namespace System.IO.Pipes
             string normalizedPipePath = Path.GetFullPath(@"\\.\pipe\" + pipeName);
 
             // Make sure the pipe name isn't one of our reserved names for anonymous pipes.
-            if (String.Compare(normalizedPipePath, @"\\.\pipe\anonymous", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Equals(normalizedPipePath, @"\\.\pipe\anonymous", StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentOutOfRangeException("pipeName", SR.ArgumentOutOfRange_AnonymousReserved);
             }
@@ -1069,7 +1069,7 @@ namespace System.IO.Pipes
 
             _normalizedPipePath = Path.GetFullPath(@"\\" + serverName + @"\pipe\" + pipeName);
 
-            if (String.Compare(_normalizedPipePath, @"\\.\pipe\anonymous", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Equals(_normalizedPipePath, @"\\.\pipe\anonymous", StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentOutOfRangeException("pipeName", SR.ArgumentOutOfRange_AnonymousReserved);
             }

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
@@ -137,7 +137,7 @@ namespace System.Xml.Linq
         static void ValidateName(string name)
         {
             XmlConvert.VerifyNCName(name);
-            if (string.Compare(name, "xml", StringComparison.OrdinalIgnoreCase) == 0) throw new ArgumentException(SR.Format(SR.Argument_InvalidPIName, name));
+            if (string.Equals(name, "xml", StringComparison.OrdinalIgnoreCase)) throw new ArgumentException(SR.Format(SR.Argument_InvalidPIName, name));
         }
     }
 }

--- a/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriter.cs
+++ b/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriter.cs
@@ -919,7 +919,7 @@ namespace System.Xml
                 }
 
                 // xml declaration is a special case (not a processing instruction, but we allow WriteProcessingInstruction as a convenience)
-                if (name.Length == 3 && string.Compare(name, XmlConst.XmlDeclarationTag, StringComparison.OrdinalIgnoreCase) == 0)
+                if (name.Length == 3 && string.Equals(name, XmlConst.XmlDeclarationTag, StringComparison.OrdinalIgnoreCase))
                 {
                     if (_currentState != State.Start)
                     {

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlImplementation.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlImplementation.cs
@@ -22,7 +22,7 @@ namespace System.Xml
         // Test if the DOM implementation implements a specific feature.
         public bool HasFeature(string strFeature, string strVersion)
         {
-            if (String.Compare("XML", strFeature, StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Equals("XML", strFeature, StringComparison.OrdinalIgnoreCase))
             {
                 if (strVersion == null || strVersion == "1.0" || strVersion == "2.0")
                     return true;

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlNode.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlNode.cs
@@ -737,7 +737,7 @@ namespace System.Xml
         // Test if the DOM implementation implements a specific feature.
         public virtual bool Supports(string feature, string version)
         {
-            if (String.Compare("XML", feature, StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Equals("XML", feature, StringComparison.OrdinalIgnoreCase))
             {
                 if (version == null || version == "1.0" || version == "2.0")
                     return true;


### PR DESCRIPTION
Per the [Best Practices for Using Strings in the .NET Framework](http://msdn.microsoft.com/en-us/library/dd465121%28v=vs.110%29.aspx):
- Use an overload of the `String.Equals` method to test whether two strings are equal.
- Use the `String.Compare` and `String.CompareTo` methods to sort strings, **not to check for equality**.
