### PR TITLE
Explicitly marked XDocument private methods with "private" keyword

### DIFF
--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XAttribute.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XAttribute.cs
@@ -670,7 +670,7 @@ namespace System.Xml.Linq
             return null;
         }
 
-        static void ValidateAttribute(XName name, string value)
+        private static void ValidateAttribute(XName name, string value)
         {
             // The following constraints apply for namespace declarations:
             string namespaceName = name.NamespaceName;

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
@@ -653,7 +653,7 @@ namespace System.Xml.Linq
             }
         }
 
-        string GetTextOnly()
+        private string GetTextOnly()
         {
             if (content == null) return null;
             string s = content as string;
@@ -670,7 +670,7 @@ namespace System.Xml.Linq
             return s;
         }
 
-        string CollectText(ref XNode n)
+        private string CollectText(ref XNode n)
         {
             string s = "";
             while (n != null && n.NodeType == XmlNodeType.Text)
@@ -789,7 +789,7 @@ namespace System.Xml.Linq
             }
         }
 
-        IEnumerable<XElement> GetElements(XName name)
+        private IEnumerable<XElement> GetElements(XName name)
         {
             XNode n = content as XNode;
             if (n != null)
@@ -1059,7 +1059,7 @@ namespace System.Xml.Linq
             if (notify) NotifyChanged(n, XObjectChangeEventArgs.Remove);
         }
 
-        void RemoveNodesSkipNotify()
+        private void RemoveNodesSkipNotify()
         {
             XNode n = content as XNode;
             if (n != null)
@@ -1113,7 +1113,7 @@ namespace System.Xml.Linq
             }
         }
 
-        static void AddContentToList(List<object> list, object content)
+        private static void AddContentToList(List<object> list, object content)
         {
             IEnumerable e = content is string ? null : content as IEnumerable;
             if (e == null)

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XDocument.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XDocument.cs
@@ -583,7 +583,7 @@ namespace System.Xml.Linq
             return ContentsHashCode();
         }
 
-        T GetFirstNode<T>() where T : XNode
+        private T GetFirstNode<T>() where T : XNode
         {
             XNode n = content as XNode;
             if (n != null)
@@ -627,7 +627,7 @@ namespace System.Xml.Linq
             }
         }
 
-        void ValidateDocument(XNode previous, XmlNodeType allowBefore, XmlNodeType allowAfter)
+        private void ValidateDocument(XNode previous, XmlNodeType allowBefore, XmlNodeType allowAfter)
         {
             XNode n = content as XNode;
             if (n != null)

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
@@ -1622,7 +1622,7 @@ namespace System.Xml.Linq
             lastAttr = a;
         }
 
-        bool AttributesEqual(XElement e)
+        private bool AttributesEqual(XElement e)
         {
             XAttribute a1 = lastAttr;
             XAttribute a2 = e.lastAttr;
@@ -1650,7 +1650,7 @@ namespace System.Xml.Linq
             return e != null && name == e.name && ContentsEqual(e) && AttributesEqual(e);
         }
 
-        IEnumerable<XAttribute> GetAttributes(XName name)
+        private IEnumerable<XAttribute> GetAttributes(XName name)
         {
             XAttribute a = lastAttr;
             if (a != null)
@@ -1663,7 +1663,7 @@ namespace System.Xml.Linq
             }
         }
 
-        string GetNamespaceOfPrefixInScope(string prefix, XElement outOfScope)
+        private string GetNamespaceOfPrefixInScope(string prefix, XElement outOfScope)
         {
             XElement e = this;
             while (e != outOfScope)
@@ -1699,7 +1699,7 @@ namespace System.Xml.Linq
             return h;
         }
 
-        void ReadElementFrom(XmlReader r, LoadOptions o)
+        private void ReadElementFrom(XmlReader r, LoadOptions o)
         {
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
             name = XNamespace.Get(r.NamespaceURI).GetName(r.LocalName);
@@ -1761,7 +1761,7 @@ namespace System.Xml.Linq
             if (notify) NotifyChanged(a, XObjectChangeEventArgs.Remove);
         }
 
-        void RemoveAttributesSkipNotify()
+        private void RemoveAttributesSkipNotify()
         {
             if (lastAttr != null)
             {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
@@ -72,7 +72,7 @@ namespace System.Xml.Linq
             }
         }
 
