### PR TITLE
Avoid scheduling to TaskScheduler.Current in dataflow tests

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/ActionBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/ActionBlockTests.cs
@@ -72,7 +72,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Throws<ArgumentNullException>(() => new ActionBlock<int>((Func<int, Task>)null));
             Assert.Throws<ArgumentNullException>(() => new ActionBlock<int>((Func<int, Task>)null));
             Assert.Throws<ArgumentNullException>(() => new ActionBlock<int>(i => { }, null));
-            Assert.Throws<ArgumentNullException>(() => new ActionBlock<int>(i => Task.Factory.StartNew(() => { }), null));
+            Assert.Throws<ArgumentNullException>(() => new ActionBlock<int>(i => Task.Run(() => { }), null));
         }
 
         [Fact]
@@ -299,7 +299,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 var ab = new ActionBlock<int>(i =>
                     {
                         localPassed &= TaskScheduler.Current.Id == sts.Id;
-                        return Task.Factory.StartNew(() => { });
+                        return Task.Run(() => { });
                     }, new ExecutionDataflowBlockOptions { TaskScheduler = sts, MaxDegreeOfParallelism = -1, MaxMessagesPerTask = 10 });
                 for (int i = 0; i < 2; i++) ab.Post(i);
                 ab.Complete();
@@ -312,7 +312,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 bool localPassed = true;
                 var barrier1 = new Barrier(2);
                 var barrier2 = new Barrier(2);
