### PR TITLE
TaskHelpers cleanup

### DIFF
--- a/src/System.Console/src/System/IO/SyncTextWriter.cs
+++ b/src/System.Console/src/System/IO/SyncTextWriter.cs
@@ -11,7 +11,6 @@ namespace System.IO
 {
     internal sealed class SyncTextWriter : TextWriter, IDisposable
     {
-        private static Task CompletedTask;
         private readonly object _methodLock = new object();
         private TextWriter _out;
 
@@ -308,48 +307,43 @@ namespace System.IO
         public override Task WriteAsync(char value)
         {
             Write(value);
-            return GetCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteAsync(String value)
         {
             Write(value);
-            return GetCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteAsync(char[] buffer, int index, int count)
         {
             Write(buffer, index, count);
-            return GetCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteLineAsync(char value)
         {
             WriteLine(value);
-            return GetCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteLineAsync(String value)
         {
             WriteLine(value);
-            return GetCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteLineAsync(char[] buffer, int index, int count)
         {
             WriteLine(buffer, index, count);
-            return GetCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task FlushAsync()
         {
             Flush();
-            return GetCompletedTask();
-        }
-
-        private static Task GetCompletedTask()
-        {
-            return CompletedTask ?? (CompletedTask = Task.FromResult(0));
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -60,9 +60,6 @@
     <Compile Include="$(CommonPath)\System\IO\StreamAsyncHelper.cs">
       <Link>Common\System\IO\StreamAsyncHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\TaskHelpers.cs">
-      <Link>Common\System\IO\TaskHelpers.cs</Link>
-    </Compile>
   </ItemGroup>
   <!-- Windows -->
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -496,7 +496,7 @@ namespace System.IO
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskHelpers.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
             if (_fileHandle.IsClosed)
             {
@@ -510,7 +510,7 @@ namespace System.IO
             }
             catch (Exception e)
             {
-                return TaskHelpers.FromException(e);
+                return Task.FromException(e);
             }
 
             // We then separately flush to disk asynchronously.  This is only 
@@ -526,7 +526,7 @@ namespace System.IO
             }
             else
             {
-                return TaskHelpers.CompletedTask();
+                return Task.CompletedTask;
             }
         }
 

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -37,9 +37,6 @@
     <Compile Include="..\..\Common\src\System\IO\StreamAsyncHelper.cs">
       <Link>System\IO\StreamAsyncHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\IO\TaskHelpers.cs">
-      <Link>System\IO\TaskHelpers.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\src\System\IO\Win32Marshal.cs">
       <Link>System\IO\Win32Marshal.cs</Link>
     </Compile>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/Pipe.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/Pipe.cs
@@ -600,7 +600,7 @@ namespace System.IO.Pipes
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskHelpers.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
 
             if (!IsAsync)
@@ -1166,7 +1166,7 @@ namespace System.IO.Pipes
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskHelpers.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
 
             // We need to measure time here, not in the lambda

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -744,7 +744,7 @@ namespace System.IO.Pipes
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskHelpers.FromCancellation<int>(cancellationToken);
+                return Task.FromCanceled<int>(cancellationToken);
             }
 
             CheckReadOperations();
@@ -774,7 +774,7 @@ namespace System.IO.Pipes
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return TaskHelpers.FromCancellation<int>(cancellationToken);
+                return Task.FromCanceled<int>(cancellationToken);
             }
 
             CheckWriteOperations();

--- a/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
@@ -16,9 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\IO\TaskHelpers.cs">
-      <Link>Common\TaskHelpers.cs</Link>
-    </Compile>
     <Compile Include="Common\__Error.cs" />
     <Compile Include="System\IO\UnmanagedMemoryAccessor.cs" />
     <Compile Include="System\IO\UnmanagedMemoryStream.cs" />

--- a/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
@@ -351,16 +351,16 @@ namespace System.IO
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
-                return TaskHelpers.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             try
             {
                 Flush();
-                return TaskHelpers.CompletedTask();
+                return Task.CompletedTask;
             }
             catch (Exception ex)
             {
-                return TaskHelpers.FromException(ex);
+                return Task.FromException(ex);
             }
         }
 
@@ -563,7 +563,7 @@ namespace System.IO
             Contract.EndContractBlock();  // contract validation copied from Read(...) 
 
             if (cancellationToken.IsCancellationRequested)
-                return TaskHelpers.FromCancellation<Int32>(cancellationToken);
+                return Task.FromCanceled<Int32>(cancellationToken);
 
             try
             {
@@ -574,7 +574,7 @@ namespace System.IO
             catch (Exception ex)
             {
                 Contract.Assert(!(ex is OperationCanceledException));
-                return TaskHelpers.FromException<Int32>(ex);
+                return Task.FromException<Int32>(ex);
             }
         }
 
@@ -811,17 +811,17 @@ namespace System.IO
             Contract.EndContractBlock();  // contract validation copied from Write(..) 
 
             if (cancellationToken.IsCancellationRequested)
-                return TaskHelpers.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             try
             {
                 Write(buffer, offset, count);
-                return TaskHelpers.CompletedTask();
+                return Task.CompletedTask;
             }
             catch (Exception ex)
             {
                 Contract.Assert(!(ex is OperationCanceledException));
-                return TaskHelpers.FromException<Int32>(ex);
+                return Task.FromException(ex);
             }
         }
 


### PR DESCRIPTION
TaskHelpers.cs is a temporary stop-gap for assemblies that don't yet depend on the latest System.Threading.Tasks contract. This change removes the dependency on the file for those assemblies that do use the latest, changing them to access the Task.CompletedTask, Task.FromCanceled, and Task.FromException members on Task instead of the corresponding workarounds on TaskHelpers.  This file should eventually go away entirely.