### PR TITLE
Allow debugging of unit tests on .NET Core using F5 VS

### DIFF
--- a/src/Common/tests/XunitTraitsDiscoverers/XunitTraitsDiscoverers.csproj
+++ b/src/Common/tests/XunitTraitsDiscoverers/XunitTraitsDiscoverers.csproj
@@ -6,7 +6,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>XunitTraitsDiscoverers</AssemblyName>
     <RootNamespace>Xunit.TraitDiscoverers</RootNamespace>

--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Win32.Primitives</RootNamespace>
     <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
+++ b/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>Microsoft.Win32.Primitives.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Microsoft.Win32.Registry</RootNamespace>
     <AssemblyName>Microsoft.Win32.Registry</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -13,7 +13,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <DocumentationFile>$(OutputPath)System.Collections.Immutable.xml</DocumentationFile>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -13,7 +13,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{00EDA5FD-E802-40D3-92D5-56C27612D36D}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Diagnostics.FileVersionInfo</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Diagnostics.FileVersionInfo/tests/Assembly1.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/Assembly1.csproj
@@ -7,7 +7,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AssemblyName>Assembly1</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <NuGetPackageImportStamp>62805582</NuGetPackageImportStamp>
     <ProjectGuid>{28EB14BE-3BC9-4543-ABA6-A932424DFBD0}</ProjectGuid>
   </PropertyGroup>

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Diagnostics.FileVersionInfo.Tests</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{6DFDB760-CC88-48AE-BD81-C64844EA3CBC}</ProjectGuid>

