### PR TITLE
Re-enable PLINQ tests

### DIFF
--- a/src/System.Linq.Parallel/tests/AssemblyInfo.cs
+++ b/src/System.Linq.Parallel/tests/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+// Tests could run slower if PLINQ itself is run in parallel, especially as concurrent
+// queries compete for thread pool resources
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("System.Linq.Parallel.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("System.Linq.Parallel.Tests")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/src/System.Linq.Parallel/tests/ExchangeTests.cs
+++ b/src/System.Linq.Parallel/tests/ExchangeTests.cs
@@ -107,6 +107,7 @@ namespace Test
         }
 
         [Fact]
+        [OuterLoop]
         public static void PartitioningTest_LongRunning()
         {
             PartitioningTestCore(true, 2, 0, 900);

--- a/src/System.Linq.Parallel/tests/PlinqDelegateExceptions.cs
+++ b/src/System.Linq.Parallel/tests/PlinqDelegateExceptions.cs
@@ -67,6 +67,7 @@ namespace Test
         }
 
         [Fact]
+        [OuterLoop]
         public static void OrderBy()
         {
             // the orderby was a particular problem for the June 2008 CTP.
@@ -104,7 +105,9 @@ namespace Test
                 Assert.NotNull(caughtAggregateException);
             }
         }
+
         [Fact]
+        [OuterLoop]
         public static void OrderBy_OnlyOneException()
         {
             // and try situations where only one user delegate exception occurs
@@ -150,6 +153,7 @@ namespace Test
         }
 
         [Fact]
+        [OuterLoop]
         public static void ZipAndOrdering()
         {
             // zip and ordering was also broken in June 2008 CTP, but this was due to the ordering component.

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <Compile Include="AggregateTests.cs" />
     <Compile Include="AllAnyTests.cs" />
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AverageMaxMinTests.cs" />
     <Compile Include="CastOfTypeTests.cs" />
     <Compile Include="ContainsTests.cs" />

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -309,7 +309,7 @@ namespace Test
                 .Select(x => x);
             var enumerator1 = query1.GetEnumerator();
             enumerator1.MoveNext();
-            Task.Delay(1000);
+            Task.Delay(1000).Wait();
             //Thread.Sleep(1000); // give the pipelining time to fill up some buffers.
             enumerator1.MoveNext();
             enumerator1.Dispose(); //can potentially hang
@@ -410,7 +410,7 @@ namespace Test
 
             var q = src.AsParallel().WithCancellation(tokenSrc.Token).Where(x => false).TakeWhile(x => true);
 
-            Task task = Task.Factory.StartNew(
+            Task task = Task.Run(
                 () =>
                 {
                     try
@@ -432,7 +432,7 @@ namespace Test
             // We wait for 100 ms. If we canceled the token source immediately, the cancellation
             // would occur at the query opening time. The goal of this test is to test cancellation
             // at query execution time.
-            Task.Delay(100);
+            Task.Delay(100).Wait();
             //Thread.Sleep(100);
 
             tokenSrc.Cancel();
@@ -445,7 +445,7 @@ namespace Test
             IEnumerable<int> src = Enumerable.Repeat(0, int.MaxValue);
             CancellationTokenSource tokenSrc = new CancellationTokenSource();
 
-            Task task = Task.Factory.StartNew(
+            Task task = Task.Run(
                 () =>
                 {
                     try
@@ -468,7 +468,7 @@ namespace Test
             // We wait for 100 ms. If we canceled the token source immediately, the cancellation
             // would occur at the query opening time. The goal of this test is to test cancellation
             // at query execution time.
-            Task.WaitAll(Task.Delay(100));
+            Task.Delay(100).Wait();
             //Thread.Sleep(100);
 
             tokenSrc.Cancel();
@@ -481,7 +481,7 @@ namespace Test
             IEnumerable<int> src = Enumerable.Repeat(0, int.MaxValue);
             CancellationTokenSource tokenSrc = new CancellationTokenSource();
 
-            Task task = Task.Factory.StartNew(
+            Task task = Task.Run(
                 () =>
                 {
                     try
@@ -505,7 +505,7 @@ namespace Test
             // We wait for 100 ms. If we canceled the token source immediately, the cancellation
             // would occur at the query opening time. The goal of this test is to test cancellation
             // at query execution time.
-            Task.Delay(100);
+            Task.Delay(100).Wait();
             //Thread.Sleep(100);
 
             tokenSrc.Cancel();
@@ -545,7 +545,7 @@ namespace Test
 
                 var walker = plinq.GetEnumerator();
 
-                t = Task.Factory.StartNew(() =>
+                t = Task.Run(() =>
                 {
                     mre.WaitOne();
                     cs.Cancel();

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -44,7 +44,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <DisabledTestAssembly Include="System.Linq.Parallel.Tests" />
     <SkipTestAssemblies Include="@(DisabledTestAssembly->'$(TestWorkingDir)**\%(Identity).dll')" />
   </ItemGroup>
 


### PR DESCRIPTION
The PLINQ tests are currently disabled.  This PR turns them back on, alleviating the deadlocks that had caused them to be disabled initially.  I also addressed a few other things, including some waits that weren't working correctly and some tests that should be OuterLoop due to their demands on the thread pool.

On my machine, the tests as they are after the PR do take ~15 seconds to run as part of the build.  I think that's completely reasonable for a set of tests for such a library, but if we're uncomfortable with that we can aim to bring it down further separately.  For now, I just want to make sure there's at least some coverage in builds and CI.