### PR TITLE
Add vim swp files to the gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,4 +237,9 @@ Temporary Items
 .apdisk
 
 # vim temporary files
-.*.swp
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# vim temporary files
+.*.swp


### PR DESCRIPTION
On a default windows LFN system and the *nix installs the swp file will be prefixed with a ., so the pattern takes that into account.  It can be relaxed if it's found to be under-matching.

This also only looks at the primary .swp, and doesn't encode the fallback logic (.swp => .swo => .swn => ... => .swa).  If needed, it can be added later.