### PR TITLE
Remove unnecessary array allocation in Process

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -483,15 +483,14 @@ namespace System.Diagnostics
 
         static ProcessInfo[] GetProcessInfos(PerformanceCounterLib library)
         {
-            ProcessInfo[] processInfos = new ProcessInfo[0];
-            byte[] dataPtr = null;
+            ProcessInfo[] processInfos;
 
             int retryCount = 5;
-            while (processInfos.Length == 0 && retryCount != 0)
+            do
             {
                 try
                 {
-                    dataPtr = library.GetPerformanceData(PerfCounterQueryString);
+                    byte[] dataPtr = library.GetPerformanceData(PerfCounterQueryString);
                     processInfos = GetProcessInfos(library, ProcessPerfCounterId, ThreadPerfCounterId, dataPtr);
                 }
                 catch (Exception e)
@@ -501,6 +500,7 @@ namespace System.Diagnostics
 
                 --retryCount;
             }
+            while (processInfos.Length == 0 && retryCount != 0);
 
             if (processInfos.Length == 0)
                 throw new InvalidOperationException(SR.ProcessDisabled);


### PR DESCRIPTION
In System.Diagnostic.Process, the GetProcessInfos(PerformanceCounterLib) method was allocating a zero-length array, only to immediately overwrite it.  This change just restructures the code slightly to avoid the need for the allocation.