### PR TITLE
Issue 208 is closed.  Removing the [ActiveIssue(208)] markers in tests.

### DIFF
--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateElementTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateElementTests.cs
@@ -61,7 +61,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void NamespaceWithNoLocalName()
         {
             var xmlDocument = new XmlDocument();
@@ -69,7 +68,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void NamespaceAndLocalNameWithColon()
         {
             var xmlDocument = new XmlDocument();

--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/ImportNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/ImportNodeTests.cs
@@ -10,7 +10,6 @@ namespace XmlDocumentTests.XmlDocumentTests
     public class ImportNodeTests
     {
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportNullNode()
         {
             var xmlDocument = new XmlDocument();
@@ -20,7 +19,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportDocumentNode()
         {
             var xmlDocument = new XmlDocument();
@@ -31,7 +29,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportDocumentFragment()
         {
             var tempDoc = new XmlDocument();
@@ -50,7 +47,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportWhiteSpace()
         {
             var whitespace = "        ";
@@ -66,7 +62,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportSignificantWhitespace()
         {
             var whitespace = "        \t";
@@ -82,7 +77,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportElementDeepFalse()
         {
             var xmlDocument = new XmlDocument();
@@ -103,7 +97,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportElementDeepTrue()
         {
             var xmlDocument = new XmlDocument();
@@ -124,7 +117,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ImportAttributeDeepFalse()
         {
             var xmlDocument = new XmlDocument();

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/CloneNodeTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/CloneNodeTests.cs
@@ -28,7 +28,6 @@ namespace XmlDocumentTests.XmlNodeTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void CloneComplexDocumentTrue()
         {
             var xmlDocument = new XmlDocument();
@@ -104,7 +103,6 @@ namespace XmlDocumentTests.XmlNodeTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void CloneComplexDocumentTrueAndManipulate()
         {
             var xmlDocument = new XmlDocument();

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/OwnerDocumentTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/OwnerDocumentTests.cs
@@ -46,7 +46,6 @@ namespace XmlDocumentTests.XmlAttributeTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void OwnerDocumentOnImportedTree()
         {
             var tempDoc = new XmlDocument();

--- a/src/System.Xml.XmlDocument/tests/XmlNodeTests/ValueTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlNodeTests/ValueTests.cs
@@ -10,7 +10,6 @@ namespace XmlDocumentTests.XmlNodeTests
     public static class ValueTests
     {
         [Fact]
-        [ActiveIssue(208)]
         public static void OnDocumentNode()
         {
             var xmlDocument = new XmlDocument();
@@ -32,7 +31,6 @@ namespace XmlDocumentTests.XmlNodeTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ElementWithNoDescendents()
         {
             var xmlDocument = new XmlDocument();
@@ -43,7 +41,6 @@ namespace XmlDocumentTests.XmlNodeTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void ElementWithDescendents()
         {
             var xmlDocument = new XmlDocument();
@@ -134,7 +131,6 @@ namespace XmlDocumentTests.XmlNodeTests
         }
 
         [Fact]
-        [ActiveIssue(208)]
         public static void DocumentFragment()
         {
             var xmlDocument = new XmlDocument();


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/208 was closed on 17 December.  Removing the ActiveIssue attribute causes the tests to go back into to the inner loop tests during the build process.

Looking through the other [ActiveIssue(issue)] attributes, the remainder appear to still be marked as Open, so this is the current "bulk re-enable".