### PR TITLE
Avoid allocating params arrays inside loops

### DIFF
--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -1007,8 +1007,16 @@ namespace System.Collections
                 if (_list.Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
 
+                if (_list.Count == 0 || count == 0)
+                    return;
+
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
                 for (int i = index; i < index + count; i++)
-                    array.SetValue(_list[i], arrayIndex++);
+                {
+                    indices[0] = arrayIndex++;
+                    array.SetValue(_list[i], indices);
+                }
             }
 
             public override IEnumerator GetEnumerator()

--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -434,12 +434,19 @@ namespace System.Collections
             Contract.Requires(array.Rank == 1);
 
             bucket[] lbuckets = _buckets;
+
+            if (lbuckets.Length == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (int i = lbuckets.Length; --i >= 0;)
             {
                 Object keyv = lbuckets[i].key;
                 if ((keyv != null) && (keyv != _buckets))
                 {
-                    array.SetValue(keyv, arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(keyv, indices);
                 }
             }
         }
@@ -453,13 +460,20 @@ namespace System.Collections
             Contract.Requires(array.Rank == 1);
 
             bucket[] lbuckets = _buckets;
+
+            if (lbuckets.Length == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (int i = lbuckets.Length; --i >= 0;)
             {
                 Object keyv = lbuckets[i].key;
                 if ((keyv != null) && (keyv != _buckets))
                 {
                     DictionaryEntry entry = new DictionaryEntry(keyv, lbuckets[i].val);
-                    array.SetValue(entry, arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(entry, indices);
                 }
             }
         }
@@ -511,12 +525,19 @@ namespace System.Collections
             Contract.Requires(array.Rank == 1);
 
             bucket[] lbuckets = _buckets;
+
+            if (lbuckets.Length == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (int i = lbuckets.Length; --i >= 0;)
             {
                 Object keyv = lbuckets[i].key;
                 if ((keyv != null) && (keyv != _buckets))
                 {
-                    array.SetValue(lbuckets[i].val, arrayIndex++);
+                    indices[0] = arrayIndex++;
+                    array.SetValue(lbuckets[i].val, indices);
                 }
             }
         }

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -367,10 +367,17 @@ namespace System.Collections
             if (array.Length - arrayIndex < Count)
                 throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
             Contract.EndContractBlock();
+
+            if (Count == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (int i = 0; i < Count; i++)
             {
                 DictionaryEntry entry = new DictionaryEntry(_keys[i], _values[i]);
-                array.SetValue(entry, i + arrayIndex);
+                indices[0] = i + arrayIndex;
+                array.SetValue(entry, indices);
             }
         }
 

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -156,9 +156,15 @@ namespace System.Collections
             }
             else
             {
+                if (_size == 0)
+                    return;
+
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
                 while (i < _size)
                 {
-                    array.SetValue(_array[_size - i - 1], i + index);
+                    indices[0] = i + index;
+                    array.SetValue(_array[_size - i - 1], indices);
                     i++;
                 }
             }

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -231,9 +231,15 @@ namespace System.Collections.Specialized
             if (array.Length - index < _count)
                 throw new ArgumentException(SR.Arg_InsufficientSpace);
 
+            if (_count == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (DictionaryNode node = _head; node != null; node = node.next)
             {
-                array.SetValue(new DictionaryEntry(node.key, node.value), index);
+                indices[0] = index;
+                array.SetValue(new DictionaryEntry(node.key, node.value), indices);
                 index++;
             }
         }
@@ -388,9 +394,16 @@ namespace System.Collections.Specialized
                     throw new ArgumentNullException("array");
                 if (index < 0)
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+
+                if (_list.Count == 0)
+                    return;
+
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
                 for (DictionaryNode node = _list._head; node != null; node = node.next)
                 {
-                    array.SetValue(_isKeys ? node.key : node.value, index);
+                    indices[0] = index;
+                    array.SetValue(_isKeys ? node.key : node.value, indices);
                     index++;
                 }
             }
