### PR TITLE
Allow building with only VS 2015 installed and no VS 2013 build tools

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -7,13 +7,13 @@ setlocal
 ::       assembly. 
 
 :: Check prerequisites
-set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/wiki/Developer%%20Guide for build instructions. && exit /b 1
-
-if not defined VSINSTALLDIR echo Error: build.cmd should be run from a Visual Studio Command Prompt.  Please see https://github.com/dotnet/corefx/wiki/Developer%%20Guide for build instructions. && exit /b 1
+if not defined VS120COMNTOOLS (
+    if not defined VS140COMNTOOLS (
+        echo Error: build.cmd should be run from a Visual Studio 2013 or 2015 Command Prompt.  
+        echo        Please see https://github.com/dotnet/corefx/wiki/Developer%%20Guide for build instructions.
+        exit /b 1
+    )
+)
 
 :: Log build command line
 set _buildprefix=echo
@@ -28,7 +28,7 @@ call :build %*
 goto :AfterBuild
 
 :build
-%_buildprefix% %_msbuildexe% "%~dp0build.proj" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%~dp0build.proj" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log";Append %* %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 

--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.21-prerelease</BuildToolsVersion>
+    <BuildToolsVersion>1.0.22-prerelease</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.21-prerelease" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.22-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
@@ -65,14 +65,12 @@ namespace System.Linq.Parallel
             Contract.Assert(sharedkeys != null);
             Contract.Assert(sharedValues != null);
             Contract.Assert(sharedBarriers != null);
-            Contract.Assert(groupState.CancellationState.MergedCancellationToken != null);
             Contract.Assert(sharedIndices.Length <= sharedkeys.Length);
             Contract.Assert(sharedIndices.Length == sharedValues.Length);
             // Multi-dim arrays are simulated using jagged arrays.
             // Because of that, when phaseCount == 0, we end up with an empty sharedBarrier array.
             // Since there are no cases when phaseCount == 0 where we actually access the sharedBarriers, I am removing this check.
             // Contract.Assert(sharedIndices.Length == sharedBarriers[0].Length);
-            Contract.Assert(groupState.CancellationState.MergedCancellationToken != null);
 
             _source = source;
             _partitionCount = partitionCount;


### PR DESCRIPTION
**NOTE** This will fail to build and should not be merged until a v1.0.22-prerelease of buildtools is published after mergning dotnet/buildtools#57 has been accepted.

3 parts:

1) Don't prefer VS2013 msbuild.exe over what is provided by current developer command prompt. 
2) Fix compiler warnings generated by VS 2015 csc.exe, but not VS 2013.
3) Bump buildtools version as we need dotnet/buildtools#57

See individual commit messages for more details.