--- a/src/System.IO.FileSystem.DriveInfo/tests/SetVolumeLabelTests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/SetVolumeLabelTests.cs
@@ -94,12 +94,16 @@ namespace System.IO.FileSystem.DriveInfoTests
             {
                 if (drives[i].IsReady && drives[i].DriveType != DriveType.CDRom && drives[i].DriveType != DriveType.Network)
                 {
+                    volumeSettable = true;
                     try
                     {
                         drives[i].VolumeLabel = null;
                     }
-                    catch (UnauthorizedAccessException) { }
-                    if (drives[i].VolumeLabel != String.Empty)
+                    catch (UnauthorizedAccessException)
+                    {
+                        volumeSettable = false;
+                    }
+                    if (volumeSettable && drives[i].VolumeLabel != String.Empty)
                     {
                         Assert.False(true, string.Format("Error, Wrong result returned, <{0}>", drives[i].VolumeLabel));
                     }

--- a/src/System.IO.FileSystem.Primitives/src/System.IO.FileSystem.Primitives.csproj
+++ b/src/System.IO.FileSystem.Primitives/src/System.IO.FileSystem.Primitives.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{6C05678E-394C-4CFF-B453-A18E28C8F2C3}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Primitives</AssemblyName>
   </PropertyGroup>

--- a/src/System.IO.FileSystem.Primitives/tests/System.IO.FileSystem.Primitives.Tests.csproj
+++ b/src/System.IO.FileSystem.Primitives/tests/System.IO.FileSystem.Primitives.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{2EF7EFA5-F171-4CAB-8A29-32833949FD87}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Primitives.Tests</AssemblyName>
   </PropertyGroup>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{879C23DC-D828-4DFB-8E92-ABBC11B71035}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
   </PropertyGroup>

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{16EE5522-F387-4C9E-9EF2-B5134B043F37}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.MemoryMappedFiles</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.Tests.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{9D6F6254-B5A3-40FF-8925-68AA8D1CE933}</ProjectGuid>
   </PropertyGroup>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.csproj
@@ -9,7 +9,6 @@
     <AssemblyName>MemoryMappedViewAccessor.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{F26FBD53-C04A-4FFC-90C9-AA804285A7AD}</ProjectGuid>
   </PropertyGroup>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{688496E1-A7B3-41AE-9E32-C6F1A1127F91}</ProjectGuid>
   </PropertyGroup>

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{16EE5522-F387-4C9E-9EF2-B5134B043F37}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.Pipes</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.BasicTests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.BasicTests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.IO.Pipes.BasicTests</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>false</SignAssembly>
     <ProjectGuid>{142469EC-D665-4FE2-845A-FDA69F9CC557}</ProjectGuid>
     <NuGetPackageImportStamp>d2615b94</NuGetPackageImportStamp>

--- a/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{BCF9255A-4321-4277-AD7D-F5094092C554}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.UnmanagedMemoryStream</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.IO.UnmanagedMemoryStream.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Linq.Parallel/src/System.Linq.Parallel.csproj
+++ b/src/System.Linq.Parallel/src/System.Linq.Parallel.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Linq.Parallel</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Linq.Parallel.Tests</RootNamespace>
     <AssemblyName>System.Linq.Parallel.Tests</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>System.Numerics</RootNamespace>
     <AssemblyName>System.Numerics.Vectors</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <DocumentationFile>$(OutputPath)System.Numerics.Vectors.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -11,7 +11,6 @@
     <RootNamespace>System.Numerics.Tests</RootNamespace>
     <AssemblyName>System.Numerics.Vectors.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <NuGetPackageImportStamp>11f13d9c</NuGetPackageImportStamp>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{F3E433C8-352F-4944-BF7F-765CE435370D}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Reflection.Metadata</AssemblyName>
     <DocumentationFile>$(OutputPath)System.Reflection.Metadata.xml</DocumentationFile>

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Reflection.Metadata.Tests</AssemblyName>
     <RootNamespace>System.Reflection.Metadata.Tests</RootNamespace>

--- a/src/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System.Text.Encoding.CodePages</RootNamespace>
     <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
   </PropertyGroup>

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Text.RegularExpressions.Tests</AssemblyName>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.WP8.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.WP8.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <DocumentationFile>$(OutputPath)System.Threading.Tasks.Dataflow.XML</DocumentationFile>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <DocumentationFile>$(OutputPath)System.Threading.Tasks.Dataflow.XML</DocumentationFile>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CONCURRENT_COLLECTIONS;FEATURE_TRACING</DefineConstants>

--- a/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{442C5A88-29C2-4B00-B1DF-730D646D3861}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument</AssemblyName>
     <RootNamespace>System.Xml</RootNamespace>

--- a/src/System.Xml.XDocument/tests/System.Xml.XDocument.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/System.Xml.XDocument.Tests.csproj
@@ -6,7 +6,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6D9B0285-5E8A-4C20-9C53-9E2084EF64C4}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XDocument.Tests</RootNamespace>

--- a/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
+++ b/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{DAA1EA56-C318-4D2E-AB8D-1AB87D9F98F5}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -6,7 +6,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{10D52320-17B7-476E-BBD2-A1064DD38CBF}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XDocument.Tests</RootNamespace>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{17CB2E3C-2904-4241-94DB-3894D24F35DA}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XmlDocument</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -6,7 +6,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{7B57D5F1-4E6C-4280-AD5B-C71C73B66B11}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XmlDocument.Tests</RootNamespace>

--- a/src/System.Xml.XPath/src/System.Xml.XPath.csproj
+++ b/src/System.Xml.XPath/src/System.Xml.XPath.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
+++ b/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
@@ -6,7 +6,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D0DF902A-2486-4A38-B7A7-232B9B6590E1}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.Tests</RootNamespace>

--- a/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
+++ b/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.csproj
@@ -5,7 +5,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{16EE5522-F387-4C9E-9EF2-B5134B043F37}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XmlDocument</AssemblyName>
     <RootNamespace>System.Xml.XmlDocument</RootNamespace>

--- a/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
@@ -6,7 +6,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7EAFC2D8-48D2-4A56-A9C6-6BADF2053499}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XmlDocument.UnitTests</RootNamespace>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -51,31 +51,35 @@
     <IsTestProject Condition="'$(IsTestProject)'=='' And $([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">True</IsTestProject>
     <RunTestsForProject Condition="'$(RunTestsForProject)'=='' and '$(IsTestProject)'=='True'">True</RunTestsForProject>
     <RunTestsForProject Condition="'$(SkipTests)'=='True'">False</RunTestsForProject>
