### PR TITLE
Remove "m_" from Pipes

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -300,13 +300,13 @@ namespace System.IO.Pipes
             RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup(tryCode, cleanupCode, execHelper);
 
             // now handle win32 impersonate/revert specific errors by throwing corresponding exceptions
-            if (execHelper.m_impersonateErrorCode != 0)
+            if (execHelper._impersonateErrorCode != 0)
             {
-                WinIOError(execHelper.m_impersonateErrorCode);
+                WinIOError(execHelper._impersonateErrorCode);
             }
-            else if (execHelper.m_revertImpersonateErrorCode != 0)
+            else if (execHelper._revertImpersonateErrorCode != 0)
             {
-                WinIOError(execHelper.m_revertImpersonateErrorCode);
+                WinIOError(execHelper._revertImpersonateErrorCode);
             }
         }
 
@@ -324,20 +324,20 @@ namespace System.IO.Pipes
             try { }
             finally
             {
-                if (UnsafeNativeMethods.ImpersonateNamedPipeClient(execHelper.m_handle))
+                if (UnsafeNativeMethods.ImpersonateNamedPipeClient(execHelper._handle))
                 {
-                    execHelper.m_mustRevert = true;
+                    execHelper._mustRevert = true;
                 }
                 else
                 {
-                    execHelper.m_impersonateErrorCode = Marshal.GetLastWin32Error();
+                    execHelper._impersonateErrorCode = Marshal.GetLastWin32Error();
                 }
 
             }
 
-            if (execHelper.m_mustRevert)
+            if (execHelper._mustRevert)
             { // impersonate passed so run user code
-                execHelper.m_userCode();
+                execHelper._userCode();
             }
         }
 
@@ -347,28 +347,28 @@ namespace System.IO.Pipes
         {
             ExecuteHelper execHelper = (ExecuteHelper)helper;
 
-            if (execHelper.m_mustRevert)
+            if (execHelper._mustRevert)
             {
                 if (!UnsafeNativeMethods.RevertToSelf())
                 {
-                    execHelper.m_revertImpersonateErrorCode = Marshal.GetLastWin32Error();
+                    execHelper._revertImpersonateErrorCode = Marshal.GetLastWin32Error();
                 }
             }
         }
 
         internal class ExecuteHelper
         {
-            internal PipeStreamImpersonationWorker m_userCode;
-            internal SafePipeHandle m_handle;
-            internal bool m_mustRevert;
-            internal int m_impersonateErrorCode;
-            internal int m_revertImpersonateErrorCode;
+            internal PipeStreamImpersonationWorker _userCode;
+            internal SafePipeHandle _handle;
+            internal bool _mustRevert;
+            internal int _impersonateErrorCode;
+            internal int _revertImpersonateErrorCode;
 
             [SecurityCritical]
             internal ExecuteHelper(PipeStreamImpersonationWorker userCode, SafePipeHandle handle)
             {
-                m_userCode = userCode;
-                m_handle = handle;
+                _userCode = userCode;
+                _handle = handle;
             }
         }
 #endif

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -952,7 +952,7 @@ namespace System.IO.Pipes
             return secAttrs;
         }
 
-        // When doing IO asynchronously (i.e., m_isAsync==true), this callback is 
+        // When doing IO asynchronously (i.e., _isAsync==true), this callback is 
         // called by a free thread in the threadpool when the IO operation 
         // completes.  
         [SecurityCritical]

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -103,7 +103,7 @@ namespace System.IO.Pipes
             _handle = handle;
             _isAsync = isAsync;
 
-            // track these separately; m_isHandleExposed will get updated if accessed though the property
+            // track these separately; _isHandleExposed will get updated if accessed though the property
             _isHandleExposed = isExposed;
             _isFromExistingHandle = isExposed;
         }


### PR DESCRIPTION
System.IO.Pipes had a few remaining fields prefixed with "m_", as well as some comments referring to some "m_" fields that had already been renamed.  This commit just cleans that up and changes the "m_" to just be an underscore.