### PR TITLE
Update usage of StartNew/ContinueWith in tests

### DIFF
--- a/src/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Concurrent.Tests
             Task[] tks = new Task[2];
             // A simple blocking consumer with no cancellation.
             int expect = 1;
-            tks[0] = Task.Factory.StartNew(() =>
+            tks[0] = Task.Run(() =>
             {
                 while (!bc.IsCompleted)
                 {
@@ -34,17 +34,17 @@ namespace System.Collections.Concurrent.Tests
                     }
                     catch (InvalidOperationException) { } // throw when CompleteAdding called
                 }
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
             // A simple blocking producer with no cancellation.
-            tks[1] = Task.Factory.StartNew(() =>
+            tks[1] = Task.Run(() =>
             {
                 bc.Add(1);
                 bc.Add(2);
                 bc.Add(3);
                 // Let consumer know we are done.
                 bc.CompleteAdding();
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
             Task.WaitAll(tks);
         }
@@ -161,10 +161,10 @@ namespace System.Collections.Concurrent.Tests
 
             producer2.CompleteAdding();
 
-            Task.Factory.StartNew(() =>
+            Task.Run(() =>
             {
                 producer1.Add(100);
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
             int ignored, index, timeout = 5000;
             index = BlockingCollection<int>.TryTakeFromAny(producerArray, out ignored, timeout);

--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -19,15 +19,15 @@ namespace System.Collections.Concurrent.Tests
         {
             ConcurrentBag<int> cb = new ConcurrentBag<int>();
             Task[] tks = new Task[2];
-            tks[0] = Task.Factory.StartNew(() =>
+            tks[0] = Task.Run(() =>
                 {
                     cb.Add(4);
                     cb.Add(5);
                     cb.Add(6);
-                }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                });
 
             // Consume the items in the bag 
-            tks[1] = Task.Factory.StartNew(() =>
+            tks[1] = Task.Run(() =>
                 {
                     int item;
                     while (!cb.IsEmpty)
@@ -40,7 +40,7 @@ namespace System.Collections.Concurrent.Tests
                             Assert.False(true, "Expected: 4|5|6; actual: " + item.ToString());
                         }
                     }
-                }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                });
 
             Task.WaitAll(tks);
         }
@@ -398,12 +398,12 @@ namespace System.Collections.Concurrent.Tests
             Task[] tasks = new Task[10];
             for (int i = 0; i < tasks.Length; i++)
             {
-                tasks[i] = Task.Factory.StartNew(() =>
+                tasks[i] = Task.Run(() =>
                     {
                         int[] array = bag.ToArray();
                         if (array == null || array.Length != 10000)
                             Interlocked.Increment(ref failCount);
-                    }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                    });
             }
 
             Task.WaitAll(tasks);

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Concurrent.Tests
             ConcurrentDictionary<int, int> cd = new ConcurrentDictionary<int, int>();
 
             Task[] tks = new Task[2];
-            tks[0] = Task.Factory.StartNew(() =>
+            tks[0] = Task.Run(() =>
             {
                 var ret = cd.TryAdd(1, 11);
                 if (!ret)
@@ -34,9 +34,9 @@ namespace System.Collections.Concurrent.Tests
                     ret = cd.TryUpdate(2, 22, 222);
                     Assert.True(ret);
                 }
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
-            tks[1] = Task.Factory.StartNew(() =>
+            tks[1] = Task.Run(() =>
             {
                 var ret = cd.TryAdd(2, 222);
                 if (!ret)
@@ -51,7 +51,7 @@ namespace System.Collections.Concurrent.Tests
                     ret = cd.TryUpdate(1, 111, 11);
                     Assert.True(ret);
                 }
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
             Task.WaitAll(tks);
         }

--- a/src/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -21,14 +21,14 @@ namespace System.Collections.Concurrent.Tests
             cs.Push(1);
 
             Task[] tks = new Task[2];
-            tks[0] = Task.Factory.StartNew(() =>
+            tks[0] = Task.Run(() =>
             {
                 cs.Push(2);
                 cs.Push(3);
                 cs.Push(4);
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
-            tks[1] = Task.Factory.StartNew(() =>
+            tks[1] = Task.Run(() =>
             {
                 int item1, item2;
                 var ret1 = cs.TryPop(out item1);
@@ -44,7 +44,7 @@ namespace System.Collections.Concurrent.Tests
                 {
                     Assert.Equal(1, item1);
                 }
-            }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            });
 
             Task.WaitAll(tks);
         }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_Synchronized.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_Synchronized.cs
@@ -162,7 +162,7 @@ public class Queue_Synchronized
         {
             for (int i = 0; i < m_ThreadsToUse; i++)
             {
-                ths[i] = Task.Factory.StartNew(new Action(this.StartEnThread), TaskCreationOptions.LongRunning);
+                ths[i] = Task.Factory.StartNew(new Action(this.StartEnThread), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
             m_ThreadCount = m_ThreadsToUse;
             Task.WaitAll(ths);
@@ -190,7 +190,7 @@ public class Queue_Synchronized
             m_ThreadCount = m_ThreadsToUse;
             for (int i = 0; i < m_ThreadsToUse; i++)
             {
-                ths[i] = Task.Factory.StartNew(new Action(this.StartDeThread), TaskCreationOptions.LongRunning);
+                ths[i] = Task.Factory.StartNew(new Action(this.StartDeThread), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
             Task.WaitAll(ths);
 
@@ -218,7 +218,7 @@ public class Queue_Synchronized
             m_ThreadCount = m_ThreadsToUse;
             for (int i = 0; i < m_ThreadsToUse; i++)
             {
-                ths[i] = Task.Factory.StartNew(new Action(this.StartDeEnThread), TaskCreationOptions.LongRunning);
+                ths[i] = Task.Factory.StartNew(new Action(this.StartDeEnThread), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
             Task.WaitAll(ths);
 
@@ -245,7 +245,7 @@ public class Queue_Synchronized
             m_ThreadCount = m_ThreadsToUse;
             for (int i = 0; i < m_ThreadsToUse; i++)
             {
-                ths[i] = Task.Factory.StartNew(new Action(this.StartEnDeThread), TaskCreationOptions.LongRunning);
+                ths[i] = Task.Factory.StartNew(new Action(this.StartEnDeThread), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
             Task.WaitAll(ths);
 

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_get_SyncRoot.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_get_SyncRoot.cs
@@ -80,15 +80,13 @@ public class Queue_get_SyncRoot
                     iCountErrors++;
                 }
 
-                //we are going to rumble with the Queues with 2 threads
-
                 workers = new Task[iNumberOfWorkers];
                 ts1 = new Action(SortElements);
                 ts2 = new Action(ReverseElements);
                 for (int iThreads = 0; iThreads < iNumberOfWorkers; iThreads += 2)
                 {
-                    workers[iThreads] = Task.Factory.StartNew(ts1, TaskCreationOptions.LongRunning);
-                    workers[iThreads + 1] = Task.Factory.StartNew(ts2, TaskCreationOptions.LongRunning);
+                    workers[iThreads] = Task.Run(ts1);
+                    workers[iThreads + 1] = Task.Run(ts2);
                 }
 
                 Task.WaitAll(workers);

--- a/src/System.Collections.NonGeneric/tests/Stack/Stack_get_SyncRoot.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/Stack_get_SyncRoot.cs
@@ -90,14 +90,13 @@ public class Stack_get_SyncRoot
                     Console.WriteLine("Err_234dnvf! Expected value not returned, " + (arrSon.SyncRoot == arrMother.SyncRoot));
                 }
 
-                //we are going to rumble with the Stacks with 2 threads
                 var ts1 = new Action(SortElements);
                 var ts2 = new Action(ReverseElements);
                 Task[] tasks = new Task[iNumberOfWorkers];
                 for (int iThreads = 0; iThreads < iNumberOfWorkers; iThreads += 2)
                 {
-                    tasks[iThreads] = Task.Factory.StartNew(ts1, TaskCreationOptions.LongRunning);
-                    tasks[iThreads + 1] = Task.Factory.StartNew(ts2, TaskCreationOptions.LongRunning);
+                    tasks[iThreads] = Task.Run(ts1);
+                    tasks[iThreads + 1] = Task.Run(ts2);
                 }
                 Task.WaitAll(tasks);
 


### PR DESCRIPTION
Searched through tests for usage of StartNew and ContinueWith.
- Replaced StartNew calls with Task.Run when the parameters to StartNew were all the defaults used by Task.Run or where no scheduler was specified but should have been. (I also changed one or two places to use Task.Run where LongRunning had been specified, but where using LongRunning with the default scheduler would have resulted in thousands of threads getting created).
- Ensured remaining StartNew and ContinueWith calls were all targeting TaskScheduler.Default explicitly.