### PR TITLE
Trivial cleanup to use Assert.True(x) and Assert.False(x)

### DIFF
--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_CultureInfo.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_CultureInfo.cs
@@ -155,7 +155,7 @@ public class CaseInsensitiveComparer_CultureInfo
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }}
 
 

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_Default.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_Default.cs
@@ -136,6 +136,6 @@ public class CaseInsensitiveComparer_Default
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_DefaultInvariant.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_DefaultInvariant.cs
@@ -126,7 +126,7 @@ public class CaseInsensitiveComparer_DefaultInvariant
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_Object.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_Object.cs
@@ -150,7 +150,7 @@ public class CaseInsensitiveComparer_Object
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }}
 
 

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_ctor.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_ctor.cs
@@ -100,7 +100,7 @@ public class CaseInsensitiveComparer_ctor
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/CollectionBase/CollectionBase_AllMethods.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionBase/CollectionBase_AllMethods.cs
@@ -392,7 +392,7 @@ public class CollectionBase_AllMethods
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
     //CollectionBase is provided to be used as the base class for strongly typed collections. Lets use one of our own here

--- a/src/System.Collections.NonGeneric/tests/CollectionBase/CollectionBase_OnMethods.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionBase/CollectionBase_OnMethods.cs
@@ -721,7 +721,7 @@ public class CollectionBase_OnMethods
             bResult = false;
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 

--- a/src/System.Collections.NonGeneric/tests/CollectionsUtil/CollectionsUtilTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionsUtil/CollectionsUtilTests.cs
@@ -132,6 +132,6 @@ public class CollectionsUtilTests
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Comparer/Comparer_CaseInsensitive.cs
+++ b/src/System.Collections.NonGeneric/tests/Comparer/Comparer_CaseInsensitive.cs
@@ -127,7 +127,7 @@ public class Comparer_CaseInsensitive
             Console.WriteLine(" : FAiL! Error Err_9999zzz! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Comparer/Comparer_DefaultInvariant.cs
+++ b/src/System.Collections.NonGeneric/tests/Comparer/Comparer_DefaultInvariant.cs
@@ -111,7 +111,7 @@ public class Comparer_DefaultInvariant
             Console.WriteLine(" : FAiL! Error Err_9999zzz! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Comparer/Comparer_Objects.cs
+++ b/src/System.Collections.NonGeneric/tests/Comparer/Comparer_Objects.cs
@@ -298,7 +298,7 @@ public class Comparer_Objects
         var runClass = new Comparer_Objects();
         Boolean bResult = runClass.runTest();
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }  
 

--- a/src/System.Collections.NonGeneric/tests/DictionaryBase/DictionaryBase_OnMethods.cs
+++ b/src/System.Collections.NonGeneric/tests/DictionaryBase/DictionaryBase_OnMethods.cs
@@ -735,7 +735,7 @@ public class DictionaryBase_OnMethods
             Console.WriteLine(" : FAiL! Error Err_9999zzz! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
     //DictionaryBase is provided to be used as the base class for strongly typed collections. Lets use one of our own here

--- a/src/System.Collections.NonGeneric/tests/DictionaryBase/DictionaryBase_UnitTests.cs
+++ b/src/System.Collections.NonGeneric/tests/DictionaryBase/DictionaryBase_UnitTests.cs
@@ -516,7 +516,7 @@ public class DictionaryBase_UnitTests
             Console.WriteLine("FAiL! Error Err_9999zzz! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
     public class FooKey : IComparable

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Clone.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Clone.cs
@@ -379,7 +379,7 @@ public class Queue_Clone
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Contains.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Contains.cs
@@ -163,7 +163,7 @@ public class Queue_Contains
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Dequeue.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Dequeue.cs
@@ -135,6 +135,6 @@ public class Queue_Dequeue
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Enqueue.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Enqueue.cs
@@ -90,7 +90,7 @@ public class Queue_Enqueue
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Peek.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Peek.cs
@@ -151,6 +151,6 @@ public class Queue_Peek
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Synchronized.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Synchronized.cs
@@ -449,7 +449,7 @@ public class Queue_Synchronized
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_ToArray.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_ToArray.cs
@@ -180,7 +180,7 @@ public class Queue_ToArray
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_TrimToSize.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_TrimToSize.cs
@@ -338,7 +338,7 @@ public class Queue_TrimToSize
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor.cs
@@ -70,7 +70,7 @@ public class Queue_ctor
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor_int.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor_int.cs
@@ -103,6 +103,6 @@ public class Queue_ctor_int
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor_int_float.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor_int_float.cs
@@ -92,7 +92,7 @@ public class Queue_ctor_int_float
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_get_Count.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_get_Count.cs
@@ -76,6 +76,6 @@ public class Queue_get_Count
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_get_SyncRoot.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_get_SyncRoot.cs
@@ -138,7 +138,7 @@ public class Queue_get_SyncRoot
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 }

--- a/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBase/ReadOnlyCollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBase/ReadOnlyCollectionBaseTests.cs
@@ -323,7 +323,7 @@ public class ReadOnlyCollectionBaseTests
             bResult = false;
             Console.WriteLine("FAiL! Error Err_9999zzz! Uncaught Exception in main(), exc_main==" + exc_main);
         }
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_Clone.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_Clone.cs
@@ -145,7 +145,7 @@ public class Stack_Clone
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_ToArray.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_ToArray.cs
@@ -92,7 +92,7 @@ public class Stack_ToArray
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 }
 

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_get_SyncRoot.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_get_SyncRoot.cs
@@ -157,7 +157,7 @@ public class Stack_get_SyncRoot
             Console.WriteLine("Fail! Error Err_main! Uncaught Exception in main(), exc_main==" + exc_main);
         }
 
