### PR TITLE
Use StringBuilderCache in additional assemblies

### DIFF
--- a/src/Common/src/System/IO/StringBuilderCache.cs
+++ b/src/Common/src/System/IO/StringBuilderCache.cs
@@ -66,6 +66,13 @@ namespace System.IO
             return new StringBuilder(capacity);
         }
 
+        public static StringBuilder Acquire(string value)
+        {
+            StringBuilder sb = Acquire(Math.Max(value.Length, DEFAULT_CAPACITY));
+            sb.Append(value);
+            return sb;
+        }
+
         public static void Release(StringBuilder sb)
         {
             if (sb.Capacity <= MAX_BUILDER_SIZE)

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -54,6 +54,9 @@
   <ItemGroup Condition=" '$(OS)' == 'Unix' ">
     <Compile Include="System\ConsolePal.Unix.cs" />
     <Compile Include="Interop\Interop.manual.Unix.cs" />
+    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
+      <Link>Common\System\IO\StringBuilderCache.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Interop.CoreFileIO.Unix.cs">
       <Link>Common\Interop\Interop.CoreFileIO.Unix.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -641,7 +641,7 @@ namespace System
                     // Create a StringBuilder to store the output of this processing.  We use the format's length as an 
                     // approximation of an upper-bound for how large the output will be, though with parameter processing,
                     // this is just an estimate, sometimes way over, sometimes under.
-                    StringBuilder output = new StringBuilder(format.Length);
+                    StringBuilder output = StringBuilderCache.Acquire(format.Length);
 
                     // Format strings support conditionals, including the equivalent of "if ... then ..." and
                     // "if ... then ... else ...", as well as "if ... then ... else ... then ..."
@@ -851,7 +851,7 @@ namespace System
                                 if (!sawIfConditional)
                                 {
                                     stack.Push(1);
-                                    return output.ToString();
+                                    return StringBuilderCache.GetStringAndRelease(output);
                                 }
 
                                 // Otherwise, we're done processing the conditional in its entirety.
@@ -861,7 +861,7 @@ namespace System
                             case ';':
                                 // Let our caller know why we're exiting, whether due to the end of the conditional or an else branch.
                                 stack.Push(AsInt(format[pos] == ';'));
-                                return output.ToString();
+                                return StringBuilderCache.GetStringAndRelease(output);
 
                             // Anything else is an error
                             default:
@@ -870,7 +870,7 @@ namespace System
                     }
 
                     stack.Push(1);
-                    return output.ToString();
+                    return StringBuilderCache.GetStringAndRelease(output);
                 }
 
                 /// <summary>Converts an Int32 to a Boolean, with 0 meaning false and all non-zero values meaning true.</summary>

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -54,6 +54,9 @@
     <Compile Include="..\..\Common\src\System\NotImplemented.cs">
       <Link>System\NotImplemented.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\System\IO\StringBuilderCache.cs">