-        void AddContent(object content)
+        private void AddContent(object content)
         {
             if (content == null) return;
             XNode n = content as XNode;
@@ -109,7 +109,7 @@ namespace System.Xml.Linq
             AddString(XContainer.GetStringValue(content));
         }
 
-        void AddNode(XNode n)
+        private void AddNode(XNode n)
         {
             _parent.ValidateNode(n, _previous);
             if (n.parent != null)
@@ -142,14 +142,14 @@ namespace System.Xml.Linq
             InsertNode(n);
         }
 
-        void AddString(string s)
+        private void AddString(string s)
         {
             _parent.ValidateString(s);
             _text += s;
         }
 
         // Prepends if previous == null, otherwise inserts after previous
-        void InsertNode(XNode n)
+        private void InsertNode(XNode n)
         {
             bool notify = _parent.NotifyChanging(n, XObjectChangeEventArgs.Add);
             if (n.parent != null) throw new InvalidOperationException(SR.InvalidOperation_ExternalCode);
@@ -245,7 +245,7 @@ namespace System.Xml.Linq
             }
         }
 
-        string GetPrefixOfNamespace(XNamespace ns, bool allowDefaultNamespace)
+        private string GetPrefixOfNamespace(XNamespace ns, bool allowDefaultNamespace)
         {
             string namespaceName = ns.NamespaceName;
             if (namespaceName.Length == 0) return string.Empty;
@@ -256,7 +256,7 @@ namespace System.Xml.Linq
             return null;
         }
 
-        void PushAncestors(XElement e)
+        private void PushAncestors(XElement e)
         {
             while (true)
             {
@@ -277,7 +277,7 @@ namespace System.Xml.Linq
             }
         }
 
-        void PushElement(XElement e)
+        private void PushElement(XElement e)
         {
             _resolver.PushScope();
             XAttribute a = e.lastAttr;
@@ -294,19 +294,19 @@ namespace System.Xml.Linq
             }
         }
 
-        void WriteEndElement()
+        private void WriteEndElement()
         {
             _writer.WriteEndElement();
             _resolver.PopScope();
         }
 
-        void WriteFullEndElement()
+        private void WriteFullEndElement()
         {
             _writer.WriteFullEndElement();
             _resolver.PopScope();
         }
 
-        void WriteStartElement(XElement e)
+        private void WriteStartElement(XElement e)
         {
             PushElement(e);
             XNamespace ns = e.Name.Namespace;
@@ -457,7 +457,7 @@ namespace System.Xml.Linq
             _resolver = new NamespaceResolver();
         }
 
-        void FlushElement()
+        private void FlushElement()
         {
             if (_element != null)
             {
@@ -476,7 +476,7 @@ namespace System.Xml.Linq
             }
         }
 
-        string GetPrefixOfNamespace(XNamespace ns, bool allowDefaultNamespace)
+        private string GetPrefixOfNamespace(XNamespace ns, bool allowDefaultNamespace)
         {
             string namespaceName = ns.NamespaceName;
             if (namespaceName.Length == 0) return string.Empty;
@@ -487,7 +487,7 @@ namespace System.Xml.Linq
             return null;
         }
 
-        void PushElement()
+        private void PushElement()
         {
             _resolver.PushScope();
             foreach (XAttribute a in _attributes)
@@ -499,7 +499,7 @@ namespace System.Xml.Linq
             }
         }
 
-        void Write(object content)
+        private void Write(object content)
         {
             if (content == null) return;
             XNode n = content as XNode;
@@ -541,13 +541,13 @@ namespace System.Xml.Linq
             WriteString(XContainer.GetStringValue(content));
         }
 
-        void WriteAttribute(XAttribute a)
+        private void WriteAttribute(XAttribute a)
         {
             if (_element == null) throw new InvalidOperationException(SR.InvalidOperation_WriteAttribute);
             _attributes.Add(a);
         }
 
-        void WriteNode(XNode n)
+        private void WriteNode(XNode n)
         {
             FlushElement();
             n.WriteTo(_writer);
@@ -571,7 +571,7 @@ namespace System.Xml.Linq
             _resolver.PopScope();
         }
 
-        void WriteString(string s)
+        private void WriteString(string s)
         {
             FlushElement();
             _writer.WriteString(s);

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
@@ -568,7 +568,7 @@ namespace System.Xml.Linq
             }
         }
 
-        IEnumerable<XElement> GetElementsAfterSelf(XName name)
+        private IEnumerable<XElement> GetElementsAfterSelf(XName name)
         {
             XNode n = this;
             while (n.parent != null && n != n.parent.content)
@@ -579,7 +579,7 @@ namespace System.Xml.Linq
             }
         }
 
