### PR TITLE
Fix UnmanagedMemoryAccessor.Initialize Accessibility

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryAccessor.cs
+++ b/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryAccessor.cs
@@ -62,7 +62,7 @@ namespace System.IO
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        void Initialize(SafeBuffer buffer, Int64 offset, Int64 capacity, FileAccess access)
+        protected void Initialize(SafeBuffer buffer, Int64 offset, Int64 capacity, FileAccess access)
         {
             if (buffer == null)
             {


### PR DESCRIPTION
The accessibility of UnmanagedMemoryAccessor.Initialize was accidentally changed when this code was ported from our internal sources.