-                var ab = new ActionBlock<int>(i => Task.Factory.StartNew(() =>
+                var ab = new ActionBlock<int>(i => Task.Run(() =>
                 {
                     barrier1.SignalAndWait();
                     barrier2.SignalAndWait();
@@ -336,7 +336,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 int prev = -1;
                 var ab = new ActionBlock<int>(i =>
                 {
-                    return Task.Factory.StartNew(() =>
+                    return Task.Run(() =>
                     {
                         if (prev + 1 != i) localPassed &= false;
                         prev = i;
@@ -354,7 +354,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 var barrier = new Barrier(2);
                 var ab = new ActionBlock<int>(i =>
                 {
-                    return Task.Factory.StartNew(() =>
+                    return Task.Run(() =>
                     {
                         barrier.SignalAndWait();
                     });
@@ -369,7 +369,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 int total = 0;
                 ab = new ActionBlock<int>(i =>
                 {
-                    return Task.Factory.StartNew(() =>
+                    return Task.Run(() =>
                     {
                         Interlocked.Add(ref total, i);
                         Task.Delay(1).Wait();
@@ -389,7 +389,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 var ab = new ActionBlock<int>(i =>
                 {
                     if ((i % 2) == 0) throw new OperationCanceledException();
-                    return Task.Factory.StartNew(() => { sumOfOdds += i; });
+                    return Task.Run(() => { sumOfOdds += i; });
                 });
                 for (int i = 0; i < 4; i++) ab.Post(i);
                 ab.Complete();
@@ -405,7 +405,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 var ab = new ActionBlock<int>(i =>
                 {
                     if ((i % 2) == 0) return null;
-                    return Task.Factory.StartNew(() => { sumOfOdds += i; });
+                    return Task.Run(() => { sumOfOdds += i; });
                 });
                 for (int i = 0; i < 4; i++) ab.Post(i);
                 ab.Complete();
@@ -433,7 +433,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             // Test faulting from the task
             {
                 bool localPassed = true;
-                var ab = new ActionBlock<int>(i => Task.Factory.StartNew(() => { throw new InvalidOperationException(); }));
+                var ab = new ActionBlock<int>(i => Task.Run(() => { throw new InvalidOperationException(); }));
                 ab.Post(42);
                 ab.Post(1);
                 ab.Post(2);

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BatchBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BatchBlockTests.cs
@@ -625,7 +625,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
                 // Queue up batchSize-1 input items
                 for (int i = 0; i < batchSize - 1; i++) sendAsyncTasks[i] = batch.SendAsync(i);
-                var racer = Task.Factory.StartNew(() =>
+                var racer = Task.Run(() =>
                                     {
                                         racerReady.Set();
                                         lastSendAsyncTask = batch.SendAsync(batchSize - 1);
@@ -716,7 +716,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
                 // Queue up batchSize-1 input items
                 for (int i = 0; i < batchSize - 1; i++) sendAsyncTasks[i] = batch.SendAsync(i);
-                var racer = Task.Factory.StartNew(() =>
+                var racer = Task.Run(() =>
                 {
                     racerReady.Set();
                     batch.Complete();

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BroadcastBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BroadcastBlockTests.cs
@@ -96,7 +96,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 // Test receiving then posting
                 localPassed = true;
                 var bb = new BroadcastBlock<int>(i => i);
-                Task.Factory.StartNew(() =>
+                Task.Run(() =>
                 {
                     Task.Delay(1).Wait();
                     bb.Post(42);

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BufferBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BufferBlockTests.cs
@@ -218,7 +218,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 {
                     var b = new BufferBlock<int>(new DataflowBlockOptions { BoundedCapacity = boundedCapacity });
 
-                    var p = Task.Factory.StartNew(() =>
+                    var p = Task.Run(() =>
                     {
                         Assert.True(b.Count == 0, "Nothing should be in the buffer yet");
                         for (int i = 0; i < ITERS; i++)
@@ -231,7 +231,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                         }
                     });
 
-                    var c = Task.Factory.StartNew(() =>
+                    var c = Task.Run(() =>
                     {
                         for (int i = 0; i < ITERS; i++)
                         {
@@ -353,7 +353,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     Enumerable.Repeat(-1, 1000)
                         .Select(_ => GetOutputAvailableAsyncTaskAfterTryReceiveAllOnNonEmptyBufferBlock()));
             var timeoutTask = Task.Delay(100);
-            var completedTask = await Task.WhenAny(multipleConcurrentTestsTask, timeoutTask);
+            var completedTask = await Task.WhenAny(multipleConcurrentTestsTask, timeoutTask).ConfigureAwait(false);
 
             Assert.True(completedTask != timeoutTask);
         }

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockTestBase.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockTestBase.cs
@@ -38,7 +38,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             for (int i = 0; i < transforms.Length - 1; i++)
             {
                 transforms[i].LinkTo(transforms[i + 1]);
-                transforms[i].Completion.ContinueWith(delegate { transforms[i].Complete(); });
+                transforms[i].Completion.ContinueWith(delegate { transforms[i].Complete(); }, TaskScheduler.Default);
             }
             return DataflowBlock.Encapsulate(transforms[0], transforms[transforms.Length - 1]);
         }
@@ -236,7 +236,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
         protected static Task TrackCapturesAsync(int i)
         {
-            return Task.Factory.StartNew(() => TrackCaptures(i));
+            return Task.Run(() => TrackCaptures(i));
         }
 
         /// <summary>
@@ -280,7 +280,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             // Launch tasks
             for (int i = 0; i < Parallelism.ActualDegreeOfParallelism; i++)
             {
-                tasks[i] = Task<bool>.Factory.StartNew(() =>
+                tasks[i] = Task.Run(() =>
                                             {
                                                 ce.Signal();
                                                 ce.Wait();
@@ -314,7 +314,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         internal static void LinkWithCompletion<T>(this ISourceBlock<T> source, ITargetBlock<T> target)
         {
             source.LinkTo(target);
-            source.Completion.ContinueWith(t => target.Complete());
+            source.Completion.ContinueWith(t => target.Complete(), TaskScheduler.Default);
         }
     }
 
@@ -420,7 +420,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             // Reserve the message only if there is no other reservation in place
             if (ReservingTask == null)
             {
-                ReservingTask = Task<bool>.Factory.StartNew(() => { return source.ReserveMessage(messageHeader, this); });
+                ReservingTask = Task.Run(() => { return source.ReserveMessage(messageHeader, this); });
                 ReleasingTask = new Task(() => { source.ReleaseReservation(messageHeader, this); });
             }
 

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
@@ -67,12 +67,12 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.True(TestHardeningTarget(new BufferBlock<ThrowOn>(), ThrowOn.ConsumeMessage, greedy: true));
             Assert.True(TestHardeningTarget(new BroadcastBlock<ThrowOn>(x => x), ThrowOn.ConsumeMessage, greedy: true));
             Assert.True(TestHardeningTarget(new ActionBlock<ThrowOn>(x => { }), ThrowOn.ConsumeMessage, greedy: true));
-            Assert.True(TestHardeningTarget(new ActionBlock<ThrowOn>(x => { return Task.Factory.StartNew(() => { }); }), ThrowOn.ConsumeMessage, greedy: true));
+            Assert.True(TestHardeningTarget(new ActionBlock<ThrowOn>(x => { return Task.Run(() => { }); }), ThrowOn.ConsumeMessage, greedy: true));
 
             // ConsumeMessage (non-greedy): Batch, Join, TargetCore sync (~Action), TargetCore async (~Action), bounded Buffer
             var nonGreedyGroupingOptions = new GroupingDataflowBlockOptions { Greedy = false }; // Sequential, non-greedy
             var nonGreedyExecutionOptions = new ExecutionDataflowBlockOptions { BoundedCapacity = 1 }; // Sequential, non-greedy
-            Assert.True(TestHardeningTarget(new ActionBlock<ThrowOn>(x => { return Task.Factory.StartNew(() => { Task.Delay(1000).Wait(); }); }, nonGreedyExecutionOptions), ThrowOn.ConsumeMessage, greedy: false));
+            Assert.True(TestHardeningTarget(new ActionBlock<ThrowOn>(x => { return Task.Run(() => { Task.Delay(1000).Wait(); }); }, nonGreedyExecutionOptions), ThrowOn.ConsumeMessage, greedy: false));
             Assert.True(TestHardeningTarget(new ActionBlock<ThrowOn>(x => { Task.Delay(1000).Wait(); }, nonGreedyExecutionOptions), ThrowOn.ConsumeMessage, greedy: false));
             Assert.True(TestHardeningTarget(new BufferBlock<ThrowOn>(new DataflowBlockOptions { BoundedCapacity = BUFFER_BOUNDED_CAPACITY_10 }), ThrowOn.ConsumeMessage, greedy: false));
 
@@ -93,9 +93,9 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => new ThrowerEnumerable(ThrowOn.GetEnumerator)), "GetEnumerator"));
             Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => new ThrowerEnumerable(ThrowOn.MoveNext)), "MoveNext"));
             Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => new ThrowerEnumerable(ThrowOn.Current)), "Current"));
-            Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => Task.Factory.StartNew(() => (IEnumerable<int>)new ThrowerEnumerable(ThrowOn.GetEnumerator))), "GetEnumerator"));
-            Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => Task.Factory.StartNew(() => (IEnumerable<int>)new ThrowerEnumerable(ThrowOn.MoveNext))), "MoveNext"));
-            Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => Task.Factory.StartNew(() => (IEnumerable<int>)new ThrowerEnumerable(ThrowOn.Current))), "Current"));
+            Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => Task.Run(() => (IEnumerable<int>)new ThrowerEnumerable(ThrowOn.GetEnumerator))), "GetEnumerator"));
+            Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => Task.Run(() => (IEnumerable<int>)new ThrowerEnumerable(ThrowOn.MoveNext))), "MoveNext"));
+            Assert.True(TestHardeningTransformMany(new TransformManyBlock<int, int>(x => Task.Run(() => (IEnumerable<int>)new ThrowerEnumerable(ThrowOn.Current))), "Current"));
 
             // Extensions: SendAsync, Receive (Sync), Receive (Async), ReceiveAsync (Sync), ReceiveAsync (Async)
             Assert.True(TestHardeningExtensionsReceive(HardeningScenario.Async));
@@ -747,7 +747,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     // In this scenario the source must not have messages prior to the receive attempt.
                     // Therefore delay the post.
                     message = ThrowOn.ConsumeMessage;
-                    Task.Factory.StartNew(() => { Task.Delay(5).Wait(); source.Post(message); });
+                    Task.Run(() => { Task.Delay(5).Wait(); source.Post(message); });
                     break;
             }
 
@@ -794,7 +794,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     // In this scenario the source must not have messages prior to the receive attempt.
                     // Therefore delay the post.
                     message = ThrowOn.ConsumeMessage;
-                    Task.Factory.StartNew(() => { Task.Delay(5).Wait(); source.Post(message); });
+                    Task.Run(() => { Task.Delay(5).Wait(); source.Post(message); });
                     break;
             }
 

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/MultiBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/MultiBlockTests.cs
@@ -70,7 +70,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             var c = new ActionBlock<int>(i => completedCount++);
 
             t.LinkTo(c, i => true);
-            t.Completion.ContinueWith(_ => c.Complete());
+            t.Completion.ContinueWith(_ => c.Complete(), TaskScheduler.Default);
 
             for (int i = 0; i < ITERS; i++) t.Post(i);
             t.Complete();
@@ -89,7 +89,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
             t.LinkTo(c, i => i % 2 == 0);
             t.LinkTo(DataflowBlock.NullTarget<int>());
-            t.Completion.ContinueWith(_ => c.Complete());
+            t.Completion.ContinueWith(_ => c.Complete(), TaskScheduler.Default);
 
             for (int i = 0; i < ITERS; i++) t.Post(i);
             t.Complete();
@@ -148,7 +148,8 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 s.LinkTo(c);
                 return s;
             }).ToList();
-            Task.Factory.ContinueWhenAll(singleAssignments.Select(s => s.Completion).ToArray(), _ => c.Complete());
+            Task.Factory.ContinueWhenAll(singleAssignments.Select(s => s.Completion).ToArray(), _ => c.Complete(), 
+                CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
 
             foreach (var s in singleAssignments) s.Post(1);
             c.Completion.Wait();
@@ -186,7 +187,8 @@ namespace System.Threading.Tasks.Dataflow.Tests
             var c = new ActionBlock<int[]>(i => completedCount++);
 
             foreach (var input in inputs) input.LinkTo(b);
-            Task.Factory.ContinueWhenAll(inputs.Select(i => i.Completion).ToArray(), _ => b.Complete());
+            Task.Factory.ContinueWhenAll(inputs.Select(i => i.Completion).ToArray(), _ => b.Complete(),
+                CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
             b.LinkWithCompletion(c);
 
             for (int i = 0; i < ITERS; i++)

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
@@ -53,7 +53,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.False(block.InputCount != 0, "Constructor failed! InputCount returned a non zero value for a brand new TransformManyBlock.");
 
             // Task without option
-            block = new TransformManyBlock<int, string>(i => Task.Factory.StartNew(() => (IEnumerable<string>)new string[10]));
+            block = new TransformManyBlock<int, string>(i => Task.Run(() => (IEnumerable<string>)new string[10]));
             Assert.False(block.InputCount != 0, "Constructor failed! InputCount returned a non zero value for a brand new TransformManyBlock.");
 
             // IEnumerable with not cancelled token and default scheduler
@@ -61,7 +61,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.False(block.InputCount != 0, "Constructor failed! InputCount returned a non zero value for a brand new TransformManyBlock.");
 
             // Task with not cancelled token and default scheduler
-            block = new TransformManyBlock<int, string>(i => Task.Factory.StartNew(() => (IEnumerable<string>)new string[10]), new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 1 });
+            block = new TransformManyBlock<int, string>(i => Task.Run(() => (IEnumerable<string>)new string[10]), new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 1 });
             Assert.False(block.InputCount != 0, "Constructor failed! InputCount returned a non zero value for a brand new TransformManyBlock.");
 
             // IEnumerable with a cancelled token and default scheduler
@@ -71,7 +71,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
             // Task with a cancelled token and default scheduler
             token = new CancellationToken(true);
-            block = new TransformManyBlock<int, string>(i => Task.Factory.StartNew(() => (IEnumerable<string>)new string[10]), new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 1, CancellationToken = token });
+            block = new TransformManyBlock<int, string>(i => Task.Run(() => (IEnumerable<string>)new string[10]), new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 1, CancellationToken = token });
             Assert.False(block.InputCount != 0, "Constructor failed! InputCount returned a non zero value for a brand new TransformManyBlock.");
         }
 
@@ -83,7 +83,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Throws<ArgumentNullException>(() => new TransformManyBlock<int, string>((Func<int, IEnumerable<string>>)null));
             Assert.Throws<ArgumentNullException>(() => new TransformManyBlock<int, string>((Func<int, Task<IEnumerable<string>>>)null));
             Assert.Throws<ArgumentNullException>(() => new TransformManyBlock<int, string>(i => new[] { i.ToString() }, null));
-            Assert.Throws<ArgumentNullException>(() => new TransformManyBlock<int, string>(i => Task.Factory.StartNew(() => (IEnumerable<string>)new[] { i.ToString() }), null));
+            Assert.Throws<ArgumentNullException>(() => new TransformManyBlock<int, string>(i => Task.Run(() => (IEnumerable<string>)new[] { i.ToString() }), null));
 
             passed &= ITargetBlockTestHelper.TestArgumentsExceptions<int>(new TransformManyBlock<int, int>(i => new int[] { i }));
             passed &= ISourceBlockTestHelper.TestArgumentsExceptions<int>(new TransformManyBlock<int, int>(i => new int[] { i }));
@@ -375,7 +375,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     Func<DataflowBlockOptions, TargetProperties<int>> transformManyBlockFactory =
                         options =>
                         {
-                            TransformManyBlock<int, int> transformManyBlock = new TransformManyBlock<int, int>(i => Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i }), (ExecutionDataflowBlockOptions)options);
+                            TransformManyBlock<int, int> transformManyBlock = new TransformManyBlock<int, int>(i => Task.Run(() => (IEnumerable<int>)new[] { i }), (ExecutionDataflowBlockOptions)options);
                             ActionBlock<int> actionBlock = new ActionBlock<int>(i => TrackCaptures(i), (ExecutionDataflowBlockOptions)options);
 
                             transformManyBlock.LinkTo(actionBlock);
@@ -400,7 +400,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 {
                     bool localPassed = true;
                     const int ITERS = 2;
-                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i * 2 })));
+                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Run(() => (IEnumerable<int>)new[] { i * 2 })));
                     for (int i = 0; i < ITERS; i++)
                     {
                         network.Post(i);
@@ -414,7 +414,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 {
                     bool localPassed = true;
                     const int ITERS = 2;
-                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i * 2 })));
+                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Run(() => (IEnumerable<int>)new[] { i * 2 })));
                     for (int i = 0; i < ITERS; i++)
                     {
                         network.SendAsync(i);
@@ -428,7 +428,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 {
                     bool localPassed = true;
                     const int ITERS = 2;
-                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i * 2 })));
+                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Run(() => (IEnumerable<int>)new[] { i * 2 })));
                     for (int i = 0; i < ITERS; i++) localPassed &= network.Post(i) == true;
                     for (int i = 0; i < ITERS; i++) localPassed &= ((IReceivableSourceBlock<int>)network).Receive() == i * 16;
                     Console.WriteLine("{0}: Chained Post all then Receive", localPassed ? "Success" : "Failure");