-        Assert.Equal(true, bResult);
+        Assert.True(bResult);
     }
 
 }

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -57,8 +57,8 @@ namespace System.IO.FileSystem.Tests
                 // Ensure that the file was re-created
                 Assert.Equal(0L, fs.Length);
                 Assert.Equal(0L, fs.Position);
-                Assert.Equal(true, fs.CanRead);
-                Assert.Equal(true, fs.CanWrite);
+                Assert.True(fs.CanRead);
+                Assert.True(fs.CanWrite);
             }
         }
 
@@ -76,8 +76,8 @@ namespace System.IO.FileSystem.Tests
             using (FileStream fs = new FileStream(fileName, FileMode.CreateNew))
             {
                 fs.WriteByte(0);
-                Assert.Equal(true, fs.CanRead);
-                Assert.Equal(true, fs.CanWrite);
+                Assert.True(fs.CanRead);
+                Assert.True(fs.CanWrite);
             }
 
             Assert.Throws<IOException>(() => new FileStream(fileName, FileMode.CreateNew));
@@ -105,8 +105,8 @@ namespace System.IO.FileSystem.Tests
                 // Ensure that the file was re-opened
                 Assert.Equal(1L, fs.Length);
                 Assert.Equal(0L, fs.Position);
-                Assert.Equal(true, fs.CanRead);
-                Assert.Equal(true, fs.CanWrite);
+                Assert.True(fs.CanRead);
+                Assert.True(fs.CanWrite);
             }
         }
 
@@ -131,8 +131,8 @@ namespace System.IO.FileSystem.Tests
                 // Ensure that the file was re-opened
                 Assert.Equal(1L, fs.Length);
                 Assert.Equal(0L, fs.Position);
-                Assert.Equal(true, fs.CanRead);
-                Assert.Equal(true, fs.CanWrite);
+                Assert.True(fs.CanRead);
+                Assert.True(fs.CanWrite);
             }
         }
 
@@ -158,8 +158,8 @@ namespace System.IO.FileSystem.Tests
                 // Ensure that the file was re-opened and truncated
                 Assert.Equal(0L, fs.Length);
                 Assert.Equal(0L, fs.Position);
-                Assert.Equal(true, fs.CanRead);
-                Assert.Equal(true, fs.CanWrite);
+                Assert.True(fs.CanRead);
+                Assert.True(fs.CanWrite);
             }
         }
 
@@ -184,9 +184,9 @@ namespace System.IO.FileSystem.Tests
                 // Ensure that the file was re-opened and position set to end
                 Assert.Equal(1L, fs.Length);
                 Assert.Equal(1L, fs.Position);
-                Assert.Equal(false, fs.CanRead);
-                Assert.Equal(true, fs.CanSeek);
-                Assert.Equal(true, fs.CanWrite);
+                Assert.False(fs.CanRead);
+                Assert.True(fs.CanSeek);
+                Assert.True(fs.CanWrite);
                 Assert.Throws<IOException>(() => fs.Seek(-1, SeekOrigin.Current));
                 Assert.Throws<NotSupportedException>(() => fs.ReadByte());
             }

