### PR TITLE
Refactor System.Diagnostics.FileVersionInfo with PAL

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/src/Interop/Interop.Windows.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/Interop/Interop.Windows.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
@@ -15,10 +15,20 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
   </PropertyGroup>
   <!-- References are resolved from packages.config -->
+
   <ItemGroup>
     <Compile Include="System\Diagnostics\FileVersionInfo.cs" />
-    <Compile Include="Interop\Interop.manual.cs" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <Compile Include="Interop\Interop.Windows.cs" />
+    <Compile Include="System\Diagnostics\FileVersionInfo.Windows.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(OS)' == 'Unix' ">
+    <Compile Include="System\Diagnostics\FileVersionInfo.Unix.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -5,8 +5,10 @@ namespace System.Diagnostics
 {
     public sealed partial class FileVersionInfo
     {
-        private void Initialize()
+        private FileVersionInfo(string fileName)
         {
+            _fileName = fileName;
+
             // TODO: Implement this
 
             _companyName = string.Empty;

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Diagnostics
+{
+    public sealed partial class FileVersionInfo
+    {
+        private void Initialize()
+        {
+            // TODO: Implement this
+
+            _companyName = string.Empty;
+            _fileDescription = string.Empty;
+            _fileVersion = string.Empty;
+            _internalName = string.Empty;
+            _legalCopyright = string.Empty;
+            _originalFilename = string.Empty;
+            _productName = string.Empty;
+            _productVersion = string.Empty;
+            _comments = string.Empty;
+            _legalTrademarks = string.Empty;
+            _privateBuild = string.Empty;
+            _specialBuild = string.Empty;
+
+            _language = string.Empty;
+
+            _fileMajor = 0;
+            _fileMinor = 0;
+            _fileBuild = 0;
+            _filePrivate = 0;
+            _productMajor = 0;
+            _productMinor = 0;
+            _productBuild = 0;
+            _productPrivate = 0;
+
+            _isDebug = false;
+            _isPatched = false;
+            _isPrivateBuild = false;
+            _isPreRelease = false;
+            _isSpecialBuild = false;
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+    }
+}

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
@@ -9,8 +9,10 @@ namespace System.Diagnostics
 {
     public sealed partial class FileVersionInfo
     {
-        private unsafe void Initialize()
+        private unsafe FileVersionInfo(string fileName)
         {
+            _fileName = fileName;
+
             uint handle;  // This variable is not used, but we need an out variable.
             uint infoSize = Interop.mincore.GetFileVersionInfoSizeEx(
                 (uint)Interop.Constants.FileVerGetLocalised, _fileName, out handle);

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System.Diagnostics
+{
+    public sealed partial class FileVersionInfo
+    {
+        private unsafe void Initialize()
+        {
+            uint handle;  // This variable is not used, but we need an out variable.
+            uint infoSize = Interop.mincore.GetFileVersionInfoSizeEx(
+                (uint)Interop.Constants.FileVerGetLocalised, _fileName, out handle);
+
+            if (infoSize != 0)
+            {
+                byte[] mem = new byte[infoSize];
+                fixed (byte* memPtr = mem)
+                {
+                    IntPtr memIntPtr = new IntPtr((void*)memPtr);
+                    if (Interop.mincore.GetFileVersionInfoEx(
+                            (uint)Interop.Constants.FileVerGetLocalised | (uint)Interop.Constants.FileVerGetNeutral,
+                            _fileName,
+                            0U,
+                            infoSize,
+                            memIntPtr))
+                    {
+                        uint langid = GetVarEntry(memIntPtr);
+                        if (!GetVersionInfoForCodePage(memIntPtr, ConvertTo8DigitHex(langid)))
+                        {
+                            // Some DLLs might not contain correct codepage information. In these cases we will fail during lookup.
+                            // Explorer will take a few shots in dark by trying several specific lang-codepages
+                            // (Explorer also randomly guesses 041D04B0=Swedish+CP_UNICODE and 040704B0=German+CP_UNICODE sometimes).
+                            // We will try to simulate similar behavior here.
+                            foreach (uint id in s_fallbackLanguageCodePages)
+                            {
+                                if (id != langid)
+                                {
+                                    if (GetVersionInfoForCodePage(memIntPtr, ConvertTo8DigitHex(id)))
+                                    {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+        // Some dlls might not contain correct codepage information,
+        // in which case the lookup will fail. Explorer will take
+        // a few shots in dark. We'll simulate similar behavior by
+        // falling back to the following lang-codepages:
+        private static readonly uint[] s_fallbackLanguageCodePages = new uint[]
+        {
+            0x040904B0, // US English + CP_UNICODE
+            0x040904E4, // US English + CP_USASCII
+            0x04090000  // US English + unknown codepage
+        };
+
+        private static string ConvertTo8DigitHex(uint value)
+        {
+            return value.ToString("X8", CultureInfo.InvariantCulture);
+        }
+
+        private static Interop.VS_FIXEDFILEINFO GetFixedFileInfo(IntPtr memPtr)
+        {
+            IntPtr memRef = IntPtr.Zero;
+            uint memLen;
+
+            if (Interop.mincore.VerQueryValue(memPtr, "\\", out memRef, out memLen))
+            {
+                return (Interop.VS_FIXEDFILEINFO)Marshal.PtrToStructure<Interop.VS_FIXEDFILEINFO>(memRef);
+            }
+
+            return new Interop.VS_FIXEDFILEINFO();
+        }
+
+        private static string GetFileVersionLanguage(IntPtr memPtr)
+        {
+            uint langid = GetVarEntry(memPtr) >> 16;
+
+            var lang = new StringBuilder(256);
+            Interop.mincore.VerLanguageName(langid, lang, (uint)lang.Capacity);
+            return lang.ToString();
+        }
+
+        private static string GetFileVersionString(IntPtr memPtr, string name)
+        {
+            IntPtr memRef = IntPtr.Zero;
+            uint memLen;
+
+            if (Interop.mincore.VerQueryValue(memPtr, name, out memRef, out memLen))
+            {
+                if (memRef != IntPtr.Zero)
+                {
+                    return Marshal.PtrToStringUni(memRef);
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static uint GetVarEntry(IntPtr memPtr)
+        {
+            IntPtr memRef = IntPtr.Zero;
+            uint memLen;
+
+            if (Interop.mincore.VerQueryValue(memPtr, "\\VarFileInfo\\Translation", out memRef, out memLen))
+            {
+                return (uint)((Marshal.ReadInt16(memRef) << 16) + Marshal.ReadInt16((IntPtr)((long)memRef + 2)));
+            }
+
+            return 0x040904E4;
+        }
+
+        //
+        // This function tries to find version information for a specific codepage.
+        // Returns true when version information is found.
+        //
+        private bool GetVersionInfoForCodePage(IntPtr memIntPtr, string codepage)
+        {
+            string template = "\\\\StringFileInfo\\\\{0}\\\\{1}";
+
+            _companyName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "CompanyName"));
+            _fileDescription = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "FileDescription"));
+            _fileVersion = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "FileVersion"));
+            _internalName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "InternalName"));
+            _legalCopyright = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "LegalCopyright"));
+            _originalFilename = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "OriginalFilename"));
+            _productName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "ProductName"));
+            _productVersion = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "ProductVersion"));
+            _comments = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "Comments"));
+            _legalTrademarks = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "LegalTrademarks"));
+            _privateBuild = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "PrivateBuild"));
+            _specialBuild = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "SpecialBuild"));
+
+            _language = GetFileVersionLanguage(memIntPtr);
+
+            Interop.VS_FIXEDFILEINFO ffi = GetFixedFileInfo(memIntPtr);
+            _fileMajor = (int)HIWORD(ffi.dwFileVersionMS);
+            _fileMinor = (int)LOWORD(ffi.dwFileVersionMS);
+            _fileBuild = (int)HIWORD(ffi.dwFileVersionLS);
+            _filePrivate = (int)LOWORD(ffi.dwFileVersionLS);
+            _productMajor = (int)HIWORD(ffi.dwProductVersionMS);
+            _productMinor = (int)LOWORD(ffi.dwProductVersionMS);
+            _productBuild = (int)HIWORD(ffi.dwProductVersionLS);
+            _productPrivate = (int)LOWORD(ffi.dwProductVersionLS);
+
+            _isDebug = (ffi.dwFileFlags & (uint)Interop.Constants.VS_FF_Debug) != 0;
+            _isPatched = (ffi.dwFileFlags & (uint)Interop.Constants.VS_FF_Patched) != 0;
+            _isPrivateBuild = (ffi.dwFileFlags & (uint)Interop.Constants.VS_FF_PrivateBuild) != 0;
+            _isPreRelease = (ffi.dwFileFlags & (uint)Interop.Constants.VS_FF_Prerelease) != 0;
+            _isSpecialBuild = (ffi.dwFileFlags & (uint)Interop.Constants.VS_FF_SpecialBuild) != 0;
+
+            // fileVersion is chosen based on best guess. Other fields can be used if appropriate.
+            return (_fileVersion != string.Empty);
+        }
+
+        private static uint HIWORD(uint dword)
+        {
+            return (dword >> 16) & 0xffff;
+        }
+
+        private static uint LOWORD(uint dword)
+        {
+            return dword & 0xffff;
+        }
+    }
+}

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.cs
@@ -40,12 +40,6 @@ namespace System.Diagnostics
         private bool _isPreRelease;
         private bool _isSpecialBuild;
 
