### PR TITLE
Implement IList<T>, IReadOnlyList<T>, and IList on Regex Collections

### DIFF
--- a/src/System.Text.RegularExpressions/src/Resources/Strings.Designer.cs
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.Designer.cs
@@ -269,6 +269,15 @@ namespace Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collection is read-only..
+        /// </summary>
+        internal static string NotSupported_ReadOnlyCollection {
+            get {
+                return ResourceManager.GetString("NotSupported_ReadOnlyCollection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This operation is only allowed once per object..
         /// </summary>
         internal static string OnlyAllowedOnce {

--- a/src/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -186,6 +186,9 @@
   <data name="NotEnoughParens" xml:space="preserve">
     <value>Not enough )'s.</value>
   </data>
+  <data name="NotSupported_ReadOnlyCollection" xml:space="preserve">
+    <value>Collection is read-only.</value>
+  </data>
   <data name="OnlyAllowedOnce" xml:space="preserve">
     <value>This operation is only allowed once per object.</value>
   </data>

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -27,6 +27,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexCaptureCollection.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCode.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexCollectionDebuggerProxy.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexFCD.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexGroup.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexGroupCollection.cs" />

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -69,12 +69,12 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public IEnumerator GetEnumerator()
         {
-            return new CaptureEnumerator(this);
+            return new Enumerator(this);
         }
 
         IEnumerator<Capture> IEnumerable<Capture>.GetEnumerator()
         {
-            return new CaptureEnumerator(this);
+            return new Enumerator(this);
         }
 
         /*
@@ -230,80 +230,54 @@ namespace System.Text.RegularExpressions
                 array.SetValue(this[j], i);
             }
         }
-    }
 
-
-    /*
-     * This non-public enumerator lists all the captures
-     * Should it be public?
-     */
-
-    internal class CaptureEnumerator : IEnumerator<Capture>
-    {
-        internal CaptureCollection _rcc;
-        internal int _curindex;
-
-        /*
-         * Nonpublic constructor
-         */
-        internal CaptureEnumerator(CaptureCollection rcc)
+        private class Enumerator : IEnumerator<Capture>
         {
-            _curindex = -1;
-            _rcc = rcc;
-        }
+            private readonly CaptureCollection _collection;
+            private int _index;
 
-        /*
-         * As required by IEnumerator
-         */
-        public bool MoveNext()
-        {
-            int size = _rcc.Count;
-
-            if (_curindex >= size)
-                return false;
-
-            _curindex++;
-
-            return (_curindex < size);
-        }
-
-        /*
-         * As required by IEnumerator
-         */
-        public Object Current
-        {
-            get { return Capture; }
-        }
-
-        Capture IEnumerator<Capture>.Current
-        {
-            get { return Capture; }
-        }
-
-        /*
-         * Returns the current capture
-         */
-        public Capture Capture
-        {
-            get
+            internal Enumerator(CaptureCollection collection)
             {
-                if (_curindex < 0 || _curindex >= _rcc.Count)
-                    throw new InvalidOperationException(SR.EnumNotStarted);
-
-                return _rcc[_curindex];
+                _collection = collection;
+                _index = -1;
             }
-        }
 
-        /*
-         * Reset to before the first item
-         */
-        public void Reset()
-        {
-            _curindex = -1;
-        }
+            public bool MoveNext()
+            {
+                int size = _collection.Count;
 
-        void IDisposable.Dispose()
-        {
+                if (_index >= size)
+                    return false;
+
+                _index++;
+
+                return (_index < size);
+            }
+
+            public Capture Current
+            {
+                get
+                {
+                    if (_index < 0 || _index >= _collection.Count)
+                        throw new InvalidOperationException(SR.EnumNotStarted);
+
+                    return _collection[_index];
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            void IEnumerator.Reset()
+            {
+                _index = -1;
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -225,9 +225,15 @@ namespace System.Text.RegularExpressions
             if (array == null)
                 throw new ArgumentNullException("array");
 
+            if (Count == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (int i = arrayIndex, j = 0; j < Count; i++, j++)
             {
-                array.SetValue(this[j], i);
+                indices[0] = i;
+                array.SetValue(this[j], indices);
             }
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -34,25 +34,6 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// The object on which to synchronize.
-        /// </summary>
-        Object ICollection.SyncRoot
-        {
-            get
-            {
-                return _group;
-            }
-        }
-
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Returns the number of captures.
         /// </summary>
         public int Count
@@ -78,15 +59,9 @@ namespace System.Text.RegularExpressions
         /// Copies all the elements of the collection to the given array
         /// beginning at the given index.
         /// </summary>
-        void ICollection.CopyTo(Array array, int arrayIndex)
+        public void CopyTo(Capture[] array, int arrayIndex)
         {
-            if (array == null)
-                throw new ArgumentNullException("array");
-
-            for (int i = arrayIndex, j = 0; j < Count; i++, j++)
-            {
-                array.SetValue(this[j], i);
-            }
+            ((ICollection)this).CopyTo(array, arrayIndex);
         }
 
         /// <summary>
@@ -174,11 +149,6 @@ namespace System.Text.RegularExpressions
             return false;
         }
 
-        void ICollection<Capture>.CopyTo(Capture[] array, int arrayIndex)
-        {
-            ((ICollection)this).CopyTo(array, arrayIndex);
-        }
-
         bool ICollection<Capture>.IsReadOnly
         {
             get { return true; }
@@ -238,6 +208,27 @@ namespace System.Text.RegularExpressions
         {
             get { return this[index]; }
             set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return _group; }
+        }
+
+        void ICollection.CopyTo(Array array, int arrayIndex)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+
+            for (int i = arrayIndex, j = 0; j < Count; i++, j++)
+            {
+                array.SetValue(this[j], i);
+            }
         }
     }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Text.RegularExpressions
 {
@@ -18,6 +19,8 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<>))]
     public class CaptureCollection : IList<Capture>, IReadOnlyList<Capture>, IList
     {
         internal Group _group;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -23,9 +23,9 @@ namespace System.Text.RegularExpressions
     [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<>))]
     public class CaptureCollection : IList<Capture>, IReadOnlyList<Capture>, IList
     {
-        internal Group _group;
-        internal int _capcount;
-        internal Capture[] _captures;
+        private readonly Group _group;
+        private readonly int _capcount;
+        private Capture[] _captures;
 
         internal CaptureCollection(Group group)
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -139,28 +139,28 @@ namespace System.Text.RegularExpressions
 
         void IList<Capture>.Insert(int index, Capture item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList<Capture>.RemoveAt(int index)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         Capture IList<Capture>.this[int index]
         {
             get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
         }
 
         void ICollection<Capture>.Add(Capture item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void ICollection<Capture>.Clear()
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool ICollection<Capture>.Contains(Capture item)
@@ -186,17 +186,17 @@ namespace System.Text.RegularExpressions
 
         bool ICollection<Capture>.Remove(Capture item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         int IList.Add(object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList.Clear()
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool IList.Contains(object value)
@@ -211,7 +211,7 @@ namespace System.Text.RegularExpressions
 
         void IList.Insert(int index, object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool IList.IsFixedSize
@@ -226,18 +226,18 @@ namespace System.Text.RegularExpressions
 
         void IList.Remove(object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList.RemoveAt(int index)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         object IList.this[int index]
         {
             get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
         }
     }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -5,6 +5,7 @@
 // contained in a compiled Regex.
 
 using System.Collections;
+using System.Collections.Generic;
 
 namespace System.Text.RegularExpressions
 {
@@ -17,7 +18,7 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
-    public class CaptureCollection : ICollection
+    public class CaptureCollection : IList<Capture>, IReadOnlyList<Capture>, IList
     {
         internal Group _group;
         internal int _capcount;
@@ -93,6 +94,11 @@ namespace System.Text.RegularExpressions
             return new CaptureEnumerator(this);
         }
 
+        IEnumerator<Capture> IEnumerable<Capture>.GetEnumerator()
+        {
+            return new CaptureEnumerator(this);
+        }
+
         /*
          * Nonpublic code to return set of captures for the group
          */
@@ -116,6 +122,120 @@ namespace System.Text.RegularExpressions
 
             return _captures[i];
         }
+
+        int IList<Capture>.IndexOf(Capture item)
+        {
+            var comparer = EqualityComparer<Capture>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        void IList<Capture>.Insert(int index, Capture item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<Capture>.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        Capture IList<Capture>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
+
+        void ICollection<Capture>.Add(Capture item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<Capture>.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<Capture>.Contains(Capture item)
+        {
+            var comparer = EqualityComparer<Capture>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return true;
+            }
+            return false;
+        }
+
+        void ICollection<Capture>.CopyTo(Capture[] array, int arrayIndex)
+        {
+            ((ICollection)this).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<Capture>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        bool ICollection<Capture>.Remove(Capture item)
+        {
+            throw new NotSupportedException();
+        }
+
+        int IList.Add(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.Contains(object value)
+        {
+            return value is Capture && ((ICollection<Capture>)this).Contains((Capture)value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return value is Capture ? ((IList<Capture>)this).IndexOf((Capture)value) : -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.IsFixedSize
+        {
+            get { return true; }
+        }
+
+        bool IList.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        object IList.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
     }
 
 
@@ -124,7 +244,7 @@ namespace System.Text.RegularExpressions
      * Should it be public?
      */
 
-    internal class CaptureEnumerator : IEnumerator
+    internal class CaptureEnumerator : IEnumerator<Capture>
     {
         internal CaptureCollection _rcc;
         internal int _curindex;
@@ -161,6 +281,11 @@ namespace System.Text.RegularExpressions
             get { return Capture; }
         }
 
+        Capture IEnumerator<Capture>.Current
+        {
+            get { return Capture; }
+        }
+
         /*
          * Returns the current capture
          */
@@ -181,6 +306,10 @@ namespace System.Text.RegularExpressions
         public void Reset()
         {
             _curindex = -1;
+        }
+
+        void IDisposable.Dispose()
+        {
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCollectionDebuggerProxy.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCollectionDebuggerProxy.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.RegularExpressions
+{
+    internal sealed class RegexCollectionDebuggerProxy<T>
+    {
+        private readonly ICollection<T> _collection;
+
+        public RegexCollectionDebuggerProxy(ICollection<T> collection)
+        {
+            if (collection == null)
+                throw new ArgumentNullException("collection");
+
+            _collection = collection;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get
+            {
+                T[] items = new T[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -170,28 +170,28 @@ namespace System.Text.RegularExpressions
 
         void IList<Group>.Insert(int index, Group item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList<Group>.RemoveAt(int index)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         Group IList<Group>.this[int index]
         {
             get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
         }
 
         void ICollection<Group>.Add(Group item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void ICollection<Group>.Clear()
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool ICollection<Group>.Contains(Group item)
@@ -217,17 +217,17 @@ namespace System.Text.RegularExpressions
 
         bool ICollection<Group>.Remove(Group item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         int IList.Add(object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList.Clear()
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool IList.Contains(object value)
@@ -242,7 +242,7 @@ namespace System.Text.RegularExpressions
 
         void IList.Insert(int index, object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool IList.IsFixedSize
@@ -257,18 +257,18 @@ namespace System.Text.RegularExpressions
 
         void IList.Remove(object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList.RemoveAt(int index)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         object IList.this[int index]
         {
             get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
         }
     }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -67,26 +67,20 @@ namespace System.Text.RegularExpressions
         {
             if (_captureMap != null)
             {
-                Object o;
-
-                o = _captureMap[groupnum];
-                if (o == null)
+                int index;
+                if (!_captureMap.TryGetValue(groupnum, out index))
                     return Group._emptygroup;
-                //throw new ArgumentOutOfRangeException("groupnum");
 
-                return GetGroupImpl((int)o);
+                return GetGroupImpl(index);
             }
             else
             {
-                //if (groupnum >= _match._regex.CapSize || groupnum < 0)
-                //   throw new ArgumentOutOfRangeException("groupnum");
                 if (groupnum >= _match._matchcount.Length || groupnum < 0)
                     return Group._emptygroup;
 
                 return GetGroupImpl(groupnum);
             }
         }
-
 
         /*
          * Caches the group objects

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -34,25 +34,6 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// The object on which to synchronize
-        /// </summary>
-        Object ICollection.SyncRoot
-        {
-            get
-            {
-                return _match;
-            }
-        }
-
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Returns the number of groups.
         /// </summary>
         public int Count
@@ -133,15 +114,9 @@ namespace System.Text.RegularExpressions
         /// Copies all the elements of the collection to the given array
         /// beginning at the given index.
         /// </summary>
-        void ICollection.CopyTo(Array array, int arrayIndex)
+        public void CopyTo(Group[] array, int arrayIndex)
         {
-            if (array == null)
-                throw new ArgumentNullException("array");
-
-            for (int i = arrayIndex, j = 0; j < Count; i++, j++)
-            {
-                array.SetValue(this[j], i);
-            }
+            ((ICollection)this).CopyTo(array, arrayIndex);
         }
 
         /// <summary>
@@ -205,11 +180,6 @@ namespace System.Text.RegularExpressions
             return false;
         }
 
-        void ICollection<Group>.CopyTo(Group[] array, int arrayIndex)
-        {
-            ((ICollection)this).CopyTo(array, arrayIndex);
-        }
-
         bool ICollection<Group>.IsReadOnly
         {
             get { return true; }
@@ -269,6 +239,27 @@ namespace System.Text.RegularExpressions
         {
             get { return this[index]; }
             set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return _match; }
+        }
+
+        void ICollection.CopyTo(Array array, int arrayIndex)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+
+            for (int i = arrayIndex, j = 0; j < Count; i++, j++)
+            {
+                array.SetValue(this[j], i);
+            }
         }
     }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -18,16 +18,16 @@ namespace System.Text.RegularExpressions
     [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<>))]
     public class GroupCollection : IList<Group>, IReadOnlyList<Group>, IList
     {
-        internal Match _match;
-        internal Dictionary<Int32, Int32> _captureMap;
+        private readonly Match _match;
+        private readonly Dictionary<int, int> _captureMap;
 
         // cache of Group objects fed to the user
-        internal Group[] _groups;
+        private Group[] _groups;
 
         /*
          * Nonpublic constructor
          */
-        internal GroupCollection(Match match, Dictionary<Int32, Int32> caps)
+        internal GroupCollection(Match match, Dictionary<int, int> caps)
         {
             _match = match;
             _captureMap = caps;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Text.RegularExpressions
 {
@@ -13,6 +14,8 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<>))]
     public class GroupCollection : IList<Group>, IReadOnlyList<Group>, IList
     {
         internal Match _match;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -250,9 +250,15 @@ namespace System.Text.RegularExpressions
             if (array == null)
                 throw new ArgumentNullException("array");
 
+            if (Count == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (int i = arrayIndex, j = 0; j < Count; i++, j++)
             {
-                array.SetValue(this[j], i);
+                indices[0] = i;
+                array.SetValue(this[j], indices);
             }
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -13,7 +13,7 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
-    public class GroupCollection : ICollection
+    public class GroupCollection : IList<Group>, IReadOnlyList<Group>, IList
     {
         internal Match _match;
         internal Dictionary<Int32, Int32> _captureMap;
@@ -148,6 +148,125 @@ namespace System.Text.RegularExpressions
         {
             return new GroupEnumerator(this);
         }
+
+        IEnumerator<Group> IEnumerable<Group>.GetEnumerator()
+        {
+            return new GroupEnumerator(this);
+        }
+
+        int IList<Group>.IndexOf(Group item)
+        {
+            var comparer = EqualityComparer<Group>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        void IList<Group>.Insert(int index, Group item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<Group>.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        Group IList<Group>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
+
+        void ICollection<Group>.Add(Group item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<Group>.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<Group>.Contains(Group item)
+        {
+            var comparer = EqualityComparer<Group>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return true;
+            }
+            return false;
+        }
+
+        void ICollection<Group>.CopyTo(Group[] array, int arrayIndex)
+        {
+            ((ICollection)this).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<Group>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        bool ICollection<Group>.Remove(Group item)
+        {
+            throw new NotSupportedException();
+        }
+
+        int IList.Add(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.Contains(object value)
+        {
+            return value is Group && ((ICollection<Group>)this).Contains((Group)value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return value is Group ? ((IList<Group>)this).IndexOf((Group)value) : -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.IsFixedSize
+        {
+            get { return true; }
+        }
+
+        bool IList.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        object IList.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
     }
 
 
@@ -155,7 +274,7 @@ namespace System.Text.RegularExpressions
      * This non-public enumerator lists all the captures
      * Should it be public?
      */
-    internal class GroupEnumerator : IEnumerator
+    internal class GroupEnumerator : IEnumerator<Group>
     {
         internal GroupCollection _rgc;
         internal int _curindex;
@@ -192,6 +311,11 @@ namespace System.Text.RegularExpressions
             get { return Capture; }
         }
 
+        Group IEnumerator<Group>.Current
+        {
+            get { return (Group)Capture; }
+        }
+
         /*
          * Returns the current capture
          */
@@ -212,6 +336,10 @@ namespace System.Text.RegularExpressions
         public void Reset()
         {
             _curindex = -1;
+        }
+
+        void IDisposable.Dispose()
+        {
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -118,12 +118,12 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public IEnumerator GetEnumerator()
         {
-            return new GroupEnumerator(this);
+            return new Enumerator(this);
         }
 
         IEnumerator<Group> IEnumerable<Group>.GetEnumerator()
         {
-            return new GroupEnumerator(this);
+            return new Enumerator(this);
         }
 
         int IList<Group>.IndexOf(Group item)
@@ -255,79 +255,54 @@ namespace System.Text.RegularExpressions
                 array.SetValue(this[j], i);
             }
         }
-    }
 
-
-    /*
-     * This non-public enumerator lists all the captures
-     * Should it be public?
-     */
-    internal class GroupEnumerator : IEnumerator<Group>
-    {
-        internal GroupCollection _rgc;
-        internal int _curindex;
-
-        /*
-         * Nonpublic constructor
-         */
-        internal GroupEnumerator(GroupCollection rgc)
+        private class Enumerator : IEnumerator<Group>
         {
-            _curindex = -1;
-            _rgc = rgc;
-        }
+            private readonly GroupCollection _collection;
+            private int _index;
 
-        /*
-         * As required by IEnumerator
-         */
-        public bool MoveNext()
-        {
-            int size = _rgc.Count;
-
-            if (_curindex >= size)
-                return false;
-
-            _curindex++;
-
-            return (_curindex < size);
-        }
-
-        /*
-         * As required by IEnumerator
-         */
-        public Object Current
-        {
-            get { return Capture; }
-        }
-
-        Group IEnumerator<Group>.Current
-        {
-            get { return (Group)Capture; }
-        }
-
-        /*
-         * Returns the current capture
-         */
-        public Capture Capture
-        {
-            get
+            internal Enumerator(GroupCollection collection)
             {
-                if (_curindex < 0 || _curindex >= _rgc.Count)
-                    throw new InvalidOperationException(SR.EnumNotStarted);
-
-                return _rgc[_curindex];
+                _collection = collection;
+                _index = -1;
             }
-        }
 
-        /*
-         * Reset to before the first item
-         */
-        public void Reset()
-        {
-            _curindex = -1;
-        }
+            public bool MoveNext()
+            {
+                int size = _collection.Count;
 
-        void IDisposable.Dispose()
-        {
+                if (_index >= size)
+                    return false;
+
+                _index++;
+
+                return (_index < size);
+            }
+
+            public Group Current
+            {
+                get
+                {
+                    if (_index < 0 || _index >= _collection.Count)
+                        throw new InvalidOperationException(SR.EnumNotStarted);
+
+                    return _collection[_index];
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            void IEnumerator.Reset()
+            {
+                _index = -1;
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -108,9 +108,7 @@ namespace System.Text.RegularExpressions
         {
             get
             {
-                Match match;
-
-                match = GetMatch(i);
+                Match match = GetMatch(i);
 
                 if (match == null)
                     throw new ArgumentOutOfRangeException("i");

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -171,28 +171,28 @@ namespace System.Text.RegularExpressions
 
         void IList<Match>.Insert(int index, Match item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList<Match>.RemoveAt(int index)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         Match IList<Match>.this[int index]
         {
             get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
         }
 
         void ICollection<Match>.Add(Match item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void ICollection<Match>.Clear()
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool ICollection<Match>.Contains(Match item)
@@ -218,17 +218,17 @@ namespace System.Text.RegularExpressions
 
         bool ICollection<Match>.Remove(Match item)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         int IList.Add(object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList.Clear()
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool IList.Contains(object value)
@@ -243,7 +243,7 @@ namespace System.Text.RegularExpressions
 
         void IList.Insert(int index, object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         bool IList.IsFixedSize
@@ -258,18 +258,18 @@ namespace System.Text.RegularExpressions
 
         void IList.Remove(object value)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         void IList.RemoveAt(int index)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
 
         object IList.this[int index]
         {
             get { return this[index]; }
-            set { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
         }
     }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -132,12 +132,12 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public IEnumerator GetEnumerator()
         {
-            return new MatchEnumerator(this);
+            return new Enumerator(this);
         }
 
         IEnumerator<Match> IEnumerable<Match>.GetEnumerator()
         {
-            return new MatchEnumerator(this);
+            return new Enumerator(this);
         }
 
         int IList<Match>.IndexOf(Match item)
@@ -264,82 +264,62 @@ namespace System.Text.RegularExpressions
             EnsureInitialized();
             ((ICollection)_matches).CopyTo(array, arrayIndex);
         }
-    }
 
-    /*
-     * This non-public enumerator lists all the group matches.
-     * Should it be public?
-     */
-    internal class MatchEnumerator : IEnumerator<Match>
-    {
-        internal MatchCollection _matchcoll;
-        internal Match _match = null;
-        internal int _curindex;
-        internal bool _done;
-
-        /*
-         * Nonpublic constructor
-         */
-        internal MatchEnumerator(MatchCollection matchcoll)
+        private class Enumerator : IEnumerator<Match>
         {
-            _matchcoll = matchcoll;
-        }
+            private readonly MatchCollection _collection;
+            private Match _match;
+            private int _index;
+            private bool _done;
 
-        /*
-         * Advance to the next match
-         */
-        public bool MoveNext()
-        {
-            if (_done)
-                return false;
-
-            _match = _matchcoll.GetMatch(_curindex);
-            _curindex++;
-
-            if (_match == null)
+            internal Enumerator(MatchCollection collection)
             {
-                _done = true;
-                return false;
+                _collection = collection;
             }
 
-            return true;
-        }
-
-        /*
-         * The current match
-         */
-        public Object Current
-        {
-            get { return Match; }
-        }
-
-        Match IEnumerator<Match>.Current
-        {
-            get { return Match; }
-        }
-
-        private Match Match
-        {
-            get
+            public bool MoveNext()
             {
+                if (_done)
+                    return false;
+
+                _match = _collection.GetMatch(_index);
+                _index++;
+
                 if (_match == null)
-                    throw new InvalidOperationException(SR.EnumNotStarted);
-                return _match;
+                {
+                    _done = true;
+                    return false;
+                }
+
+                return true;
             }
-        }
 
-        /*
-         * Position before the first item
-         */
-        public void Reset()
-        {
-            _curindex = 0;
-            _done = false;
-            _match = null;
-        }
+            public Match Current
+            {
+                get
+                {
+                    if (_match == null)
+                        throw new InvalidOperationException(SR.EnumNotStarted);
 
-        void IDisposable.Dispose()
-        {
+                    return _match;
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            void IEnumerator.Reset()
+            {
+                _index = 0;
+                _done = false;
+                _match = null;
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -32,7 +32,7 @@ namespace System.Text.RegularExpressions
         internal int _startat;
         internal int _prevlen;
 
-        private static int s_infinite = 0x7FFFFFFF;
+        private const int Infinite = 0x7FFFFFFF;
 
         internal MatchCollection(Regex regex, String input, int beginning, int length, int startat)
         {
@@ -85,7 +85,7 @@ namespace System.Text.RegularExpressions
         {
             if (!_done)
             {
-                GetMatch(s_infinite);
+                GetMatch(Infinite);
             }
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Text.RegularExpressions
 {
@@ -18,6 +19,8 @@ namespace System.Text.RegularExpressions
     /// Represents the set of names appearing as capturing group
     /// names in a regular expression.
     /// </summary>
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<>))]
     public class MatchCollection : IList<Match>, IReadOnlyList<Match>, IList
     {
         internal Regex _regex;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -18,7 +18,7 @@ namespace System.Text.RegularExpressions
     /// Represents the set of names appearing as capturing group
     /// names in a regular expression.
     /// </summary>
-    public class MatchCollection : ICollection
+    public class MatchCollection : IList<Match>, IReadOnlyList<Match>, IList
     {
         internal Regex _regex;
         internal List<Match> _matches;
@@ -149,13 +149,132 @@ namespace System.Text.RegularExpressions
         {
             return new MatchEnumerator(this);
         }
+
+        IEnumerator<Match> IEnumerable<Match>.GetEnumerator()
+        {
+            return new MatchEnumerator(this);
+        }
+
+        int IList<Match>.IndexOf(Match item)
+        {
+            var comparer = EqualityComparer<Match>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        void IList<Match>.Insert(int index, Match item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<Match>.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        Match IList<Match>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
+
+        void ICollection<Match>.Add(Match item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<Match>.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<Match>.Contains(Match item)
+        {
+            var comparer = EqualityComparer<Match>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return true;
+            }
+            return false;
+        }
+
+        void ICollection<Match>.CopyTo(Match[] array, int arrayIndex)
+        {
+            ((ICollection)this).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<Match>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        bool ICollection<Match>.Remove(Match item)
+        {
+            throw new NotSupportedException();
+        }
+
+        int IList.Add(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.Contains(object value)
+        {
+            return value is Match && ((ICollection<Match>)this).Contains((Match)value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return value is Match ? ((IList<Match>)this).IndexOf((Match)value) : -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.IsFixedSize
+        {
+            get { return true; }
+        }
+
+        bool IList.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        object IList.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
     }
 
     /*
      * This non-public enumerator lists all the group matches.
      * Should it be public?
      */
-    internal class MatchEnumerator : IEnumerator
+    internal class MatchEnumerator : IEnumerator<Match>
     {
         internal MatchCollection _matchcoll;
         internal Match _match = null;
@@ -195,6 +314,16 @@ namespace System.Text.RegularExpressions
          */
         public Object Current
         {
+            get { return Match; }
+        }
+
+        Match IEnumerator<Match>.Current
+        {
+            get { return Match; }
+        }
+
+        private Match Match
+        {
             get
             {
                 if (_match == null)
@@ -211,6 +340,10 @@ namespace System.Text.RegularExpressions
             _curindex = 0;
             _done = false;
             _match = null;
+        }
+
+        void IDisposable.Dispose()
+        {
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -101,22 +101,6 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        Object ICollection.SyncRoot
-        {
-            get
-            {
-                return this;
-            }
-        }
-
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
-
         /// <summary>
         /// Returns the ith Match in the collection.
         /// </summary>
@@ -139,10 +123,10 @@ namespace System.Text.RegularExpressions
         /// Copies all the elements of the collection to the given array
         /// starting at the given index.
         /// </summary>
-        void ICollection.CopyTo(Array array, int arrayIndex)
+        public void CopyTo(Match[] array, int arrayIndex)
         {
             EnsureInitialized();
-            ((ICollection)_matches).CopyTo(array, arrayIndex);
+            _matches.CopyTo(array, arrayIndex);
         }
 
         /// <summary>
@@ -206,11 +190,6 @@ namespace System.Text.RegularExpressions
             return false;
         }
 
-        void ICollection<Match>.CopyTo(Match[] array, int arrayIndex)
-        {
-            ((ICollection)this).CopyTo(array, arrayIndex);
-        }
-
         bool ICollection<Match>.IsReadOnly
         {
             get { return true; }
@@ -270,6 +249,22 @@ namespace System.Text.RegularExpressions
         {
             get { return this[index]; }
             set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
+
+        void ICollection.CopyTo(Array array, int arrayIndex)
+        {
+            EnsureInitialized();
+            ((ICollection)_matches).CopyTo(array, arrayIndex);
         }
     }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -23,18 +23,18 @@ namespace System.Text.RegularExpressions
     [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<>))]
     public class MatchCollection : IList<Match>, IReadOnlyList<Match>, IList
     {
-        internal Regex _regex;
-        internal List<Match> _matches;
-        internal bool _done;
-        internal String _input;
-        internal int _beginning;
-        internal int _length;
-        internal int _startat;
-        internal int _prevlen;
+        private readonly Regex _regex;
+        private readonly List<Match> _matches;
+        private bool _done;
+        private readonly string _input;
+        private readonly int _beginning;
+        private readonly int _length;
+        private int _startat;
+        private int _prevlen;
 
         private const int Infinite = 0x7FFFFFFF;
 
-        internal MatchCollection(Regex regex, String input, int beginning, int length, int startat)
+        internal MatchCollection(Regex regex, string input, int beginning, int length, int startat)
         {
             if (startat < 0 || startat > input.Length)
                 throw new ArgumentOutOfRangeException("startat", SR.BeginIndexNotNegative);


### PR DESCRIPTION
Fixes #271

This is still a work-in-progress.

### TODO

- [x] Implement `IList<T>`, `IReadOnlyList<T>`, and `IList`
- [x] Add `RegexCollectionDebuggerProxy`
- [x] API review
- [x] Changes based on API review and initial code review feedback
- [ ] Cleanup
- [ ] Add tests
- [ ] Final code review

### Questions/Notes

- As @sharwell noted in #277: `GroupEnumerator` is internal, so it might be possible to change the type of `GroupEnumerator.Capture` from `Capture` to `Group`. This would make the explicit cast in the generic `Current` property unnecessary.