### PR TITLE
Revert "Simple cleanup in XDocument  classes"

### DIFF
--- a/src/Common/src/System/IO/StringBuilderCache.cs
+++ b/src/Common/src/System/IO/StringBuilderCache.cs
@@ -33,6 +33,7 @@
 **
 ===========================================================*/
 
+using System.Threading;
 using System.Text;
 
 namespace System.IO
@@ -49,14 +50,14 @@ namespace System.IO
         {
             if (capacity <= MAX_BUILDER_SIZE)
             {
-                StringBuilder sb = t_cachedInstance;
+                StringBuilder sb = StringBuilderCache.t_cachedInstance;
                 if (sb != null)
                 {
                     // Avoid stringbuilder block fragmentation by getting a new StringBuilder
                     // when the requested size is larger than the current capacity
                     if (capacity <= sb.Capacity)
                     {
-                        t_cachedInstance = null;
+                        StringBuilderCache.t_cachedInstance = null;
                         sb.Clear();
                         return sb;
                     }
@@ -76,7 +77,7 @@ namespace System.IO
         {
             if (sb.Capacity <= MAX_BUILDER_SIZE)
             {
-                t_cachedInstance = sb;
+                StringBuilderCache.t_cachedInstance = sb;
             }
         }
 

--- a/src/System.Xml.XDocument/src/System/Linq/Enumerable.cs
+++ b/src/System.Xml.XDocument/src/System/Linq/Enumerable.cs
@@ -40,10 +40,10 @@ namespace System.Linq
 
     internal class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
     {
-        internal readonly OrderedEnumerable<TElement> parent;
-        internal readonly Func<TElement, TKey> keySelector;
-        internal readonly IComparer<TKey> comparer;
-        internal readonly bool descending;
+        internal OrderedEnumerable<TElement> parent;
+        internal Func<TElement, TKey> keySelector;
+        internal IComparer<TKey> comparer;
+        internal bool descending;
 
         internal OrderedEnumerable(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
@@ -116,10 +116,10 @@ namespace System.Linq
 
     internal class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
     {
-        internal readonly Func<TElement, TKey> keySelector;
-        internal readonly IComparer<TKey> comparer;
-        internal readonly bool descending;
-        internal readonly EnumerableSorter<TElement> next;
+        internal Func<TElement, TKey> keySelector;
+        internal IComparer<TKey> comparer;
+        internal bool descending;
+        internal EnumerableSorter<TElement> next;
         internal TKey[] keys;
 
         internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement> next)
@@ -151,8 +151,8 @@ namespace System.Linq
 
     struct Buffer<TElement>
     {
-        internal readonly TElement[] items;
-        internal readonly int count;
+        internal TElement[] items;
+        internal int count;
 
         internal Buffer(IEnumerable<TElement> source)
         {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/BaseUriAnnotation.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/BaseUriAnnotation.cs
@@ -5,7 +5,7 @@ namespace System.Xml.Linq
 {
     class BaseUriAnnotation
     {
-        internal readonly string baseUri;
+        internal string baseUri;
 
         public BaseUriAnnotation(string baseUri)
         {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/Extensions.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/Extensions.cs
@@ -275,7 +275,7 @@ namespace System.Xml.Linq
         /// <summary>
         /// Removes each <see cref="XAttribute"/> represented in this <see cref="IEnumerable"/> of
         /// <see cref="XAttribute"/>.  Note that this method uses snapshot semantics (copies the
-        /// attributes to a <see cref="List{T}"/> before deleting each).
+        /// attributes to a <see cref="List&lt;T>"/> before deleting each).
         /// </summary>
         public static void Remove(this IEnumerable<XAttribute> source)
         {
@@ -374,10 +374,9 @@ namespace System.Xml.Linq
                     XContainer c = root;
                     while (true)
                     {
-                        XNode content = c != null ? c.content as XNode : null;
-                        if (content != null)
+                        if (c != null && c.content is XNode)
                         {
-                            n = content.next;
+                            n = ((XNode)c.content).next;
                         }
                         else
                         {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/LineInfoAnnotation.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/LineInfoAnnotation.cs
@@ -13,8 +13,8 @@ namespace System.Xml.Linq
     /// </summary>
     class LineInfoAnnotation
     {
-        internal readonly int lineNumber;
-        internal readonly int linePosition;
+        internal int lineNumber;
+        internal int linePosition;
 
         public LineInfoAnnotation(int lineNumber, int linePosition)
         {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XAttribute.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XAttribute.cs
@@ -33,7 +33,7 @@ namespace System.Xml.Linq
         }
 
         internal XAttribute next;
-        internal readonly XName name;
+        internal XName name;
         internal string value;
 
         /// <overloads>
@@ -682,7 +682,7 @@ namespace System.Xml.Linq
                     // the default namespace declaration
                     throw new ArgumentException(SR.Format(SR.Argument_NamespaceDeclarationPrefixed, name.LocalName));
                 }
-                if (value == XNamespace.xmlPrefixNamespace)
+                else if (value == XNamespace.xmlPrefixNamespace)
                 {
                     // 'http://www.w3.org/XML/1998/namespace' can only
                     // be declared by the 'xml' prefix namespace declaration.
@@ -703,7 +703,7 @@ namespace System.Xml.Linq
                         // prefix namespace declaration. 
                         throw new ArgumentException(SR.Argument_NamespaceDeclarationXml);
                     }
-                    if (localName == "xmlns")
+                    else if (localName == "xmlns")
                     {
                         // The 'xmlns' prefix must not be declared. 
                         throw new ArgumentException(SR.Argument_NamespaceDeclarationXmlns);
@@ -718,7 +718,7 @@ namespace System.Xml.Linq
                     // be declared by the 'xml' prefix namespace declaration.
                     throw new ArgumentException(SR.Argument_NamespaceDeclarationXml);
                 }
-                if (value == XNamespace.xmlnsPrefixNamespace)
+                else if (value == XNamespace.xmlnsPrefixNamespace)
                 {
                     // 'http://www.w3.org/2000/xmlns/' must not be declared
                     // by any namespace declaration.

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
@@ -588,10 +588,9 @@ namespace System.Xml.Linq
             }
             else if (s.Length > 0)
             {
-                string stringContent = content as string;
-                if (stringContent != null)
+                if (content is string)
                 {
-                    content = stringContent + s;
+                    content = (string)content + s;
                 }
                 else
                 {
@@ -772,10 +771,9 @@ namespace System.Xml.Linq
             XContainer c = this;
             while (true)
             {
-                XNode content = c != null ? c.content as XNode : null;
-                if (content != null)
+                if (c != null && c.content is XNode)
                 {
-                    n = content.next;
+                    n = ((XNode)c.content).next;
                 }
                 else
                 {
@@ -805,12 +803,12 @@ namespace System.Xml.Linq
 
         internal static string GetStringValue(object value)
         {
-            string s = value as string;
-            if (s != null)
+            string s;
+            if (value is string)
             {
-                return s;
+                s = (string)value;
             }
-            if (value is double)
+            else if (value is double)
             {
                 s = XmlConvert.ToString((double)value);
             }
@@ -1089,16 +1087,15 @@ namespace System.Xml.Linq
         {
             if (content != null)
             {
-                string stringContent = content as string;
-                if (stringContent != null)
+                if (content is string)
                 {
                     if (this is XDocument)
                     {
-                        writer.WriteWhitespace(stringContent);
+                        writer.WriteWhitespace((string)content);
                     }
                     else
                     {
-                        writer.WriteString(stringContent);
+                        writer.WriteString((string)content);
                     }
                 }
                 else

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XElement.cs
@@ -34,7 +34,11 @@ namespace System.Xml.Linq
         /// </summary>
         public static IEnumerable<XElement> EmptySequence
         {
-            get { return s_emptySequence ?? (s_emptySequence = new XElement[0]); }
+            get
+            {
+                if (s_emptySequence == null) s_emptySequence = new XElement[0];
+                return s_emptySequence;
+            }
         }
 
         internal XName name;

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
@@ -118,7 +118,7 @@ namespace System.Xml.Linq
 
                     // Replacing with Interlocked.CompareExchange for now (with no effect)
                     //   which will do a very similar thing to MemoryBarrier (it's just slower)
-                    Interlocked.CompareExchange<XHashtableState>(ref _state, null, null);
+                    System.Threading.Interlocked.CompareExchange<XHashtableState>(ref _state, null, null);
 #endif // SILVERLIGHT
                     _state = newState;
                 }
@@ -140,10 +140,10 @@ namespace System.Xml.Linq
         /// </remarks>
         private sealed class XHashtableState
         {
-            private readonly int[] _buckets;                  // Buckets contain indexes into entries array (bucket values are SHARED STATE)
+            private int[] _buckets;                  // Buckets contain indexes into entries array (bucket values are SHARED STATE)
             private Entry[] _entries;                // Entries contain linked lists of buckets (next pointers are SHARED STATE)
             private int _numEntries;                 // SHARED STATE: Current number of entries (including orphaned entries)
-            private readonly ExtractKeyDelegate _extractKey;  // Delegate called in order to extract string key embedded in hashed TValue
+            private ExtractKeyDelegate _extractKey;  // Delegate called in order to extract string key embedded in hashed TValue
 
             private const int EndOfList = 0;        // End of linked list marker
             private const int FullList = -1;        // Indicates entries should not be added to end of linked list
@@ -310,7 +310,7 @@ namespace System.Xml.Linq
 
                 // Replacing with Interlocked.CompareExchange for now (with no effect)
                 //   which will do a very similar thing to MemoryBarrier (it's just slower)
-                Interlocked.CompareExchange<Entry[]>(ref _entries, null, null);
+                System.Threading.Interlocked.CompareExchange<Entry[]>(ref _entries, null, null);
 #endif // SILVERLIGHT
 
                 // Loop until a matching entry is found, a new entry is added, or linked list is found to be full

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
@@ -10,7 +10,7 @@ namespace System.Xml.Linq
 {
     internal struct Inserter
     {
-        private readonly XContainer _parent;
+        private XContainer _parent;
         private XNode _previous;
         private string _text;
 
@@ -58,10 +58,9 @@ namespace System.Xml.Linq
                 }
                 else if (_text.Length > 0)
                 {
-                    XText prevXText = _previous as XText;
-                    if (prevXText != null && !(_previous is XCData))
+                    if (_previous is XText && !(_previous is XCData))
                     {
-                        prevXText.Value += _text;
+                        ((XText)_previous).Value += _text;
                     }
                     else
                     {
@@ -127,10 +126,9 @@ namespace System.Xml.Linq
             {
                 if (_text.Length > 0)
                 {
-                    XText prevXText = _previous as XText;
-                    if (prevXText != null && !(_previous is XCData))
+                    if (_previous is XText && !(_previous is XCData))
                     {
-                        prevXText.Value += _text;
+                        ((XText)_previous).Value += _text;
                     }
                     else
                     {
@@ -192,7 +190,7 @@ namespace System.Xml.Linq
 
     internal struct ElementWriter
     {
-        private readonly XmlWriter _writer;
+        private XmlWriter _writer;
         private NamespaceResolver _resolver;
 
         public ElementWriter(XmlWriter writer)
@@ -430,7 +428,7 @@ namespace System.Xml.Linq
                                 _rover = d;
                                 return d.prefix;
                             }
-                            if (d.prefix.Length > 0)
+                            else if (d.prefix.Length > 0)
                             {
                                 return d.prefix;
                             }
@@ -444,9 +442,9 @@ namespace System.Xml.Linq
 
     internal struct StreamingElementWriter
     {
-        private readonly XmlWriter _writer;
+        private XmlWriter _writer;
         private XStreamingElement _element;
-        private readonly List<XAttribute> _attributes;
+        private List<XAttribute> _attributes;
         private NamespaceResolver _resolver;
 
         public StreamingElementWriter(XmlWriter w)

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XName.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XName.cs
@@ -11,9 +11,9 @@ namespace System.Xml.Linq
     [SuppressMessage("Microsoft.Usage", "CA2229:ImplementSerializationConstructors", Justification = "Deserialization handled by NameSerializer.")]
     public sealed class XName : IEquatable<XName>
     {
-        private readonly XNamespace _ns;
-        private readonly string _localName;
-        private readonly int _hashCode;
+        private XNamespace _ns;
+        private string _localName;
+        private int _hashCode;
 
         /// <summary>
         /// Constructor, internal so that external users must go through the Get() method to create an XName.
@@ -78,7 +78,10 @@ namespace System.Xml.Linq
                 if (i <= 1 || i == expandedName.Length - 1) throw new ArgumentException(SR.Format(SR.Argument_InvalidExpandedName, expandedName));
                 return XNamespace.Get(expandedName, 1, i - 1).GetName(expandedName, i + 1, expandedName.Length - i - 1);
             }
-            return XNamespace.None.GetName(expandedName);
+            else
+            {
+                return XNamespace.None.GetName(expandedName);
+            }
         }
 
         /// <summary>

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNamespace.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNamespace.cs
@@ -20,9 +20,9 @@ namespace System.Xml.Linq
         private static WeakReference s_refXml;
         private static WeakReference s_refXmlns;
 
-        private readonly string _namespaceName;
-        private readonly int _hashCode;
-        private readonly XHashtable<XName> _names;
+        private string _namespaceName;
+        private int _hashCode;
+        private XHashtable<XName> _names;
 
         private const int NamesCapacity = 8;           // Starting capacity of XName table, which must be power of 2
         private const int NamespacesCapacity = 32;     // Starting capacity of XNamespace table, which must be power of 2

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNode.cs
@@ -76,7 +76,11 @@ namespace System.Xml.Linq
         /// </summary>
         public static XNodeDocumentOrderComparer DocumentOrderComparer
         {
-            get { return s_documentOrderComparer ?? (s_documentOrderComparer = new XNodeDocumentOrderComparer()); }
+            get
+            {
+                if (s_documentOrderComparer == null) s_documentOrderComparer = new XNodeDocumentOrderComparer();
+                return s_documentOrderComparer;
+            }
         }
 
         /// <summary>
@@ -84,7 +88,11 @@ namespace System.Xml.Linq
         /// </summary>
         public static XNodeEqualityComparer EqualityComparer
         {
-            get { return s_equalityComparer ?? (s_equalityComparer = new XNodeEqualityComparer()); }
+            get
+            {
+                if (s_equalityComparer == null) s_equalityComparer = new XNodeEqualityComparer();
+                return s_equalityComparer;
+            }
         }
 
         /// <overloads>

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeBuilder.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeBuilder.cs
@@ -11,7 +11,7 @@ namespace System.Xml.Linq
         private XContainer _parent;
         private XName _attrName;
         private string _attrValue;
-        private readonly XContainer _root;
+        private XContainer _root;
 
         public XNodeBuilder(XContainer container)
         {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeReader.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeReader.cs
@@ -7,7 +7,7 @@ namespace System.Xml.Linq
 {
     internal class XNodeReader : XmlReader, IXmlLineInfo
     {
-        private static readonly char[] s_WhitespaceChars = { ' ', '\t', '\n', '\r' };
+        private static readonly char[] s_WhitespaceChars = new char[] { ' ', '\t', '\n', '\r' };
 
         // The reader position is encoded by the tuple (source, parent).
         // Lazy text uses (instance, parent element). Attribute value
@@ -17,14 +17,14 @@ namespace System.Xml.Linq
         private object _parent;
         private ReadState _state;
         private XNode _root;
-        private readonly XmlNameTable _nameTable;
-        private readonly bool _omitDuplicateNamespaces;
+        private XmlNameTable _nameTable;
+        private bool _omitDuplicateNamespaces;
 
         internal XNodeReader(XNode node, XmlNameTable nameTable, ReaderOptions options)
         {
             _source = node;
             _root = node;
-            _nameTable = nameTable ?? CreateNameTable();
+            _nameTable = nameTable != null ? nameTable : CreateNameTable();
             _omitDuplicateNamespaces = (options & ReaderOptions.OmitDuplicateNamespaces) != 0 ? true : false;
         }
 
@@ -139,9 +139,15 @@ namespace System.Xml.Linq
                     {
                         return GetFirstNonDuplicateNamespaceAttribute(e.lastAttr.next) != null;
                     }
-                    return true;
+                    else
+                    {
+                        return true;
+                    }
                 }
-                return false;
+                else
+                {
+                    return false;
+                }
             }
         }
 
@@ -430,6 +436,8 @@ namespace System.Xml.Linq
                                     return XmlSpace.Preserve;
                                 case "default":
                                     return XmlSpace.Default;
+                                default:
+                                    break;
                             }
                         }
                         e = e.parent as XElement;
@@ -478,7 +486,10 @@ namespace System.Xml.Linq
                             {
                                 return null;
                             }
-                            return a.Value;
+                            else
+                            {
+                                return a.Value;
+                            }
                         }
                     } while (a != e.lastAttr);
                 }
@@ -530,7 +541,10 @@ namespace System.Xml.Linq
                             {
                                 return null;
                             }
-                            return a.Value;
+                            else
+                            {
+                                return a.Value;
+                            }
                         }
                     } while (a != e.lastAttr);
                 }
@@ -617,9 +631,12 @@ namespace System.Xml.Linq
                                 // If it's a duplicate namespace attribute just act as if it doesn't exist
                                 return false;
                             }
-                            _source = a;
-                            _parent = null;
-                            return true;
+                            else
+                            {
+                                _source = a;
+                                _parent = null;
+                                return true;
+                            }
                         }
                     } while (a != e.lastAttr);
                 }
@@ -661,9 +678,12 @@ namespace System.Xml.Linq
                                 // If it's a duplicate namespace attribute just act as if it doesn't exist
                                 return false;
                             }
-                            _source = a;
-                            _parent = null;
-                            return true;
+                            else
+                            {
+                                _source = a;
+                                _parent = null;
+                                return true;
+                            }
                         }
                     } while (a != e.lastAttr);
                 }
@@ -1265,12 +1285,11 @@ namespace System.Xml.Linq
                 IsEndElement = true;
                 return true;
             }
-
-            XAttribute parent = _parent as XAttribute;
-            if (parent != null)
+            if (_parent is XAttribute)
             {
+                XAttribute a = (XAttribute)_parent;
                 _parent = null;
-                return ReadOverAttribute(parent, skipContent);
+                return ReadOverAttribute(a, skipContent);
             }
             return ReadToEnd();
         }
@@ -1293,9 +1312,11 @@ namespace System.Xml.Linq
             {
                 return false;
             }
-
-            // Split the method in two to enable inlining of this piece (Which will work for 95% of cases)
-            return IsDuplicateNamespaceAttributeInner(candidateAttribute);
+            else
+            {
+                // Split the method in two to enable inlining of this piece (Which will work for 95% of cases)
+                return IsDuplicateNamespaceAttributeInner(candidateAttribute);
+            }
         }
 
         private bool IsDuplicateNamespaceAttributeInner(XAttribute candidateAttribute)
@@ -1338,10 +1359,12 @@ namespace System.Xml.Linq
                                 // And it's for the same namespace URI as well - so ours is a duplicate
                                 return true;
                             }
-
-                            // It's not for the same namespace URI - which means we have to keep ours
-                            //   (no need to continue the search as this one overrides anything above it)
-                            return false;
+                            else
+                            {
+                                // It's not for the same namespace URI - which means we have to keep ours
+                                //   (no need to continue the search as this one overrides anything above it)
+                                return false;
+                            }
                         }
                         a = a.next;
                     } while (a != element.lastAttr);

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XObjectChangeEventArgs.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XObjectChangeEventArgs.cs
@@ -10,7 +10,7 @@ namespace System.Xml.Linq
     /// </summary>
     public class XObjectChangeEventArgs : EventArgs
     {
-        private readonly XObjectChange _objectChange;
+        private XObjectChange _objectChange;
 
         /// <summary>
         /// Event argument for a <see cref="XObjectChange.Add"/> change event.


### PR DESCRIPTION
See comments in PR #482 for reasons why this was reverted.