### PR TITLE
Run tests after building the test projects

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -49,7 +49,6 @@
   
   <PropertyGroup>
     <IsTestProject Condition="'$(IsTestProject)'=='' And $([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">True</IsTestProject>
-    <IsTestProject Condition="'$(IsTestProject)'=='' And !$([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">False</IsTestProject>
     <RunTestsForProject Condition="'$(RunTestsForProject)'=='' and '$(IsTestProject)'=='True'">True</RunTestsForProject>
   </PropertyGroup>
 
@@ -75,9 +74,12 @@
       <XunitOptions Condition="'@(ExcludeTraitsItems)'!=''">$(XunitOptions) -notrait @(ExcludeTraitsItems, ' -notrait ')</XunitOptions>
     </PropertyGroup>
 
-    <Exec
-      Command="$(XunitCommandLine) $(XunitOptions)"
-      WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)" />
+    <Exec Command="$(XunitCommandLine) $(XunitOptions)"
+          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          ContinueOnError="True">
+      <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
+    </Exec>
 
+    <Error Condition="'$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
   </Target>
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -46,5 +46,38 @@
   <Import Project="$(ToolsDir)sign.targets" Condition="Exists('$(ToolsDir)sign.targets')" />
   
   <Import Project="$(ToolsDir)publishtest.targets" Condition="Exists('$(ToolsDir)publishtest.targets')" />
+  
+  <PropertyGroup>
+    <IsTestProject Condition="'$(IsTestProject)'=='' And $([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">True</IsTestProject>
+    <IsTestProject Condition="'$(IsTestProject)'=='' And !$([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">False</IsTestProject>
+    <RunTestsForProject Condition="'$(RunTestsForProject)'=='' and '$(IsTestProject)'=='True'">True</RunTestsForProject>
+  </PropertyGroup>
 
+  <Target Name="RunTestsForProject"
+          AfterTargets="PrepareForRun"
+          Condition="'$(RunTestsForProject)'=='True'">
+
+    <!-- xUnit Traits -->
+    <PropertyGroup>
+      <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
+    </PropertyGroup>
+    <ItemGroup>
+      <IncludeTraitsItems Include="$(IncludeTraits)" />
+      <ExcludeTraitsItems Include="$(ExcludeTraits)" />
+    </ItemGroup>
+    
+    <!-- Construct and invoke xunit console runner via corerun.exe -->
+    <PropertyGroup>
+      <XunitCommandLine>corerun.exe xunit.console.netcore.exe</XunitCommandLine>
+      
+      <XunitOptions>$(XunitOptions) $(TargetFileName)</XunitOptions>
+      <XunitOptions Condition="'@(IncludeTraitsItems)'!=''">$(XunitOptions) -trait @(IncludeTraitsItems, ' -trait ')</XunitOptions>
+      <XunitOptions Condition="'@(ExcludeTraitsItems)'!=''">$(XunitOptions) -notrait @(ExcludeTraitsItems, ' -notrait ')</XunitOptions>
+    </PropertyGroup>
+
+    <Exec
+      Command="$(XunitCommandLine) $(XunitOptions)"
+      WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)" />
+
+  </Target>
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -50,6 +50,7 @@
   <PropertyGroup>
     <IsTestProject Condition="'$(IsTestProject)'=='' And $([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">True</IsTestProject>
     <RunTestsForProject Condition="'$(RunTestsForProject)'=='' and '$(IsTestProject)'=='True'">True</RunTestsForProject>
+    <RunTestsForProject Condition="'$(SkipTests)'=='True'">False</RunTestsForProject>
   </PropertyGroup>
 
   <Target Name="RunTestsForProject"

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -43,20 +43,4 @@
     </TraversalBuildDependsOn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- <DisabledTestAssembly Include="TestAssemblyName" /> -->
-    <SkipTestAssemblies Include="@(DisabledTestAssembly->'$(TestWorkingDir)**\%(Identity).dll')" />
-  </ItemGroup>
-
-  <Import Project="$(ToolsDir)tests.targets" Condition="Exists('$(ToolsDir)tests.targets')" />
-  <Target Name="RunDirTests" DependsOnTargets="RunTests">
-    <Error Text="One or more tests failed. See the log file for more details." Condition="'@(XUnitExitCodes)' != '' and '%(XUnitExitCodes.Identity)' != '0'" />
-  </Target>
-  <PropertyGroup Condition="Exists('$(ToolsDir)tests.targets')">
-    <TraversalBuildDependsOn>
-      $(TraversalBuildDependsOn);
-      RunDirTests;
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
This change switches the running of the tests to happen as a post build step for the individual test project itself as opposed to an all up run of all of them together. This enables people to build an individual solution in isolation and have it also run the tests for that solution as part of the build. 

It also enables the tests to run in parallel because they are chained to the msbuild process that builds the project and so we get some speed up while running all projects. It does have the side effect of mixing up the log output in some cases as well but that can happen with build failures as well. You can however rebuild an individual test project now to repro which is nice.

This still supports SkipTests=True from the root to disable the running of all the tests if necessary. It also now allows you to disable tests for an individual project by setting <RunTestsForProject>False</RunTestsForProject> in an individual test project to disable the entire test project. 