### PR TITLE
Avoid unnecessary closure in Win32FileStreamAsyncResult

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStreamAsyncResult.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStreamAsyncResult.cs
@@ -207,7 +207,8 @@ namespace System.IO
                     // Set completedSynchronously to false, since it's on another 
                     // thread, not the main thread.
                     _completedSynchronously = false;
-                    Task.Run(() => CallUserCallbackWorker());
+                    Task.Factory.StartNew(state => ((FileStreamAsyncResult)state).CallUserCallbackWorker(),
+                        this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
                 }
                 else
                 {


### PR DESCRIPTION
Changes FileStreamAsyncResult.CallUserCallback to pass 'this' via object state instead of via a closure, saving two allocations (no closure object is needed, and the compiler can cache the delegate).