### PR TITLE
Remove AppVeyor configuration file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,0 @@
-build_script:
-  - '"%VS120COMNTOOLS%VsDevCmd.bat"'
-  - build.cmd
-test: off  # disable automatic test discovery, xUnit already runs as part of build.cmd
-
-artifacts:
-  - path: msbuild.log
-    name: MSBuild Log


### PR DESCRIPTION
Since we moved our CI system to Jenkins, this file is no longer needed. If we ever need to go back, we can simply retrieve from the history.