@@ -439,7 +439,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 {
                     bool localPassed = true;
                     const int ITERS = 2;
-                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i * 2 })));
+                    var network = Chain<TransformManyBlock<int, int>, int>(4, () => new TransformManyBlock<int, int>(i => Task.Run(() => (IEnumerable<int>)new[] { i * 2 })));
                     var tasks = new Task[ITERS];
                     for (int i = 1; i <= ITERS; i++) tasks[i - 1] = network.SendAsync(i);
                     Task.WaitAll(tasks);
@@ -454,7 +454,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 {
                     bool localPassed = true;
 
-                    var t = new TransformManyBlock<int, int>(i => Task.Factory.StartNew(() => (IEnumerable<int>)Enumerable.Range(0, 10).ToArray()));
+                    var t = new TransformManyBlock<int, int>(i => Task.Run(() => (IEnumerable<int>)Enumerable.Range(0, 10).ToArray()));
                     t.Post(42);
                     t.Complete();
                     for (int i = 0; i < 10; i++)
@@ -493,7 +493,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     var t = new TransformManyBlock<int, int>(i =>
                     {
                         if ((i % 2) == 0) return null;
-                        return Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i });
+                        return Task.Run(() => (IEnumerable<int>)new[] { i });
                     });
                     for (int i = 0; i < 10; i++) t.Post(i);
                     t.Complete();
