### PR TITLE
Update solution nuget config to include all the test-runtime dependencies

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.21-prerelease" />
-  <package id="Microsoft.DotNet.TestHost" version="1.0.1-prerelease" />
+  <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
+  <package id="System.Collections" version="4.0.10-beta-22412" />
+  <package id="System.Collections.Concurrent" version="4.0.10-beta-22412" />
+  <package id="System.Console" version="4.0.0-beta-22412" />
+  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22412" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22412" />
+  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22412" />
+  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22412" />
+  <package id="System.Globalization" version="4.0.10-beta-22412" />
+  <package id="System.IO" version="4.0.10-beta-22412" />
+  <package id="System.IO.FileSystem" version="4.0.0-beta-22412" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22412" />
+  <package id="System.Linq" version="4.0.0-beta-22412" />
+  <package id="System.Reflection" version="4.0.10-beta-22412" />
+  <package id="System.Reflection.Extensions" version="4.0.0-beta-22412" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22412" />
+  <package id="System.Runtime" version="4.0.20-beta-22412" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22412" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22412" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22412" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22412" />
+  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22412" />
+  <package id="System.Threading" version="4.0.0-beta-22412" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22412" />
+  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
+  <package id="System.Xml.XDocument" version="4.0.0-beta-22412" />
+  <package id="xunit.console.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.runner.dependencies.netcore" version="1.0.0-prerelease" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>


### PR DESCRIPTION
This is a temporary workaround to fix the build issues of building projects
from within VS. All the test projects will not successfully build in VS from
a clean clone because the test-runtine dependencies are missing and not restored.

I'm working on another solution to make these consistent but that is much more involved so this is just to unblock the current solutions.