-        private FileVersionInfo(string fileName)
-        {
-            _fileName = fileName;
-            Initialize();
-        }
-
         /// <summary>
         /// Gets the comments associated with the file.
         /// </summary>

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.cs
@@ -1,32 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
-using System.Runtime.InteropServices;
-using System;
 using System.IO;
-using System.Globalization;
-using System.Runtime.Versioning;
+using System.Text;
 
 namespace System.Diagnostics
 {
     /// <summary>
     /// Provides version information for a physical file on disk.
     /// </summary>
-    public sealed class FileVersionInfo
+    public sealed partial class FileVersionInfo
     {
-        // Some dlls might not contain correct codepage information,
-        // in which case the lookup will fail. Explorer will take
-        // a few shots in dark. We'll simulate similar behavior by
-        // falling back to the following lang-codepages:
-        private static readonly uint[] s_fallbackLanguageCodePages = new uint[]
-        {
-            0x040904B0, // US English + CP_UNICODE
-            0x040904E4, // US English + CP_USASCII
-            0x04090000  // US English + unknown codepage
-        };
-
         private readonly string _fileName;
+
         private string _companyName;
         private string _fileDescription;
         private string _fileVersion;
@@ -40,15 +26,19 @@ namespace System.Diagnostics
         private string _privateBuild;
         private string _specialBuild;
         private string _language;
-        private uint _fileMajor;
-        private uint _fileMinor;
-        private uint _fileBuild;
-        private uint _filePrivate;
-        private uint _productMajor;
-        private uint _productMinor;
-        private uint _productBuild;
-        private uint _productPrivate;
-        private uint _fileFlags;
+        private int _fileMajor;
+        private int _fileMinor;
+        private int _fileBuild;
+        private int _filePrivate;
+        private int _productMajor;
+        private int _productMinor;
+        private int _productBuild;
+        private int _productPrivate;
+        private bool _isDebug;
+        private bool _isPatched;
+        private bool _isPrivateBuild;
+        private bool _isPreRelease;
+        private bool _isSpecialBuild;
 
         private FileVersionInfo(string fileName)
         {
@@ -60,10 +50,7 @@ namespace System.Diagnostics
         /// </summary>
         public string Comments
         {
-            get
-            {
-                return _comments;
-            }
+            get { return _comments; }
         }
 
         /// <summary>
@@ -71,10 +58,7 @@ namespace System.Diagnostics
         /// </summary>
         public string CompanyName
         {
-            get
-            {
-                return _companyName;
-            }
+            get { return _companyName; }
         }
 
         /// <summary>
@@ -82,10 +66,7 @@ namespace System.Diagnostics
         /// </summary>
         public int FileBuildPart
         {
-            get
-            {
-                return (int)_fileBuild;
-            }
+            get { return _fileBuild; }
         }
 
         /// <summary>
@@ -93,10 +74,7 @@ namespace System.Diagnostics
         /// </summary>
         public string FileDescription
         {
-            get
-            {
-                return _fileDescription;
-            }
+            get { return _fileDescription; }
         }
 
         /// <summary>
@@ -104,10 +82,7 @@ namespace System.Diagnostics
         /// </summary>
         public int FileMajorPart
         {
-            get
-            {
-                return (int)_fileMajor;
-            }
+            get { return _fileMajor; }
         }
 
         /// <summary>
@@ -115,10 +90,7 @@ namespace System.Diagnostics
         /// </summary>
         public int FileMinorPart
         {
-            get
-            {
-                return (int)_fileMinor;
-            }
+            get { return _fileMinor; }
         }
 
         /// <summary>
@@ -126,10 +98,7 @@ namespace System.Diagnostics
         /// </summary>
         public string FileName
         {
-            get
-            {
-                return _fileName;
-            }
+            get { return _fileName; }
         }
 
         /// <summary>
@@ -137,10 +106,7 @@ namespace System.Diagnostics
         /// </summary>
         public int FilePrivatePart
         {
-            get
-            {
-                return (int)_filePrivate;
-            }
+            get { return _filePrivate; }
         }
 
         /// <summary>
@@ -148,10 +114,7 @@ namespace System.Diagnostics
         /// </summary>
         public string FileVersion
         {
-            get
-            {
-                return _fileVersion;
-            }
+            get { return _fileVersion; }
         }
 
         /// <summary>
@@ -159,10 +122,7 @@ namespace System.Diagnostics
         /// </summary>
         public string InternalName
         {
-            get
-            {
-                return _internalName;
-            }
+            get { return _internalName; }
         }
 
         /// <summary>
@@ -171,10 +131,7 @@ namespace System.Diagnostics
         /// </summary>
         public bool IsDebug
         {
-            get
-            {
-                return (_fileFlags & (uint)Interop.Constants.VS_FF_Debug) != 0;
-            }
+            get { return _isDebug; }
         }
 
         /// <summary>
@@ -183,10 +140,7 @@ namespace System.Diagnostics
         /// </summary>
         public bool IsPatched
         {
-            get
-            {
-                return (_fileFlags & (uint)Interop.Constants.VS_FF_Patched) != 0;
-            }
+            get { return _isPatched; }
         }
 
         /// <summary>
@@ -194,10 +148,7 @@ namespace System.Diagnostics
         /// </summary>
         public bool IsPrivateBuild
         {
-            get
-            {
-                return (_fileFlags & (uint)Interop.Constants.VS_FF_PrivateBuild) != 0;
-            }
+            get { return _isPrivateBuild; }
         }
 
         /// <summary>
@@ -206,10 +157,7 @@ namespace System.Diagnostics
         /// </summary>
         public bool IsPreRelease
         {
-            get
-            {
-                return (_fileFlags & (uint)Interop.Constants.VS_FF_Prerelease) != 0;
-            }
+            get { return _isPreRelease; }
         }
 
         /// <summary>
@@ -217,10 +165,7 @@ namespace System.Diagnostics
         /// </summary>
         public bool IsSpecialBuild
         {
-            get
-            {
-                return (_fileFlags & (uint)Interop.Constants.VS_FF_SpecialBuild) != 0;
-            }
+            get { return _isSpecialBuild; }
         }
 
         /// <summary>
@@ -228,10 +173,7 @@ namespace System.Diagnostics
         /// </summary>
         public string Language
         {
-            get
-            {
-                return _language;
-            }
+            get { return _language; }
         }
 
         /// <summary>
@@ -239,10 +181,7 @@ namespace System.Diagnostics
         /// </summary>
         public string LegalCopyright
         {
-            get
-            {
-                return _legalCopyright;
-            }
+            get { return _legalCopyright; }
         }
 
         /// <summary>
@@ -250,10 +189,7 @@ namespace System.Diagnostics
         /// </summary>
         public string LegalTrademarks
         {
-            get
-            {
-                return _legalTrademarks;
-            }
+            get { return _legalTrademarks; }
         }
 
         /// <summary>
@@ -261,10 +197,7 @@ namespace System.Diagnostics
         /// </summary>
         public string OriginalFilename
         {
-            get
-            {
-                return _originalFilename;
-            }
+            get { return _originalFilename; }
         }
 
         /// <summary>
@@ -272,10 +205,7 @@ namespace System.Diagnostics
         /// </summary>
         public string PrivateBuild
         {
-            get
-            {
-                return _privateBuild;
-            }
+            get { return _privateBuild; }
         }
 
         /// <summary>
@@ -283,10 +213,7 @@ namespace System.Diagnostics
         /// </summary>
         public int ProductBuildPart
         {
-            get
-            {
-                return (int)_productBuild;
-            }
+            get { return _productBuild; }
         }
 
         /// <summary>
@@ -294,10 +221,7 @@ namespace System.Diagnostics
         /// </summary>
         public int ProductMajorPart
         {
-            get
-            {
-                return (int)_productMajor;
-            }
+            get { return _productMajor; }
         }
 
         /// <summary>
@@ -305,10 +229,7 @@ namespace System.Diagnostics
         /// </summary>
         public int ProductMinorPart
         {
-            get
-            {
-                return (int)_productMinor;
-            }
+            get { return _productMinor; }
         }
 
         /// <summary>
@@ -316,10 +237,7 @@ namespace System.Diagnostics
         /// </summary>
         public string ProductName
         {
-            get
-            {
-                return _productName;
-            }
+            get { return _productName; }
         }
 
         /// <summary>
@@ -327,10 +245,7 @@ namespace System.Diagnostics
         /// </summary>
         public int ProductPrivatePart
         {
-            get
-            {
-                return (int)_productPrivate;
-            }
+            get { return _productPrivate; }
         }
 
         /// <summary>
@@ -338,10 +253,7 @@ namespace System.Diagnostics
         /// </summary>
         public string ProductVersion
         {
-            get
-            {
-                return _productVersion;
-            }
+            get { return _productVersion; }
         }
 
         /// <summary>
@@ -349,176 +261,23 @@ namespace System.Diagnostics
         /// </summary>
         public string SpecialBuild
         {
-            get
-            {
-                return _specialBuild;
-            }
-        }
-
-        private static string ConvertTo8DigitHex(uint value)
-        {
-            return value.ToString("X8", CultureInfo.InvariantCulture);
-        }
-
-        private static Interop.VS_FIXEDFILEINFO GetFixedFileInfo(IntPtr memPtr)
-        {
-            IntPtr memRef = IntPtr.Zero;
-            uint memLen;
-
-            if (Interop.mincore.VerQueryValue(memPtr, "\\", out memRef, out memLen))
-            {
-                Interop.VS_FIXEDFILEINFO fixedFileInfo =
-                    (Interop.VS_FIXEDFILEINFO)Marshal.PtrToStructure<Interop.VS_FIXEDFILEINFO>(memRef);
-                return fixedFileInfo;
-            }
-
-            return new Interop.VS_FIXEDFILEINFO();
-        }
-
-        private static string GetFileVersionLanguage(IntPtr memPtr)
-        {
-            uint langid = GetVarEntry(memPtr) >> 16;
-
-            StringBuilder lang = new StringBuilder(256);
-            Interop.mincore.VerLanguageName(langid, lang, (uint)lang.Capacity);
-            return lang.ToString();
-        }
-
-        private static string GetFileVersionString(IntPtr memPtr, string name)
-        {
-            string data = "";
-
-            IntPtr memRef = IntPtr.Zero;
-            uint memLen;
-
-            if (Interop.mincore.VerQueryValue(memPtr, name, out memRef, out memLen))
-            {
-                if (memRef != IntPtr.Zero)
-                {
-                    data = Marshal.PtrToStringUni(memRef);
-                }
-            }
-            return data;
-        }
-
-        private static uint GetVarEntry(IntPtr memPtr)
-        {
-            IntPtr memRef = IntPtr.Zero;
-            uint memLen;
-
-            if (Interop.mincore.VerQueryValue(memPtr, "\\VarFileInfo\\Translation", out memRef, out memLen))
-            {
-                return (uint)((Marshal.ReadInt16(memRef) << 16) + Marshal.ReadInt16((IntPtr)((long)memRef + 2)));
-            }
-
-            return 0x040904E4;
-        }
-
-        //
-        // This function tries to find version information for a specific codepage.
-        // Returns true when version information is found.
-        //
-        private bool GetVersionInfoForCodePage(IntPtr memIntPtr, string codepage)
-        {
-            string template = "\\\\StringFileInfo\\\\{0}\\\\{1}";
-
-            _companyName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "CompanyName"));
-            _fileDescription = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "FileDescription"));
-            _fileVersion = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "FileVersion"));
-            _internalName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "InternalName"));
-            _legalCopyright = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "LegalCopyright"));
-            _originalFilename = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "OriginalFilename"));
-            _productName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "ProductName"));
-            _productVersion = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "ProductVersion"));
-            _comments = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "Comments"));
-            _legalTrademarks = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "LegalTrademarks"));
-            _privateBuild = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "PrivateBuild"));
-            _specialBuild = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "SpecialBuild"));
-
-            _language = GetFileVersionLanguage(memIntPtr);
-
-            Interop.VS_FIXEDFILEINFO ffi = GetFixedFileInfo(memIntPtr);
-            _fileMajor = HIWORD(ffi.dwFileVersionMS);
-            _fileMinor = LOWORD(ffi.dwFileVersionMS);
-            _fileBuild = HIWORD(ffi.dwFileVersionLS);
-            _filePrivate = LOWORD(ffi.dwFileVersionLS);
-            _productMajor = HIWORD(ffi.dwProductVersionMS);
-            _productMinor = LOWORD(ffi.dwProductVersionMS);
-            _productBuild = HIWORD(ffi.dwProductVersionLS);
-            _productPrivate = LOWORD(ffi.dwProductVersionLS);
-            _fileFlags = ffi.dwFileFlags;
-
-            // fileVersion is chosen based on best guess. Other fields can be used if appropriate.
-            return (_fileVersion != string.Empty);
+            get { return _specialBuild; }
         }
 
         /// <summary>
         /// Returns a System.Windows.Forms.FileVersionInfo representing the version information associated with the specified file.
         /// </summary>
