### PR TITLE
Remove defunct PRENET45 from TPL Dataflow

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
@@ -118,7 +118,7 @@ namespace System.Threading.Tasks.Dataflow
                     dataflowBlockOptions.CancellationToken, Completion, state => ((TargetCore<TInput>)state).Complete(exception: null, dropPendingMessages: true), _defaultTarget);
             }
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
@@ -187,17 +187,10 @@ namespace System.Threading.Tasks.Dataflow
             else
             {
                 // Otherwise, join with the asynchronous operation when it completes.
-#if PRENET45
-                task.ContinueWith(completed =>
-                {
-                    this.AsyncCompleteProcessMessageWithTask(completed);
-                }, CancellationToken.None, Common.GetContinuationOptions(TaskContinuationOptions.ExecuteSynchronously), TaskScheduler.Default);
-#else
                 task.ContinueWith((completed, state) =>
                 {
                     ((ActionBlock<TInput>)state).AsyncCompleteProcessMessageWithTask(completed);
                 }, this, CancellationToken.None, Common.GetContinuationOptions(TaskContinuationOptions.ExecuteSynchronously), TaskScheduler.Default);
-#endif
             }
         }
 

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
@@ -81,20 +81,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((BatchBlock<T>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
@@ -92,7 +92,7 @@ namespace System.Threading.Tasks.Dataflow
             Common.WireCancellationToComplete(
                 dataflowBlockOptions.CancellationToken, _source.Completion, state => ((BatchBlockTargetCore)state).Complete(exception: null, dropPendingMessages: true, releaseReservedMessages: false), _target);
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);
@@ -330,7 +330,7 @@ namespace System.Threading.Tasks.Dataflow
                 _dataflowBlockOptions = dataflowBlockOptions;
 
                 // We'll be using _nonGreedyState even if we are greedy with bounding
-                var boundingEnabled = dataflowBlockOptions.BoundedCapacity > 0;
+                bool boundingEnabled = dataflowBlockOptions.BoundedCapacity > 0;
                 if (!_dataflowBlockOptions.Greedy || boundingEnabled) _nonGreedyState = new NonGreedyState(batchSize);
                 if (boundingEnabled) _boundingState = new BoundingState(dataflowBlockOptions.BoundedCapacity);
             }
@@ -648,7 +648,7 @@ namespace System.Threading.Tasks.Dataflow
                                                     Common.GetCreationOptionsForTask(isReplacementReplica));
 
 #if FEATURE_TRACING
