### PR TITLE
[Issue #451] Quote build path for findstr as it may have spaces

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -35,6 +35,6 @@ goto :eof
 
 echo.
 :: Pull the build summary from the log file
-findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" %~dp0msbuild.log
+findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%~dp0msbuild.log"
 
 endlocal


### PR DESCRIPTION
The build path that is passed to findstr was not quoted which fails if the path has spaces in it

Issue #451 