### PR TITLE
Fix rebuild target when building from the root

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="_RestoreBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
   <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
@@ -24,6 +24,7 @@
   </UsingTask>
 
   <Target Name="_RestoreBuildTools"
+    BeforeTargets="BuildAllProjects"
     Inputs="$(BuildToolsTargetInputs)"
     Outputs="$(BuildToolsTargetOutputs)"
     >


### PR DESCRIPTION
Rebuild naturally calls Clean followed by Build but the _RestoreBuildTools
was set as the InitialTargets in the build.proj which means you restore tools
clean tools then try to build which doesn't work so well. This change set the
restore build tools target to before BuildAllProjects so that the target align
correctly.

This addresses build issue #415