### PR TITLE
Make read-only fields readonly

### DIFF
--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/HybridDictionary.cs
@@ -27,7 +27,7 @@ namespace System.Collections.Specialized
         // Instance variables. This keeps the HybridDictionary very light-weight when empty
         private ListDictionary _list;
         private Hashtable _hashtable;
-        private bool _caseInsensitive;
+        private readonly bool _caseInsensitive;
 
         public HybridDictionary()
         {

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Specialized
         private DictionaryNode _head;
         private int _version;
         private int _count;
-        private IComparer _comparer;
+        private readonly IComparer _comparer;
         private Object _syncRoot;
 
         public ListDictionary()

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -30,7 +30,7 @@ namespace System.Collections.Specialized
         private int _version;
         private Object _syncRoot;
 
-        private static StringComparer s_defaultComparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
+        private static readonly StringComparer s_defaultComparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
 
         /// <devdoc>
         /// <para> Creates an empty <see cref='System.Collections.Specialized.NameObjectCollectionBase'/> instance with the default initial capacity and using the default case-insensitive hash

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -21,9 +21,9 @@ namespace System.Collections.Specialized
     {
         private ArrayList _objectsArray;
         private Hashtable _objectsTable;
-        private int _initialCapacity;
-        private IEqualityComparer _comparer;
-        private bool _readOnly;
+        private readonly int _initialCapacity;
+        private readonly IEqualityComparer _comparer;
+        private readonly bool _readOnly;
         private Object _syncRoot;
 
         public OrderedDictionary() : this(0)

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringCollection.cs
@@ -11,7 +11,7 @@ namespace System.Collections.Specialized
     /// </devdoc>
     public class StringCollection : IList
     {
-        private ArrayList _data = new ArrayList();
+        private readonly ArrayList _data = new ArrayList();
 
         /// <devdoc>
         /// <para>Represents the entry at the specified index of the <see cref='System.Collections.Specialized.StringCollection'/>.</para>

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Specialized
         // That means using ToLower in each property on this type.  Also for backwards
         // compatibility, we will be converting strings to lower-case, which has a 
         // problem for some Georgian alphabets.  
-        internal Hashtable contents = new Hashtable();
+        private readonly Hashtable contents = new Hashtable();
 
 
         /// <devdoc>

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/StringDictionary.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Specialized
         // That means using ToLower in each property on this type.  Also for backwards
         // compatibility, we will be converting strings to lower-case, which has a 
         // problem for some Georgian alphabets.  
-        private readonly Hashtable contents = new Hashtable();
+        private readonly Hashtable _contents = new Hashtable();
 
 
         /// <devdoc>
@@ -42,7 +42,7 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return contents.Count;
+                return _contents.Count;
             }
         }
 
@@ -55,7 +55,7 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return contents.IsSynchronized;
+                return _contents.IsSynchronized;
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Collections.Specialized
                     throw new ArgumentNullException("key");
                 }
 
-                return (string)contents[key.ToLowerInvariant()];
+                return (string)_contents[key.ToLowerInvariant()];
             }
             set
             {
@@ -80,7 +80,7 @@ namespace System.Collections.Specialized
                     throw new ArgumentNullException("key");
                 }
 
-                contents[key.ToLowerInvariant()] = value;
+                _contents[key.ToLowerInvariant()] = value;
             }
         }
 
@@ -91,7 +91,7 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return contents.Keys;
+                return _contents.Keys;
             }
         }
 
@@ -103,7 +103,7 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return contents.SyncRoot;
+                return _contents.SyncRoot;
             }
         }
 
@@ -114,7 +114,7 @@ namespace System.Collections.Specialized
         {
             get
             {
-                return contents.Values;
+                return _contents.Values;
             }
         }
 
@@ -128,7 +128,7 @@ namespace System.Collections.Specialized
                 throw new ArgumentNullException("key");
             }
 
-            contents.Add(key.ToLowerInvariant(), value);
+            _contents.Add(key.ToLowerInvariant(), value);
         }
 
         /// <devdoc>
@@ -136,7 +136,7 @@ namespace System.Collections.Specialized
         /// </devdoc>
         public virtual void Clear()
         {
-            contents.Clear();
+            _contents.Clear();
         }
 
         /// <devdoc>
@@ -149,7 +149,7 @@ namespace System.Collections.Specialized
                 throw new ArgumentNullException("key");
             }
 
-            return contents.ContainsKey(key.ToLowerInvariant());
+            return _contents.ContainsKey(key.ToLowerInvariant());
         }
 
         /// <devdoc>
@@ -157,7 +157,7 @@ namespace System.Collections.Specialized
         /// </devdoc>
         public virtual bool ContainsValue(string value)
         {
-            return contents.ContainsValue(value);
+            return _contents.ContainsValue(value);
         }
 
         /// <devdoc>
@@ -166,7 +166,7 @@ namespace System.Collections.Specialized
         /// </devdoc>
         public virtual void CopyTo(Array array, int index)
         {
-            contents.CopyTo(array, index);
+            _contents.CopyTo(array, index);
         }
 
         /// <devdoc>
@@ -174,7 +174,7 @@ namespace System.Collections.Specialized
         /// </devdoc>
         public virtual IEnumerator GetEnumerator()
         {
-            return contents.GetEnumerator();
+            return _contents.GetEnumerator();
         }
 
         /// <devdoc>
@@ -187,7 +187,7 @@ namespace System.Collections.Specialized
                 throw new ArgumentNullException("key");
             }
 
-            contents.Remove(key.ToLowerInvariant());
+            _contents.Remove(key.ToLowerInvariant());
         }
     }
 }


### PR DESCRIPTION
There are a number of fields in `System.Collections.Specialized` that can be `readonly`. Also, `StringDictionary`'s `contents` field was internal but can be `private` since it isn't being used anywhere else in this assembly; and therefore was renamed `_contents` to match the coding style.