+    
+    <!-- Don't run unit tests as post-build in VS, use F5 on test project instead (see below). -->
+    <RunTestsForProject Condition="'$(BuildingInsideVisualStudio)' == 'True'">False</RunTestsForProject>
   </PropertyGroup>
 
+  <!-- xUnit command line -->
+  <PropertyGroup>
+    <XunitHost>corerun.exe</XunitHost>
+    <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
+    <XunitOptions>$(XunitOptions) -notrait category=outerloop</XunitOptions>
+    <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+  </PropertyGroup>
+  
+  <!-- In VS: Debug to run unit tests on CoreCLR. -->
+  <PropertyGroup Condition="'$(IsTestProject)'=='True'">
+    <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
+    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
+    <StartAction Condition="'$(StartAction)' == ''">Program</StartAction>
+    <StartProgram Condition="'$(StartProgram)' == ''">$(StartWorkingDirectory)\$(XunitHost)</StartProgram>
+    <StartArguments Condition="'$(StartArguments)' == ''">$(XunitCommandLine) $(XunitOptions)</StartArguments>
+    <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
+  </PropertyGroup>
+
+  <!-- On command line: run unit tests on CoreCLR as post-build step. -->
   <Target Name="RunTestsForProject"
           AfterTargets="PrepareForRun"
           Condition="'$(RunTestsForProject)'=='True'">
 
-    <!-- xUnit Traits -->
-    <PropertyGroup>
-      <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
-    </PropertyGroup>
-    <ItemGroup>
-      <IncludeTraitsItems Include="$(IncludeTraits)" />
-      <ExcludeTraitsItems Include="$(ExcludeTraits)" />
-    </ItemGroup>
-    
-    <!-- Construct and invoke xunit console runner via corerun.exe -->
-    <PropertyGroup>
-      <XunitCommandLine>corerun.exe xunit.console.netcore.exe</XunitCommandLine>
-      
-      <XunitOptions>$(XunitOptions) $(TargetFileName)</XunitOptions>
-      <XunitOptions Condition="'@(IncludeTraitsItems)'!=''">$(XunitOptions) -trait @(IncludeTraitsItems, ' -trait ')</XunitOptions>
-      <XunitOptions Condition="'@(ExcludeTraitsItems)'!=''">$(XunitOptions) -notrait @(ExcludeTraitsItems, ' -notrait ')</XunitOptions>
-    </PropertyGroup>
-
-    <Exec Command="$(XunitCommandLine) $(XunitOptions)"
+    <Exec Command="$(XunitHost) $(XunitCommandLine) $(XunitOptions)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
           ContinueOnError="True">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -64,7 +64,7 @@
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
   </PropertyGroup>
   
-  <!-- In VS: Debug to run unit tests on CoreCLR. -->
+  <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='True'">
     <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>


### PR DESCRIPTION
Added the correct debug engine and xunit invocation in to the common targets for all test projects.

With this change, it is possible to set any test project as startup, put breakpoints in unit tests and debug the test run by just pressing F5. VS 2015 Preview or later is required for it to work. There are some cumbersome workarounds for debugging in VS 2013. If we get feedback that customers want to debug in VS 2013, we can document them, but the far easier path is to just install VS 2015.

Post-build unit tests runs are now disabled in VS since you can press Ctrl+F5 to run. This allows a workflow where you can build to check for compiler errors without necessarily running the tests. When building from the command line, tests are still run.

Also in this PR (see later two commits):
* Fix non-admin issue in DriveInfo tests. I followed the pattern that was there just above, but we really shouldn't be modifying machine state in inner loop tests like that.
* Remove the PLIB ProjectTypeGuids, which blocks editing the debug info for a class library.

