### PR TITLE
Disable running tests System.Collections.NonGeneric tests in parallel.

### DIFF
--- a/src/System.Collections.NonGeneric/tests/AssemblyInfo.cs
+++ b/src/System.Collections.NonGeneric/tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="CaseInsensitiveComparer\CaseInsensitiveComparer_ctor.cs" />
     <Compile Include="CaseInsensitiveComparer\CaseInsensitiveComparer_CultureInfo.cs" />
     <Compile Include="CaseInsensitiveComparer\CaseInsensitiveComparer_Default.cs" />


### PR DESCRIPTION
These tests were hanging on one of my machines, apparently because there were not enough threads in thread pool.  Multiple tests were queuing up a bunch of tasks and then waiting on all of them at the same time.  This resulted in all of the threadpool threads waiting for the tasks to be completed with no threads left over to actually make progress on the tasks.