### PR TITLE
Minor code cleanup in collections

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -400,7 +400,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <param name="list">The list to steal</param>
         /// <returns>True if can steal, false otherwise</returns>
-        private bool CanSteal(ThreadLocalList list)
+        private static bool CanSteal(ThreadLocalList list)
         {
             if (list.Count <= 2 && list._currentOp != (int)ListOperation.None)
             {
@@ -410,11 +410,7 @@ namespace System.Collections.Concurrent
                     spinner.SpinOnce();
                 }
             }
-            if (list.Count > 0)
-            {
-                return true;
-            }
-            return false;
+            return list.Count > 0;
         }
 
         /// <summary>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -912,10 +912,6 @@ namespace System.Collections.Concurrent
     /// </summary>
     struct VolatileBool
     {
-        public VolatileBool(bool value)
-        {
-            _value = value;
-        }
         public volatile bool _value;
     }
 }

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -402,7 +402,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Local helper function to validate the Pop Push range methods input
         /// </summary>
-        private void ValidatePushPopRangeInput(T[] items, int startIndex, int count)
+        private static void ValidatePushPopRangeInput(T[] items, int startIndex, int count)
         {
             if (items == null)
             {
@@ -663,7 +663,7 @@ namespace System.Collections.Concurrent
         /// <param name="collection">The collection to place the popped items in</param>
         /// <param name="startIndex">the beginning of index of where to place the popped items</param>
         /// <param name="nodesCount">The number of nodes.</param>
-        private void CopyRemovedItems(Node head, T[] collection, int startIndex, int nodesCount)
+        private static void CopyRemovedItems(Node head, T[] collection, int startIndex, int nodesCount)
         {
             Node current = head;
             for (int i = startIndex; i < startIndex + nodesCount; i++)

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -619,7 +619,7 @@ namespace System.Collections.Concurrent
                     else
                     {
                         return new InternalPartitionEnumerator(_sharedReader, _sharedIndex,
-                            _hasNoElementsLeft, _sharedLock, _activePartitionCount, this, _useSingleChunking);
+                            _hasNoElementsLeft, _activePartitionCount, this, _useSingleChunking);
                     }
                 }
 
@@ -890,7 +890,6 @@ namespace System.Collections.Concurrent
                 // the values of the following two fields are passed in from
                 // outside(already initialized) by the constructor, 
                 private readonly SharedBool _hasNoElementsLeft;
-                private readonly object _sharedLock;
                 private readonly SharedInt _activePartitionCount;
                 private InternalPartitionEnumerable _enumerable;
 
@@ -899,14 +898,12 @@ namespace System.Collections.Concurrent
                     IEnumerator<TSource> sharedReader,
                     SharedLong sharedIndex,
                     SharedBool hasNoElementsLeft,
-                    object sharedLock,
                     SharedInt activePartitionCount,
                     InternalPartitionEnumerable enumerable,
                     bool useSingleChunking)
                     : base(sharedReader, sharedIndex, useSingleChunking)
                 {
                     _hasNoElementsLeft = hasNoElementsLeft;
-                    _sharedLock = sharedLock;
                     _enumerable = enumerable;
                     _activePartitionCount = activePartitionCount;
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -103,7 +103,6 @@ namespace System.Collections.Immutable
                     {
                         // truncation mode
                         // Clear the elements of the elements that are effectively removed.
-                        var e = _elements;
 
                         // PERF: Array.Clear works well for big arrays, 
                         //       but may have too much overhead with small ones (which is the common case here)

--- a/src/System.Collections.NonGeneric/src/System/Collections/KeyValuePairs.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/KeyValuePairs.cs
@@ -18,25 +18,15 @@ namespace System.Collections
     internal class KeyValuePairs
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private object _key;
+        private readonly object _key;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private object _value;
+        private readonly object _value;
 
         public KeyValuePairs(object key, object value)
         {
             _value = value;
             _key = key;
-        }
-
-        public object Key
-        {
-            get { return _key; }
-        }
-
-        public object Value
-        {
-            get { return _value; }
         }
     }
 }

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -145,9 +145,9 @@ namespace System.Collections
             Contract.EndContractBlock();
 
             int i = 0;
-            if (array is Object[])
+            object[] objArray = array as object[];
+            if (objArray != null)
             {
-                Object[] objArray = (Object[])array;
                 while (i < _size)
                 {
                     objArray[i + index] = _array[_size - i - 1];


### PR DESCRIPTION
Playing around with code analysis in VS2015, found some minor things to be cleaned up in the collections libraries:
- Removed some dead code
- Eliminated an unnecessary cast
- Made some methods static that weren't using instance state

Etc.