### PR TITLE
Fix file name collision in MemoryMappedFiles tests

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateFromFile.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateFromFile.cs
@@ -225,10 +225,10 @@ public class CreateFromFile : MMFTestBase
             VerifyCreateFromFile("Loc216", "CreateFromFile_test2.txt", FileMode.Open, "map215");
 
             // "global/" prefix
-            VerifyCreateFromFile("Loc217", "CreateFromFile_test2.txt", FileMode.Open, "global/mapname");
+            VerifyCreateFromFile("Loc217", "CreateFromFile_test2.txt", FileMode.Open, "global/CFF_0");
 
             // "local/" prefix
-            VerifyCreateFromFile("Loc218", "CreateFromFile_test2.txt", FileMode.Open, "local/mapname");
+            VerifyCreateFromFile("Loc218", "CreateFromFile_test2.txt", FileMode.Open, "local/CFF_1");
 
 
             ////////////////////////////////////////////////////////////////////////
@@ -391,13 +391,13 @@ public class CreateFromFile : MMFTestBase
             // "global/" prefix
             using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
             {
-                VerifyCreateFromFile("Loc417", fs, "global/mapname", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc417", fs, "global/CFF_2", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // "local/" prefix
             using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
             {
-                VerifyCreateFromFile("Loc418", fs, "local/mapname", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc418", fs, "local/CFF_3", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // [] capacity

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateNew.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateNew.cs
@@ -60,10 +60,10 @@ public class CreateNew : MMFTestBase
             VerifyCreateNew("Loc116", "map115", 500);
 
             // "global/" prefix
-            VerifyCreateNew("Loc117", "global/mapname", 4096);
+            VerifyCreateNew("Loc117", "global/CN_0", 4096);
 
             // "local/" prefix
-            VerifyCreateNew("Loc118", "local/mapname", 4096);
+            VerifyCreateNew("Loc118", "local/CN_1", 4096);
 
             // [] capacity
 
@@ -146,10 +146,10 @@ public class CreateNew : MMFTestBase
             VerifyCreateNew("Loc416", "map415", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // "global/" prefix
-            VerifyCreateNew("Loc417", "global/mapname", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc417", "global/CN_2", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // "local/" prefix
-            VerifyCreateNew("Loc418", "local/mapname", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc418", "local/CN_3", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // [] capacity
 


### PR DESCRIPTION
There are a couple of tests in MemoryMappedFiles which are using the same file name in different tests. These are causing some intermittent failures, which seem to be extremely rare (I'm not able to reproduce locally but can see some CI failures). These are generally caused by the tests running in parallel and attempting to create memory mapped files with the same name. I have already removed most of the possible name collisions in these tests, so hopefully these are the last of them.

NOTE: I believe this should still give us the same coverage as before, as these cases are intended to test the "local" and "global" prefixes, which are still preserved here. I've just modified the suffixes for these so they don't collide.