### PR TITLE
Remove boxing of chars when concatenated with strings

### DIFF
--- a/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriter.cs
+++ b/src/System.Xml.XPath.XmlDocument/src/System/Xml/XmlWellformedWriter.cs
@@ -2179,7 +2179,7 @@ namespace System.Xml
                 case State.Start:
                     if (_conformanceLevel == ConformanceLevel.Document)
                     {
-                        throw new InvalidOperationException(wrongTokenMessage + ' ' + SR.Xml_ConformanceLevelFragment);
+                        throw new InvalidOperationException(wrongTokenMessage + " " + SR.Xml_ConformanceLevelFragment);
                     }
                     break;
             }

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/BaseAxisQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/BaseAxisQuery.cs
@@ -138,7 +138,7 @@ namespace MS.Internal.Xml.XPath
             w.WriteStartElement(this.GetType().Name);
             if (NameTest)
             {
-                w.WriteAttributeString("name", Prefix.Length != 0 ? Prefix + ':' + Name : Name);
+                w.WriteAttributeString("name", Prefix.Length != 0 ? Prefix + ":" + Name : Name);
             }
             if (TypeTest != XPathNodeType.Element)
             {

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/DescendantBaseQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/DescendantBaseQuery.cs
@@ -64,7 +64,7 @@ namespace MS.Internal.Xml.XPath
             }
             if (NameTest)
             {
-                w.WriteAttributeString("name", Prefix.Length != 0 ? Prefix + ':' + Name : Name);
+                w.WriteAttributeString("name", Prefix.Length != 0 ? Prefix + ":" + Name : Name);
             }
             if (TypeTest != XPathNodeType.Element)
             {

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/FunctionQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/FunctionQuery.cs
@@ -123,7 +123,7 @@ namespace MS.Internal.Xml.XPath
         public override void PrintQuery(XmlWriter w)
         {
             w.WriteStartElement(this.GetType().Name);
-            w.WriteAttributeString("name", prefix.Length != 0 ? prefix + ':' + name : name);
+            w.WriteAttributeString("name", prefix.Length != 0 ? prefix + ":" + name : name);
             foreach (Query arg in _args)
             {
                 arg.PrintQuery(w);

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/VariableQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/VariableQuery.cs
@@ -70,7 +70,7 @@ namespace MS.Internal.Xml.XPath
         public override void PrintQuery(XmlWriter w)
         {
             w.WriteStartElement(this.GetType().Name);
-            w.WriteAttributeString("name", prefix.Length != 0 ? prefix + ':' + name : name);
+            w.WriteAttributeString("name", prefix.Length != 0 ? prefix + ":" + name : name);
             w.WriteEndElement();
         }
     }

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/XPathAncestorQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/XPathAncestorQuery.cs
@@ -70,7 +70,7 @@ namespace MS.Internal.Xml.XPath
             }
             if (NameTest)
             {
-                w.WriteAttributeString("name", Prefix.Length != 0 ? Prefix + ':' + Name : Name);
+                w.WriteAttributeString("name", Prefix.Length != 0 ? Prefix + ":" + Name : Name);
             }
             if (TypeTest != XPathNodeType.Element)
             {

--- a/src/System.Xml.XPath/src/System/Xml/XPath/XPathNavigator.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/XPathNavigator.cs
@@ -1695,19 +1695,19 @@ namespace System.Xml.XPath
                 switch (_nav.NodeType)
                 {
                     case XPathNodeType.Element:
-                        result += ", Name=\"" + _nav.Name + '"';
+                        result += ", Name=\"" + _nav.Name + "\"";
                         break;
                     case XPathNodeType.Attribute:
                     case XPathNodeType.Namespace:
                     case XPathNodeType.ProcessingInstruction:
-                        result += ", Name=\"" + _nav.Name + '"';
-                        result += ", Value=\"" + XmlConvertEx.EscapeValueForDebuggerDisplay(_nav.Value) + '"';
+                        result += ", Name=\"" + _nav.Name + "\"";
+                        result += ", Value=\"" + XmlConvertEx.EscapeValueForDebuggerDisplay(_nav.Value) + "\"";
                         break;
                     case XPathNodeType.Text:
                     case XPathNodeType.Whitespace:
                     case XPathNodeType.SignificantWhitespace:
                     case XPathNodeType.Comment:
-                        result += ", Value=\"" + XmlConvertEx.EscapeValueForDebuggerDisplay(_nav.Value) + '"';
+                        result += ", Value=\"" + XmlConvertEx.EscapeValueForDebuggerDisplay(_nav.Value) + "\"";
                         break;
                 }
                 return result;


### PR DESCRIPTION
Changed chars to strings when joining them to other strings to prevent the boxing of the char literal.