### PR TITLE
Add some useful information on the console output from build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -25,8 +25,16 @@ set _buildprefix=
 set _buildpostfix=
 call :build %*
 
-goto :eof
+goto :AfterBuild
 
 :build
 %_buildprefix% %_msbuildexe% "%~dp0build.proj" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log";Append %* %_buildpostfix%
 goto :eof
+
+:AfterBuild
+
+echo.
+:: Pull the build summary from the log file
+findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" %~dp0msbuild.log
+
+endlocal

--- a/build.proj
+++ b/build.proj
@@ -28,6 +28,7 @@
     Inputs="$(BuildToolsTargetInputs)"
     Outputs="$(BuildToolsTargetOutputs)"
     >
+    <Message Importance="High" Text="Restoring build tools..." />
 
     <!-- Download latest nuget.exe -->
     <DownloadFile

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -18,7 +18,10 @@
   </ItemGroup>
   
   <Import Project="$(ToolsDir)depending.targets" Condition="Exists('$(ToolsDir)depending.targets')" />
-  <Target Name="RestoreAllPackages" DependsOnTargets="EnsureDependencies" />
+  <Target Name="RestoreAllPackages">
+    <Message Importance="High" Text="Restoring all package dependencies..." />
+    <CallTarget Targets="EnsureDependencies" />
+  </Target>
 
   <ItemGroup>
     <Project Include="*\src\*.csproj" />
@@ -47,7 +50,7 @@
 
   <Import Project="$(ToolsDir)tests.targets" Condition="Exists('$(ToolsDir)tests.targets')" />
   <Target Name="RunDirTests" DependsOnTargets="RunTests">
-    <Error Text="One or more tests failed" Condition="'@(XUnitExitCodes)' != '' and '%(XUnitExitCodes.Identity)' != '0'" />
+    <Error Text="One or more tests failed. See the log file for more details." Condition="'@(XUnitExitCodes)' != '' and '%(XUnitExitCodes.Identity)' != '0'" />
   </Target>
   <PropertyGroup Condition="Exists('$(ToolsDir)tests.targets')">
     <TraversalBuildDependsOn>


### PR DESCRIPTION
This changes causes a summary like such:

   0 Warning(s)
   0 Error(s)
Time Elapsed 00:02:02.23

To be dumped to the console at the end of the build.cmd output.

It also add a few messages for when we are restoring build tools or dependencies so people know why there is a pause in the build.