### PR TITLE
Fix missing file updates in System.IO.FileSystem

### DIFF
--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -116,6 +116,9 @@
     <Compile Include="$(CommonPath)\Interop\Interop.Errors.Unix.cs">
       <Link>Common\Interop\Interop.Errors.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Interop.strerror.Unix.cs">
+      <Link>Common\Interop\Interop.strerror.Unix.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>
     </Compile>


### PR DESCRIPTION
When System.IO.FileSystem was added to the repo, internal changes made to SafeFileHandle did not migrate with it.  There was also a file reference missing from its .csproj file.  Both of these broke the Unix build.  This change just brings those back in sync to fix the build.
