### PR TITLE
Fix DebuggerDisplay attribute

### DIFF
--- a/src/System.Collections.NonGeneric/src/System/Collections/KeyValuePairs.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/KeyValuePairs.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace System.Collections
 {
-    [DebuggerDisplay("{value}", Name = "[{key}]", Type = "")]
+    [DebuggerDisplay("{_value}", Name = "[{_key}]", Type = "")]
     internal class KeyValuePairs
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]


### PR DESCRIPTION
Renaming privates in KeyValuePairs broke its DebuggerDisplay attribute.