### PR TITLE
Minor concurrent collections code cleanup

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/CDSCollectionETWBCLProvider.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/CDSCollectionETWBCLProvider.cs
@@ -52,7 +52,6 @@ namespace System.Collections.Concurrent
         private const int CONCURRENTBAG_TRYTAKESTEALS_ID = 4;
         private const int CONCURRENTBAG_TRYPEEKSTEALS_ID = 5;
 
-
         /////////////////////////////////////////////////////////////////////////////////////
         //
         // ConcurrentStack Events
@@ -76,7 +75,6 @@ namespace System.Collections.Concurrent
             }
         }
 
-
         /////////////////////////////////////////////////////////////////////////////////////
         //
         // ConcurrentDictionary Events
@@ -90,8 +88,6 @@ namespace System.Collections.Concurrent
                 WriteEvent(CONCURRENTDICTIONARY_ACQUIRINGALLLOCKS_ID, numOfBuckets);
             }
         }
-
-
 
         //
         // Events below this point are used by the CDS types in System.DLL

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -8,15 +8,11 @@
 // An unordered collection that allows duplicates and that provides add and get operations.
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.Threading;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Collections.Concurrent
 {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -11,16 +11,12 @@
 **
 ===========================================================*/
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Threading;
 
 namespace System.Collections.Concurrent
@@ -82,7 +78,6 @@ namespace System.Collections.Concurrent
 
         // Whether TValue is a type that can be written atomically (i.e., with no danger of torn reads)
         private static readonly bool s_isValueWriteAtomic = IsValueWriteAtomic();
-
 
         /// <summary>
         /// Determines whether type TValue can be written atomically

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -9,13 +9,10 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Threading;
 
 namespace System.Collections.Concurrent

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -9,12 +9,8 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
-using System.Security;
 using System.Threading;
 
 namespace System.Collections.Concurrent

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/IProducerConsumerCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/IProducerConsumerCollection.cs
@@ -11,7 +11,6 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/OrderablePartitioner.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/OrderablePartitioner.cs
@@ -11,9 +11,7 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace System.Collections.Concurrent
 {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/Partitioner.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/Partitioner.cs
@@ -11,9 +11,7 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace System.Collections.Concurrent
 {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PlatformHelper.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PlatformHelper.cs
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.Runtime;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Threading.Tasks;
-
 namespace System.Threading
 {
     /// <summary>
@@ -36,14 +28,6 @@ namespace System.Threading
 
                 return s_processorCount;
             }
-        }
-
-        /// <summary>
-        /// Gets whether the current machine has only a single processor.
-        /// </summary>
-        internal static bool IsSingleProcessor
-        {
-            get { return ProcessorCount == 1; }
         }
     }
 }


### PR DESCRIPTION
Remove unused usings.
Rename fields with correct style guideline.
Delete some dead code.