--- a/src/System.Reflection.Metadata/tests/Utilities/BlobReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/BlobReaderTests.cs
@@ -37,112 +37,112 @@ namespace System.Reflection.Metadata.Tests
             {
                 var reader = new BlobReader(new MemoryBlock(bufferPtr, buffer.Length));
 
-                Assert.Equal(false, reader.SeekOffset(-1));
-                Assert.Equal(false, reader.SeekOffset(Int32.MaxValue));
-                Assert.Equal(false, reader.SeekOffset(Int32.MinValue));
-                Assert.Equal(false, reader.SeekOffset(buffer.Length));
-                Assert.Equal(true, reader.SeekOffset(buffer.Length - 1));
+                Assert.False(reader.SeekOffset(-1));
+                Assert.False(reader.SeekOffset(Int32.MaxValue));
+                Assert.False(reader.SeekOffset(Int32.MinValue));
+                Assert.False(reader.SeekOffset(buffer.Length));
+                Assert.True(reader.SeekOffset(buffer.Length - 1));
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Equal(0, reader.Offset);
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUInt64());
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(1));
+                Assert.True(reader.SeekOffset(1));
                 Assert.Equal(1, reader.Offset);
                 Assert.Throws<BadImageFormatException>(() => reader.ReadDouble());
                 Assert.Equal(1, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(2));
+                Assert.True(reader.SeekOffset(2));
                 Assert.Equal(2, reader.Offset);
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUInt32());
                 Assert.Equal((ushort)0x0200, reader.ReadUInt16());
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(2));
+                Assert.True(reader.SeekOffset(2));
                 Assert.Equal(2, reader.Offset);
                 Assert.Throws<BadImageFormatException>(() => reader.ReadSingle());
                 Assert.Equal(2, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Equal(9.404242E-38F, reader.ReadSingle());
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(3));
+                Assert.True(reader.SeekOffset(3));
                 Assert.Equal(3, reader.Offset);
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUInt16());
                 Assert.Equal((byte)0x02, reader.ReadByte());
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Equal("\u0000\u0001\u0000\u0002", reader.ReadUTF8(4));
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUTF8(5));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUTF8(-1));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Equal("\u0100\u0200", reader.ReadUTF16(4));
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUTF16(5));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUTF16(-1));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadUTF16(6));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 AssertEx.Equal(buffer, reader.ReadBytes(4));
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Same(String.Empty, reader.ReadUtf8NullTerminated());
                 Assert.Equal(1, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(1));
+                Assert.True(reader.SeekOffset(1));
                 Assert.Equal("\u0001", reader.ReadUtf8NullTerminated());
                 Assert.Equal(3, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(3));
+                Assert.True(reader.SeekOffset(3));
                 Assert.Equal("\u0002", reader.ReadUtf8NullTerminated());
                 Assert.Equal(4, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Same(String.Empty, reader.ReadUtf8NullTerminated());
                 Assert.Equal(1, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadBytes(5));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.ReadBytes(Int32.MinValue));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.GetMemoryBlockAt(-1, 1));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Throws<BadImageFormatException>(() => reader.GetMemoryBlockAt(1, -1));
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(0));
+                Assert.True(reader.SeekOffset(0));
                 Assert.Equal(3, reader.GetMemoryBlockAt(1, 3).Length);
                 Assert.Equal(0, reader.Offset);
 
-                Assert.Equal(true, reader.SeekOffset(3));
+                Assert.True(reader.SeekOffset(3));
                 reader.ReadByte();
                 Assert.Equal(4, reader.Offset);
 
@@ -151,7 +151,7 @@ namespace System.Reflection.Metadata.Tests
 
                 Assert.Equal(4, reader.Offset);
                 int value;
-                Assert.Equal(false, reader.TryReadCompressedInteger(out value));
+                Assert.False(reader.TryReadCompressedInteger(out value));
                 Assert.Equal(BlobReader.InvalidCompressedInteger, value);
 
                 Assert.Equal(4, reader.Offset);


### PR DESCRIPTION
Search and replace across all tests :
  Assert.Equal(true, x); => Assert.True(x);
  Assert.Equal(false, x); => Assert.False(x);

Changed files:
  System.Collections.NonGeneric.Tests.dll
  System.IO.FileSystem.Tests.dll
  System.Reflection.Metadata.Tests.dll