### PR TITLE
Change SafeFileHandle, SafeFindHandle (Win) to use IntPtr.Zero instead of new IntPtr(0)

### DIFF
--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Win32.SafeHandles
             [System.Security.SecurityCritical]
             get
             {
-                return handle == new IntPtr(0) || handle == new IntPtr(-1);
+                return handle == IntPtr.Zero || handle == new IntPtr(-1);
             }
         }
     }

--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Win32.SafeHandles
             [System.Security.SecurityCritical]
             get
             {
-                return handle == new IntPtr(0) || handle == new IntPtr(-1);
+                return handle == IntPtr.Zero || handle == new IntPtr(-1);
             }
         }
     }


### PR DESCRIPTION
As per consistency with https://github.com/dotnet/corefx/pull/437 and https://github.com/dotnet/corefx/commit/4d22f75d9b95c0e7cc18f54d94dacf463f8c682d