### PR TITLE
XunitTraitsDiscoverers: add reference to System.Threading

### DIFF
--- a/src/Common/tests/XunitTraitsDiscoverers/packages.config
+++ b/src/Common/tests/XunitTraitsDiscoverers/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22405" />
   <package id="System.Runtime" version="4.0.20-beta-22405" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22405" />
+  <package id="System.Threading" version="4.0.0-beta-22405" />
   <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.abstractions" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />


### PR DESCRIPTION
This allows the test project to be built with Mono's xbuild.
It's the same change as in https://github.com/dotnet/corefx/pull/288.
