### PR TITLE
Simplify MatchCollection's ICollection.CopyTo

### DIFF
--- a/src/System.Text.RegularExpressions/src/Resources/Strings.Designer.cs
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.Designer.cs
@@ -80,24 +80,6 @@ namespace Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Target array type is not compatible with the type of items in the collection..
-        /// </summary>
-        internal static string Arg_InvalidArrayType {
-            get {
-                return ResourceManager.GetString("Arg_InvalidArrayType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Only single dimensional arrays are supported for the requested action..
-        /// </summary>
-        internal static string Arg_RankMultiDimNotSupported {
-            get {
-                return ResourceManager.GetString("Arg_RankMultiDimNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot include class \{0} in character range..
         /// </summary>
         internal static string BadClassInCharRange {

--- a/src/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -123,12 +123,6 @@
   <data name="AlternationCantHaveComment" xml:space="preserve">
     <value>Alternation conditions cannot be comments.</value>
   </data>
-  <data name="Arg_InvalidArrayType" xml:space="preserve">
-    <value>Target array type is not compatible with the type of items in the collection.</value>
-  </data>
-  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
-    <value>Only single dimensional arrays are supported for the requested action.</value>
-  </data>
   <data name="BadClassInCharRange" xml:space="preserve">
     <value>Cannot include class \{0} in character range.</value>
   </data>

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -134,8 +134,8 @@ namespace System.Text.RegularExpressions
         /// </summary>
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
-            // property access to force computation of whole array
-            int count = Count;
+            if (!_done)
+                GetMatch(s_infinite);
 
             ((ICollection)_matches).CopyTo(array, arrayIndex);
         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -78,6 +78,14 @@ namespace System.Text.RegularExpressions
             return match;
         }
 
+        private void EnsureInitialized()
+        {
+            if (!_done)
+            {
+                GetMatch(s_infinite);
+            }
+        }
+
         /// <summary>
         /// Returns the number of captures.
         /// </summary>
@@ -85,11 +93,7 @@ namespace System.Text.RegularExpressions
         {
             get
             {
-                if (_done)
-                    return _matches.Count;
-
-                GetMatch(s_infinite);
-
+                EnsureInitialized();
                 return _matches.Count;
             }
         }
@@ -134,9 +138,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
-            if (!_done)
-                GetMatch(s_infinite);
-
+            EnsureInitialized();
             ((ICollection)_matches).CopyTo(array, arrayIndex);
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -134,22 +134,10 @@ namespace System.Text.RegularExpressions
         /// </summary>
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
-            if ((array != null) && (array.Rank != 1))
-            {
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
-            }
-
             // property access to force computation of whole array
             int count = Count;
-            try
-            {
-                // Array.Copy will check for null.
-                Array.Copy(_matches.ToArray(), 0, array, arrayIndex, count);
-            }
-            catch (ArrayTypeMismatchException ex)
-            {
-                throw new ArgumentException(SR.Arg_InvalidArrayType, ex);
-            }
+
+            ((ICollection)_matches).CopyTo(array, arrayIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
- Uses [`List<T>`'s implementation of `ICollection.CopyTo`](https://github.com/Microsoft/referencesource/blob/9da503f9ef21e8d1f2905c78d4e3e5cbb3d6f85a/mscorlib/system/collections/generic/list.cs#L394-L407) which is behavior compatible with the previous implementation.
- Avoids an unnecessary array allocation by no longer using
`List<T>.ToArray()`.
- `SR.Arg_RankMultiDimNotSupported` and `SR.Arg_InvalidArrayType` are no
longer needed.
- Avoids accessing a property to trigger a side effect.