### PR TITLE
Bug fix in UMS tests

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -30,8 +30,6 @@ public class UmsSecurityTests
                         //change via PositionPointer
                         fixed (byte* invalidbytePtr = positionPointerByteArrays[positionLoop])
                         {
-                            // This depends on the layout of pinned memory
-                            Assert.True((long)invalidbytePtr > ((long)bytePtr + data.Length), String.Format("{0} > {1} + {2}", (long)invalidbytePtr, (long)bytePtr, data.Length));
                             // not throw currently
                             stream.PositionPointer = invalidbytePtr;
                             VerifyNothingCanBeReadOrWritten(stream, data);


### PR DESCRIPTION
The test had an assert that assumed arrays are allocated in memory adress order.
This is not a guarantee that we make, and so the tests were failing often.