### PR TITLE
Add CastUp and CastArray to ImmutableArray<T>

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -358,22 +358,6 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImmutableArray"/> struct based on the contents
-        /// of an existing instance, allowing a covariant static cast to efficiently reuse the existing array.
-        /// </summary>
-        /// <param name="items">The array to initialize the array with. No copy is made.</param>
-        /// <remarks>
-        /// Covariant upcasts from this method may be reversed by calling the
-        /// <see cref="ImmutableArray&lt;T&gt;.As&lt;TOther&gt;"/> instance method.
-        /// </remarks>
-        [Pure]
-        public static ImmutableArray<T> Create<T, TDerived>(ImmutableArray<TDerived> items)
-            where TDerived : class, T
-        {
-            return new ImmutableArray<T>(items.array);
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableArray&lt;T&gt;.Builder"/> class.
         /// </summary>
         /// <typeparam name="T">The type of elements stored in the array.</typeparam>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1029,6 +1029,33 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ImmutableArray{T}"/> struct based on the contents
+        /// of an existing instance, allowing a covariant static cast to efficiently reuse the existing array.
+        /// </summary>
+        /// <param name="items">The array to initialize the array with. No copy is made.</param>
+        /// <remarks>
+        /// Covariant upcasts from this method may be reversed by calling the
+        /// <see cref="ImmutableArray&lt;T&gt;.As&lt;TOther&gt;"/> instance method.
+        /// </remarks>
+        [Pure]
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T
+        {
+            return new ImmutableArray<T>(items.array);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmutableArray{T}"/> struct by casting the underlying
+        /// array to an array of type <typeparam name="TOther"/>.
+        /// </summary>
+        /// <exception cref="InvalidCastException">Thrown if the cast is illegal.</exception>
+        [Pure]
+        public ImmutableArray<TOther> CastArray<TOther>() where TOther : class
+        {
+            return new ImmutableArray<TOther>((TOther[])(object)array);
+        }
+
+        /// <summary>
         /// Creates an immutable array for this array, cast to a different element type.
         /// </summary>
         /// <typeparam name="TOther">The type of array element to return.</typeparam>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1035,7 +1035,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The array to initialize the array with. No copy is made.</param>
         /// <remarks>
         /// Covariant upcasts from this method may be reversed by calling the
-        /// <see cref="ImmutableArray&lt;T&gt;.As&lt;TOther&gt;"/> instance method.
+        /// <see cref="ImmutableArray{T}.As{TOther};"/>  or <see cref="ImmutableArray{T}.CastArray{TOther}"/>method.
         /// </remarks>
         [Pure]
         public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -368,7 +368,7 @@ namespace System.Collections.Immutable.Test
         }
 
         [Fact]
-        public void CastArrayUnleratedInterface()
+        public void CastArrayUnrelatedInterface()
         {
             var strArray = ImmutableArray.Create<string>("cat", "dog");
             var compArray = ImmutableArray<IComparable>.CastUp(strArray);

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -381,8 +381,8 @@ namespace System.Collections.Immutable.Test
         [Fact]
         public void CastArrayBadInterface()
         {
-            var formatableArray = ImmutableArray.Create<IFormattable>(1, 2);
-            Assert.Throws(typeof(InvalidCastException), () => formatableArray.CastArray<IComparable>());
+            var formattableArray = ImmutableArray.Create<IFormattable>(1, 2);
+            Assert.Throws(typeof(InvalidCastException), () => formattableArray.CastArray<IComparable>());
         }
 
         [Fact]

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -292,22 +292,22 @@ namespace System.Collections.Immutable.Test
         }
 
         [Fact]
-        public void CreateByCovariantStaticCast()
+        public void CastUpReference()
         {
             ImmutableArray<string> derivedImmutable = ImmutableArray.Create("a", "b", "c");
-            ImmutableArray<object> baseImmutable = ImmutableArray.Create<object, string>(derivedImmutable);
+            ImmutableArray<object> baseImmutable = ImmutableArray<object>.CastUp(derivedImmutable);
             Assert.Equal(derivedImmutable, baseImmutable);
 
             // Make sure we can reverse that, as a means to verify the underlying array is the same instance.
-            ImmutableArray<string> derivedImmutable2 = baseImmutable.As<string>();
-            Assert.Equal(derivedImmutable, derivedImmutable2);
+            Assert.Equal(derivedImmutable, baseImmutable.As<string>());
+            Assert.Equal(derivedImmutable, baseImmutable.CastArray<string>());
         }
 
         [Fact]
-        public void CreateByCovariantStaticCastDefault()
+        public void CastUpReferenceDefaultValue()
         {
             ImmutableArray<string> derivedImmutable = default(ImmutableArray<string>);
-            ImmutableArray<object> baseImmutable = ImmutableArray.Create<object, string>(derivedImmutable);
+            ImmutableArray<object> baseImmutable = ImmutableArray<object>.CastUp(derivedImmutable);
             Assert.True(baseImmutable.IsDefault);
             Assert.True(derivedImmutable.IsDefault);
 
@@ -315,6 +315,81 @@ namespace System.Collections.Immutable.Test
             ImmutableArray<string> derivedImmutable2 = baseImmutable.As<string>();
             Assert.True(derivedImmutable2.IsDefault);
             Assert.True(derivedImmutable == derivedImmutable2);
+        }
+
+        [Fact]
+        public void CastUpRefToInterface()
+        {
+            var stringArray = ImmutableArray.Create("a", "b");
+            var enumArray = ImmutableArray<IEnumerable>.CastUp(stringArray);
+            Assert.Equal(2, enumArray.Length);
+            Assert.Equal(stringArray, enumArray.CastArray<string>());
+            Assert.Equal(stringArray, enumArray.As<string>());
+        }
+
+        [Fact]
+        public void CastUpInterfaceToInterface()
+        {
+            var genericEnumArray = ImmutableArray.Create<IEnumerable<int>>(new List<int>(), new List<int>());
+            var legacyEnumArray = ImmutableArray<IEnumerable>.CastUp(genericEnumArray);
+            Assert.Equal(2, legacyEnumArray.Length);
+            Assert.Equal(genericEnumArray, legacyEnumArray.As<IEnumerable<int>>());
+            Assert.Equal(genericEnumArray, legacyEnumArray.CastArray<IEnumerable<int>>());
+        }
+
+        [Fact]
+        public void CastUpArrayToSystemArray()
+        {
+            var arrayArray = ImmutableArray.Create(new int[] { 1, 2 }, new int[] { 3, 4 });
+            var sysArray = ImmutableArray<Array>.CastUp(arrayArray);
+            Assert.Equal(2, sysArray.Length);
+            Assert.Equal(arrayArray, sysArray.As<int[]>());
+            Assert.Equal(arrayArray, sysArray.CastArray<int[]>());
+        }
+
+        [Fact]
+        public void CastUpArrayToObject()
+        {
+            var arrayArray = ImmutableArray.Create(new int[] { 1, 2 }, new int[] { 3, 4 });
+            var objArray = ImmutableArray<object>.CastUp(arrayArray);
+            Assert.Equal(2, objArray.Length);
+            Assert.Equal(arrayArray, objArray.As<int[]>());
+            Assert.Equal(arrayArray, objArray.CastArray<int[]>());
+        }
+
+        [Fact]
+        public void CastUpDelegateToSystemDelegate()
+        {
+            var delArray = ImmutableArray.Create<Action>(() => { }, () => { });
+            var sysDelArray = ImmutableArray<Delegate>.CastUp(delArray);
+            Assert.Equal(2, sysDelArray.Length);
+            Assert.Equal(delArray, sysDelArray.As<Action>());
+            Assert.Equal(delArray, sysDelArray.CastArray<Action>());
+        }
+
+        [Fact]
+        public void CastArrayUnleratedInterface()
+        {
+            var strArray = ImmutableArray.Create<string>("cat", "dog");
+            var compArray = ImmutableArray<IComparable>.CastUp(strArray);
+            var enumArray = compArray.CastArray<IEnumerable>();
+            Assert.Equal(2, enumArray.Length);
+            Assert.Equal(strArray, enumArray.As<string>());
+            Assert.Equal(strArray, enumArray.CastArray<string>());
+        }
+
+        [Fact]
+        public void CastArrayBadInterface()
+        {
+            var formatableArray = ImmutableArray.Create<IFormattable>(1, 2);
+            Assert.Throws(typeof(InvalidCastException), () => formatableArray.CastArray<IComparable>());
+        }
+
+        [Fact]
+        public void CastArrayBadRef()
+        {
+            var objArray = ImmutableArray.Create<object>("cat", "dog");
+            Assert.Throws(typeof(InvalidCastException), () => objArray.CastArray<string>());
         }
 
         [Fact]


### PR DESCRIPTION
This is the PR that corresponds with API request issue #400.  The issue
has the full details of this change but in summary

Adds ImmutableArray<T>.CastUp<TDerived> static method.  This allows the
caller to convert from an immutable array of derived elements to parent
elements (ex: string to object).  This conversion is statically
verifiable and has no allocation or dynamic type check.

Adds the ImmutableArray.CastArray<TOther> method.  This method is the
immutable array equivalent of casting a standard CLR array to a related
array type.

http://msdn.microsoft.com/en-us/library/aa664572%28v=vs.71%29.aspx

If the conversion fails an InvalidCastException will be thrown.