### PR TITLE
Avoid an unnecessary string allocation

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
@@ -1514,12 +1514,13 @@ namespace System.Numerics
         public string ToString(string format, IFormatProvider formatProvider)
         {
             StringBuilder sb = new StringBuilder();
-            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
             for (int g = 0; g < Count - 1; g++)
             {
                 sb.Append(((IFormattable)this[g]).ToString(format, formatProvider));
                 sb.Append(separator);
+                sb.Append(' ');
             }
             // Append last element w/out separator
             sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -540,12 +540,13 @@ namespace System.Numerics
         public string ToString(string format, IFormatProvider formatProvider)
         {
             StringBuilder sb = new StringBuilder();
-            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
             for (int g = 0; g < Count - 1; g++)
             {
                 sb.Append(((IFormattable)this[g]).ToString(format, formatProvider));
                 sb.Append(separator);
+                sb.Append(' ');
             }
             // Append last element w/out separator
             sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
@@ -85,10 +85,11 @@ namespace System.Numerics
         public string ToString(string format, IFormatProvider formatProvider)
         {
             StringBuilder sb = new StringBuilder();
-            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
             sb.Append(this.X.ToString(format, formatProvider));
             sb.Append(separator);
+            sb.Append(' ');
             sb.Append(this.Y.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
@@ -91,12 +91,14 @@ namespace System.Numerics
         public string ToString(string format, IFormatProvider formatProvider)
         {
             StringBuilder sb = new StringBuilder();
-            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
             sb.Append(((IFormattable)this.X).ToString(format, formatProvider));
             sb.Append(separator);
+            sb.Append(' ');
             sb.Append(((IFormattable)this.Y).ToString(format, formatProvider));
             sb.Append(separator);
+            sb.Append(' ');
             sb.Append(((IFormattable)this.Z).ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
@@ -95,14 +95,17 @@ namespace System.Numerics
         public string ToString(string format, IFormatProvider formatProvider)
         {
             StringBuilder sb = new StringBuilder();
-            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator + " ";
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
             sb.Append(this.X.ToString(format, formatProvider));
             sb.Append(separator);
+            sb.Append(' ');
             sb.Append(this.Y.ToString(format, formatProvider));
             sb.Append(separator);
+            sb.Append(' ');
             sb.Append(this.Z.ToString(format, formatProvider));
             sb.Append(separator);
+            sb.Append(' ');
             sb.Append(this.W.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();


### PR DESCRIPTION
Append the space character instead of concatenating it with the `NumberGroupSeparator`.