-                var etwLog = DataflowEtwProvider.Log;
+                DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
                 if (etwLog.IsEnabled())
                 {
                     etwLog.TaskLaunchedForMessageHandling(
@@ -658,7 +658,7 @@ namespace System.Threading.Tasks.Dataflow
 #endif
 
                 // Start the task handling scheduling exceptions
-                var exception = Common.StartTaskSafe(_nonGreedyState.TaskForInputProcessing, _dataflowBlockOptions.TaskScheduler);
+                Exception exception = Common.StartTaskSafe(_nonGreedyState.TaskForInputProcessing, _dataflowBlockOptions.TaskScheduler);
                 if (exception != null)
                 {
                     // Get out from under currently held locks. Complete re-acquires the locks it needs.
@@ -676,7 +676,7 @@ namespace System.Threading.Tasks.Dataflow
                 Common.ContractAssertMonitorStatus(IncomingLock, held: false);
                 try
                 {
-                    var maxMessagesPerTask = _dataflowBlockOptions.ActualMaxMessagesPerTask;
+                    int maxMessagesPerTask = _dataflowBlockOptions.ActualMaxMessagesPerTask;
                     int timesThroughLoop = 0;
                     bool madeProgress;
                     do
@@ -766,9 +766,9 @@ namespace System.Threading.Tasks.Dataflow
                 Common.ContractAssertMonitorStatus(IncomingLock, held: false);
 
                 // Shortcuts just to keep the code cleaner
-                var postponed = _nonGreedyState.PostponedMessages;
-                var postponedTemp = _nonGreedyState.PostponedMessagesTemp;
-                var reserved = _nonGreedyState.ReservedSourcesTemp;
+                QueuedMap<ISourceBlock<T>, DataflowMessageHeader> postponed = _nonGreedyState.PostponedMessages;
+                KeyValuePair<ISourceBlock<T>, DataflowMessageHeader>[] postponedTemp = _nonGreedyState.PostponedMessagesTemp;
+                List<KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader,T>>> reserved = _nonGreedyState.ReservedSourcesTemp;
 
                 // Clear the temporary buffer.  This is safe to do without a lock because
                 // it is only accessed by the serial message loop.
@@ -798,7 +798,7 @@ namespace System.Threading.Tasks.Dataflow
                 // Try to reserve the initial batch of messages.
                 for (int i = 0; i < poppedInitially; i++)
                 {
-                    var sourceAndMessage = postponedTemp[i];
+                    KeyValuePair<ISourceBlock<T>, DataflowMessageHeader> sourceAndMessage = postponedTemp[i];
                     if (sourceAndMessage.Key.ReserveMessage(sourceAndMessage.Value, _owningBatch))
                     {
                         var reservedMessage = new KeyValuePair<DataflowMessageHeader, T>(sourceAndMessage.Value, default(T));
@@ -884,9 +884,9 @@ namespace System.Threading.Tasks.Dataflow
                 Common.ContractAssertMonitorStatus(IncomingLock, held: false);
 
                 // Shortcuts just to keep the code cleaner
-                var postponed = _nonGreedyState.PostponedMessages;
-                var postponedTemp = _nonGreedyState.PostponedMessagesTemp;
-                var reserved = _nonGreedyState.ReservedSourcesTemp;
+                QueuedMap<ISourceBlock<T>, DataflowMessageHeader> postponed = _nonGreedyState.PostponedMessages;
+                KeyValuePair<ISourceBlock<T>, DataflowMessageHeader>[] postponedTemp = _nonGreedyState.PostponedMessagesTemp;
+                List<KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>> reserved = _nonGreedyState.ReservedSourcesTemp;
 
                 // Clear the temporary buffer.  This is safe to do without a lock because
                 // it is only accessed by the serial message loop.
@@ -915,7 +915,7 @@ namespace System.Threading.Tasks.Dataflow
                 // We don't have to formally reserve because we are in greedy mode.
                 for (int i = 0; i < poppedInitially; i++)
                 {
-                    var sourceAndMessage = postponedTemp[i];
+                    KeyValuePair<ISourceBlock<T>, DataflowMessageHeader> sourceAndMessage = postponedTemp[i];
                     var reservedMessage = new KeyValuePair<DataflowMessageHeader, T>(sourceAndMessage.Value, default(T));
                     var reservedSourceAndMessage = new KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>(sourceAndMessage.Key, reservedMessage);
                     reserved.Add(reservedSourceAndMessage);
@@ -993,7 +993,7 @@ namespace System.Threading.Tasks.Dataflow
                 Common.ContractAssertMonitorStatus(IncomingLock, held: false);
 
                 // Consume the reserved items and store the data.
-                var reserved = _nonGreedyState.ReservedSourcesTemp;
+                List<KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>> reserved = _nonGreedyState.ReservedSourcesTemp;
                 for (int i = 0; i < reserved.Count; i++)
                 {
                     // We can only store the data into _messages while holding the IncomingLock, we 
@@ -1002,10 +1002,10 @@ namespace System.Threading.Tasks.Dataflow
                     // the consumed message rather than the initial one.  To handle this, because KeyValuePair is immutable,
                     // we store a new KVP with the newly consumed message back into the temp list, so that we can
                     // then enumerate the temp list en mass while taking the lock once afterwards.
-                    var sourceAndMessage = reserved[i];
+                    KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>> sourceAndMessage = reserved[i];
                     reserved[i] = default(KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>); // in case of exception from ConsumeMessage
                     bool consumed;
-                    var consumedValue = sourceAndMessage.Key.ConsumeMessage(sourceAndMessage.Value.Key, _owningBatch, out consumed);
+                    T consumedValue = sourceAndMessage.Key.ConsumeMessage(sourceAndMessage.Value.Key, _owningBatch, out consumed);
                     if (!consumed)
                     {
                         // The protocol broke down, so throw an exception, as this is fatal.  Before doing so, though,
@@ -1025,7 +1025,7 @@ namespace System.Threading.Tasks.Dataflow
                     if (_boundingState != null) _boundingState.CurrentCount += reserved.Count;
 
                     // Enqueue the consumed mesasages
-                    foreach (var sourceAndMessage in reserved)
+                    foreach (KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>> sourceAndMessage in reserved)
                     {
                         _messages.Enqueue(sourceAndMessage.Value.Value);
                     }
@@ -1045,7 +1045,7 @@ namespace System.Threading.Tasks.Dataflow
 
                 // Consume the reserved items and store the data.
                 int consumedCount = 0;
-                var reserved = _nonGreedyState.ReservedSourcesTemp;
+                List<KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>> reserved = _nonGreedyState.ReservedSourcesTemp;
                 for (int i = 0; i < reserved.Count; i++)
                 {
                     // We can only store the data into _messages while holding the IncomingLock, we 
@@ -1054,10 +1054,10 @@ namespace System.Threading.Tasks.Dataflow
                     // the consumed message rather than the initial one.  To handle this, because KeyValuePair is immutable,
                     // we store a new KVP with the newly consumed message back into the temp list, so that we can
                     // then enumerate the temp list en mass while taking the lock once afterwards.
-                    var sourceAndMessage = reserved[i];
+                    KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>> sourceAndMessage = reserved[i];
                     reserved[i] = default(KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>); // in case of exception from ConsumeMessage
                     bool consumed;
-                    var consumedValue = sourceAndMessage.Key.ConsumeMessage(sourceAndMessage.Value.Key, _owningBatch, out consumed);
+                    T consumedValue = sourceAndMessage.Key.ConsumeMessage(sourceAndMessage.Value.Key, _owningBatch, out consumed);
                     if (consumed)
                     {
                         var consumedMessage = new KeyValuePair<DataflowMessageHeader, T>(sourceAndMessage.Value.Key, consumedValue);
@@ -1074,7 +1074,7 @@ namespace System.Threading.Tasks.Dataflow
                     if (_boundingState != null) _boundingState.CurrentCount += consumedCount;
 
                     // Enqueue the consumed mesasages
-                    foreach (var sourceAndMessage in reserved)
+                    foreach (KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>> sourceAndMessage in reserved)
                     {
                         // If we didn't consume this message, the KeyValuePai will be default, i.e. the source will be null
                         if (sourceAndMessage.Key != null) _messages.Enqueue(sourceAndMessage.Value.Value);
@@ -1098,13 +1098,13 @@ namespace System.Threading.Tasks.Dataflow
 
                 List<Exception> exceptions = null;
 
-                var reserved = _nonGreedyState.ReservedSourcesTemp;
+                List<KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>> reserved = _nonGreedyState.ReservedSourcesTemp;
                 for (int i = 0; i < reserved.Count; i++)
                 {
-                    var sourceAndMessage = reserved[i];
+                    KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>> sourceAndMessage = reserved[i];
                     reserved[i] = default(KeyValuePair<ISourceBlock<T>, KeyValuePair<DataflowMessageHeader, T>>);
-                    var source = sourceAndMessage.Key;
-                    var message = sourceAndMessage.Value;
+                    ISourceBlock<T> source = sourceAndMessage.Key;
+                    KeyValuePair<DataflowMessageHeader, T> message = sourceAndMessage.Value;
                     if (source != null && message.Key.IsValid)
                     {
                         try { source.ReleaseReservation(message.Key, _owningBatch); }
@@ -1155,7 +1155,7 @@ namespace System.Threading.Tasks.Dataflow
 
                 // multipleOutputItems != null. Count the elements in each item.
                 int count = 0;
-                foreach (var item in multipleOutputItems) count += item.Length;
+                foreach (T[] item in multipleOutputItems) count += item.Length;
                 return count;
             }
 

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
@@ -109,7 +109,7 @@ namespace System.Threading.Tasks.Dataflow
             Common.WireCancellationToComplete(
                 dataflowBlockOptions.CancellationToken, _source.Completion, state => ((BatchedJoinBlock<T1, T2>)state).CompleteEachTarget(), this);
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);
@@ -374,7 +374,7 @@ namespace System.Threading.Tasks.Dataflow
             Common.WireCancellationToComplete(
                 dataflowBlockOptions.CancellationToken, _source.Completion, state => ((BatchedJoinBlock<T1, T2, T3>)state).CompleteEachTarget(), this);
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);
@@ -586,7 +586,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         {
             Common.ContractAssertMonitorStatus(_sharedResources._incomingLock, held: true);
 
-            var toReturn = _messages;
+            IList<T> toReturn = _messages;
             _messages = new List<T>();
             return toReturn;
         }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
@@ -98,20 +98,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((BatchedJoinBlock<T1, T2>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(
@@ -371,20 +363,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((BatchedJoinBlock<T1, T2, T3>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
@@ -88,20 +88,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((BroadcastBlock<T>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
@@ -80,7 +80,7 @@ namespace System.Threading.Tasks.Dataflow
             Common.WireCancellationToComplete(
                 dataflowBlockOptions.CancellationToken, _source.Completion, owningSource => ((BufferBlock<T>)owningSource).Complete(), this);
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);
@@ -263,7 +263,7 @@ namespace System.Threading.Tasks.Dataflow
                         Common.GetCreationOptionsForTask(isReplacementReplica));
 
 #if FEATURE_TRACING
-                var etwLog = DataflowEtwProvider.Log;
+                DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
                 if (etwLog.IsEnabled())
                 {
                     etwLog.TaskLaunchedForMessageHandling(
@@ -273,7 +273,7 @@ namespace System.Threading.Tasks.Dataflow
 #endif
 
                 // Start the task handling scheduling exceptions
-                var exception = Common.StartTaskSafe(_boundingState.TaskForInputProcessing, _source.DataflowBlockOptions.TaskScheduler);
+                Exception exception = Common.StartTaskSafe(_boundingState.TaskForInputProcessing, _source.DataflowBlockOptions.TaskScheduler);
                 if (exception != null)
                 {
                     // Get out from under currently held locks. CompleteCore re-acquires the locks it needs.
@@ -296,7 +296,7 @@ namespace System.Threading.Tasks.Dataflow
 
             try
             {
-                var maxMessagesPerTask = _source.DataflowBlockOptions.ActualMaxMessagesPerTask;
+                int maxMessagesPerTask = _source.DataflowBlockOptions.ActualMaxMessagesPerTask;
                 for (int i = 0;
                     i < maxMessagesPerTask && ConsumeAndStoreOneMessageIfAvailable();
                     i++)
@@ -359,7 +359,7 @@ namespace System.Threading.Tasks.Dataflow
                 bool consumed = false;
                 try
                 {
-                    var consumedValue = sourceAndMessage.Key.ConsumeMessage(sourceAndMessage.Value, this, out consumed);
+                    T consumedValue = sourceAndMessage.Key.ConsumeMessage(sourceAndMessage.Value, this, out consumed);
                     if (consumed)
                     {
                         _source.AddMessage(consumedValue);

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
@@ -69,20 +69,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((BufferBlock<T>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/JoinBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/JoinBlock.cs
@@ -92,20 +92,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((JoinBlock<T1, T2>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(
@@ -333,20 +325,12 @@ namespace System.Threading.Tasks.Dataflow
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((JoinBlock<T1, T2, T3>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
@@ -150,7 +150,7 @@ namespace System.Threading.Tasks.Dataflow
             Common.WireCancellationToComplete(
                 dataflowBlockOptions.CancellationToken, Completion, state => ((TargetCore<TInput>)state).Complete(exception: null, dropPendingMessages: true), _target);
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
@@ -128,39 +128,23 @@ namespace System.Threading.Tasks.Dataflow
             // As the target has completed, and as the target synchronously pushes work
             // through the reordering buffer when async processing completes, 
             // we know for certain that no more messages will need to be sent to the source.
-#if PRENET45
-            _target.Completion.ContinueWith(completed =>
-            {
-                if (completed.IsFaulted) _source.AddAndUnwrapAggregateException(completed.Exception);
-                _source.Complete();
-            }, CancellationToken.None, Common.GetContinuationOptions(), TaskScheduler.Default);
-#else
             _target.Completion.ContinueWith((completed, state) =>
             {
                 var sourceCore = (SourceCore<TOutput>)state;
                 if (completed.IsFaulted) sourceCore.AddAndUnwrapAggregateException(completed.Exception);
                 sourceCore.Complete();
             }, _source, CancellationToken.None, Common.GetContinuationOptions(), TaskScheduler.Default);
-#endif
 
             // It is possible that the source half may fault on its own, e.g. due to a task scheduler exception.
             // In those cases we need to fault the target half to drop its buffered messages and to release its 
             // reservations. This should not create an infinite loop, because all our implementations are designed
             // to handle multiple completion requests and to carry over only one.
-#if PRENET45
-            _source.Completion.ContinueWith(completed =>
-            {
-                Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
-                (this as IDataflowBlock).Fault(completed.Exception);
-            }, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#else
             _source.Completion.ContinueWith((completed, state) =>
             {
                 var thisBlock = ((TransformBlock<TInput, TOutput>)state) as IDataflowBlock;
                 Contract.Assert(completed.IsFaulted, "The source must be faulted in order to trigger a target completion.");
                 thisBlock.Fault(completed.Exception);
             }, this, CancellationToken.None, Common.GetContinuationOptions() | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-#endif
 
             // Handle async cancellation requests by declining on the target
             Common.WireCancellationToComplete(
@@ -251,19 +235,12 @@ namespace System.Threading.Tasks.Dataflow
             }
 
             // Otherwise, join with the asynchronous operation when it completes.
-#if PRENET45
-            task.ContinueWith(completed =>
-            {
-                this.AsyncCompleteProcessMessageWithTask(completed, messageWithId);
-            }, CancellationToken.None, Common.GetContinuationOptions(TaskContinuationOptions.ExecuteSynchronously), TaskScheduler.Default);
-#else
             task.ContinueWith((completed, state) =>
             {
                 var tuple = (Tuple<TransformBlock<TInput, TOutput>, KeyValuePair<TInput, long>>)state;
                 tuple.Item1.AsyncCompleteProcessMessageWithTask(completed, tuple.Item2);
             }, Tuple.Create(this, messageWithId), CancellationToken.None,
             Common.GetContinuationOptions(TaskContinuationOptions.ExecuteSynchronously), TaskScheduler.Default);
-#endif
         }
 
         /// <summary>Completes the processing of an asynchronous message.</summary>

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
@@ -169,7 +169,7 @@ namespace System.Threading.Tasks.Dataflow
             Common.WireCancellationToComplete(
                 dataflowBlockOptions.CancellationToken, Completion, state => ((TargetCore<TInput>)state).Complete(exception: null, dropPendingMessages: true), _target);
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);
@@ -188,7 +188,7 @@ namespace System.Threading.Tasks.Dataflow
             try
             {
                 // Run the user transform and store the results.
-                var outputItems = transformFunction(messageWithId.Key);
+                IEnumerable<TOutput> outputItems = transformFunction(messageWithId.Key);
                 userDelegateSucceeded = true;
                 StoreOutputItems(messageWithId, outputItems);
             }
@@ -279,7 +279,7 @@ namespace System.Threading.Tasks.Dataflow
             switch (completed.Status)
             {
                 case TaskStatus.RanToCompletion:
-                    var outputItems = completed.Result;
+                    IEnumerable<TOutput> outputItems = completed.Result;
                     try
                     {
                         // Get the resulting enumerable and persist it.
@@ -371,7 +371,7 @@ namespace System.Threading.Tasks.Dataflow
             Contract.Requires(id != Common.INVALID_REORDERING_ID, "This ID should never have been handed out.");
 
             // Grab info about the transform
-            var target = _target;
+            TargetCore<TInput> target = _target;
             bool isBounded = target.IsBounded;
 
             // Handle invalid items (null enumerables) by delegating to the base
@@ -480,7 +480,7 @@ namespace System.Threading.Tasks.Dataflow
                 bool outputFirstItem = false;
                 try
                 {
-                    foreach (var item in outputItems)
+                    foreach (TOutput item in outputItems)
                     {
                         if (outputFirstItem) _target.ChangeBoundingCount(count: 1);
                         else outputFirstItem = true;
@@ -495,7 +495,7 @@ namespace System.Threading.Tasks.Dataflow
             // If we're not bounding, just output each individual item.
             else
             {
-                foreach (var item in outputItems) _source.AddMessage(item);
+                foreach (TOutput item in outputItems) _source.AddMessage(item);
             }
         }
 

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ActionOnDispose.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ActionOnDispose.cs
@@ -87,7 +87,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             /// <summary>Invoke the action.</summary>
             void IDisposable.Dispose()
             {
-                var toRun = _action;
+                Action<T1, T2> toRun = _action;
                 if (toRun != null &&
                     Interlocked.CompareExchange(ref _action, null, toRun) == toRun)
                 {
@@ -130,7 +130,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             /// <summary>Invoke the action.</summary>
             void IDisposable.Dispose()
             {
-                var toRun = _action;
+                Action<T1, T2, T3> toRun = _action;
                 if (toRun != null &&
                     Interlocked.CompareExchange(ref _action, null, toRun) == toRun)
                 {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -42,13 +42,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// <summary>The cached completed TaskCompletionSource{VoidResult}.</summary>
         internal static readonly TaskCompletionSource<VoidResult> CompletedVoidResultTaskCompletionSource = CreateCachedTaskCompletionSource<VoidResult>();
 
-#if PRENET45
-#if DEBUG
-        /// <summary>Determines whether ContractAssertMonitorStatus checks monitor status.</summary>
-        internal readonly static bool ShouldCheckMonitorStatus = false;
-#endif
-#endif
-
         /// <summary>Asserts that a given synchronization object is either held or not held.</summary>
         /// <param name="syncObj">The monitor to check.</param>
         /// <param name="held">Whether we want to assert that it's currently held or not held.</param>
@@ -56,25 +49,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         internal static void ContractAssertMonitorStatus(object syncObj, bool held)
         {
             Contract.Requires(syncObj != null, "The monitor object to check must be provided.");
-#if PRENET45
-#if DEBUG
-            // PRENET45 CHK PERF WARNING: This implementation adds a huge amount of runtime cost for checked builds,
-            // which is why it's protected by ShouldCheckMonitorStatus and controlled by an environment variable DEBUGSYNC.
-            if (ShouldCheckMonitorStatus)
-            {
-                bool exceptionThrown;
-                try
-                {
-                    Monitor.Pulse(syncObj); // throws a SynchronizationLockException if the monitor isn't held by this thread
-                    exceptionThrown = false;
-                }
-                catch (SynchronizationLockException) { exceptionThrown = true; }
-                Contract.Assert(held == !exceptionThrown, "The locking scheme was not correctly followed.");
-            }
-#endif
-#else
             Contract.Assert(Monitor.IsEntered(syncObj) == held, "The locking scheme was not correctly followed.");
-#endif
         }
 
         /// <summary>Keeping alive processing tasks: maximum number of processed messages.</summary>
@@ -113,56 +88,16 @@ namespace System.Threading.Tasks.Dataflow.Internal
             return false;
         }
 
-        /// <summary>
-        /// Disposes of the provided CancellationTokenRegistration in a manner 
-        /// that's safe from ObjectDisposedException.
-        /// </summary>
-        /// <param name="registration">The token registraiton to dispose.</param>
-        internal static void SafeDisposeTokenRegistration(CancellationTokenRegistration registration)
-        {
-#if PRENET45
-            try { registration.Dispose(); }
-            catch (ObjectDisposedException) { } // This handling is built-in post-.NET 4
-#else
-            registration.Dispose();
-#endif
-        }
-
         /// <summary>Unwraps an instance T from object state that is a WeakReference to that instance.</summary>
         /// <typeparam name="T">The type of the data to be unwrapped.</typeparam>
         /// <param name="state">The weak reference.</param>
         /// <returns>The T instance.</returns>
         internal static T UnwrapWeakReference<T>(object state) where T : class
         {
-#if PRENET45
-            var wr = state as WeakReference;
-            Contract.Assert(wr != null, "Expected a WeakReference to a T as the state argument");
-            return wr.Target as T;
-#else
             var wr = state as WeakReference<T>;
             Contract.Assert(wr != null, "Expected a WeakReference<T> as the state argument");
             T item;
             return wr.TryGetTarget(out item) ? item : null;
-#endif
-        }
-
-        /// <summary>Wraps an instance of T in a WeakReference.</summary>
-        /// <typeparam name="T">The type of the data to be wrapped.</typeparam>
-        /// <param name="state">The state to wrap.</param>
-        /// <returns>The weak reference to the instance.</returns>
-        internal static
-#if PRENET45
-            WeakReference
-#else
-            WeakReference<T>
-#endif
-            WrapWeakReference<T>(T state) where T : class
-        {
-#if PRENET45
-            return new WeakReference(state);
-#else
-            return new WeakReference<T>(state);
-#endif
         }
 
         /// <summary>Gets an ID for the dataflow block.</summary>
@@ -261,14 +196,8 @@ namespace System.Threading.Tasks.Dataflow.Internal
             else if (cancellationToken.CanBeCanceled)
             {
                 var reg = cancellationToken.Register(completeAction, completeState);
-#if PRENET45
-                completionTask.ContinueWith((completed) => SafeDisposeTokenRegistration(reg),
-                    // try/catch needed due to .NET 4 design (changed post-.NET 4)
-                    cancellationToken, Common.GetContinuationOptions(), TaskScheduler.Default);
-#else
-                completionTask.ContinueWith((completed, state) => SafeDisposeTokenRegistration((CancellationTokenRegistration)state),
+                completionTask.ContinueWith((completed, state) => ((CancellationTokenRegistration)state).Dispose(),
                     reg, cancellationToken, Common.GetContinuationOptions(), TaskScheduler.Default);
-#endif
             }
         }
 
@@ -340,7 +269,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private static void StoreStringIntoExceptionData(Exception exception, string key, string value)
         {
-#if !PRENET45
             Contract.Requires(exception != null, "An exception is needed to store the data into.");
             Contract.Requires(key != null, "A key into the exception's data collection is needed.");
             Contract.Requires(value != null, "The value to store must be provided.");
@@ -357,7 +285,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 // It's ok to eat all exceptions here.  This could throw if an Exception type 
                 // has overridden Data to behave differently than we expect.
             }
-#endif
         }
 
         /// <summary>Throws an exception asynchronously on the thread pool.</summary>
@@ -370,12 +297,8 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// </remarks>
         internal static void ThrowAsync(Exception error)
         {
-#if PRENET45
-            ThreadPool.QueueUserWorkItem(state => { throw (Exception)state; }, error);
-#else
             var edi = ExceptionDispatchInfo.Capture(error);
             ThreadPool.QueueUserWorkItem(state => { ((ExceptionDispatchInfo)state).Throw(); }, edi);
-#endif
         }
 
         /// <summary>Adds the exception to the list, first initializing the list if the list is null.</summary>
@@ -410,29 +333,11 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// <summary>A task that never completes.</summary>
         internal static readonly Task NeverCompletingTask = new TaskCompletionSource<VoidResult>().Task;
 
-        /// <summary>Creates a task completed with the specified result.</summary>
-        /// <typeparam name="TResult">Specifies the type of the result for this task.</typeparam>
-        /// <param name="result">The result with which to complete the task.</param>
-        /// <returns>The completed task.</returns>
-        internal static Task<TResult> CreateTaskFromResult<TResult>(TResult result)
-        {
-#if PRENET45
-            var tcs = new TaskCompletionSource<TResult>();
-            tcs.TrySetResult(result);
-            return tcs.Task;
-#else
-            return Task.FromResult(result);
-#endif
-        }
-
         /// <summary>Creates a task we can cache for the desired Boolean result.</summary>
         /// <param name="value">The value of the Boolean.</param>
         /// <returns>A task that may be cached.</returns>
         private static Task<Boolean> CreateCachedBooleanTask(bool value)
         {
-#if PRENET45
-            return CreateTaskFromResult<bool>(value);
-#else
             // AsyncTaskMethodBuilder<Boolean> caches tasks that are non-disposable.
             // By using these same tasks, we're a bit more robust against disposals,
             // in that such a disposed task's ((IAsyncResult)task).AsyncWaitHandle
@@ -440,7 +345,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             var atmb = System.Runtime.CompilerServices.AsyncTaskMethodBuilder<Boolean>.Create();
             atmb.SetResult(value);
             return atmb.Task; // must be accesseed after SetResult to get the cached task
-#endif
         }
 
         /// <summary>Creates a TaskCompletionSource{T} completed with a value of default(T) that we can cache.</summary>
@@ -458,15 +362,9 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// <returns>The faulted task.</returns>
         internal static Task<TResult> CreateTaskFromException<TResult>(Exception exception)
         {
-#if PRENET45
-            var tcs = new TaskCompletionSource<TResult>();
-            tcs.TrySetException(exception);
-            return tcs.Task;
-#else
             var atmb = System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.Create();
             atmb.SetException(exception);
             return atmb.Task;
-#endif
         }
 
         /// <summary>Creates a task canceled with the specified cancellation token.</summary>
@@ -516,12 +414,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         }
 
         /// <summary>An infinite TimeSpan.</summary>
-        internal static readonly TimeSpan InfiniteTimeSpan =
-#if PRENET45
-            new TimeSpan(0, 0, 0, 0, -1);
-#else
-            Timeout.InfiniteTimeSpan;
-#endif
+        internal static readonly TimeSpan InfiniteTimeSpan = Timeout.InfiniteTimeSpan;
 
         /// <summary>Validates that a timeout either is -1 or is non-negative and within the range of an Int32.</summary>
         /// <param name="timeout">The timeout to validate.</param>
@@ -537,11 +430,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// <returns>The options to use.</returns>
         internal static TaskContinuationOptions GetContinuationOptions(TaskContinuationOptions toInclude = TaskContinuationOptions.None)
         {
-#if PRENET45
-            return toInclude;
-#else
             return toInclude | TaskContinuationOptions.DenyChildAttach;
-#endif
         }
 
         /// <summary>Gets the options to use for tasks.</summary>
@@ -553,12 +442,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// <returns>The options to use.</returns>
         internal static TaskCreationOptions GetCreationOptionsForTask(bool isReplacementReplica = false)
         {
-            TaskCreationOptions options =
-#if PRENET45
-                TaskCreationOptions.None;
-#else
-                TaskCreationOptions.DenyChildAttach;
-#endif
+            TaskCreationOptions options = TaskCreationOptions.DenyChildAttach;
             if (isReplacementReplica) options |= TaskCreationOptions.PreferFairness;
             return options;
         }
@@ -691,13 +575,8 @@ namespace System.Threading.Tasks.Dataflow.Internal
         {
             Contract.Requires(sourceCompletionTask != null, "sourceCompletionTask may not be null.");
             Contract.Requires(target != null, "The target where completion is to be propagated may not be null.");
-#if PRENET45
-            sourceCompletionTask.ContinueWith(task => Common.PropagateCompletion(task, target, AsyncExceptionHandler),
-                CancellationToken.None, Common.GetContinuationOptions(), TaskScheduler.Default);
-#else
             sourceCompletionTask.ContinueWith((task, state) => Common.PropagateCompletion(task, (IDataflowBlock)state, AsyncExceptionHandler),
                 target, CancellationToken.None, Common.GetContinuationOptions(), TaskScheduler.Default);
-#endif
         }
 
         /// <summary>

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -195,7 +195,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // leak into a long-living cancellation token.
             else if (cancellationToken.CanBeCanceled)
             {
-                var reg = cancellationToken.Register(completeAction, completeState);
+                CancellationTokenRegistration reg = cancellationToken.Register(completeAction, completeState);
                 completionTask.ContinueWith((completed, state) => ((CancellationTokenRegistration)state).Dispose(),
                     reg, cancellationToken, Common.GetContinuationOptions(), TaskScheduler.Default);
             }
@@ -248,7 +248,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 var aggregate = exc as AggregateException;
                 if (aggregate != null)
                 {
-                    foreach (var innerException in aggregate.InnerExceptions)
+                    foreach (Exception innerException in aggregate.InnerExceptions)
                     {
                         StoreStringIntoExceptionData(innerException, Common.EXCEPTIONDATAKEY_DATAFLOWMESSAGEVALUE, strValue);
                     }
@@ -297,7 +297,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         /// </remarks>
         internal static void ThrowAsync(Exception error)
         {
-            var edi = ExceptionDispatchInfo.Capture(error);
+            ExceptionDispatchInfo edi = ExceptionDispatchInfo.Capture(error);
             ThreadPool.QueueUserWorkItem(state => { ((ExceptionDispatchInfo)state).Throw(); }, edi);
         }
 
@@ -488,7 +488,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 Contract.Assert(task.IsFaulted, "The task should have been faulted if it failed to start.");
 
                 // Observe the task's exception
-                var ignoredTaskException = task.Exception;
+                AggregateException ignoredTaskException = task.Exception;
 
                 schedulingException = caughtException;
             }
@@ -554,7 +554,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             Contract.Requires(target != null, "The target where completion is to be propagated may not be null.");
             Contract.Assert(sourceCompletionTask.IsCompleted, "sourceCompletionTask must be completed in order to propagate its completion.");
 
-            var exception = sourceCompletionTask.IsFaulted ? sourceCompletionTask.Exception : null;
+            AggregateException exception = sourceCompletionTask.IsFaulted ? sourceCompletionTask.Exception : null;
 
             try
             {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
@@ -148,13 +148,13 @@ namespace System.Threading.Tasks.Dataflow.Internal
             Contract.Requires(block != null, "Block needed for the ETW event.");
             if (IsEnabled(EventLevel.Informational, ALL_KEYWORDS))
             {
-                var completionTask = Common.GetPotentiallyNotSupportedCompletionTask(block);
+                Task completionTask = Common.GetPotentiallyNotSupportedCompletionTask(block);
                 bool blockIsCompleted = completionTask != null && completionTask.IsCompleted;
                 Contract.Assert(blockIsCompleted, "Block must be completed for this event to be valid.");
                 if (blockIsCompleted)
                 {
                     var reason = (BlockCompletionReason)completionTask.Status;
-                    var exceptionData = string.Empty;
+                    string exceptionData = string.Empty;
 
                     if (completionTask.IsFaulted)
                     {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ProducerConsumerQueues.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ProducerConsumerQueues.cs
@@ -159,7 +159,7 @@ namespace System.Threading.Tasks
         public void Enqueue(T item)
         {
             Segment segment = _tail;
-            var array = segment._array;
+            T[] array = segment._array;
             int last = segment._state._last; // local copy to avoid multiple volatile reads
 
             // Fast path: there's obviously room in the current segment
@@ -212,7 +212,7 @@ namespace System.Threading.Tasks
         public bool TryDequeue(out T result)
         {
             Segment segment = _head;
-            var array = segment._array;
+            T[] array = segment._array;
             int first = segment._state._first; // local copy to avoid multiple volatile reads
 
             // Fast path: there's obviously data available in the current segment
@@ -250,7 +250,7 @@ namespace System.Threading.Tasks
                 _head = segment;
             }
 
-            var first = segment._state._first; // local copy to avoid extraneous volatile reads
+            int first = segment._state._first; // local copy to avoid extraneous volatile reads
 
             if (first == segment._state._last)
             {
@@ -272,7 +272,7 @@ namespace System.Threading.Tasks
         public bool TryPeek(out T result)
         {
             Segment segment = _head;
-            var array = segment._array;
+            T[] array = segment._array;
             int first = segment._state._first; // local copy to avoid multiple volatile reads
 
             // Fast path: there's obviously data available in the current segment
@@ -308,7 +308,7 @@ namespace System.Threading.Tasks
                 _head = segment;
             }
 
-            var first = segment._state._first; // local copy to avoid extraneous volatile reads
+            int first = segment._state._first; // local copy to avoid extraneous volatile reads
 
             if (first == segment._state._last)
             {
@@ -327,7 +327,7 @@ namespace System.Threading.Tasks
         public bool TryDequeueIf(Predicate<T> predicate, out T result)
         {
             Segment segment = _head;
-            var array = segment._array;
+            T[] array = segment._array;
             int first = segment._state._first; // local copy to avoid multiple volatile reads
 
             // Fast path: there's obviously data available in the current segment
@@ -374,7 +374,7 @@ namespace System.Threading.Tasks
                 _head = segment;
             }
 
-            var first = segment._state._first; // local copy to avoid extraneous volatile reads
+            int first = segment._state._first; // local copy to avoid extraneous volatile reads
 
             if (first == segment._state._last)
             {
@@ -410,7 +410,7 @@ namespace System.Threading.Tasks
             // This implementation is optimized for calls from the consumer.
             get
             {
-                var head = _head;
+                Segment head = _head;
                 if (head._state._first != head._state._lastCopy) return false; // _first is volatile, so the read of _lastCopy cannot get reordered
                 if (head._state._first != head._state._last) return false;
                 return head._next == null;

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
@@ -744,11 +744,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // where a derived type's incoming lock is held.
 
             bool targetsAvailable = true;
-#if PRENET45
-            if (outgoingLockKnownAcquired)
-#else
             if (outgoingLockKnownAcquired || Monitor.IsEntered(OutgoingLock))
-#endif
             {
                 Common.ContractAssertMonitorStatus(OutgoingLock, held: true);
                 targetsAvailable = _targetRegistry.FirstTargetNode != null;

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
@@ -173,7 +173,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                     // We won the race.  This task is now the consumer.
 
 #if FEATURE_TRACING
-                    var etwLog = DataflowEtwProvider.Log;
+                    DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
                     if (etwLog.IsEnabled())
                     {
                         etwLog.TaskLaunchedForMessageHandling(
@@ -257,7 +257,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                         else
                         {
                             // Mark that we're exiting.
-                            var previousConsumer = Interlocked.Exchange(ref _activeConsumer, null);
+                            Task previousConsumer = Interlocked.Exchange(ref _activeConsumer, null);
                             Contract.Assert(previousConsumer != null && previousConsumer.Id == Task.CurrentId,
                                 "The running task should have been denoted as the active task.");
 

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
@@ -381,7 +381,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                                                       Common.GetCreationOptionsForTask(repeat));
 
 #if FEATURE_TRACING
-                var etwLog = DataflowEtwProvider.Log;
+                DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
                 if (etwLog.IsEnabled())
                 {
                     etwLog.TaskLaunchedForMessageHandling(
@@ -391,7 +391,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
 #endif
 
                 // Start the task handling scheduling exceptions
-                var exception = Common.StartTaskSafe(taskForInputProcessing, _dataflowBlockOptions.TaskScheduler);
+                Exception exception = Common.StartTaskSafe(taskForInputProcessing, _dataflowBlockOptions.TaskScheduler);
                 if (exception != null)
                 {
                     // Get out from under currently held locks. Complete re-acquires the locks it needs.
@@ -415,7 +415,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 bool shouldAttemptPostponedTransfer = _boundingState != null && _boundingState.BoundedCapacity > 1;
                 int numberOfMessagesProcessedByThisTask = 0;
                 int numberOfMessagesProcessedSinceTheLastKeepAlive = 0;
-                var maxMessagesPerTask = _dataflowBlockOptions.ActualMaxMessagesPerTask;
+                int maxMessagesPerTask = _dataflowBlockOptions.ActualMaxMessagesPerTask;
 
                 while (numberOfMessagesProcessedByThisTask < maxMessagesPerTask && !CanceledOrFaulted)
                 {
@@ -672,7 +672,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 } // Must not call to source while holding lock
 
                 bool consumed;
-                var consumedValue = element.Key.ConsumeMessage(element.Value, _owningTarget, out consumed);
+                TInput consumedValue = element.Key.ConsumeMessage(element.Value, _owningTarget, out consumed);
                 if (consumed)
                 {
                     result = new KeyValuePair<TInput, long>(consumedValue, messageId);
@@ -771,7 +771,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // which may still contain orphaned data if we were canceled or faulted.  However,
             // we don't reset the bounding count here, as the block as a whole may still be active.
             KeyValuePair<TInput, long> ignored;
-            var messages = _messages;
+            IProducerConsumerQueue<KeyValuePair<TInput, long>> messages = _messages;
             while (messages.TryDequeue(out ignored)) ;
 
             // If we completed with any unhandled exception, finish in an error state

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/TargetRegistry.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/TargetRegistry.cs
@@ -100,7 +100,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             Contract.Assert(_linksWithRemainingMessages >= 0, "_linksWithRemainingMessages must be non-negative at any time.");
             if (node.RemainingMessages > 0) _linksWithRemainingMessages++;
 #if FEATURE_TRACING
-            var etwLog = DataflowEtwProvider.Log;
+            DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
             if (etwLog.IsEnabled())
             {
                 etwLog.DataflowBlockLinking(_owningSource, target);
@@ -163,7 +163,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                     if (node.RemainingMessages == 0) _linksWithRemainingMessages--;
                     Contract.Assert(_linksWithRemainingMessages >= 0, "_linksWithRemainingMessages must be non-negative at any time.");
 #if FEATURE_TRACING
-                    var etwLog = DataflowEtwProvider.Log;
+                    DataflowEtwProvider etwLog = DataflowEtwProvider.Log;
                     if (etwLog.IsEnabled())
                     {
                         etwLog.DataflowBlockUnlinking(_owningSource, target);
@@ -183,7 +183,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         internal LinkedTargetInfo ClearEntryPoints()
         {
             // Save _firstTarget so we can return it
-            var firstTarget = _firstTarget;
+            LinkedTargetInfo firstTarget = _firstTarget;
 
             // Clear out the entry points
             _firstTarget = _lastTarget = null;
@@ -201,10 +201,10 @@ namespace System.Threading.Tasks.Dataflow.Internal
             Contract.Assert(_owningSource.Completion.IsCompleted, "The owning source must have completed before propagating completion.");
 
             // Cache the owning source's completion task to avoid calling the getter many times
-            var owningSourceCompletion = _owningSource.Completion;
+            Task owningSourceCompletion = _owningSource.Completion;
 
             // Propagate completion to those targets that have requested it
-            for (var node = firstTarget; node != null; node = node.Next)
+            for (LinkedTargetInfo node = firstTarget; node != null; node = node.Next)
             {
                 if (node.PropagateCompletion) Common.PropagateCompletion(owningSourceCompletion, node.Target, Common.AsyncExceptionHandler);
             }
@@ -257,8 +257,8 @@ namespace System.Threading.Tasks.Dataflow.Internal
             Contract.Requires(node != null, "Node to remove is required.");
             Contract.Assert(_firstTarget != null && _lastTarget != null, "Both first and last node must be non-null before RemoveFromList.");
 
-            var previous = node.Previous;
-            var next = node.Next;
+            LinkedTargetInfo previous = node.Previous;
+            LinkedTargetInfo next = node.Next;
 
             // Remove the node by linking the adjacent nodes
             if (node.Previous != null)
@@ -290,7 +290,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             {
                 var targets = new ITargetBlock<T>[Count];
                 int i = 0;
-                for (var node = _firstTarget; node != null; node = node.Next)
+                for (LinkedTargetInfo node = _firstTarget; node != null; node = node.Next)
                 {
                     targets[i++] = node.Target;
                 }

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
@@ -224,7 +224,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
             return passed;
         }
 
-#if !PRENET45
         // Test to make sure we appropriately store data into exceptions for debugging purposes
         [Fact]
         [OuterLoop]
@@ -323,7 +322,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 Assert.True(localPassed, string.Format("Handle faulty Exception.Data property: {0}", localPassed ? "Passed" : "FAILED"));
             }
         }
-#endif
+
         private class ThrowFromToString
         {
             public override string ToString() { throw new InvalidOperationException(); }


### PR DESCRIPTION
This PRENET45 compilation constant is legacy from when the library was building in CTPs for .NET 4, but it's not been used for a while and the library won't actually build as written with the flag set.