### PR TITLE
Fix Unix build of System.IO.MemoryMappedFiles

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -50,8 +50,8 @@ namespace System.IO.MemoryMappedFiles
         /// </summary>
         [SecurityCritical]
         private static SafeMemoryMappedFileHandle CreateOrOpenCore(
-            SafeFileHandle fileHandle, String mapName, HandleInheritability inheritability, 
-            MemoryMappedFileAccess access, MemoryMappedFileOptions options, Int64 capacity)
+            String mapName, HandleInheritability inheritability, MemoryMappedFileAccess access, 
+            MemoryMappedFileOptions options, Int64 capacity)
         {
             throw NotImplemented.ByDesign; // TODO: Implement this
         }


### PR DESCRIPTION
A method signature had an extra parameter in the stubbed-out Unix file.