### PR TITLE
Consume 1.0.21 version of build tools.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.20-prerelease</BuildToolsVersion>
+    <BuildToolsVersion>1.0.21-prerelease</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.20-prerelease" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.21-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.1-prerelease" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>


### PR DESCRIPTION
Fixes issues with the include and exclude traits for xunit.  Now we actually don't run outerloop tests.