### PR TITLE
Remove faulty asserts in dataflow tests

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BatchBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BatchBlockTests.cs
@@ -24,7 +24,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 Assert.Equal(expected: i + 1, actual: blocks[i].BatchSize);
                 Assert.Equal(expected: 0, actual: blocks[i].OutputCount);
                 Assert.NotNull(blocks[i].Completion);
-                Assert.False(blocks[i].Completion.IsCompleted);
             }
         }
 

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BroadcastBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/BroadcastBlockTests.cs
@@ -23,7 +23,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
             foreach (var block in blocks)
             {
                 Assert.NotNull(block.Completion);
-                Assert.False(block.Completion.IsCompleted);
                 int item;
                 Assert.False(block.TryReceive(out item));
             }


### PR DESCRIPTION
Several ctor tests were asserting that block.Completion.IsCompleted was false, but also creating the block with a canceled cancellation token.  That's erroneous.  But this wasn't caught initially because there's a race.