### PR TITLE
Add ImmutableInterlocked.ApplyChange method and tests.

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -54,6 +54,50 @@ namespace System.Collections.Immutable
             return true;
         }
 
+        /// <summary>
+        /// Mutates a value in-place with optimistic locking transaction semantics
+        /// via a specified transformation function.
+        /// The transformation is retried as many times as necessary to win the optimistic locking race.
+        /// </summary>
+        /// <typeparam name="T">The type of data.</typeparam>
+        /// <typeparam name="TArg">The type of argument passed to the <paramref name="transformer"/>.</typeparam>
+        /// <param name="location">
+        /// The variable or field to be changed, which may be accessed by multiple threads.
+        /// </param>
+        /// <param name="transformer">
+        /// A function that mutates the value. This function should be side-effect free, 
+        /// as it may run multiple times when races occur with other threads.</param>
+        /// <param name="transformerArgument">The argument to pass to <paramref name="transformer"/>.</param>
+        /// <returns>
+        /// <c>true</c> if the location's value is changed by applying the result of the 
+        /// <paramref name="transformer"/> function;
+        /// <c>false</c> if the location's value remained the same because the last 
+        /// invocation of <paramref name="transformer"/> returned the existing value.
+        /// </returns>
+        public static bool ApplyChange<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument) where T : class
+        {
+            Requires.NotNull(transformer, "applyChange");
+
+            bool successful;
+            T oldValue = Volatile.Read(ref location);
+            do
+            {
+                T newValue = transformer(oldValue, transformerArgument);
+                if (ReferenceEquals(oldValue, newValue))
+                {
+                    // No change was actually required.
+                    return false;
+                }
+
+                T interlockedResult = Interlocked.CompareExchange(ref location, newValue, oldValue);
+                successful = ReferenceEquals(oldValue, interlockedResult);
+                oldValue = interlockedResult; // we already have a volatile read that we can reuse for the next loop
+            }
+            while (!successful);
+
+            return true;
+        }
+
         #region ImmutableArray<T> members
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -32,7 +32,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public static bool ApplyChange<T>(ref T location, Func<T, T> transformer) where T : class
         {
-            Requires.NotNull(transformer, "applyChange");
+            Requires.NotNull(transformer, "transformer");
 
             bool successful;
             T oldValue = Volatile.Read(ref location);
@@ -76,7 +76,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public static bool ApplyChange<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument) where T : class
         {
-            Requires.NotNull(transformer, "applyChange");
+            Requires.NotNull(transformer, "transformer");
 
             bool successful;
             T oldValue = Volatile.Read(ref location);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -30,7 +30,7 @@ namespace System.Collections.Immutable
         /// <c>false</c> if the location's value remained the same because the last 
         /// invocation of <paramref name="transformer"/> returned the existing value.
         /// </returns>
-        public static bool ApplyChange<T>(ref T location, Func<T, T> transformer) where T : class
+        public static bool Update<T>(ref T location, Func<T, T> transformer) where T : class
         {
             Requires.NotNull(transformer, "transformer");
 
@@ -74,7 +74,7 @@ namespace System.Collections.Immutable
         /// <c>false</c> if the location's value remained the same because the last 
         /// invocation of <paramref name="transformer"/> returned the existing value.
         /// </returns>
-        public static bool ApplyChange<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument) where T : class
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument) where T : class
         {
             Requires.NotNull(transformer, "transformer");
 

--- a/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
@@ -77,7 +77,6 @@ namespace System.Collections.Immutable.Test
         public void ApplyChange_CarefullyScheduled()
         {
             var set = ImmutableHashSet.Create<int>();
-            var task1TransformEntered = new AutoResetEvent(false);
             var task2TransformEntered = new AutoResetEvent(false);
             var task1TransformExited = new AutoResetEvent(false);
 
@@ -89,7 +88,6 @@ namespace System.Collections.Immutable.Test
                     s =>
                     {
                         Assert.Equal(1, ++transform1ExecutionCounter);
-                        task1TransformEntered.Set();
                         task2TransformEntered.WaitOne();
                         return s.Add(1);
                     });

--- a/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableInterlockedTests.cs
@@ -50,14 +50,13 @@ namespace System.Collections.Immutable.Test
             int concurrencyLevel = Environment.ProcessorCount;
             int iterations = 500;
             Task[] tasks = new Task[concurrencyLevel];
-            var countdown = new CountdownEvent(tasks.Length);
+            var barrier = new Barrier(tasks.Length);
             for (int i = 0; i < tasks.Length; i++)
             {
                 tasks[i] = Task.Run(delegate
                 {
                     // Maximize concurrency by blocking this thread until all the other threads are ready to go as well.
-                    countdown.Signal();
-                    countdown.Wait();
+                    barrier.SignalAndWait();
 
                     for (int j = 0; j < iterations; j++)
                     {


### PR DESCRIPTION
Interlocked.CompareExchange leaves quite a bit of insight into the runtime and threading requirements to the programmer when it comes to lock-free mutations of immutable collections.
The ImmutableInterlocked.ApplyChange method makes such lock-free mutations trivial:

This fixes #318 

----
**Updates**

The following naming proposals exist so far:

```CSharp
ImmutableInterlocked.ApplyChange(ref _list, list => list.Add(2));
```
```CSharp
ImmutableInterlocked.AssignValue(ref _list, list => list.Add(2));
```
```CSharp
ImmutableInterlocked.Update(ref _list, list => list.Add(2));
```