### PR TITLE
Remove double type checks in System.Xml

### DIFF
--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XContainer.cs
@@ -588,9 +588,10 @@ namespace System.Xml.Linq
             }
             else if (s.Length > 0)
             {
-                if (content is string)
+                string stringContent = content as string;
+                if (stringContent != null)
                 {
-                    content = (string)content + s;
+                    content = stringContent + s;
                 }
                 else
                 {
@@ -803,10 +804,10 @@ namespace System.Xml.Linq
 
         internal static string GetStringValue(object value)
         {
-            string s;
-            if (value is string)
+            string s = value as string;
+            if (s != null)
             {
-                s = (string)value;
+                return s;
             }
             else if (value is double)
             {
@@ -1087,15 +1088,16 @@ namespace System.Xml.Linq
         {
             if (content != null)
             {
-                if (content is string)
+                string stringContent = content as string;
+                if (stringContent != null)
                 {
                     if (this is XDocument)
                     {
-                        writer.WriteWhitespace((string)content);
+                        writer.WriteWhitespace(stringContent);
                     }
                     else
                     {
-                        writer.WriteString((string)content);
+                        writer.WriteString(stringContent);
                     }
                 }
                 else

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XLinq.cs
@@ -58,9 +58,10 @@ namespace System.Xml.Linq
                 }
                 else if (_text.Length > 0)
                 {
-                    if (_previous is XText && !(_previous is XCData))
+                    XText prevXText = _previous as XText;
+                    if (prevXText != null && !(_previous is XCData))
                     {
-                        ((XText)_previous).Value += _text;
+                        prevXText.Value += _text;
                     }
                     else
                     {
@@ -126,9 +127,10 @@ namespace System.Xml.Linq
             {
                 if (_text.Length > 0)
                 {
-                    if (_previous is XText && !(_previous is XCData))
+                    XText prevXText = _previous as XText;
+                    if (prevXText != null && !(_previous is XCData))
                     {
-                        ((XText)_previous).Value += _text;
+                        prevXText.Value += _text;
                     }
                     else
                     {

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeReader.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XNodeReader.cs
@@ -1285,11 +1285,12 @@ namespace System.Xml.Linq
                 IsEndElement = true;
                 return true;
             }
-            if (_parent is XAttribute)
+
+            XAttribute parent = _parent as XAttribute;
+            if (parent != null)
             {
-                XAttribute a = (XAttribute)_parent;
                 _parent = null;
-                return ReadOverAttribute(a, skipContent);
+                return ReadOverAttribute(parent, skipContent);
             }
             return ReadToEnd();
         }

--- a/src/System.Xml.XPath.XDocument/src/System/Xml/XPath/XNodeNavigator.cs
+++ b/src/System.Xml.XPath.XDocument/src/System/Xml/XPath/XNodeNavigator.cs
@@ -858,9 +858,10 @@ namespace System.Xml.XPath
         {
             XPathNavigator navigator = node.CreateNavigator();
             object result = navigator.Evaluate(expression, resolver);
-            if (result is XPathNodeIterator)
+            XPathNodeIterator iterator = result as XPathNodeIterator;
+            if (iterator != null)
             {
-                return EvaluateIterator<T>((XPathNodeIterator)result);
+                return EvaluateIterator<T>(iterator);
             }
             if (!(result is T)) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedEvaluation, result.GetType()));
             return (T)result;

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/BooleanFunctions.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/BooleanFunctions.cs
@@ -60,7 +60,10 @@ namespace MS.Internal.Xml.XPath
         {
             object result = _arg.Evaluate(nodeIterator);
             if (result is XPathNodeIterator) return _arg.Advance() != null;
-            if (result is string) return toBoolean((string)result);
+
+            string str = result as string;
+            if (str != null) return toBoolean(str);
+
             if (result is double) return toBoolean((double)result);
             if (result is bool) return (bool)result;
             Debug.Assert(result is XPathNavigator, "Unknown value type");

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/CompiledXpathExpr.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/CompiledXpathExpr.cs
@@ -51,17 +51,22 @@ namespace MS.Internal.Xml.XPath
             // sort makes sense only when we are dealing with a query that
             // returns a nodeset.
             Query evalExpr;
-            if (expr is string)
+            string query = expr as string;
+            if (query != null)
             {
-                evalExpr = new QueryBuilder().Build((string)expr, out _needContext); // this will throw if expr is invalid
-            }
-            else if (expr is CompiledXpathExpr)
-            {
-                evalExpr = ((CompiledXpathExpr)expr).QueryTree;
+                evalExpr = new QueryBuilder().Build(query, out _needContext); // this will throw if expr is invalid
             }
             else
             {
-                throw XPathException.Create(SR.Xp_BadQueryObject);
+                CompiledXpathExpr xpathExpr = expr as CompiledXpathExpr;
+                if (xpathExpr != null)
+                {
+                    evalExpr = xpathExpr.QueryTree;
+                }
+                else
+                {
+                    throw XPathException.Create(SR.Xp_BadQueryObject);
+                }
             }
             SortQuery sortQuery = _query as SortQuery;
             if (sortQuery == null)

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlElement.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlElement.cs
@@ -58,8 +58,11 @@ namespace System.Xml
                 foreach (XmlAttribute attr in Attributes)
                 {
                     XmlAttribute newAttr = (XmlAttribute)(attr.CloneNode(true));
-                    if (attr is XmlUnspecifiedAttribute && attr.Specified == false)
-                        ((XmlUnspecifiedAttribute)newAttr).SetSpecified(false);
+                    XmlUnspecifiedAttribute unspecAttr = newAttr as XmlUnspecifiedAttribute;
+                    if (unspecAttr != null && attr.Specified == false)
+                    {
+                        unspecAttr.SetSpecified(false);
+                    }
                     element.Attributes.InternalAppendAttribute(newAttr);
                 }
             }

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlLoader.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlLoader.cs
@@ -547,10 +547,11 @@ namespace System.Xml
             // Process all xmlns, xmlns:prefix, xml:space and xml:lang attributes
             while (node != null && node != _doc)
             {
-                if (node is XmlElement && ((XmlElement)node).HasAttributes)
+                XmlElement element = node as XmlElement;
+                if (element != null && element.HasAttributes)
                 {
                     mgr.PushScope();
-                    foreach (XmlAttribute attr in ((XmlElement)node).Attributes)
+                    foreach (XmlAttribute attr in element.Attributes)
                     {
                         if (attr.Prefix == _doc.strXmlns && !prefixes.Contains(attr.LocalName))
                         {


### PR DESCRIPTION
Replace code like this:

     if (obj is Foo)
         ((Foo)obj).DoSomething();
with

    Foo foo = obj as Foo;
    if (foo != null)
        foo.DoSomething();
Most of these changes were verified in #491 and #482, but these PRs were reverted due reasons non-related with these changes.