### PR TITLE
Change build status image to new job

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build status][build-status-image]][build-status]  [![Issue Stats][pull-requests-image]][pull-requests]  [![Issue Stats][issues-closed-image]][issues-closed]
 
-[build-status-image]: http://corefx-ci.cloudapp.net/jenkins/job/dotnet_corefx_windows/badge/icon
-[build-status]: http://corefx-ci.cloudapp.net/jenkins/job/dotnet_corefx_windows/
+[build-status-image]: http://corefx-ci.cloudapp.net/jenkins/job/dotnet_corefx/badge/icon
+[build-status]: http://corefx-ci.cloudapp.net/jenkins/job/dotnet_corefx/
 [pull-requests-image]: http://www.issuestats.com/github/dotnet/corefx/badge/pr
 [pull-requests]: http://www.issuestats.com/github/dotnet/corefx
 [issues-closed-image]: http://www.issuestats.com/github/dotnet/corefx/badge/issue


### PR DESCRIPTION
Changes the build status image to the new job, which builds Linux + Windows, Debug and Release in a single job