### PR TITLE
Register msbuild.log as an asset on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,3 +2,7 @@ build_script:
   - '"%VS120COMNTOOLS%VsDevCmd.bat"'
   - build.cmd
 test: off  # disable automatic test discovery, xUnit already runs as part of build.cmd
+
+artifacts:
+  - path: msbuild.log
+    name: MSBuild Log


### PR DESCRIPTION
If we need to debug the build issues it's pretty convenient if we can directly download the diagnostic log.

cc: @FiveTimesTheFun, @weshaggard, @nguerrera 