-        IEnumerable<XElement> GetElementsBeforeSelf(XName name)
+        private IEnumerable<XElement> GetElementsBeforeSelf(XName name)
         {
             if (parent != null)
             {
@@ -620,7 +620,7 @@ namespace System.Xml.Linq
             return ws;
         }
 
-        string GetXmlString(SaveOptions o)
+        private string GetXmlString(SaveOptions o)
         {
             using (StringWriter sw = new StringWriter(CultureInfo.InvariantCulture))
             {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeBuilder.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeBuilder.cs
@@ -204,7 +204,7 @@ namespace System.Xml.Linq
             AddString(ws);
         }
 
-        void Add(object o)
+        private void Add(object o)
         {
             if (_content == null)
             {
@@ -213,7 +213,7 @@ namespace System.Xml.Linq
             _content.Add(o);
         }
 
-        void AddNode(XNode n)
+        private void AddNode(XNode n)
         {
             if (_parent != null)
             {
@@ -230,7 +230,7 @@ namespace System.Xml.Linq
             }
         }
 
-        void AddString(string s)
+        private void AddString(string s)
         {
             if (s == null)
             {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeReader.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeReader.cs
@@ -104,7 +104,7 @@ namespace System.Xml.Linq
             }
         }
 
-        static int GetDepth(XObject o)
+        private static int GetDepth(XObject o)
         {
             int depth = 0;
             while (o.parent != null)
@@ -191,7 +191,7 @@ namespace System.Xml.Linq
             get { return _nameTable.Add(GetLocalName()); }
         }
 
-        string GetLocalName()
+        private string GetLocalName()
         {
             if (!IsInteractive)
             {
@@ -238,7 +238,7 @@ namespace System.Xml.Linq
             get { return _nameTable.Add(GetNamespaceURI()); }
         }
 
-        string GetNamespaceURI()
+        private string GetNamespaceURI()
         {
             if (!IsInteractive)
             {
@@ -306,7 +306,7 @@ namespace System.Xml.Linq
             get { return _nameTable.Add(GetPrefix()); }
         }
 
-        string GetPrefix()
+        private string GetPrefix()
         {
             if (!IsInteractive)
             {
@@ -1040,18 +1040,18 @@ namespace System.Xml.Linq
             }
         }
 
-        bool IsEndElement
+        private bool IsEndElement
         {
             get { return _parent == _source; }
             set { _parent = value ? _source : null; }
         }
 
-        bool IsInteractive
+        private bool IsInteractive
         {
             get { return _state == ReadState.Interactive; }
         }
 
-        static XmlNameTable CreateNameTable()
+        private static XmlNameTable CreateNameTable()
         {
             XmlNameTable nameTable = new NameTable();
             nameTable.Add(string.Empty);
@@ -1060,7 +1060,7 @@ namespace System.Xml.Linq
             return nameTable;
         }
 
-        XElement GetElementInAttributeScope()
+        private XElement GetElementInAttributeScope()
         {
             XElement e = _source as XElement;
             if (e != null)
@@ -1084,7 +1084,7 @@ namespace System.Xml.Linq
             return null;
         }
 
-        XElement GetElementInScope()
+        private XElement GetElementInScope()
         {
             XElement e = _source as XElement;
             if (e != null)
@@ -1114,7 +1114,7 @@ namespace System.Xml.Linq
             return null;
         }
 
-        static void GetNameInAttributeScope(string qualifiedName, XElement e, out string localName, out string namespaceName)
+        private static void GetNameInAttributeScope(string qualifiedName, XElement e, out string localName, out string namespaceName)
         {
             if (!string.IsNullOrEmpty(qualifiedName))
             {
@@ -1140,7 +1140,7 @@ namespace System.Xml.Linq
             namespaceName = null;
         }
 
-        bool Read(bool skipContent)
+        private bool Read(bool skipContent)
         {
             XElement e = _source as XElement;
             if (e != null)
@@ -1164,7 +1164,7 @@ namespace System.Xml.Linq
             return ReadOverText(skipContent);
         }
 
-        bool ReadIntoDocument(XDocument d)
+        private bool ReadIntoDocument(XDocument d)
         {
             XNode n = d.content as XNode;
             if (n != null)
@@ -1185,7 +1185,7 @@ namespace System.Xml.Linq
             return ReadToEnd();
         }
 
-        bool ReadIntoElement(XElement e)
+        private bool ReadIntoElement(XElement e)
         {
             XNode n = e.content as XNode;
             if (n != null)
@@ -1211,14 +1211,14 @@ namespace System.Xml.Linq
             return ReadToEnd();
         }
 
-        bool ReadIntoAttribute(XAttribute a)
+        private bool ReadIntoAttribute(XAttribute a)
         {
             _source = a.value;
             _parent = a;
             return true;
         }
 
-        bool ReadOverAttribute(XAttribute a, bool skipContent)
+        private bool ReadOverAttribute(XAttribute a, bool skipContent)
         {
             XElement e = (XElement)a.parent;
             if (e != null)
@@ -1232,7 +1232,7 @@ namespace System.Xml.Linq
             return ReadToEnd();
         }
 
-        bool ReadOverNode(XNode n)
+        private bool ReadOverNode(XNode n)
         {
             if (n == _root)
             {
@@ -1256,7 +1256,7 @@ namespace System.Xml.Linq
             return true;
         }
 
-        bool ReadOverText(bool skipContent)
+        private bool ReadOverText(bool skipContent)
         {
             if (_parent is XElement)
             {
@@ -1275,7 +1275,7 @@ namespace System.Xml.Linq
             return ReadToEnd();
         }
 
-        bool ReadToEnd()
+        private bool ReadToEnd()
         {
             _state = ReadState.EndOfFile;
             return false;
@@ -1287,7 +1287,7 @@ namespace System.Xml.Linq
         /// </summary>
         /// <param name="candidateAttribute">The attribute to test.</param>
         /// <returns>true if the attribute is a duplicate namespace declaration attribute</returns>
-        bool IsDuplicateNamespaceAttribute(XAttribute candidateAttribute)
+        private bool IsDuplicateNamespaceAttribute(XAttribute candidateAttribute)
         {
             if (!candidateAttribute.IsNamespaceDeclaration)
             {
@@ -1298,7 +1298,7 @@ namespace System.Xml.Linq
             return IsDuplicateNamespaceAttributeInner(candidateAttribute);
         }
 
-        bool IsDuplicateNamespaceAttributeInner(XAttribute candidateAttribute)
+        private bool IsDuplicateNamespaceAttributeInner(XAttribute candidateAttribute)
         {
             // First of all - if this is an xmlns:xml declaration then it's a duplicate
             //   since xml prefix can't be redeclared and it's declared by default always.
@@ -1360,7 +1360,7 @@ namespace System.Xml.Linq
         /// </summary>
         /// <param name="candidate">The attribute to start with</param>
         /// <returns>The first attribute which is not a namespace attribute or null if the end of attributes has bean reached</returns>
-        XAttribute GetFirstNonDuplicateNamespaceAttribute(XAttribute candidate)
+        private XAttribute GetFirstNonDuplicateNamespaceAttribute(XAttribute candidate)
         {
             Debug.Assert(_omitDuplicateNamespaces, "This method should only be called if we're omitting duplicate namespace attribute." +
                                                   "For perf reason it's better to test this flag in the caller method.");

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XObject.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XObject.cs
@@ -197,7 +197,7 @@ namespace System.Xml.Linq
             return AnnotationsIterator(type);
         }
 
-        IEnumerable<object> AnnotationsIterator(Type type)
+        private IEnumerable<object> AnnotationsIterator(Type type)
         {
             if (annotations != null)
             {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XProcessingInstruction.cs
@@ -134,7 +134,7 @@ namespace System.Xml.Linq
             return target.GetHashCode() ^ data.GetHashCode();
         }
 
-        static void ValidateName(string name)
+        private static void ValidateName(string name)
         {
             XmlConvert.VerifyNCName(name);
             if (string.Equals(name, "xml", StringComparison.OrdinalIgnoreCase)) throw new ArgumentException(SR.Format(SR.Argument_InvalidPIName, name));

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XStreamingElement.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XStreamingElement.cs
@@ -194,7 +194,7 @@ namespace System.Xml.Linq
             new StreamingElementWriter(writer).WriteStreamingElement(this);
         }
 
-        string GetXmlString(SaveOptions o)
+        private string GetXmlString(SaveOptions o)
         {
             using (StringWriter sw = new StringWriter(CultureInfo.InvariantCulture))
             {


### PR DESCRIPTION
The `private` keyword was used for fields within the XDocument classes but not the method definitions. Updated for consistency.