### PR TITLE
Change some of the DriveInfo tests to pick unique file names across tests

### DIFF
--- a/src/System.IO.FileSystem.DriveInfo/tests/GetAvailableFreeSpaceTests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/GetAvailableFreeSpaceTests.cs
@@ -91,7 +91,7 @@ namespace System.IO.FileSystem.DriveInfoTests
                 if ((long)win32Values[drives[i].Name] != -1)
                 {
                     //We are not using Path.GetTempFileName bacause that will limit us to only one drive
-                    String tempFileName = "Laks_";
+                    String tempFileName = "AvailableFreeSpaceTests_";
                     int fileCount = -1;
                     while (fileCount++ < 1000 && File.Exists(drives[i].Name + tempFileName + fileCount)) ;
                     if (fileCount >= 1000)

--- a/src/System.IO.FileSystem.DriveInfo/tests/GetTotalFreeSpaceTests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/GetTotalFreeSpaceTests.cs
@@ -91,7 +91,7 @@ namespace System.IO.FileSystem.DriveInfoTests
                 //We will add a random file to these drives and see if that changes anythig - should not at all!
                 if ((long)win32Values[drives[i].Name] != -1)
                 {
-                    String tempFileName = "Laks_";
+                    String tempFileName = "TotalFreeSpaceTests_";
                     int fileCount = -1;
                     while (fileCount++ < 1000 && File.Exists(drives[i].Name + tempFileName + fileCount)) ;
                     if (fileCount >= 1000)

--- a/src/System.IO.FileSystem.DriveInfo/tests/GetTotalSizeTests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/GetTotalSizeTests.cs
@@ -85,7 +85,7 @@ namespace System.IO.FileSystem.DriveInfoTests
                 //We will add a random file to these drives and see if that changes anythig - should not at all!
                 if ((long)win32Values[drives[i].Name] != -1)
                 {
-                    String tempFileName = "Laks_";
+                    String tempFileName = "TotalSizeTests_";
                     int fileCount = -1;
                     while (fileCount++ < 1000 && File.Exists(drives[i].Name + tempFileName + fileCount)) ;
                     if (fileCount >= 1000)


### PR DESCRIPTION
Fix some DriveInfo tests that have a race condition and conflict with common file names. This seems to hit randomly on the CI server (see http://corefx-ci.cloudapp.net/jenkins/job/dotnet_corefx/84/Configuration=Release,OS=Windows_NT,SkipTests=false/console as an example) but on my 8 core machine I hit it on every run of build.cmd so I'm fixing it.

/cc @Priya91 