### PR TITLE
RegexCharClass Improvements and Cleanup

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -87,7 +87,7 @@ namespace System.Text.RegularExpressions
         internal const String EmptyClass = "\x00\x00\x00";
 
         // UnicodeCategory is zero based, so we add one to each value and subtract it off later
-        private static readonly Dictionary<String, String> s_definedCategories = new Dictionary<String, String>
+        private static readonly Dictionary<String, String> s_definedCategories = new Dictionary<String, String>(38)
         {
             // Others
             { "Cc", "\u000F" }, // UnicodeCategory.Control + 1

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1067,7 +1067,7 @@ namespace System.Text.RegularExpressions
             int i;
             int j;
             char last;
-            bool Done;
+            bool done;
 
             _canonical = true;
             _rangelist.Sort();
@@ -1078,7 +1078,7 @@ namespace System.Text.RegularExpressions
 
             if (_rangelist.Count > 1)
             {
-                Done = false;
+                done = false;
 
                 for (i = 1, j = 0; ; i++)
                 {
@@ -1086,7 +1086,7 @@ namespace System.Text.RegularExpressions
                     {
                         if (i == _rangelist.Count || last == LastChar)
                         {
-                            Done = true;
+                            done = true;
                             break;
                         }
 
@@ -1101,7 +1101,7 @@ namespace System.Text.RegularExpressions
 
                     j++;
 
-                    if (Done)
+                    if (done)
                         break;
 
                     if (j < i)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -43,7 +43,7 @@ namespace System.Text.RegularExpressions
 
         private const String NullCharString = "\0";
 
-        private const char Nullchar = '\0';
+        private const char NullChar = '\0';
         private const char Lastchar = '\uFFFF';
 
         private const char GroupChar = (char)0;
@@ -1129,7 +1129,7 @@ namespace System.Text.RegularExpressions
                     Debug.Assert(!String.IsNullOrEmpty(set), "Found a null/empty element in RegexCharClass prop table");
                     if (invert)
                     {
-                        if (set[0] == Nullchar)
+                        if (set[0] == NullChar)
                         {
                             return set.Substring(1);
                         }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1320,10 +1320,10 @@ namespace System.Text.RegularExpressions
                 _data = data;
             }
 
-            internal char _chMin;
-            internal char _chMax;
-            internal int _lcOp;
-            internal int _data;
+            internal readonly char _chMin;
+            internal readonly char _chMax;
+            internal readonly int _lcOp;
+            internal readonly int _data;
         }
 
         /// <summary>

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1292,17 +1292,16 @@ namespace System.Text.RegularExpressions
         */
         internal static String CharDescription(char ch)
         {
-            StringBuilder sb = new StringBuilder();
-            int shift;
-
             if (ch == '\\')
                 return "\\\\";
 
             if (ch >= ' ' && ch <= '~')
             {
-                sb.Append(ch);
-                return sb.ToString();
+                return ch.ToString();
             }
+
+            var sb = new StringBuilder();
+            int shift;
 
             if (ch < 256)
             {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1100,7 +1100,7 @@ namespace System.Text.RegularExpressions
             bool Done;
 
             _canonical = true;
-            _rangelist.Sort(0, _rangelist.Count, new SingleRangeComparer());
+            _rangelist.Sort();
 
             //
             // Find and eliminate overlapping or abutting ranges
@@ -1360,25 +1360,11 @@ namespace System.Text.RegularExpressions
         }
 
         /*
-         * SingleRangeComparer
-         *
-         * For sorting ranges; compare based on the first char in the range.
-         */
-        private sealed class SingleRangeComparer : IComparer<SingleRange>
-        {
-            public int Compare(SingleRange x, SingleRange y)
-            {
-                return ((x)._first < (y)._first ? -1
-                       : ((x)._first > (y)._first ? 1 : 0));
-            }
-        }
-
-        /*
          * SingleRange
          *
          * A first/last pair representing a single range of characters.
          */
-        private struct SingleRange
+        private struct SingleRange : IComparable<SingleRange>
         {
             internal SingleRange(char first, char last)
             {
@@ -1388,6 +1374,12 @@ namespace System.Text.RegularExpressions
 
             internal readonly char _first;
             internal readonly char _last;
+
+            public int CompareTo(SingleRange other)
+            {
+                // For sorting ranges; compare based on the first char in the range
+                return _first.CompareTo(other._first);
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -415,7 +415,7 @@ namespace System.Text.RegularExpressions
             // Make sure the _propTable is correctly ordered
             int len = s_propTable.Length;
             for (int i = 0; i < len - 1; i++)
-                Debug.Assert(String.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass _propTable is out of order at (" + s_propTable[i][0] + ", " + s_propTable[i + 1][0] + ")");
+                Debug.Assert(String.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass s_propTable is out of order at (" + s_propTable[i][0] + ", " + s_propTable[i + 1][0] + ")");
         }
 #endif
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -87,7 +87,8 @@ namespace System.Text.RegularExpressions
         internal const String EmptyClass = "\x00\x00\x00";
 
         // UnicodeCategory is zero based, so we add one to each value and subtract it off later
-        private static readonly Dictionary<String, String> s_definedCategories = new Dictionary<String, String>(38)
+        private const int DefinedCategoriesCapacity = 38;
+        private static readonly Dictionary<String, String> s_definedCategories = new Dictionary<String, String>(DefinedCategoriesCapacity)
         {
             // Others
             { "Cc", "\u000F" }, // UnicodeCategory.Control + 1
@@ -412,7 +413,15 @@ namespace System.Text.RegularExpressions
 #if DEBUG
         static RegexCharClass()
         {
-            // Make sure the _propTable is correctly ordered
+            // Make sure the initial capacity for s_definedCategories is correct
+            Debug.Assert(
+                s_definedCategories.Count == DefinedCategoriesCapacity,
+                "RegexCharClass s_definedCategories's initial capacity (DefinedCategoriesCapacity) is incorrect.",
+                "Expected (s_definedCategories.Count): {0}, Actual (DefinedCategoriesCapacity): {1}",
+                s_definedCategories.Count,
+                DefinedCategoriesCapacity);
+
+            // Make sure the s_propTable is correctly ordered
             int len = s_propTable.Length;
             for (int i = 0; i < len - 1; i++)
                 Debug.Assert(String.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass s_propTable is out of order at (" + s_propTable[i][0] + ", " + s_propTable[i + 1][0] + ")");

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -42,6 +42,8 @@ namespace System.Text.RegularExpressions
         private const int CATEGORYLENGTH = 2;
         private const int SETSTART = 3;
 
+        private const String NullCharString = "\0";
+
         private const char Nullchar = '\0';
         private const char Lastchar = '\uFFFF';
 
@@ -1239,7 +1241,7 @@ namespace System.Text.RegularExpressions
                         {
                             return set.Substring(1);
                         }
-                        return Nullchar + set;
+                        return NullCharString + set;
                     }
                     else
                     {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1266,7 +1266,9 @@ namespace System.Text.RegularExpressions
             int myCategoryLength = set[CATEGORYLENGTH];
             int myEndPosition = SETSTART + mySetLength + myCategoryLength;
 
-            StringBuilder desc = new StringBuilder("[");
+            StringBuilder desc = new StringBuilder();
+
+            desc.Append('[');
 
             int index = SETSTART;
             char ch1;
@@ -1304,15 +1306,17 @@ namespace System.Text.RegularExpressions
                     int lastindex = set.IndexOf(GroupChar, index + 1);
                     string group = set.Substring(index, lastindex - index + 1);
 
-                    IDictionaryEnumerator en = _definedCategories.GetEnumerator();
-                    while (en.MoveNext())
+                    foreach (var kvp in _definedCategories)
                     {
-                        if (group.Equals(en.Value))
+                        if (group.Equals(kvp.Value))
                         {
                             if ((short)set[index + 1] > 0)
-                                desc.Append("\\p{" + en.Key + "}");
+                                desc.Append("\\p{");
                             else
-                                desc.Append("\\P{" + en.Key + "}");
+                                desc.Append("\\P{");
+
+                            desc.Append(kvp.Key);
+                            desc.Append('}');
 
                             found = true;
                             break;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -19,10 +19,9 @@
 //      m+1...n The categories.  This is a list of UnicodeCategory enum values which describe categories
 //              included in this class.
 
-using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 
 namespace System.Text.RegularExpressions

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1070,7 +1070,7 @@ namespace System.Text.RegularExpressions
             bool done;
 
             _canonical = true;
-            _rangelist.Sort();
+            _rangelist.Sort(SingleRangeComparer.Instance);
 
             //
             // Find and eliminate overlapping or abutting ranges
@@ -1327,9 +1327,26 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
+        /// For sorting ranges; compare based on the first char in the range.
+        /// </summary>
+        private sealed class SingleRangeComparer : IComparer<SingleRange>
+        {
+            public static readonly SingleRangeComparer Instance = new SingleRangeComparer();
+
+            private SingleRangeComparer()
+            {
+            }
+
+            public int Compare(SingleRange x, SingleRange y)
+            {
+                return x._first.CompareTo(y._first);
+            }
+        }
+
+        /// <summary>
         /// A first/last pair representing a single range of characters.
         /// </summary>
-        private struct SingleRange : IComparable<SingleRange>
+        private struct SingleRange
         {
             internal SingleRange(char first, char last)
             {
@@ -1339,12 +1356,6 @@ namespace System.Text.RegularExpressions
 
             internal readonly char _first;
             internal readonly char _last;
-
-            public int CompareTo(SingleRange other)
-            {
-                // For sorting ranges; compare based on the first char in the range
-                return _first.CompareTo(other._first);
-            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -613,23 +613,20 @@ namespace System.Text.RegularExpressions
 
         internal void AddCategoryFromName(string categoryName, bool invert, bool caseInsensitive, string pattern)
         {
-            String cat;
-            _definedCategories.TryGetValue(categoryName, out cat);
-            if (cat != null && !categoryName.Equals(s_internalRegexIgnoreCase))
+            string category;
+            if (_definedCategories.TryGetValue(categoryName, out category) && !categoryName.Equals(s_internalRegexIgnoreCase))
             {
-                string catstr = cat;
-
                 if (caseInsensitive)
                 {
                     if (categoryName.Equals("Ll") || categoryName.Equals("Lu") || categoryName.Equals("Lt"))
                         // when RegexOptions.IgnoreCase is specified then {Ll}, {Lu}, and {Lt} cases should all match
-                        catstr = (string)_definedCategories[s_internalRegexIgnoreCase];
+                        category = _definedCategories[s_internalRegexIgnoreCase];
                 }
 
                 if (invert)
-                    catstr = NegateCategory(catstr); // negate the category
+                    category = NegateCategory(category); // negate the category
 
-                _categories.Append((string)catstr);
+                _categories.Append(category);
             }
             else
                 AddSet(SetFromProperty(categoryName, invert, pattern));

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -311,7 +311,7 @@ namespace System.Text.RegularExpressions
         private const int LowercaseBor = 2;    // Bitwise or with 1.
         private const int LowercaseBad = 3;    // Bitwise and with 1 and add original.
 
-        private static readonly LowerCaseMapping[] _lcTable = new LowerCaseMapping[]
+        private static readonly LowerCaseMapping[] s_lcTable = new LowerCaseMapping[]
         {
             new LowerCaseMapping('\u0041', '\u005A', LowercaseAdd, 32),
             new LowerCaseMapping('\u00C0', '\u00DE', LowercaseAdd, 32),
@@ -582,19 +582,19 @@ namespace System.Text.RegularExpressions
             char chMinT, chMaxT;
             LowerCaseMapping lc;
 
-            for (i = 0, iMax = _lcTable.Length; i < iMax;)
+            for (i = 0, iMax = s_lcTable.Length; i < iMax;)
             {
                 iMid = (i + iMax) / 2;
-                if (_lcTable[iMid]._chMax < chMin)
+                if (s_lcTable[iMid]._chMax < chMin)
                     i = iMid + 1;
                 else
                     iMax = iMid;
             }
 
-            if (i >= _lcTable.Length)
+            if (i >= s_lcTable.Length)
                 return;
 
-            for (; i < _lcTable.Length && (lc = _lcTable[i])._chMin <= chMax; i++)
+            for (; i < s_lcTable.Length && (lc = s_lcTable[i])._chMin <= chMax; i++)
             {
                 if ((chMinT = lc._chMin) < chMin)
                     chMinT = chMin;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -419,11 +419,9 @@ namespace System.Text.RegularExpressions
         }
 #endif
 
-        /*
-         * RegexCharClass()
-         *
-         * Creates an empty character class.
-         */
+        /// <summary>
+        /// Creates an empty character class.
+        /// </summary>
         internal RegexCharClass()
         {
             _rangelist = new List<SingleRange>(6);
@@ -458,11 +456,9 @@ namespace System.Text.RegularExpressions
             AddRange(c, c);
         }
 
-        /*
-         * AddCharClass()
-         *
-         * Adds a regex char class
-         */
+        /// <summary>
+        /// Adds a regex char class
+        /// </summary>
         internal void AddCharClass(RegexCharClass cc)
         {
             int i;
@@ -485,11 +481,9 @@ namespace System.Text.RegularExpressions
             _categories.Append(cc._categories.ToString());
         }
 
-        /*
-         * AddSet()
-         *
-         * Adds a set (specified by its string represenation) to the class.
-         */
+        /// <summary>
+        /// Adds a set (specified by its string represenation) to the class.
+        /// </summary>
         private void AddSet(String set)
         {
             int i;
@@ -515,11 +509,9 @@ namespace System.Text.RegularExpressions
             _subtractor = sub;
         }
 
-        /*
-         * AddRange()
-         *
-         * Adds a single range of characters to the class.
-         */
+        /// <summary>
+        /// Adds a single range of characters to the class.
+        /// </summary>
         internal void AddRange(char first, char last)
         {
             _rangelist.Add(new SingleRange(first, last));
@@ -556,12 +548,10 @@ namespace System.Text.RegularExpressions
             _categories.Append(category);
         }
 
-        /*
-         * AddLowerCase()
-         *
-         * Adds to the class any lowercase versions of characters already
-         * in the class. Used for case-insensitivity.
-         */
+        /// <summary>
+        /// Adds to the class any lowercase versions of characters already
+        /// in the class. Used for case-insensitivity.
+        /// </summary>
         internal void AddLowercase(CultureInfo culture)
         {
             int i;
@@ -585,12 +575,10 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * AddLowercaseRange()
-         *
-         * For a single range that's in the set, adds any additional ranges
-         * necessary to ensure that lowercase equivalents are also included.
-         */
+        /// <summary>
+        /// For a single range that's in the set, adds any additional ranges
+        /// necessary to ensure that lowercase equivalents are also included.
+        /// </summary>
         private void AddLowercaseRange(char chMin, char chMax, CultureInfo culture)
         {
             int i, iMax, iMid;
@@ -714,11 +702,9 @@ namespace System.Text.RegularExpressions
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
-        /*
-         * SingletonChar()
-         *
-         * Returns the char
-         */
+        /// <summary>
+        /// Returns the char
+        /// </summary>
         internal static char SingletonChar(String set)
         {
             Debug.Assert(IsSingleton(set) || IsSingletonInverse(set), "Tried to get the singleton char out of a non singleton character class");
@@ -738,11 +724,9 @@ namespace System.Text.RegularExpressions
                 return false;
         }
 
-        /*
-         * IsSingleton()
-         *
-         * True if the set contains a single character only
-         */
+        /// <summary>
+        /// <c>true</c> if the set contains a single character only
+        /// </summary>
         internal static bool IsSingleton(String set)
         {
             if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
@@ -819,12 +803,10 @@ namespace System.Text.RegularExpressions
             return b && !subtracted;
         }
 
-        /*
-         * CharInClass()
-         *
-         * Determines a character's membership in a character class (via the
-         * string representation of the class).
-         */
+        /// <summary>
+        /// Determines a character's membership in a character class (via the
+        /// string representation of the class).
+        /// </summary>
         private static bool CharInClassInternal(char ch, string set, int start, int mySetLength, int myCategoryLength)
         {
             int min;
@@ -921,11 +903,10 @@ namespace System.Text.RegularExpressions
             return false;
         }
 
-        /*
-        *  CharInCategoryGroup
-        *  This is used for categories which are composed of other categories - L, N, Z, W...
-        *  These groups need special treatment when they are negated
-        */
+        /// <summary>
+        /// This is used for categories which are composed of other categories - L, N, Z, W...
+        /// These groups need special treatment when they are negated
+        /// </summary>
         private static bool CharInCategoryGroup(char ch, UnicodeCategory chcategory, string category, ref int i)
         {
             i++;
@@ -1021,21 +1002,17 @@ namespace System.Text.RegularExpressions
             return new RegexCharClass(charClass[start + FLAGS] == 1, ranges, new StringBuilder(charClass.Substring(end, myCategoryLength)), sub);
         }
 
-        /*
-         * RangeCount()
-         *
-         * The number of single ranges that have been accumulated so far.
-         */
+        /// <summary>
+        /// The number of single ranges that have been accumulated so far.
+        /// </summary>
         private int RangeCount()
         {
             return _rangelist.Count;
         }
 
-        /*
-         * ToString()
-         *
-         * Constructs the string representation of the class.
-         */
+        /// <summary>
+        /// Constructs the string representation of the class.
+        /// </summary>
         internal String ToStringClass()
         {
             if (!_canonical)
@@ -1076,21 +1053,17 @@ namespace System.Text.RegularExpressions
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
-        /*
-         * GetRangeAt(int i)
-         *
-         * The ith range.
-         */
+        /// <summary>
+        /// The ith range.
+        /// </summary>
         private SingleRange GetRangeAt(int i)
         {
             return _rangelist[i];
         }
 
-        /*
-         * Canonicalize()
-         *
-         * Logic to reduce a character class to a unique, sorted form.
-         */
+        /// <summary>
+        /// Logic to reduce a character class to a unique, sorted form.
+        /// </summary>
         private void Canonicalize()
         {
             SingleRange CurrentRange;
@@ -1176,11 +1149,9 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
 
-        /*
-         * SetDescription()
-         *
-         * Produces a human-readable description for a set string.
-         */
+        /// <summary>
+        /// Produces a human-readable description for a set string.
+        /// </summary>
         internal static String SetDescription(String set)
         {
             int mySetLength = set[SETLENGTH];
@@ -1285,11 +1256,9 @@ namespace System.Text.RegularExpressions
                                                                      "Sm", "Sc", "Sk", "So",
                                                                      "Cn" };
 
-        /*
-        * CharDescription()
-        *
-        * Produces a human-readable description for a single character.
-        */
+        /// <summary>
+        /// Produces a human-readable description for a single character.
+        /// </summary>
         internal static String CharDescription(char ch)
         {
             if (ch == '\\')
@@ -1341,7 +1310,9 @@ namespace System.Text.RegularExpressions
 
 #endif
 
-        // Lower case mapping descriptor.
+        /// <summary>
+        /// Lower case mapping descriptor.
+        /// </summary>
         private struct LowerCaseMapping
         {
             internal LowerCaseMapping(char chMin, char chMax, int lcOp, int data)
@@ -1358,11 +1329,9 @@ namespace System.Text.RegularExpressions
             internal int _data;
         }
 
-        /*
-         * SingleRange
-         *
-         * A first/last pair representing a single range of characters.
-         */
+        /// <summary>
+        /// A first/last pair representing a single range of characters.
+        /// </summary>
         private struct SingleRange : IComparable<SingleRange>
         {
             internal SingleRange(char first, char last)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -153,7 +153,7 @@ namespace System.Text.RegularExpressions
          *
         **/
         // Has to be sorted by the first column
-        private static readonly String[][] _propTable = {
+        private static readonly String[][] s_propTable = {
             new [] {"IsAlphabeticPresentationForms",       "\uFB00\uFB50"},
             new [] {"IsArabic",                            "\u0600\u0700"},
             new [] {"IsArabicPresentationForms-A",         "\uFB50\uFE00"},
@@ -413,9 +413,9 @@ namespace System.Text.RegularExpressions
         static RegexCharClass()
         {
             // Make sure the _propTable is correctly ordered
-            int len = _propTable.Length;
+            int len = s_propTable.Length;
             for (int i = 0; i < len - 1; i++)
-                Debug.Assert(String.Compare(_propTable[i][0], _propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass _propTable is out of order at (" + _propTable[i][0] + ", " + _propTable[i + 1][0] + ")");
+                Debug.Assert(String.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, "RegexCharClass _propTable is out of order at (" + s_propTable[i][0] + ", " + s_propTable[i + 1][0] + ")");
         }
 #endif
 
@@ -1114,18 +1114,18 @@ namespace System.Text.RegularExpressions
         private static String SetFromProperty(String capname, bool invert, string pattern)
         {
             int min = 0;
-            int max = _propTable.Length;
+            int max = s_propTable.Length;
             while (min != max)
             {
                 int mid = (min + max) / 2;
-                int res = String.Compare(capname, _propTable[mid][0], StringComparison.Ordinal);
+                int res = String.Compare(capname, s_propTable[mid][0], StringComparison.Ordinal);
                 if (res < 0)
                     max = mid;
                 else if (res > 0)
                     min = mid + 1;
                 else
                 {
-                    String set = _propTable[mid][1];
+                    String set = s_propTable[mid][1];
                     Debug.Assert(!String.IsNullOrEmpty(set), "Found a null/empty element in RegexCharClass prop table");
                     if (invert)
                     {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -574,9 +574,14 @@ namespace System.Text.RegularExpressions
             {
                 range = _rangelist[i];
                 if (range._first == range._last)
-                    range._first = range._last = culture.TextInfo.ToLower(range._first);
+                {
+                    char lower = culture.TextInfo.ToLower(range._first);
+                    _rangelist[i] = new SingleRange(lower, lower);
+                }
                 else
+                {
                     AddLowercaseRange(range._first, range._last, culture);
+                }
             }
         }
 
@@ -1122,7 +1127,7 @@ namespace System.Text.RegularExpressions
                             last = CurrentRange._last;
                     }
 
-                    _rangelist[j]._last = last;
+                    _rangelist[j] = new SingleRange(_rangelist[j]._first, last);
 
                     j++;
 
@@ -1373,7 +1378,7 @@ namespace System.Text.RegularExpressions
          *
          * A first/last pair representing a single range of characters.
          */
-        private sealed class SingleRange
+        private struct SingleRange
         {
             internal SingleRange(char first, char last)
             {
@@ -1381,8 +1386,8 @@ namespace System.Text.RegularExpressions
                 _last = last;
             }
 
-            internal char _first;
-            internal char _last;
+            internal readonly char _first;
+            internal readonly char _last;
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -4,20 +4,20 @@
 // This RegexCharClass class provides the "set of Unicode chars" functionality
 // used by the regexp engine.
 
-// The main function of RegexCharClass is as a builder to turn ranges, characters and 
-// Unicode categories into a single string.  This string is used as a black box 
+// The main function of RegexCharClass is as a builder to turn ranges, characters and
+// Unicode categories into a single string.  This string is used as a black box
 // representation of a character class by the rest of Regex.  The format is as follows.
 //
 // Char index   Use
 //      0       Flags - currently this only holds the "negate" flag
 //      1       length of the string representing the "set" portion, eg [a-z0-9] only has a "set"
 //      2       length of the string representing the "category" portion, eg [\p{Lu}] only has a "category"
-//      3...m   The set.  These are a series of ranges which define the characters included in the set. 
+//      3...m   The set.  These are a series of ranges which define the characters included in the set.
 //              To determine if a given character is in the set, we binary search over this set of ranges
 //              and see where the character should go.  Based on whether the ending index is odd or even,
-//              we know if the character is in the set. 
+//              we know if the character is in the set.
 //      m+1...n The categories.  This is a list of UnicodeCategory enum values which describe categories
-//              included in this class.  
+//              included in this class.
 
 using System.Collections;
 using System.Collections.Generic;
@@ -147,11 +147,11 @@ namespace System.Text.RegularExpressions
         };
 
         /*
-         *   The property table contains all the block definitions defined in the 
-         *   XML schema spec (http://www.w3.org/TR/2001/PR-xmlschema-2-20010316/#charcter-classes), Unicode 4.0 spec (www.unicode.org), 
-         *   and Perl 5.6 (see Programming Perl, 3rd edition page 167).   Three blocks defined by Perl (and here) may 
-         *   not be in the Unicode: IsHighPrivateUseSurrogates, IsHighSurrogates, and IsLowSurrogates.   
-         *   
+         *   The property table contains all the block definitions defined in the
+         *   XML schema spec (http://www.w3.org/TR/2001/PR-xmlschema-2-20010316/#charcter-classes), Unicode 4.0 spec (www.unicode.org),
+         *   and Perl 5.6 (see Programming Perl, 3rd edition page 167).   Three blocks defined by Perl (and here) may
+         *   not be in the Unicode: IsHighPrivateUseSurrogates, IsHighSurrogates, and IsLowSurrogates.
+         *
         **/
         // Has to be sorted by the first column
         private static readonly String[][] _propTable = {
@@ -283,26 +283,26 @@ namespace System.Text.RegularExpressions
             Let U be the set of Unicode character values and let L be the lowercase
             function, mapping from U to U. To perform case insensitive matching of
             character sets, we need to be able to map an interval I in U, say
-    
+
                 I = [chMin, chMax] = { ch : chMin <= ch <= chMax }
-    
+
             to a set A such that A contains L(I) and A is contained in the union of
             I and L(I).
-    
+
             The table below partitions U into intervals on which L is non-decreasing.
             Thus, for any interval J = [a, b] contained in one of these intervals,
             L(J) is contained in [L(a), L(b)].
-    
+
             It is also true that for any such J, [L(a), L(b)] is contained in the
             union of J and L(J). This does not follow from L being non-decreasing on
             these intervals. It follows from the nature of the L on each interval.
             On each interval, L has one of the following forms:
-    
+
                 (1) L(ch) = constant            (LowercaseSet)
                 (2) L(ch) = ch + offset         (LowercaseAdd)
                 (3) L(ch) = ch | 1              (LowercaseBor)
                 (4) L(ch) = ch + (ch & 1)       (LowercaseBad)
-    
+
             It is easy to verify that for any of these forms [L(a), L(b)] is
             contained in the union of [a, b] and L([a, b]).
         ***************************************************************************/
@@ -770,9 +770,9 @@ namespace System.Text.RegularExpressions
         internal static bool IsECMAWordChar(char ch)
         {
             // According to ECMA-262, \s, \S, ., ^, and $ use Unicode-based interpretations of
-            // whitespace and newline, while \d, \D\, \w, \W, \b, and \B use ASCII-only 
+            // whitespace and newline, while \d, \D\, \w, \W, \b, and \B use ASCII-only
             // interpretations of digit, word character, and word boundary.  In other words,
-            // no special treatment of Unicode ZERO WIDTH NON-JOINER (ZWNJ U+200C) and 
+            // no special treatment of Unicode ZERO WIDTH NON-JOINER (ZWNJ U+200C) and
             // ZERO WIDTH JOINER (ZWJ U+200D) is required for ECMA word boundaries.
             return CharInClass(ch, ECMAWordClass);
         }
@@ -808,7 +808,7 @@ namespace System.Text.RegularExpressions
             bool b = CharInClassInternal(ch, set, start, mySetLength, myCategoryLength);
 
             // Note that we apply the negation *before* performing the subtraction.  This is because
-            // the negation only applies to the first char class, not the entire subtraction. 
+            // the negation only applies to the first char class, not the entire subtraction.
             if (set[start + FLAGS] == 1)
                 b = !b;
 
@@ -839,11 +839,11 @@ namespace System.Text.RegularExpressions
             }
 
             // The starting position of the set within the character class determines
-            // whether what an odd or even ending position means.  If the start is odd, 
-            // an *even* ending position means the character was in the set.  With recursive 
-            // subtractions in the mix, the starting position = start+SETSTART.  Since we know that 
-            // SETSTART is odd, we can simplify it out of the equation.  But if it changes we need to 
-            // reverse this check. 
+            // whether what an odd or even ending position means.  If the start is odd,
+            // an *even* ending position means the character was in the set.  With recursive
+            // subtractions in the mix, the starting position = start+SETSTART.  Since we know that
+            // SETSTART is odd, we can simplify it out of the equation.  But if it changes we need to
+            // reverse this check.
             Debug.Assert((SETSTART & 0x1) == 1, "If SETSTART is not odd, the calculation below this will be reversed");
             if ((min & 0x1) == (start & 0x1))
                 return true;
@@ -1037,9 +1037,9 @@ namespace System.Text.RegularExpressions
             if (!_canonical)
                 Canonicalize();
 
-            // make a guess about the length of the ranges.  We'll update this at the end. 
+            // make a guess about the length of the ranges.  We'll update this at the end.
             // This is important because if the last range ends in LastChar, we won't append
-            // LastChar to the list. 
+            // LastChar to the list.
             int rangeLen = _rangelist.Count * 2;
             StringBuilder sb = StringBuilderCache.Acquire(rangeLen + _categories.Length + 3);
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -44,7 +44,7 @@ namespace System.Text.RegularExpressions
         private const String NullCharString = "\0";
 
         private const char NullChar = '\0';
-        private const char Lastchar = '\uFFFF';
+        private const char LastChar = '\uFFFF';
 
         private const char GroupChar = (char)0;
 
@@ -499,7 +499,7 @@ namespace System.Text.RegularExpressions
 
             if (i < set.Length)
             {
-                _rangelist.Add(new SingleRange(set[i], Lastchar));
+                _rangelist.Add(new SingleRange(set[i], LastChar));
             }
         }
 
@@ -727,7 +727,7 @@ namespace System.Text.RegularExpressions
         internal static bool IsSingleton(String set)
         {
             if (set[FLAGS] == 0 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
-                (set[SETSTART] == Lastchar || set[SETSTART] + 1 == set[SETSTART + 1]))
+                (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
                 return true;
             else
                 return false;
@@ -736,7 +736,7 @@ namespace System.Text.RegularExpressions
         internal static bool IsSingletonInverse(String set)
         {
             if (set[FLAGS] == 1 && set[CATEGORYLENGTH] == 0 && set[SETLENGTH] == 2 && !IsSubtraction(set) &&
-                (set[SETSTART] == Lastchar || set[SETSTART] + 1 == set[SETSTART + 1]))
+                (set[SETSTART] == LastChar || set[SETSTART] + 1 == set[SETSTART + 1]))
                 return true;
             else
                 return false;
@@ -987,7 +987,7 @@ namespace System.Text.RegularExpressions
                 if (i < end)
                     last = (char)(charClass[i] - 1);
                 else
-                    last = Lastchar;
+                    last = LastChar;
                 i++;
                 ranges.Add(new SingleRange(first, last));
             }
@@ -1036,7 +1036,7 @@ namespace System.Text.RegularExpressions
                 SingleRange currentRange = _rangelist[i];
                 sb.Append(currentRange._first);
 
-                if (currentRange._last != Lastchar)
+                if (currentRange._last != LastChar)
                     sb.Append((char)(currentRange._last + 1));
             }
 
@@ -1084,7 +1084,7 @@ namespace System.Text.RegularExpressions
                 {
                     for (last = _rangelist[j]._last; ; i++)
                     {
-                        if (i == _rangelist.Count || last == Lastchar)
+                        if (i == _rangelist.Count || last == LastChar)
                         {
                             Done = true;
                             break;
@@ -1172,7 +1172,7 @@ namespace System.Text.RegularExpressions
                 if (index + 1 < set.Length)
                     ch2 = (char)(set[index + 1] - 1);
                 else
-                    ch2 = Lastchar;
+                    ch2 = LastChar;
 
                 desc.Append(CharDescription(ch1));
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -554,15 +554,12 @@ namespace System.Text.RegularExpressions
         /// </summary>
         internal void AddLowercase(CultureInfo culture)
         {
-            int i;
-            int origSize;
-            SingleRange range;
-
             _canonical = false;
 
-            for (i = 0, origSize = _rangelist.Count; i < origSize; i++)
+            int count = _rangelist.Count;
+            for (int i = 0; i < count; i++)
             {
-                range = _rangelist[i];
+                SingleRange range = _rangelist[i];
                 if (range._first == range._last)
                 {
                     char lower = culture.TextInfo.ToLower(range._first);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -88,7 +88,7 @@ namespace System.Text.RegularExpressions
         internal const String EmptyClass = "\x00\x00\x00";
 
         // UnicodeCategory is zero based, so we add one to each value and subtract it off later
-        private static readonly Dictionary<String, String> _definedCategories = new Dictionary<String, String>
+        private static readonly Dictionary<String, String> s_definedCategories = new Dictionary<String, String>
         {
             // Others
             { "Cc", "\u000F" }, // UnicodeCategory.Control + 1
@@ -534,13 +534,13 @@ namespace System.Text.RegularExpressions
         internal void AddCategoryFromName(string categoryName, bool invert, bool caseInsensitive, string pattern)
         {
             string category;
-            if (_definedCategories.TryGetValue(categoryName, out category) && !categoryName.Equals(s_internalRegexIgnoreCase))
+            if (s_definedCategories.TryGetValue(categoryName, out category) && !categoryName.Equals(s_internalRegexIgnoreCase))
             {
                 if (caseInsensitive)
                 {
                     if (categoryName.Equals("Ll") || categoryName.Equals("Lu") || categoryName.Equals("Lt"))
                         // when RegexOptions.IgnoreCase is specified then {Ll}, {Lu}, and {Lt} cases should all match
-                        category = _definedCategories[s_internalRegexIgnoreCase];
+                        category = s_definedCategories[s_internalRegexIgnoreCase];
                 }
 
                 if (invert)
@@ -1223,7 +1223,7 @@ namespace System.Text.RegularExpressions
                     int lastindex = set.IndexOf(GroupChar, index + 1);
                     string group = set.Substring(index, lastindex - index + 1);
 
-                    foreach (var kvp in _definedCategories)
+                    foreach (var kvp in s_definedCategories)
                     {
                         if (group.Equals(kvp.Value))
                         {


### PR DESCRIPTION
Apologies in advance for the large pull request. Normally, I'd break these changes up into separate smaller pull requests, but in this case the changes were all to the same file and some changes build on top of earlier changes, so it was easier to submit as one larger pull request.

Each commit is factored appropriately, so it may be easiest to review each commit separately for more sane diffs.

The most significant change was to precompute the constants instead of computing the values at runtime in the static constructor. I have a [one-off test](https://gist.github.com/justinvp/0c1b5faf72349b56a2ed) (not intended to be checked-in) that asserts that the precomputed values from the new implementation are equal to the values that would have been computed at runtime using the previous implementation.