@@ -399,12 +412,7 @@ namespace System.Collections.Specialized
             {
                 get
                 {
-                    int count = 0;
-                    for (DictionaryNode node = _list._head; node != null; node = node.next)
-                    {
-                        count++;
-                    }
-                    return count;
+                    return _list.Count;
                 }
             }
 

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -351,8 +351,16 @@ namespace System.Collections.Specialized
                 throw new ArgumentException(SR.Arg_InsufficientSpace);
             }
 
+            if (_entriesArray.Count == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             for (IEnumerator e = this.GetEnumerator(); e.MoveNext();)
-                array.SetValue(e.Current, index++);
+            {
+                indices[0] = index++;
+                array.SetValue(e.Current, indices);
+            }
         }
 
         Object ICollection.SyncRoot
@@ -599,8 +607,16 @@ namespace System.Collections.Specialized
                     throw new ArgumentException(SR.Arg_InsufficientSpace);
                 }
 
+                if (_coll.Count == 0)
+                    return;
+
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
                 for (IEnumerator e = this.GetEnumerator(); e.MoveNext();)
-                    array.SetValue(e.Current, index++);
+                {
+                    indices[0] = index++;
+                    array.SetValue(e.Current, indices);
+                }
             }
 
             Object ICollection.SyncRoot

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -203,13 +203,20 @@ namespace System.Collections.Specialized
             }
 
             int n = Count;
+
+            if (n == 0)
+                return;
+
+            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
             if (_all == null)
             {
                 String[] all = new String[n];
                 for (int i = 0; i < n; i++)
                 {
                     all[i] = Get(i);
-                    dest.SetValue(all[i], i + index);
+                    indices[0] = i + index;
+                    dest.SetValue(all[i], indices);
                 }
                 _all = all; // wait until end of loop to set _all reference in case Get throws
             }
@@ -217,7 +224,8 @@ namespace System.Collections.Specialized
             {
                 for (int i = 0; i < n; i++)
                 {
-                    dest.SetValue(_all[i], i + index);
+                    indices[0] = i + index;
+                    dest.SetValue(_all[i], indices);
                 }
             }
         }

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/OrderedDictionary.cs
@@ -470,9 +470,16 @@ namespace System.Collections.Specialized
                     throw new ArgumentNullException("array");
                 if (index < 0)
                     throw new ArgumentOutOfRangeException("index");
+
+                if (_objects.Count == 0)
+                    return;
+
+                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
+
                 foreach (object o in _objects)
                 {
-                    array.SetValue(_isKeys ? ((DictionaryEntry)o).Key : ((DictionaryEntry)o).Value, index);
+                    indices[0] = index;
+                    array.SetValue(_isKeys ? ((DictionaryEntry)o).Key : ((DictionaryEntry)o).Value, indices);
                     index++;
                 }
             }


### PR DESCRIPTION
There are several places where `Array.SetValue` is used within loops. This results in a params array allocation on each loop iteration, because `Array.SetValue(object, int)` does not exist in .NET Core -- only `Array.SetValue(object, params int[])` is available.

This change lifts out the implicit allocation from the loops. The change is consistent with similar implementations in [Immutable Collections](https://github.com/dotnet/corefx/blob/ba8180fdcd863cb6accfb01a98891efe6d989fcd/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs#L138-L148) and [XmlDocument](https://github.com/dotnet/corefx/blob/4d10331799c027fbc4ab4649b2ad5b2c94049a74/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs#L251-L261).

One minor unrelated change as part of this: I noticed that `ListDictionary.NodeKeyValueCollection.Count` could just return the count of the list instead of looping through the list to generate the count.

Notes:
 - There are some uses of `Array.SetValue(object, params int[])` in `Regex`, that will be optimized as part of #316.
 - There are tests that use `Array.SetValue(object, params int[])` that could still be optimized; I chose not to spend time fixing those.