@@ -517,7 +517,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                             Task.Delay(1000).Wait();
                             return null;
                         }
-                        return Task.Factory.StartNew(() => (IEnumerable<int>)new[] { i });
+                        return Task.Run(() => (IEnumerable<int>)new[] { i });
                     }), new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2 });
                     t.Post(0);
                     t.Post(1);
@@ -554,7 +554,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 // Test faulting from the task
                 {
                     bool localPassed = true;
-                    var t = new TransformManyBlock<int, int>(new Func<int, Task<IEnumerable<int>>>(i => Task<IEnumerable<int>>.Factory.StartNew(() => { throw new InvalidOperationException(); })));
+                    var t = new TransformManyBlock<int, int>(new Func<int, Task<IEnumerable<int>>>(i => Task.Run<IEnumerable<int>>(new Func<IEnumerable<int>>(() => { throw new InvalidOperationException(); }))));
                     t.Post(42);
                     t.Post(1);
                     t.Post(2);
@@ -590,7 +590,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                                 TransformManyBlock<int, int> tmb1 = null;
                                 tmb1 = new TransformManyBlock<int, int>(i =>
                                 {
-                                    return Task.Factory.StartNew(() =>
+                                    return Task.Run(() =>
                                     {
                                         if (i == 1000)
                                         {
@@ -652,7 +652,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                                 var tmb = new TransformManyBlock<int, int>(i =>
                                 {
                                     var cts = new CancellationTokenSource();
-                                    return Task.Factory.StartNew(() =>
+                                    return Task.Run(() =>
                                     {
                                         if (i < ITERS - 1)
                                         {

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/WriteOnceBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/WriteOnceBlockTests.cs
@@ -104,7 +104,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 // Test receiving then posting
                 localPassed = true;
                 var wob = new WriteOnceBlock<int>(i => i);
-                Task.Factory.StartNew(() =>
+                Task.Run(() =>
                 {
                     Task.Delay(1000).Wait();
                     wob.Post(42);


### PR DESCRIPTION
xunit uses a TaskScheduler that limits DOP, and it schedules the execution of tests to that scheduler.  As such, if a test blocks while waiting for another task that the test has scheduled back to TaskScheduler.Current, the test can deadlock.  This commit changes task scheduling to avoid going to TaskScheduler.Current, either by explicitly passing in a scheduler to StartNew/ContinueWith/etc. or by using Task.Run (which implicitly targets TaskScheduler.Default).