### PR TITLE
Fix build exit code

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -29,6 +29,7 @@ goto :AfterBuild
 
 :build
 %_buildprefix% %_msbuildexe% "%~dp0build.proj" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log";Append %* %_buildpostfix%
+set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 
 :AfterBuild
@@ -36,5 +37,6 @@ goto :eof
 echo.
 :: Pull the build summary from the log file
 findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%~dp0msbuild.log"
+echo Build Exit Code = %BUILDERRORLEVEL%
 
-endlocal
+exit /b %BUILDERRORLEVEL%


### PR DESCRIPTION
This will hopefully capture the build exit code and set the exit code for the build.cmd so the CI system correctly fails on failed builds.

With this PR I also submitted a commit that contains a compile error to verify the CI system. Once I see it fail I will squash that commit out and retest and then merge once that works.