### PR TITLE
Remove unused namespace and fix package reference in FS

### DIFF
--- a/src/System.Collections.Specialized/tests/NameObjectCollectionBase/MyNameObjectCollection.cs
+++ b/src/System.Collections.Specialized/tests/NameObjectCollectionBase/MyNameObjectCollection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
-using System.Runtime.Serialization;
 
 // Derived class to test NameObjectCollectionBase
 

--- a/src/System.IO.FileSystem/tests/packages.config
+++ b/src/System.IO.FileSystem/tests/packages.config
@@ -3,6 +3,7 @@
   <package id="System.IO" version="4.0.10-beta-22412" targetFramework="portable-net45+win+wpa81" />  
   <package id="System.Runtime" version="4.0.20-beta-22412" targetFramework="portable-net45+win+wpa81" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" targetFramework="portable-net45+win+wpa81" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22412" targetFramework="portable-net45+win+wpa81" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22412" targetFramework="portable-net45+win+wpa81" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22412" targetFramework="portable-net45+win+wpa81" />
   <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />


### PR DESCRIPTION
The System.Runtime.Serialization namespace isn't defined in any of the
NuGet packages and is not used in the project, so it can be removed.

The System.IO.FileSystem tests were missing a reference to
System.Runtime.Handles in packages.config (SafeHandle is defined there).

This fixes compilation errors on the Mono compiler.