### PR TITLE
Remove unnecessary char-related allocations

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -59,7 +59,7 @@ namespace System.IO
             String fullPathWithTrailingDirectorySeparator;
 
             if (!PathHelpers.EndsInDirectorySeparator(fullPath))
-                fullPathWithTrailingDirectorySeparator = fullPath + Path.DirectorySeparatorChar;
+                fullPathWithTrailingDirectorySeparator = fullPath + PathHelpers.DirectorySeparatorCharAsString;
             else
                 fullPathWithTrailingDirectorySeparator = fullPath;
 

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -408,13 +408,13 @@ namespace System.IO
 
             String fullDestDirName = PathHelpers.GetFullPathInternal(destDirName);
             if (fullDestDirName[fullDestDirName.Length - 1] != Path.DirectorySeparatorChar)
-                fullDestDirName = fullDestDirName + Path.DirectorySeparatorChar;
+                fullDestDirName = fullDestDirName + PathHelpers.DirectorySeparatorCharAsString;
 
             String fullSourcePath;
             if (FullPath.Length > 0 && FullPath[FullPath.Length - 1] == Path.DirectorySeparatorChar)
                 fullSourcePath = FullPath;
             else
-                fullSourcePath = FullPath + Path.DirectorySeparatorChar;
+                fullSourcePath = FullPath + PathHelpers.DirectorySeparatorCharAsString;
 
             if (String.Compare(fullSourcePath, fullDestDirName, StringComparison.OrdinalIgnoreCase) == 0)
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -24,7 +24,7 @@ namespace System.IO
 
         // String-representation of the directory-separator character, used when appending the character to another
         // string so as to avoid the boxing of the character when calling String.Concat(..., object).
-        internal static readonly string DirectorySeparatorCharAsString = new string(Path.DirectorySeparatorChar, 1);
+        internal static readonly string DirectorySeparatorCharAsString = Path.DirectorySeparatorChar.ToString();
 
         // Gets the length of the root DirectoryInfo or whatever DirectoryInfo markers
         // are specified for the first part of the DirectoryInfo name.

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -19,6 +19,13 @@ namespace System.IO
         internal static readonly char[] TrimEndChars = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
         internal static readonly char[] TrimStartChars = { ' ' };
 
+        // Array of the separator chars
+        internal static readonly char[] DirectorySeparatorChars = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        // String-representation of the directory-separator character, used when appending the character to another
+        // string so as to avoid the boxing of the character when calling String.Concat(..., object).
+        internal static readonly string DirectorySeparatorCharAsString = new string(Path.DirectorySeparatorChar, 1);
+
         // Gets the length of the root DirectoryInfo or whatever DirectoryInfo markers
         // are specified for the first part of the DirectoryInfo name.
         // 
@@ -37,7 +44,7 @@ namespace System.IO
                 {
                     i = 2;
                     int n = 2;
-                    while (i < length && ((path[i] != Path.DirectorySeparatorChar && path[i] != Path.AltDirectorySeparatorChar) || --n > 0)) i++;
+                    while (i < length && (!IsDirectorySeparator(path[i]) || --n > 0)) i++;
                 }
             }
             else if (length >= 2 && path[1] == Path.VolumeSeparatorChar)
@@ -62,8 +69,7 @@ namespace System.IO
                 if (index + 2 == searchPattern.Length) // Terminal ".." . Files names cannot end in ".."
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern);
 
-                if ((searchPattern[index + 2] == Path.DirectorySeparatorChar)
-                   || (searchPattern[index + 2] == Path.AltDirectorySeparatorChar))
+                if (IsDirectorySeparator(searchPattern[index + 2]))
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern);
 
                 searchPattern = searchPattern.Substring(index + 2);

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -216,7 +216,7 @@ namespace System.IO
                 findData = new Interop.WIN32_FIND_DATA();
 
                 // Remove trialing slash since this can cause grief to FindFirstFile. You will get an invalid argument error
-                String tempPath = path.TrimEnd(new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
+                String tempPath = path.TrimEnd(PathHelpers.DirectorySeparatorChars);
 
                 // For floppy drives, normally the OS will pop up a dialog saying
                 // there is no disk in drive A:, please insert one.  We don't want that.
@@ -507,7 +507,7 @@ namespace System.IO
                 Interop.WIN32_FIND_DATA data = new Interop.WIN32_FIND_DATA();
 
                 // Open a Find handle
-                using (SafeFindHandle hnd = Interop.mincore.FindFirstFile(fullPath + Path.DirectorySeparatorChar + "*", ref data))
+                using (SafeFindHandle hnd = Interop.mincore.FindFirstFile(fullPath + PathHelpers.DirectorySeparatorCharAsString + "*", ref data))
                 {
                     if (hnd.IsInvalid)
                         throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
@@ -546,7 +546,7 @@ namespace System.IO
                                 if (data.dwReserved0 == Interop.IO_REPARSE_TAG_MOUNT_POINT)
                                 {
                                     // Use full path plus a trailing '\'
-                                    String mountPoint = Path.Combine(fullPath, data.cFileName + Path.DirectorySeparatorChar);
+                                    String mountPoint = Path.Combine(fullPath, data.cFileName + PathHelpers.DirectorySeparatorCharAsString);
                                     r = Interop.mincore.DeleteVolumeMountPoint(mountPoint);
                                     if (!r)
                                     {

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -502,7 +502,7 @@ namespace System.IO
             char lastChar = tempStr[tempStr.Length - 1];
             if (PathHelpers.IsDirectorySeparator(lastChar) || lastChar == Path.VolumeSeparatorChar)
             {
-                tempStr = tempStr + '*';
+                tempStr = tempStr + "*";
             }
 
             return tempStr;


### PR DESCRIPTION
This commit removes several unnecessary char-related allocations in System.IO.FileSystem.  Most of them stemmed from appending the DirectorySeparatorChar to a string, which results in the compiler using String.Concat(..., object) for the concatenation, which means the char gets boxed.  Others stemmed from array allocations that could have been cached, e.g. allocating an array for the directory separator chars on each call to TrimEnd.

In fixing these, I also noticed and fixed a few places where duplicated logic could be replaced with a call to IsDirectoryChar.