-        public unsafe static FileVersionInfo GetVersionInfo(string fileName)
+        public static FileVersionInfo GetVersionInfo(string fileName)
         {
-            // Check for the existence of the file. File.Exists returns false
-            // if Read permission is denied.
+            // Check for the existence of the file. File.Exists returns false if Read permission is denied.
             if (!File.Exists(fileName))
             {
                 throw new FileNotFoundException(fileName);
             }
 
-            uint handle;  // This variable is not used, but we need an out variable.
-            uint infoSize = Interop.mincore.GetFileVersionInfoSizeEx(
-                (uint)Interop.Constants.FileVerGetLocalised, fileName, out handle);
-            FileVersionInfo versionInfo = new FileVersionInfo(fileName);
-
-            if (infoSize != 0)
-            {
-                byte[] mem = new byte[infoSize];
-                fixed (byte* memPtr = mem)
-                {
-                    IntPtr memIntPtr = new IntPtr((void*)memPtr);
-                    if (Interop.mincore.GetFileVersionInfoEx(
-                            (uint)Interop.Constants.FileVerGetLocalised | (uint)Interop.Constants.FileVerGetNeutral,
-                            fileName,
-                            0U,
-                            infoSize,
-                            memIntPtr))
-                    {
-                        uint langid = GetVarEntry(memIntPtr);
-                        if (!versionInfo.GetVersionInfoForCodePage(memIntPtr, ConvertTo8DigitHex(langid)))
-                        {
-                            // Some dlls might not contain correct codepage information. In this case we will fail during lookup.
-                            // Explorer will take a few shots in dark by trying following lang-codepages:
-                            //
-                            // 040904B0 // US English + CP_UNICODE
-                            // 040904E4 // US English + CP_USASCII
-                            // 04090000 // US English + unknown codepage
-                            // Explorer also randomly guesses 041D04B0=Swedish+CP_UNICODE and 040704B0=German+CP_UNICODE sometimes.
-                            // We will try to simulate similar behavior here.
-                            foreach (uint id in s_fallbackLanguageCodePages)
-                            {
-                                if (id != langid)
-                                {
-                                    if (versionInfo.GetVersionInfoForCodePage(memIntPtr, ConvertTo8DigitHex(id)))
-                                    {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
+            var versionInfo = new FileVersionInfo(fileName);
+            versionInfo.Initialize();
             return versionInfo;
-        }
-
-        private static uint HIWORD(uint dword)
-        {
-            return (dword >> 16) & 0xffff;
-        }
-
-        private static uint LOWORD(uint dword)
-        {
-            return dword & 0xffff;
         }
 
         /// <summary>

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.cs
@@ -43,6 +43,7 @@ namespace System.Diagnostics
         private FileVersionInfo(string fileName)
         {
             _fileName = fileName;
+            Initialize();
         }
 
         /// <summary>
@@ -275,9 +276,7 @@ namespace System.Diagnostics
                 throw new FileNotFoundException(fileName);
             }
 
-            var versionInfo = new FileVersionInfo(fileName);
-            versionInfo.Initialize();
-            return versionInfo;
+            return new FileVersionInfo(fileName);
         }
 
         /// <summary>


### PR DESCRIPTION
Introduce a Windows and Unix build for System.Diagnostics.FileVersionInfo.dll.  Windows-specific functionality has been moved to separate files, with Unix-specific (but stubbed out) files added to match.