### PR TITLE
Guard _processInfo access with EnsureState checks

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -314,6 +314,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._poolNonpagedBytes;
             }
         }
@@ -323,6 +324,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._pageFileBytes;
             }
         }
@@ -332,6 +334,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._poolPagedBytes;
             }
         }
@@ -341,6 +344,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._pageFileBytesPeak;
             }
         }
@@ -350,6 +354,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._workingSetPeak;
             }
         }
@@ -359,6 +364,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._virtualBytesPeak;
             }
         }
@@ -424,6 +430,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._privateBytes;
             }
         }
@@ -472,6 +479,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._sessionId;
             }
         }
@@ -533,6 +541,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._virtualBytes;
             }
         }
@@ -643,6 +652,7 @@ namespace System.Diagnostics
         {
             get
             {
+                EnsureState(State.HaveProcessInfo);
                 return _processInfo._workingSet;
             }
         }


### PR DESCRIPTION
In introducing a PAL layer into System.Diagnostics.Process, I removed some EnsureState(State.HaveNtProcessInfo) calls, because EnsureState wasn't checking for HaveNtProcessInfo and it appeared platform specific.  However, HaveNtProcessInfo was a bit flag that or'd HaveProcessInfo and IsNt, and while IsNt was defunct, HaveProcessInfo was not.  This commit puts back guards for EnsureState(State.HaveProcessInfo) prior to any usage of _processInfo, ensuring that it's appropriately initialized.

Closes #478.