### PR TITLE
Rename ImmutableArray<T>.Builder::ReverseContents to Reverse

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -623,7 +623,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// Reverses the order of elements in the collection.
             /// </summary>
-            public void ReverseContents()
+            public void Reverse()
             {
                 Array.Reverse(_elements, 0, _count);
             }

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -239,23 +239,23 @@ namespace System.Collections.Immutable.Test
         {
             var builder = new ImmutableArray<int>.Builder();
             builder.AddRange(1, 2, 3, 4);
-            builder.ReverseContents();
+            builder.Reverse();
             Assert.Equal(new[] { 4, 3, 2, 1 }, builder);
 
             builder.RemoveAt(0);
-            builder.ReverseContents();
+            builder.Reverse();
             Assert.Equal(new[] { 1, 2, 3 }, builder);
 
             builder.RemoveAt(0);
-            builder.ReverseContents();
+            builder.Reverse();
             Assert.Equal(new[] { 3, 2 }, builder);
 
             builder.RemoveAt(0);
-            builder.ReverseContents();
+            builder.Reverse();
             Assert.Equal(new[] { 2 }, builder);
 
             builder.RemoveAt(0);
-            builder.ReverseContents();
+            builder.Reverse();
             Assert.Equal(new int[0], builder);
         }
 


### PR DESCRIPTION
This issue came up during the MoveToImmutable API review.

The ImmutableArray<T>.Builder type draws a bit of its design from
List<T>.   It seemed odd for its reverse elements method to have a
different name than List<T>.  In searching through the APIs we found no
other instances of ReverseContents.  After some discussion we decided to
rename it to Reverse.