### PR TITLE
Added System.Diagnostics.Process tests.

### DIFF
--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -6,6 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8FFE99C0-22F8-4462-B839-970EAC1B3472}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Win32.Primitives</RootNamespace>
     <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -18,6 +19,7 @@
   </PropertyGroup>
   <!-- References are resolved from packages.config -->
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Interop\Interop.cs" />
     <Compile Include="System\ComponentModel\Win32Exception.cs" />
   </ItemGroup>

--- a/src/Microsoft.Win32.Primitives/src/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Win32.Primitives/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyCopyright("\x00a9 Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyFileVersion("999.999.999.0")]
+[assembly: AssemblyInformationalVersion("999.999.999.0")]
+[assembly: AssemblyVersion("999.999.999.0")]
+
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCulture("")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyProduct("Microsoft.Win32.Primitives")]
+[assembly: AssemblyTitle("Microsoft.Win32.Primitives")]
+[assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguageAttribute("en-US")]
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+

--- a/src/Microsoft.Win32.Primitives/src/packages.config
+++ b/src/Microsoft.Win32.Primitives/src/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Runtime" version="4.0.20-beta-22405" />
-  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22405" />  
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22405" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22405" />
 </packages>

--- a/src/System.Diagnostics.Process.sln
+++ b/src/System.Diagnostics.Process.sln
@@ -5,10 +5,19 @@ VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process", "System.Diagnostics.Process\src\System.Diagnostics.Process.csproj", "{63634289-90D7-4947-8BF3-DBBE98D76C85}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process.Tests", "System.Diagnostics.Process\tests\System.Diagnostics.Process.Tests\System.Diagnostics.Process.Tests.csproj", "{E1114510-844C-4BB2-BBAD-8595BD16E24B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{69E46A6F-9966-45A5-8945-2559FE337827} = {69E46A6F-9966-45A5-8945-2559FE337827}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProcessTest_ConsoleApp", "System.Diagnostics.Process\tests\ProcessTest_ConsoleApp\ProcessTest_ConsoleApp.csproj", "{69E46A6F-9966-45A5-8945-2559FE337827}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{EFFF9E5B-58A0-4D0E-891D-40EF450FE7DA}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTraitsDiscoverers", "Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj", "{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +29,18 @@ Global
 		{63634289-90D7-4947-8BF3-DBBE98D76C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63634289-90D7-4947-8BF3-DBBE98D76C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63634289-90D7-4947-8BF3-DBBE98D76C85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1114510-844C-4BB2-BBAD-8595BD16E24B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69E46A6F-9966-45A5-8945-2559FE337827}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69E46A6F-9966-45A5-8945-2559FE337827}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69E46A6F-9966-45A5-8945-2559FE337827}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69E46A6F-9966-45A5-8945-2559FE337827}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/App.config
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+</configuration>