+      <Link>System\IO\StringBuilderCache.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Resource files -->
   <ItemGroup>

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -13,6 +13,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 
 namespace System.Text.RegularExpressions
 {
@@ -56,10 +57,10 @@ namespace System.Text.RegularExpressions
             // consistent.
             if (caseInsensitive)
             {
-                StringBuilder sb = new StringBuilder(pattern.Length);
+                StringBuilder sb = StringBuilderCache.Acquire(pattern.Length);
                 for (int i = 0; i < pattern.Length; i++)
                     sb.Append(culture.TextInfo.ToLower(pattern[i]));
-                pattern = sb.ToString();
+                pattern = StringBuilderCache.GetStringAndRelease(sb);
             }
 
             _pattern = pattern;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -23,6 +23,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Diagnostics;
+using System.IO;
 
 namespace System.Text.RegularExpressions
 {
@@ -771,7 +772,7 @@ namespace System.Text.RegularExpressions
 
         internal static string ConvertOldStringsToClass(string set, string category)
         {
-            StringBuilder sb = new StringBuilder(set.Length + category.Length + 3);
+            StringBuilder sb = StringBuilderCache.Acquire(set.Length + category.Length + 3);
 
             if (set.Length >= 2 && set[0] == '\0' && set[1] == '\0')
             {
@@ -789,7 +790,7 @@ namespace System.Text.RegularExpressions
             }
             sb.Append(category);
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         /*
@@ -1054,14 +1055,14 @@ namespace System.Text.RegularExpressions
             if (category == null)
                 return null;
 
-            StringBuilder sb = new StringBuilder(category.Length);
+            StringBuilder sb = StringBuilderCache.Acquire(category.Length);
 
             for (int i = 0; i < category.Length; i++)
             {
                 short ch = (short)category[i];
                 sb.Append((char)-ch);
             }
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         internal static RegexCharClass Parse(string charClass)
@@ -1123,7 +1124,7 @@ namespace System.Text.RegularExpressions
             // This is important because if the last range ends in LastChar, we won't append
             // LastChar to the list. 
             int rangeLen = _rangelist.Count * 2;
-            StringBuilder sb = new StringBuilder(rangeLen + _categories.Length + 3);
+            StringBuilder sb = StringBuilderCache.Acquire(rangeLen + _categories.Length + 3);
 
             int flags;
             if (_negate)
@@ -1151,7 +1152,7 @@ namespace System.Text.RegularExpressions
             if (_subtractor != null)
                 sb.Append(_subtractor.ToStringClass());
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         /*

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -12,6 +12,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 
 namespace System.Text.RegularExpressions
 {
@@ -104,7 +105,7 @@ namespace System.Text.RegularExpressions
             {
                 if (IsMetachar(input[i]))
                 {
-                    StringBuilder sb = new StringBuilder();
+                    StringBuilder sb = StringBuilderCache.Acquire();
                     char ch = input[i];
                     int lastpos;
 
@@ -143,7 +144,7 @@ namespace System.Text.RegularExpressions
                         sb.Append(input, lastpos, i - lastpos);
                     } while (i < input.Length);
 
-                    return sb.ToString();
+                    return StringBuilderCache.GetStringAndRelease(sb);
                 }
             }
 
@@ -159,7 +160,7 @@ namespace System.Text.RegularExpressions
             {
                 if (input[i] == '\\')
                 {
-                    StringBuilder sb = new StringBuilder();
+                    StringBuilder sb = StringBuilderCache.Acquire();
                     RegexParser p = new RegexParser(CultureInfo.InvariantCulture);
                     int lastpos;
                     p.SetPattern(input);
@@ -178,7 +179,7 @@ namespace System.Text.RegularExpressions
                         sb.Append(input, lastpos, i - lastpos);
                     } while (i < input.Length);
 
-                    return sb.ToString();
+                    return StringBuilderCache.GetStringAndRelease(sb);
                 }
             }
 
@@ -2037,10 +2038,10 @@ namespace System.Text.RegularExpressions
                     // a ToLower on the entire string could actually change the surrogate pair.  This is more correct
                     // linguistically, but since Regex doesn't support surrogates, it's more important to be
                     // consistent.
-                    StringBuilder sb = new StringBuilder(str.Length);
+                    StringBuilder sb = StringBuilderCache.Acquire(str.Length);
                     for (int i = 0; i < str.Length; i++)
                         sb.Append(_culture.TextInfo.ToLower(str[i]));
-                    str = sb.ToString();
+                    str = StringBuilderCache.GetStringAndRelease(sb);
                 }
 
                 node = new RegexNode(RegexNode.Multi, _options, str);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -7,6 +7,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 
 namespace System.Text.RegularExpressions
 {
@@ -19,19 +20,14 @@ namespace System.Text.RegularExpressions
          */
         internal RegexReplacement(String rep, RegexNode concat, Dictionary<Int32, Int32> _caps)
         {
-            StringBuilder sb;
-            List<String> strings;
-            List<Int32> rules;
-            int slot;
-
             _rep = rep;
 
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
-            sb = new StringBuilder();
-            strings = new List<String>();
-            rules = new List<Int32>();
+            StringBuilder sb = StringBuilderCache.Acquire();
+            List<String> strings = new List<String>();
+            List<Int32> rules = new List<Int32>();
 
             for (int i = 0; i < concat.ChildCount(); i++)
             {
@@ -52,7 +48,7 @@ namespace System.Text.RegularExpressions
                             strings.Add(sb.ToString());
                             sb.Length = 0;
                         }
-                        slot = child._m;
+                        int slot = child._m;
 
                         if (_caps != null && slot >= 0)
                             slot = (int)_caps[slot];
@@ -69,6 +65,8 @@ namespace System.Text.RegularExpressions
                 rules.Add(strings.Count);
                 strings.Add(sb.ToString());
             }
+
+            StringBuilderCache.Release(sb);
 
             _strings = strings;
             _rules = rules;
@@ -170,11 +168,11 @@ namespace System.Text.RegularExpressions
          */
         internal String Replacement(Match match)
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.Acquire();
 
             ReplacementImpl(sb, match);
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         /*
@@ -211,11 +209,10 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                StringBuilder sb;
+                StringBuilder sb = StringBuilderCache.Acquire();
 
                 if (!regex.RightToLeft)
                 {
-                    sb = new StringBuilder();
                     int prevat = 0;
 
                     do
@@ -252,8 +249,6 @@ namespace System.Text.RegularExpressions
                         match = match.NextMatch();
                     } while (match.Success);
 
-                    sb = new StringBuilder();
-
                     if (prevat > 0)
                         sb.Append(input, 0, prevat);
 
@@ -263,7 +258,7 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                return sb.ToString();
+                return StringBuilderCache.GetStringAndRelease(sb);
             }
         }
 
@@ -299,11 +294,10 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                StringBuilder sb;
+                StringBuilder sb = StringBuilderCache.Acquire();
 
                 if (!regex.RightToLeft)
                 {
-                    sb = new StringBuilder();
                     int prevat = 0;
 
                     do
@@ -344,8 +338,6 @@ namespace System.Text.RegularExpressions
                         match = match.NextMatch();
                     } while (match.Success);
 
-                    sb = new StringBuilder();
-
                     if (prevat > 0)
                         sb.Append(input, 0, prevat);
 
@@ -355,7 +347,7 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                return sb.ToString();
+                return StringBuilderCache.GetStringAndRelease(sb);
             }
         }
 

--- a/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
@@ -21,6 +21,9 @@
     <Compile Include="$(CommonPath)\System\SR.cs">
       <Link>Resources\SR.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
+      <Link>System\StringBuilderCache.cs</Link>
+    </Compile>
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XDeclaration.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XDeclaration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using StringBuilder = System.Text.StringBuilder;
 
 namespace System.Xml.Linq
@@ -101,7 +102,7 @@ namespace System.Xml.Linq
         /// <returns>A formatted XML string.</returns>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder("<?xml");
+            StringBuilder sb = StringBuilderCache.Acquire("<?xml");
             if (_version != null)
             {
                 sb.Append(" version=\"");
@@ -121,7 +122,7 @@ namespace System.Xml.Linq
                 sb.Append('\"');
             }
             sb.Append("?>");
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
     }
 }

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
@@ -239,9 +239,9 @@ namespace System.Xml.Linq
                 if (content == null) return string.Empty;
                 string s = content as string;
                 if (s != null) return s;
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = StringBuilderCache.Acquire();
                 AppendText(sb);
-                return sb.ToString();
+                return StringBuilderCache.GetStringAndRelease(sb);
             }
             set
             {

--- a/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
+++ b/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
@@ -22,6 +22,7 @@
   </PropertyGroup>
   <!-- References are resolved from packages.config -->
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs" />
     <Compile Include="$(CommonPath)\System\Xml\Ref.cs" />
     <Compile Include="$(CommonPath)\System\Xml\SecureStringHasher.cs" />
     <Compile Include="$(CommonPath)\System\Xml\XmlTextWriter.cs" />

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlDeclaration.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlDeclaration.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Diagnostics;
+using System.IO;
 
 namespace System.Xml
 {
@@ -72,7 +73,7 @@ namespace System.Xml
         {
             get
             {
-                StringBuilder strb = new StringBuilder("version=\"");
+                StringBuilder strb = StringBuilderCache.Acquire("version=\"");
                 strb.Append(Version);
                 strb.Append('"');
                 if (Encoding.Length > 0)
@@ -87,7 +88,7 @@ namespace System.Xml
                     strb.Append(Standalone);
                     strb.Append('"');
                 }
-                return strb.ToString();
+                return StringBuilderCache.GetStringAndRelease(strb);
             }
 
             set

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlNode.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlNode.cs
@@ -661,7 +661,7 @@ namespace System.Xml
         public virtual void Normalize()
         {
             XmlNode firstChildTextLikeNode = null;
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.Acquire();
             for (XmlNode crtChild = this.FirstChild; crtChild != null;)
             {
                 XmlNode nextChild = crtChild.NextSibling;
@@ -705,6 +705,8 @@ namespace System.Xml
             }
             if (firstChildTextLikeNode != null && sb.Length > 0)
                 firstChildTextLikeNode.Value = sb.ToString();
+
+            StringBuilderCache.Release(sb);
         }
 
         private XmlNode NormalizeWinner(XmlNode firstNode, XmlNode secondNode)
@@ -850,9 +852,9 @@ namespace System.Xml
                             return fc.Value;
                     }
                 }
-                StringBuilder builder = new StringBuilder();
+                StringBuilder builder = StringBuilderCache.Acquire();
                 AppendChildText(builder);
-                return builder.ToString();
+                return StringBuilderCache.GetStringAndRelease(builder);
             }
 
             set


### PR DESCRIPTION
StringBuilderCache maintains a cache of up to a single StringBuilder per thread, avoiding StringBuilder allocations for the common pattern of:
```C#
    StringBuilder sb = new StringBuilder();
    // ... do some appends
    return sb.ToString();
```
and instead enabling:
```C#
    StringBuilder sb = StringBuilderCache.Acquire();
    // ... do some appends
    return StringBuilderCache.GetStringAndRelease(sb);
```

It was added to the repo as part of System.IO.FileSystem.  This change deploys usage of it through other assemblies.  Not all "new StringBuilder(...)" usage has been replaced, just those instances that are expected to be most impactful, e.g. tests were ignored, places where StringBuilders are stored into fields were ignored, debug code was ignored, less common members were ignored, etc.

Simple microbenchmarks showed measurable improvements as a result.  For example, a test around Regex.Replace showed that ~10% of the allocations incurred were for StringBuilder instances; using StringBuilderCache mostly eliminated these and improved throughput by a corresponding ~10%.  This will of course vary based on the test employed, but it's a data point.