### PR TITLE
Fix DebuggerDisplay to handle renamed member variables.

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -1767,7 +1767,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// A node in the AVL tree storing this set.
         /// </summary>
-        [DebuggerDisplay("{key}")]
+        [DebuggerDisplay("{_key}")]
         internal sealed class Node : IBinaryTree<T>, IEnumerable<T>
         {
             /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -1149,7 +1149,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// A node in the AVL tree storing this map.
         /// </summary>
-        [DebuggerDisplay("{key} = {value}")]
+        [DebuggerDisplay("{_key} = {_value}")]
         internal sealed class Node : IBinaryTree<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>
         {
             /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1382,7 +1382,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// A node in the AVL tree storing this set.
         /// </summary>
-        [DebuggerDisplay("{key}")]
+        [DebuggerDisplay("{_key}")]
         internal sealed class Node : IBinaryTree<T>, IEnumerable<T>
         {
             /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Immutable
     /// An immutable stack.
     /// </summary>
     /// <typeparam name="T">The type of element stored by the stack.</typeparam>
-    [DebuggerDisplay("IsEmpty = {IsEmpty}; Top = {head}")]
+    [DebuggerDisplay("IsEmpty = {IsEmpty}; Top = {_head}")]
     [DebuggerTypeProxy(typeof(ImmutableStackDebuggerProxy<>))]
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "Ignored")]
     [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification = "Ignored")]

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Immutable
     /// and then an interface call to Int32's IComparable's CompareTo method as part of
     /// the GenericComparer{Int32}'s Compare implementation.
     /// </remarks>
-    [DebuggerDisplay("{key} = {value}")]
+    [DebuggerDisplay("{_key} = {_value}")]
     internal sealed class SortedInt32KeyNode<TValue> : IBinaryTree
     {
         /// <summary>


### PR DESCRIPTION
Commit ae98591 renamed all member variables to begin with an underscore
but failed to update the DebuggerDisplay attribute accordingly.  This led
to certain objects showing error messages in the debug watch window rather
than the intended content.  This commit fixes that oversight.