--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading;
+
+namespace ProcessTest_ConsoleApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length > 0)
+            {
+                if (args[0].Equals("infinite"))
+                {
+                    Console.WriteLine("ProcessTest_ConsoleApp.exe started with an endless loop");
+                    Thread.Sleep(-1);
+                }
+                if (args[0].Equals("error"))
+                {
+                    Exception ex = new Exception("Intentional Exception thrown");
+                    throw ex;
+                }
+                if (args[0].Equals("input"))
+                {
+                    string str = Console.ReadLine();
+                    Console.WriteLine(str);
+                }
+            }
+            else
+            {
+                Console.WriteLine("ProcessTest_ConsoleApp.exe started");
+                Console.WriteLine("ProcessTest_ConsoleApp.exe closed");
+            }
+
+            return 100;
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.csproj
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{69E46A6F-9966-45A5-8945-2559FE337827}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ProcessTest_ConsoleApp</RootNamespace>
+    <AssemblyName>ProcessTest_ConsoleApp</AssemblyName>
+    <TargetFrameworkVersion>4.5</TargetFrameworkVersion>
+    <OutputPath Condition="'$(OutputPath)'==''">..\..\..\..\bin\$(Configuration)\System.Diagnostics.Process.Tests\</OutputPath>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ProcessTest_ConsoleApp.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -1,0 +1,830 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace Test_System_Diagnostics_Process
+{
+    public partial class ProcessTest
+    {
+        private const string s_ProcessName = "ProcessTest_ConsoleApp.exe";
+
+        static Process CreateProcessInfinite()
+        {
+            // Create a process that does not exit and check the base priority of the Process.
+            Process p = new Process();
+            p.StartInfo.FileName = s_ProcessName;
+            p.StartInfo.Arguments = "infinite";
+            return p;
+        }
+
+        static Process CreateProcessError()
+        {
+            // Create a process that does not exit and check the base priority of the Process.
+            Process p = new Process();
+            p.StartInfo.FileName = s_ProcessName;
+            p.StartInfo.Arguments = "error";
+            return p;
+        }
+
+        static Process CreateProcessInput()
+        {
+            // Create a process that does not exit and check the base priority of the Process.
+            Process p = new Process();
+            p.StartInfo.FileName = s_ProcessName;
+            p.StartInfo.Arguments = "input";
+            return p;
+        }
+
+        static Process CreateProcess()
+        {
+            // Create a process that does not exit and check the base priority of the Process.
+            Process p = new Process();
+            p.StartInfo.FileName = s_ProcessName;
+            return p;
+        }
+
+        [Fact]
+        public static void Process_BasePriority()
+        {
+            Process p = CreateProcessInfinite();
+            p.Start();
+            Assert.True(p.BasePriority == 8 /*Normal*/, String.Format("Err:Process_BasePriority. Incorrect Process.BasePriority of {0}", p.BasePriority));
+            p.Kill();
+            p.WaitForExit();
+        }
+
+        private static bool s_Process_EnableRaiseEvents_isExitedEventHandlerCalled = false;
+
+        [Fact]
+        public static void Process_EnableRaiseEvents()
+        {
+            // EnableRaisingEvent = true;
+            // Check whether the event is called.
+            Process p = CreateProcessInfinite();
+            p.EnableRaisingEvents = true;
+            p.Exited += p_Exited;
+            p.Start();
+            p.Kill();
+            p.WaitForExit();
+            Assert.True(s_Process_EnableRaiseEvents_isExitedEventHandlerCalled, String.Format("Process_CanRaiseEvents0001: {0}", "isExited Event not called when EnableRaisingEvent is set to true."));
+
+            s_Process_EnableRaiseEvents_isExitedEventHandlerCalled = false;
+
+            // Check with the default settings which is set this to false.
+            p.Refresh();
+            p = CreateProcessInfinite();
+            p.Exited += p_Exited;
+            p.Start();
+            p.Kill();
+            p.WaitForExit();
+            Assert.True(!s_Process_EnableRaiseEvents_isExitedEventHandlerCalled, String.Format("Process_CanRaiseEvents0002: {0}", "isExited Event called with the default settings for EnableRaiseEvents"));
+
+            s_Process_EnableRaiseEvents_isExitedEventHandlerCalled = false;
+
+            // Check with the default settings which is set this to false.
+            p = CreateProcessInfinite();
+            p.EnableRaisingEvents = false;
+            p.Exited += p_Exited;
+            p.Start();
+            p.Kill();
+            p.WaitForExit();
+            Assert.True(!s_Process_EnableRaiseEvents_isExitedEventHandlerCalled, String.Format("Process_CanRaiseEvents0003: {0}", "isExited Event called with the EnableRaiseEvents = false"));
+
+            s_Process_EnableRaiseEvents_isExitedEventHandlerCalled = false;
+        }
+
+        static void p_Exited(object sender, EventArgs e)
+        {
+            s_Process_EnableRaiseEvents_isExitedEventHandlerCalled = true;
+        }
+
+        [Fact]
+        public static void Process_ExitCode()
+        {
+            Process p = CreateProcess();
+
+            p.Start();
+            p.WaitForExit();
+            Assert.True(p.ExitCode == 100, String.Format("Process_ExitCode001:Unexpected Exit code {0}", p.ExitCode));
+
+            p = CreateProcessInfinite();
+            p.Start();
+            p.Kill();
+            p.WaitForExit();
+            Assert.True(p.ExitCode < 0, String.Format("Process_ExitCode002:Unexpected Exit code {0}", p.ExitCode));
+        }
+
+        [Fact]
+        public static void Process_ExitTime()
+        {
+            Process p = CreateProcessInfinite();
+            p.Start();
+            p.Kill();
+            p.WaitForExit();
+            DateTime exitTime = p.ExitTime;
+            DateTime dt2 = DateTime.Now;
+            TimeSpan elapsedTime = new TimeSpan(dt2.Ticks - exitTime.Ticks);
+            Assert.True(elapsedTime.Seconds <= 1, "Process_ExitTime001 is incorrect.");
+        }
+
+        [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]
+        static extern int GetProcessId(SafeProcessHandle nativeHandle);
+
+        [Fact]
+        public static void Process_GetHandle()
+        {
+            Process p = CreateProcessInfinite();
+            p.Start();
+            Assert.True(p.Id == GetProcessId(p.SafeHandle), String.Format("Process_GetHandle returned incorrect value Expected {0} Recieved {1}", p.Id, GetProcessId(p.SafeHandle)));
+            p.Kill();
+            p.WaitForExit();
+        }
+
+        [Fact]
+        public static void Process_HasExited()
+        {
+            Process p = CreateProcess();
+            p.Start();
+            p.WaitForExit();
+            Assert.True(p.HasExited, "Process_HasExited001 failed");
+
+            p = CreateProcessInfinite();
+            p.Start();
+            Assert.True(!p.HasExited, "Process_HasExited002 failed");
+            p.Kill();
+            p.WaitForExit();
+            Assert.True(p.HasExited, "Process_HasExited003 failed");
+        }
+
+        [Fact]
+        public static void Process_MachineName()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                Console.WriteLine(p.MachineName);
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_MachineName failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_MainModule()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                ProcessModule pMainModule = p.MainModule;
+
+                // Check that the mainModule is present in the modules list.
+                bool foundMainModule = false;
+                foreach (ProcessModule pModule in p.Modules)
+                {
+                    if ((pModule.BaseAddress == pMainModule.BaseAddress) && pModule.FileName.Equals(pMainModule.FileName))
+                    {
+                        foundMainModule = true;
+                        break;
+                    }
+                }
+
+                Assert.True(foundMainModule, "Process_MainModule set to incorrect module");
+                Assert.True("ProcessTest_ConsoleApp.exe" == pMainModule.ModuleName, "MainModule.ModuleName failed");
+                Assert.True(pMainModule.FileName.Contains(pMainModule.ModuleName), "MainModule.FileName failed");
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_MainModule failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_MaxWorkingSet()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                Assert.True(p.MaxWorkingSet != null, "Process_MaxWorkingSet can't be null");
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_MaxWorkingSet failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_MinWorkingSet()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                Assert.True(p.MinWorkingSet != null, "Process_MinWorkingSet can't be null");
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_MinWorkingSet failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_Modules()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                foreach (ProcessModule pModule in p.Modules)
+                {
+                    // Validated that we can get a value for each of the following.
+                    Assert.True(pModule != null, "Process_Modules pModule can't be null");
+                    Assert.True(pModule.BaseAddress != null, "Process_Modules BaseAddress can't be null");
+                    Assert.True(pModule.EntryPointAddress != null, "Process_Modules EntryPointAddress can't be null");
+                    Assert.True(pModule.FileName != null, "Process_Modules FileName can't be null");
+                    int memSize = pModule.ModuleMemorySize;
+                    Assert.True(pModule.ModuleName != null, "Process_Modules ModuleName can't be null");
+                }
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_MaxWorkingSet failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [DllImport("psapi.dll", SetLastError = true)]
+        static extern bool GetProcessMemoryInfo(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS counters, uint size);
+
+
+        [StructLayout(LayoutKind.Sequential, Size = 40)]
+        private struct PROCESS_MEMORY_COUNTERS
+        {
+            public uint cb;
+            public uint PageFaultCount;
+            public uint PeakWorkingSetSize;
+            public uint WorkingSetSize;
+            public uint QuotaPeakPagedPoolUsage;
+            public uint QuotaPagedPoolUsage;
+            public uint QuotaPeakNonPagedPoolUsage;
+            public uint QuotaNonPagedPoolUsage;
+            public uint PagefileUsage;
+            public uint PeakPagefileUsage;
+        }
+
+        [DllImport("api-ms-win-core-memory-l1-1-1.dll")]
+        static extern bool GetProcessWorkingSetSizeEx(SafeProcessHandle hProcess,
+   out IntPtr lpMinimumWorkingSetSize, out IntPtr lpMaximumWorkingSetSize, out uint flags);
+
+        [Fact]
+        public static void Process_WorkingSet()
+        {
+            Process p = CreateProcessInfinite();
+            p.Start();
+            IntPtr minWorkingSet, maxWorkingset;
+            uint flags;
+            GetProcessWorkingSetSizeEx(p.SafeHandle, out minWorkingSet, out maxWorkingset, out flags);
+            Assert.True(p.MinWorkingSet == minWorkingSet, "Process_WorkingSet001 failed");
+            Assert.True(p.MaxWorkingSet == maxWorkingset, "Process_WorkingSet002 failed");
+            p.Kill();
+            p.WaitForExit();
+        }
+
+        [DllImport("api-ms-win-core-processthreads-l1-1-0", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+        static extern int GetPriorityClass(SafeProcessHandle handle);
+
+        [Fact]
+        public static void Process_NonpagedSystemMemorySize64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.NonpagedSystemMemorySize64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_NonpagedSystemMemorySize64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PagedMemorySize64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.PagedMemorySize64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PagedMemorySize64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PagedSystemMemorySize64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.PagedSystemMemorySize64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PagedSystemMemorySize64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PeakPagedMemorySize64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.PeakPagedMemorySize64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PeakPagedMemorySize64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PeakVirtualMemorySize64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.PeakVirtualMemorySize64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PeakVirtualMemorySize64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PeakWorkingSet64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.PeakWorkingSet64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PeakWorkingSet64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PrivateMemorySize64()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                long x = p.PrivateMemorySize64;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PeakWorkingSet64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PrivilegedProcessorTime()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                TimeSpan x = p.PrivilegedProcessorTime;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PeakWorkingSet64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_ProcessorAffinity()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                IntPtr x = p.ProcessorAffinity;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Process_PeakWorkingSet64 failed");
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_SessionId()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            try
+            {
+                int x = p.SessionId;
+            }
+            catch (Exception ex)
+            {
+                Assert.True(false, String.Format("Process_PeakWorkingSet64 failed. {0}", ex.ToString()));
+            }
+            finally
+            {
+                p.Kill();
+                p.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public static void Process_PriorityBoostEnabled()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            Assert.True(p.PriorityBoostEnabled, "Process_PriorityBoostEnabled001 failed");
+            p.PriorityBoostEnabled = false;
+            Assert.True(!p.PriorityBoostEnabled, "Process_PriorityBoostEnabled002 failed");
+            p.Kill();
+            p.WaitForExit();
+        }
+
+        [Fact]
+        public static void Process_PriorityClass()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            Assert.True(p.PriorityClass == ProcessPriorityClass.Normal, "Process_PriorityBoostEnabled001 failed");
+            p.PriorityClass = ProcessPriorityClass.High;
+            Assert.True(p.PriorityClass == ProcessPriorityClass.High, "Process_PriorityBoostEnabled002 failed");
+            p.Kill();
+            p.WaitForExit();
+        }
+
+        [Fact]
+        public static void Process_InvalidPriorityClass()
+        {
+            Process p = new Process();
+            Assert.Throws<ArgumentException>(() => { p.PriorityClass = ProcessPriorityClass.Normal | ProcessPriorityClass.Idle; });
+        }
+
+        [Fact]
+        public static void Process_ProcessName()
+        {
+            // Checking that the MachineName returns some value.
+            Process p = CreateProcessInfinite();
+            p.Start();
+            Assert.True(p.ProcessName == "ProcessTest_ConsoleApp", "Process_ProcessName failed");
+            p.Kill();
+            p.WaitForExit();
+        }
+
+
+        [DllImport("kernel32.dll", CharSet = System.Runtime.InteropServices.CharSet.Ansi, SetLastError = true)]
+        public static extern SafeProcessHandle GetCurrentProcess();
+
+        [Fact]
+        public static void Process_GetCurrentProcess()
+        {
+            string processName = Process.GetCurrentProcess().ProcessName;
+            Assert.True(processName == "CoreRun", String.Format("Process_GetCurrentProcess() failed. Actual process name found is {0}", processName));
+        }
+
+        [Fact]
+        public static void Process_GetProcessById()
+        {
+            Process p = Process.GetCurrentProcess();
+            Process p_copy = Process.GetProcessById(p.Id);
+            Assert.True(p.ProcessName == p_copy.ProcessName, "Process_GetProcessById001 failed");
+            Assert.True(p.Id == p_copy.Id, "Process_GetProcessById002 failed");
+        }
+
+        [Fact]
+        public static void Process_GetProcesses()
+        {
+            // Get all the processes running on the machine.
+            Process currentProcess = Process.GetCurrentProcess();
+            bool foundCurrentProcess = false;
+            foreach (Process p in Process.GetProcesses())
+            {
+                if ((p.Id == currentProcess.Id) && (p.ProcessName.Equals(currentProcess.ProcessName)))
+                    foundCurrentProcess = true;
+            }
+            Assert.True(foundCurrentProcess, "Process_GetProcesses001 failed");
+
+            foundCurrentProcess = false;
+            string machineName = currentProcess.MachineName;
+            foreach (Process p in Process.GetProcesses(machineName))
+            {
+                if ((p.Id == currentProcess.Id) && (p.ProcessName.Equals(currentProcess.ProcessName)))
+                    foundCurrentProcess = true;
+            }
+            Assert.True(foundCurrentProcess, "Process_GetProcesses002 failed");
+        }
+
+        [Fact]
+        public static void Process_GetProcessesByName()
+        {
+            // Get all the processes running on the machine.
+            Process currentProcess = Process.GetCurrentProcess();
+            string processName = currentProcess.ProcessName;
+            string machineName = currentProcess.MachineName;
+            bool found = false;
+            foreach (Process p in Process.GetProcessesByName(processName))
+            {
+                found = true;
+                break;
+            }
+            Assert.True(found, "Process_GetProcessesByName001 failed");
+
+            found = false;
+            foreach (Process p in Process.GetProcessesByName(processName, machineName))
+            {
+                found = true;
+                break;
+            }
+            Assert.True(found, "Process_GetProcessesByName002 failed");
+        }
+
+        [Fact]
+        public static void Process_Environment()
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+
+            // Creating a detached ProcessStartInfo will pre-populate the environment
+            // with current environmental variables. 
+
+            // When used with an existing Process.ProcessStartInfo the following behavior
+            //  * Desktop - Populates with current EnvironmentVariable
+            //  * Project K - Does NOT pre-populate environment.
+
+            var Environment2 = psi.Environment;
+
+            Assert.True(Environment2.Count != 0);
+
+            int CountItems = Environment2.Count;
+
+            Environment2.Add("NewKey", "NewValue");
+            Environment2.Add("NewKey2", "NewValue2");
+
+            Assert.Equal(CountItems + 2, Environment2.Count);
+            Environment2.Remove("NewKey");
+            Assert.Equal(CountItems + 1, Environment2.Count);
+
+            //Exception not thrown with invalid key
+            Assert.Throws<ArgumentException>(() => { Environment2.Add("NewKey2", "NewValue2"); });
+
+            //Clear
+            Environment2.Clear();
+            Assert.Equal(0, Environment2.Count);
+
+            //ContainsKey 
+            Environment2.Add("NewKey", "NewValue");
+            Environment2.Add("NewKey2", "NewValue2");
+            Assert.True(Environment2.ContainsKey("NewKey"));
+            Assert.False(Environment2.ContainsKey("NewKey99"));
+
+            //Iterating
+            string result = null;
+            int index = 0;
+            foreach (string e1 in Environment2.Values)
+            {
+                index++;
+                result += e1;
+            }
+            Assert.Equal(2, index);
+            Assert.Equal("NewValueNewValue2", result);
+
+            result = null;
+            index = 0;
+            foreach (string e1 in Environment2.Keys)
+            {
+                index++;
+                result += e1;
+            }
+            Assert.Equal("NewKeyNewKey2", result);
+            Assert.Equal(2, index);
+
+            result = null;
+            index = 0;
+            foreach (System.Collections.Generic.KeyValuePair<string, string> e1 in Environment2)
+            {
+                index++;
+                result += e1.Key;
+            }
+            Assert.Equal("NewKeyNewKey2", result);
+            Assert.Equal(2, index);
+
+            //Contains
+            Assert.True(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey", "NewValue")));
+            Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey99", "NewValue99")));
+
+            //Exception not thrown with invalid key
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>(null, "NewValue99"));
+            }
+            );
+
+            Environment2.Add(new System.Collections.Generic.KeyValuePair<string, string>("NewKey98", "NewValue98"));
+
+            //Indexed
+            string newIndexItem = Environment2["NewKey98"];
+            Assert.Equal("NewValue98", newIndexItem);
+
+            //TryGetValue
+            string stringout = null;
+            bool retval = false;
+            retval = Environment2.TryGetValue("NewKey", out stringout);
+            Assert.Equal("NewValue", stringout);
+            Assert.True(retval);
+
+            stringout = null;
+            retval = false;
+            retval = Environment2.TryGetValue("NewKey99", out stringout);
+            Assert.Equal(null, stringout);
+            Assert.False(retval);
+
+            //Exception not thrown with invalid key
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                string stringout1 = null;
+                bool retval1 = false;
+                retval1 = Environment2.TryGetValue(null, out stringout1);
+            }
+            );
+
+            //Exception not thrown with invalid key
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                Environment2.Add(null, "NewValue2");
+            }
+            );
+
+            //Invalid Key to add
+            Assert.Throws<ArgumentException>(() =>
+            {
+                Environment2.Add("NewKey2", "NewValue2");
+            }
+            );
+            //Remove Item
+            Environment2.Remove("NewKey98");
+            Environment2.Remove("NewKey98");   //2nd occurence should not assert
+
+            //Exception not thrown with null key
+            Assert.Throws<ArgumentNullException>(() => { Environment2.Remove(null); });
+
+            //"Exception not thrown with null key"
+            Assert.Throws<System.Collections.Generic.KeyNotFoundException>(() => { string a1 = Environment2["1bB"]; });
+
+            Assert.True(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey2", "NewValue2")));
+            Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("newkey2", "NewValue2")));
+            Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey2", "newvalue2")));
+            Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("newkey2", "newvalue2")));
+
+            //Use KeyValuePair Enumerator
+            var x = Environment2.GetEnumerator();
+            x.MoveNext();
+            var y1 = x.Current;
+            Assert.True("NewKey NewValue" == y1.Key + " " + y1.Value, "Did not return expected value");
+            x.MoveNext();
+            y1 = x.Current;
+            Assert.True("NewKey2 NewValue2" == y1.Key + " " + y1.Value, "Did not return expected value");
+
+            //IsReadonly
+            Assert.False(Environment2.IsReadOnly);
+
+            Environment2.Add(new System.Collections.Generic.KeyValuePair<string, string>("NewKey3", "NewValue3"));
+            Environment2.Add(new System.Collections.Generic.KeyValuePair<string, string>("NewKey4", "NewValue4"));
+
+
+            //CopyTo
+            System.Collections.Generic.KeyValuePair<String, String>[] kvpa = new System.Collections.Generic.KeyValuePair<string, string>[10];
+            Environment2.CopyTo(kvpa, 0);
+            Assert.True("NewKey" == kvpa[0].Key, "Did not return expected value");
+            Assert.True("NewKey3" == kvpa[2].Key, "Did not return expected value");
+
+            Environment2.CopyTo(kvpa, 6);
+            Assert.True("NewKey" == kvpa[6].Key, "Did not return expected value");
+
+            //Exception not thrown with null key
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => { Environment2.CopyTo(kvpa, -1); });
+
+            //Exception not thrown with null key
+            Assert.Throws<System.ArgumentException>(() => { Environment2.CopyTo(kvpa, 9); });
+
+            //Exception not thrown with null key
+            Assert.Throws<System.ArgumentNullException>(() =>
+            {
+                System.Collections.Generic.KeyValuePair<String, String>[] kvpanull = null;
+                Environment2.CopyTo(kvpanull, 0);
+            }
+            );
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Diagnostics;
+using Xunit;
+
+namespace Test_System_Diagnostics_Process
+{
+    public partial class ProcessTest
+    {
+        [System.Runtime.InteropServices.DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        private extern static int GetConsoleCP();
+
+        [System.Runtime.InteropServices.DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        private extern static int GetConsoleOutputCP();
+
+        [System.Runtime.InteropServices.DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        private extern static int SetConsoleCP(int codePage);
+
+        [System.Runtime.InteropServices.DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        private extern static int SetConsoleOutputCP(int codePage);
+
+        private const int s_ConsoleEncoding = 437;
+
+        [Fact]
+        [ActiveIssue(335)]
+        public static void Process_EncodingBeforeProvider()
+        {
+            SetConsoleCP(s_ConsoleEncoding);
+            SetConsoleOutputCP(s_ConsoleEncoding);
+
+            int inputEncoding = GetConsoleCP();
+            int outputEncoding = GetConsoleOutputCP();
+
+            try
+            {
+                Process p = CreateProcessInfinite();
+                p.StartInfo.RedirectStandardInput = true;
+                p.Start();
+                Assert.True(p.StandardInput.Encoding.CodePage == Encoding.UTF8.CodePage, "Process_EncodingBeforeProvider001 failed");
+                p.Kill();
+                p.WaitForExit();
+
+                p = CreateProcessInfinite();
+                p.StartInfo.RedirectStandardOutput = true;
+                p.Start();
+                Assert.True(p.StandardOutput.CurrentEncoding.CodePage == Encoding.UTF8.CodePage, "Process_EncodingBeforeProvider002 failed");
+                p.Kill();
+                p.WaitForExit();
+
+                p = CreateProcessInfinite();
+                p.StartInfo.RedirectStandardError = true;
+                p.Start();
+                Assert.True(p.StandardError.CurrentEncoding.CodePage == Encoding.UTF8.CodePage, "Process_EncodingBeforeProvider003 failed");
+                p.Kill();
+                p.WaitForExit();
+
+
+                // Register the codeprovider which will ensure 437 is enabled.
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                p = CreateProcessInfinite();
+                p.StartInfo.RedirectStandardInput = true;
+                p.Start();
+                Assert.True(p.StandardInput.Encoding.CodePage == inputEncoding, "Process_EncodingBeforeProvider004 failed");
+                p.Kill();
+                p.WaitForExit();
+
+                p = CreateProcessInfinite();
+                p.StartInfo.RedirectStandardOutput = true;
+                p.Start();
+                Assert.True(p.StandardOutput.CurrentEncoding.CodePage == outputEncoding, "Process_EncodingBeforeProvider005 failed");
+                p.Kill();
+                p.WaitForExit();
+
+                p = CreateProcessInfinite();
+                p.StartInfo.RedirectStandardError = true;
+                p.Start();
+                Assert.True(p.StandardError.CurrentEncoding.CodePage == outputEncoding, "Process_EncodingBeforeProvider006 failed");
+                p.Kill();
+                p.WaitForExit();
+            }
+            finally
+            {
+                foreach (Process p in Process.GetProcessesByName(s_ProcessName))
+                {
+                    p.Kill();
+                    p.WaitForExit();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.IO;
+using System.Diagnostics;
+using Xunit;
+
+namespace Test_System_Diagnostics_Process
+{
+    public partial class ProcessTest
+    {
+        [Fact]
+        public static void Process_SyncErrorStream()
+        {
+            Process p = CreateProcessError();
+            p.StartInfo.RedirectStandardError = true;
+            p.Start();
+            if (!p.HasExited)
+            {
+                string s = p.StandardError.ReadToEnd();
+                p.WaitForExit();
+                Assert.True(s.Contains("\nUnhandled Exception: System.Exception: Intentional Exception thrown\r\n   at ProcessTest_ConsoleApp.Program.Main(String[] args)"));
+            }
+        }
+
+        private static StringBuilder s_process_AsyncErrorStream_sb = new StringBuilder();
+
+        [Fact]
+        public static void Process_AsyncErrorStream()
+        {
+            s_process_AsyncErrorStream_sb.Clear();
+            Process p = CreateProcessError();
+            p.StartInfo.RedirectStandardError = true;
+            p.ErrorDataReceived += process_AsyncErrorStream_ErrorDataReceived;
+            p.Start();
+            if (!p.HasExited)
+            {
+                p.BeginErrorReadLine();
+                p.WaitForExit();
+                Assert.True(s_process_AsyncErrorStream_sb.ToString().Contains(@"Unhandled Exception: System.Exception: Intentional Exception thrown   at ProcessTest_ConsoleApp.Program.Main(String[] args)"));
+            }
+        }
+
+        public static void process_AsyncErrorStream_ErrorDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            s_process_AsyncErrorStream_sb.Append(e.Data);
+        }
+
+        [Fact]
+        public static void Process_SyncOutputStream()
+        {
+            Process p = CreateProcess();
+            p.StartInfo.RedirectStandardOutput = true;
+            p.Start();
+            if (!p.HasExited)
+            {
+                string s = p.StandardOutput.ReadToEnd();
+                p.WaitForExit();
+                Assert.Equal(s, "ProcessTest_ConsoleApp.exe started\r\nProcessTest_ConsoleApp.exe closed\r\n");
+            }
+        }
+
+        private static StringBuilder s_process_AsyncOutputStream_sb = new StringBuilder();
+
+        [Fact]
+        public static void Process_AsyncOutputStream()
+        {
+            s_process_AsyncOutputStream_sb.Clear();
+            Process p = CreateProcess();
+            p.StartInfo.RedirectStandardOutput = true;
+            p.OutputDataReceived += process_AsyncOutputStream_OutputDataReceived;
+            p.Start();
+            if (!p.HasExited)
+            {
+                p.BeginOutputReadLine();
+                p.WaitForExit();
+                Assert.True(s_process_AsyncOutputStream_sb.ToString() == "ProcessTest_ConsoleApp.exe startedProcessTest_ConsoleApp.exe closed", "Process_AsyncOutputStream001 failed");
+            }
+
+            // Now add the CancelAsyncAPI as well.
+            s_process_AsyncOutputStream_sb.Clear();
+            p = CreateProcess();
+            p.StartInfo.RedirectStandardOutput = true;
+            p.OutputDataReceived += process_AsyncOutputStream_OutputDataReceived2;
+            p.Start();
+            if (!p.HasExited)
+            {
+                p.BeginOutputReadLine();
+                p.WaitForExit();
+                Assert.True(s_process_AsyncOutputStream_sb.ToString() == "ProcessTest_ConsoleApp.exe started", "Process_AsyncOutputStream002 failed");
+            }
+        }
+
+        static void process_AsyncOutputStream_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            s_process_AsyncOutputStream_sb.Append(e.Data);
+        }
+
+        static void process_AsyncOutputStream_OutputDataReceived2(object sender, DataReceivedEventArgs e)
+        {
+            s_process_AsyncOutputStream_sb.Append(e.Data);
+            Process p = sender as Process;
+            p.CancelOutputRead();
+        }
+
+        [Fact]
+        public static void Process_SyncStreams()
+        {
+            // Check whether the input streams works correctly.
+
+            //1. Check with RedirectStandardInut
+            Process p = CreateProcessInput();
+            p.StartInfo.RedirectStandardInput = true;
+            p.StartInfo.RedirectStandardOutput = true;
+            p.OutputDataReceived += process_SyncStreams_OutputDataReceived;
+            p.Start();
+            if (!p.HasExited)
+            {
+                using (StreamWriter writer = p.StandardInput)
+                {
+                    string str = "This string should come as output";
+                    writer.WriteLine(str);
+                }
+                // Check that we get this as output
+            }
+        }
+
+        public static void process_SyncStreams_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data != null)
+            {
+                Assert.True(e.Data == "This string should come as output", "Process_SyncStreams001: Failed to get the expected output");
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_UseShellExecute.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_UseShellExecute.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using Xunit;
+
+namespace Test_System_Diagnostics_Process
+{
+    public partial class ProcessTest
+    {
+        [Fact]
+        public static void ProcessStartInfo_UseShellExecute()
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+
+            // Calling the setter
+            try
+            {
+                psi.UseShellExecute = false;
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "ProcessStartInfo_UseShellExecute001 failed");
+            }
+
+            //"ProcessStartInfo_UseShellExecute002 failed"
+            Assert.Throws<PlatformNotSupportedException>(() => { psi.UseShellExecute = true; });
+
+            // Calling the getter
+            Assert.True(!psi.UseShellExecute, "ProcessStartInfo_UseShellExecute003 failed");
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Properties/AssemblyInfo.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Resources;
+using System.Reflection;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("System.Diagnostics.Process.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("System.Diagnostics.Process.Tests")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E1114510-844C-4BB2-BBAD-8595BD16E24B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Diagnostics.Process.Tests</RootNamespace>
+    <AssemblyName>System.Diagnostics.Process.Tests</AssemblyName>
+    <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ProcessTest.cs" />
+    <Compile Include="Process_EncodingTest.cs" />
+    <Compile Include="Process_StreamTests.cs" />
+    <Compile Include="Process_UseShellExecute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Diagnostics.Process.csproj">
+      <Project>{63634289-90d7-4947-8bf3-dbbe98d76c85}</Project>
+      <Name>System.Diagnostics.Process</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">
+      <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
+      <Name>XunitTraitsDiscoverers</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="ProcessTest_ConsoleApp">
+      <HintPath>$(BaseOutputPath)\$(Configuration)\$(AssemblyName)\ProcessTest_ConsoleApp.exe</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Console" version="4.0.0-beta-22405" />
+  <package id="System.IO" version="4.0.10-beta-22405" />
+  <package id="System.Runtime" version="4.0.20-beta-22405" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22405" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22405" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22405" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22405" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22405" />
+  <package id="System.Text.Encoding.CodePages" version="4.0.0-beta-22405" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22405" />
+  <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+  <package id="xunit.abstractions" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+  <package id="xunit.assert" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+  <package id="xunit.core" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win" />
+</packages>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <Project Include="*\src\*.csproj" />
-    <Project Include="*\tests\*.csproj" />
+    <Project Include="*\tests\**\*.csproj" />
   </ItemGroup>
 
   <Import Project="..\dir.traversal.targets" />


### PR DESCRIPTION
Added AssemblyInfo.cs file to Microsoft.Win32.Primitives, upped the version number to maximum. Tests dependent on this assembly and looking for any version of this assembly should be able to pick this up.
Fix dirs.proj to pick up csproj files that don't immediately exist under test directory but a level below.