### PR TITLE
StringBuilder append with single length strings changed to chars

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
@@ -1134,7 +1134,7 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Vector<T>))
+            if (!(obj is Vector<T>))
             {
                 return false;
             }
@@ -1515,7 +1515,7 @@ namespace System.Numerics
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
-            sb.Append("<");
+            sb.Append('<');
             for (int g = 0; g < Count - 1; g++)
             {
                 sb.Append(((IFormattable)this[g]).ToString(format, formatProvider));
@@ -1523,7 +1523,7 @@ namespace System.Numerics
             }
             // Append last element w/out separator
             sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));
-            sb.Append(">");
+            sb.Append('>');
             return sb.ToString();
         }
         #endregion Public Instance Methods

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -7,11 +7,9 @@
 <#@ import namespace="System.Runtime.InteropServices" #>
 <#@ include file="GenerationConfig.ttinclude" #><# GenerateCopyrightHeader(); #>
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.Numerics
@@ -391,7 +389,7 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Vector<T>))
+            if (!(obj is Vector<T>))
             {
                 return false;
             }
@@ -543,7 +541,7 @@ namespace System.Numerics
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
-            sb.Append("<");
+            sb.Append('<');
             for (int g = 0; g < Count - 1; g++)
             {
                 sb.Append(((IFormattable)this[g]).ToString(format, formatProvider));
@@ -551,7 +549,7 @@ namespace System.Numerics
             }
             // Append last element w/out separator
             sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));
-            sb.Append(">");
+            sb.Append('>');
             return sb.ToString();
         }
         #endregion Public Instance Methods

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
@@ -86,11 +86,11 @@ namespace System.Numerics
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
-            sb.Append("<");
+            sb.Append('<');
             sb.Append(this.X.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(this.Y.ToString(format, formatProvider));
-            sb.Append(">");
+            sb.Append('>');
             return sb.ToString();
         }
 

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
@@ -92,13 +92,13 @@ namespace System.Numerics
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
-            sb.Append("<");
+            sb.Append('<');
             sb.Append(((IFormattable)this.X).ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(((IFormattable)this.Y).ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(((IFormattable)this.Z).ToString(format, formatProvider));
-            sb.Append(">");
+            sb.Append('>');
             return sb.ToString();
         }
 

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
@@ -96,7 +96,7 @@ namespace System.Numerics
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
-            sb.Append("<");
+            sb.Append('<');
             sb.Append(this.X.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(this.Y.ToString(format, formatProvider));
@@ -104,7 +104,7 @@ namespace System.Numerics
             sb.Append(this.Z.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(this.W.ToString(format, formatProvider));
-            sb.Append(">");
+            sb.Append('>');
             return sb.ToString();
         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1325,7 +1325,7 @@ namespace System.Text.RegularExpressions
                         else if (group.Equals(s_notWord))
                             desc.Append("\\W");
                         else
-                            Debug.Assert(false, "Couldn't find a goup to match '" + group + "'");
+                            Debug.Assert(false, "Couldn't find a group to match '" + group + "'");
                     }
 
                     index = lastindex;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -363,7 +363,7 @@ namespace System.Text.RegularExpressions
                     break;
             }
 
-            sb.Append(")");
+            sb.Append(')');
 
             return sb.ToString();
         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -578,7 +578,7 @@ namespace System.Text.RegularExpressions
             if (Sb.Length < 8)
                 Sb.Append(' ', 8 - Sb.Length);
 
-            Sb.Append("(");
+            Sb.Append('(');
 
             for (int i = Index; i < A.Length; i++)
             {


### PR DESCRIPTION
Some StringBuilder.Append calls made with single length symbol strings. These can be a char so that they get directly assigned to the internal char array buffer. Also more consistent with other areas of the codebase.
