### PR TITLE
Fix a syntax error in an ImmutableArray XML comment

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1035,7 +1035,7 @@ namespace System.Collections.Immutable
         /// <param name="items">The array to initialize the array with. No copy is made.</param>
         /// <remarks>
         /// Covariant upcasts from this method may be reversed by calling the
-        /// <see cref="ImmutableArray{T}.As{TOther};"/>  or <see cref="ImmutableArray{T}.CastArray{TOther}"/>method.
+        /// <see cref="ImmutableArray{T}.As{TOther}"/>  or <see cref="ImmutableArray{T}.CastArray{TOther}"/>method.
         /// </remarks>
         [Pure]
         public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)


### PR DESCRIPTION
Addresses a couple of warnings getting generated when building the immutable collections library: