### PR TITLE
Allow for building with an "alternate" buildtools package.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -40,7 +40,17 @@
       StandardOutputImportance="Low"
       Command="&quot;$(NuGetToolPath)&quot; install &quot; $(SourceDir).nuget\packages.config &quot;  -o &quot; $(PackagesDir) &quot; $(NuGetConfigCommandLine)" />
 
-    <Touch Files="$(BuildToolsInstallSempahore)" AlwaysCreate="true" />
+    <!-- Testing build tools packages before deployment is an interesting scenario.  There isn't an easy way to do this in the
+         nuget workflow (especially outside vs/powershell).  For now, we'll delete the BuildTools package directory, then reinstall with
+         an alternate source for the build tools directory. The alternate source is specified by BuildToolsAlternateSource. -->
+    
+    <RemoveDir Directories="$(ToolsPackageDir)" Condition="$(BuildToolsUseAlternateSource)" />
+    <Exec
+      StandardOutputImportance="Low"
+      Command="&quot;$(NuGetToolPath)&quot; install &quot; $(SourceDir).nuget\packages.config &quot;  -o &quot; $(PackagesDir) &quot; -Source  &quot; $(BuildToolsAlternateSource) &quot; -NoCache $(NuGetConfigCommandLine)"
+      Condition="$(BuildToolsUseAlternateSource)" />
+      
+    <Touch Files="$(BuildToolsInstallSemaphore)" AlwaysCreate="true" />
   </Target>
 
   <ItemGroup>

--- a/dir.props
+++ b/dir.props
@@ -11,12 +11,13 @@
     <BinDir>$(ProjectDir)bin\</BinDir>
     <TestWorkingDir>$(BinDir)tests\</TestWorkingDir>
     <PackagesDir>$(SourceDir)packages\</PackagesDir>
-    <ToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
+    <ToolsPackageDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\</ToolsPackageDir>
+    <ToolsDir>$(ToolsPackageDir)lib\</ToolsDir>
   </PropertyGroup>
 
   <!-- Common nuget properties -->
   <PropertyGroup>
-    <NuGetToolPath>$(ToolsDir)NuGet.exe</NuGetToolPath>
+    <NuGetToolPath>$(PackagesDir)NuGet.exe</NuGetToolPath>
     <NuGetConfigFile>$(SourceDir)NuGet.Config</NuGetConfigFile>
     <NuGetConfigCommandLine
       Condition="Exists('$(NuGetConfigFile)')">-ConfigFile &quot;$(NuGetConfigFile)&quot;</NuGetConfigCommandLine>
@@ -24,9 +25,16 @@
 
   <!-- Common build tool properties -->
   <PropertyGroup>
-    <BuildToolsInstallSempahore>$(ToolsDir)BuildTools.$(BuildToolsVersion).installed.semaphore</BuildToolsInstallSempahore>
+    <!-- If we specified an alternate source for the build tools, we can assume that the version number is not getting updated
+         with each build (this is typically for testing).  We set the semaphore file to a different name, then avoid
+         touching that file when the build tools are installed.  This ensures a forced install each time. -->
+    <BuildToolsUseAlternateSource>false</BuildToolsUseAlternateSource>
+    <BuildToolsUseAlternateSource Condition="'$(BuildToolsAlternateSource)' != ''">true</BuildToolsUseAlternateSource>
+    
+    <BuildToolsInstallSemaphore>$(ToolsDir)BuildTools.$(BuildToolsVersion).installed.semaphore</BuildToolsInstallSemaphore>
+    <BuildToolsInstallAlternateSemaphore Condition="$(BuildToolsUseAlternateSource)">$(ToolsDir)BuildTools.Alternate.installed.semaphore</BuildToolsInstallAlternateSemaphore>
 
-    <BuildToolsTargetInputs>$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)build.proj</BuildToolsTargetInputs>
-    <BuildToolsTargetOutputs>$(BuildToolsInstallSempahore)</BuildToolsTargetOutputs>
+    <BuildToolsTargetInputs>$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)build.proj;</BuildToolsTargetInputs>
+    <BuildToolsTargetOutputs>$(BuildToolsInstallSemaphore);$(BuildToolsInstallAlternateSemaphore)</BuildToolsTargetOutputs>
   </PropertyGroup>
 </Project>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -5,11 +5,12 @@
     Inputs="$(BuildToolsTargetInputs)"
     Outputs="$(BuildToolsTargetOutputs)"
     >
-    <Error Condition="!Exists('$(BuildToolsInstallSempahore)')" 
+    <Error Condition="!Exists('$(BuildToolsInstallSemaphore)')" 
       Text="The build tools have not been installed. Please run build.cmd from the root of the repo at least once to get the tools installed." />
 
     <!-- If we enter this target at all then the inputs are newer then the outputs so give a warning. -->
-    <Warning Text="Looks like there may be an update to the build tools. Please run build.cmd from the root of the repo to refresh the build tools." /> 
+    <Warning Condition="!$(BuildToolsUseAlternateSource)"
+      Text="Looks like there may be an update to the build tools. Please run build.cmd from the root of the repo to refresh the build tools." /> 
   </Target>
 
   <Import Project="$(ToolsDir)depending.targets" Condition="Exists('$(ToolsDir)depending.targets')" />


### PR DESCRIPTION
This change allows us to test building of corefx using an alternate set of build tools (instead of the nuget package).  This allows for pre-commit testing of build tools and was also an exploration of how cross-OS testing might work later on (with regard to package management).

NuGet has some limitations with regard to testing newly built packages.  What you'd like to be able to do is build a package containing your new library, then build some dependent project based on the regular dependencies + the new package without publishing it first.  Unfortunately this isn't easy to do. To work around various issues, the following optional workflow was added to the build process:

If /p:BuildToolsAlternateSource=<directory containing build tools package>
    - Install build tools as normal, along with dependencies
    - Delete "old" build tools directory.  This will force nuget to reinstall just the nuget package (since it's missing)
    - Install build tools based on configuration, specifying BuildToolsAlternateSource as the sourdce directory

Some other notes:

    - There is an additional semaphore output added when the alternate source is specified.  This semaphore is never created.  This ensures that we always install the tools.
    - Fixed spelling of semaphore
    - Moved nuget into the root of src\packages.  Since we have to delete the whole BuildTools directory to get nuget to reinstall the relevant package, we can't put NuGet there.