### PR TITLE
Improve performance and allocations of xpath string functions

### DIFF
--- a/src/Common/tests/System.Xml.XPath/CoreFunctionLibrary/StringFunctionsTests.cs
+++ b/src/Common/tests/System.Xml.XPath/CoreFunctionLibrary/StringFunctionsTests.cs
@@ -539,8 +539,8 @@ namespace XPathTests.FunctionalTests.CoreFunctionLibrary
             var expected = @"";
 
             Utils.XPathStringTest(xml, testExpression, expected);
-        }        
-        
+        }
+
         /// <summary>
         /// Verify result.
         /// normalize-space(" \t\n\r") = ""
@@ -551,6 +551,21 @@ namespace XPathTests.FunctionalTests.CoreFunctionLibrary
             var xml = "dummy.xml";
             var testExpression = "normalize-space(\" \t\n\r\")";
             var expected = @"";
+
+            Utils.XPathStringTest(xml, testExpression, expected);
+        }
+
+        /// <summary>
+        /// Verify result.
+        /// normalize-space(" Surrogate-Pair-String ") = ""
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2475()
+        {
+            var xml = "dummy.xml";
+            var fourCircles = char.ConvertFromUtf32(0x1F01C);
+            var testExpression = "normalize-space(\" " + fourCircles + " \")";
+            var expected = fourCircles;
 
             Utils.XPathStringTest(xml, testExpression, expected);
         }
@@ -763,6 +778,50 @@ namespace XPathTests.FunctionalTests.CoreFunctionLibrary
             var xml = "dummy.xml";
             var testExpression = @"translate("""", ""abc"", ""ABC"")";
             var expected = @"";
+
+            Utils.XPathStringTest(xml, testExpression, expected);
+        }
+
+        /// <summary>
+        /// Verify result.
+        /// translate("unicode", "unicode", "uppercase-unicode") = "uppercase -unicode"
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2476()
+        {
+            var xml = "dummy.xml";
+            var testExpression = "translate(\"\0x03B1\0x03B2\0x03B3\", \"\0x03B1\0x03B2\0x03B3\", \"\0x0391\0x0392\0x0393\")";
+            var expected = "\0x0391\0x0392\0x0393";
+
+            Utils.XPathStringTest(xml, testExpression, expected);
+        }
+
+        /// <summary>
+        /// Verify result.
+        /// translate("surrogate-pairs", "ABC", "") = "surrogate-pairs"
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2477()
+        {
+            var xml = "dummy.xml";
+            var fourOClock = char.ConvertFromUtf32(0x1F553);
+            var fiveOClock = char.ConvertFromUtf32(0x1F554);
+            var testExpression = @"translate(""" + fourOClock + fiveOClock + @""", ""ABC"", """")";
+            var expected = fourOClock + fiveOClock;
+
+            Utils.XPathStringTest(xml, testExpression, expected);
+        }
+
+        /// <summary>
+        /// Verify result.
+        /// translate("abc", "abca", "ABCZ") = "ABC"
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2478()
+        {
+            var xml = "dummy.xml";
+            var testExpression = @"translate(""abc"", ""abca"", ""ABCZ"")";
+            var expected = "ABC";
 
             Utils.XPathStringTest(xml, testExpression, expected);
         }

--- a/src/Common/tests/System.Xml.XPath/CoreFunctionLibrary/StringFunctionsTests.cs
+++ b/src/Common/tests/System.Xml.XPath/CoreFunctionLibrary/StringFunctionsTests.cs
@@ -529,6 +529,34 @@ namespace XPathTests.FunctionalTests.CoreFunctionLibrary
 
         /// <summary>
         /// Verify result.
+        /// normalize-space("") = ""
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2473()
+        {
+            var xml = "dummy.xml";
+            var testExpression = @"normalize-space("""")";
+            var expected = @"";
+
+            Utils.XPathStringTest(xml, testExpression, expected);
+        }        
+        
+        /// <summary>
+        /// Verify result.
+        /// normalize-space(" \t\n\r") = ""
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2474()
+        {
+            var xml = "dummy.xml";
+            var testExpression = "normalize-space(\" \t\n\r\")";
+            var expected = @"";
+
+            Utils.XPathStringTest(xml, testExpression, expected);
+        }
+
+        /// <summary>
+        /// Verify result.
         /// normalize-space(" AB") = "AB"
         /// </summary>
         [Fact]
@@ -723,6 +751,20 @@ namespace XPathTests.FunctionalTests.CoreFunctionLibrary
             var expected = @"A B";
 
             Utils.XPathStringTest(xml, testExpression, expected, startingNodePath: startingNodePath);
+        }
+
+        /// <summary>
+        /// Verify result.
+        /// translate("", "abc", "ABC") = ""
+        /// </summary>
+        [Fact]
+        public static void StringFunctionsTest2472()
+        {
+            var xml = "dummy.xml";
+            var testExpression = @"translate("""", ""abc"", ""ABC"")";
+            var expected = @"";
+
+            Utils.XPathStringTest(xml, testExpression, expected);
         }
 
         /// <summary>

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/StringFunctions.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/StringFunctions.cs
@@ -212,60 +212,70 @@ namespace MS.Internal.Xml.XPath
 
         private string Normalize(XPathNodeIterator nodeIterator)
         {
-            string str1;
+            string value;
             if (_argList.Count > 0)
             {
-                str1 = _argList[0].Evaluate(nodeIterator).ToString();
+                value = _argList[0].Evaluate(nodeIterator).ToString();
             }
             else
             {
-                str1 = nodeIterator.Current.Value;
+                value = nodeIterator.Current.Value;
             }
-            str1 = XmlConvertEx.TrimString(str1);
-            int count = 0;
-            StringBuilder str2 = new StringBuilder();
-            bool FirstSpace = true;
+            int modifyPos = -1;
+            char[] chars = value.ToCharArray();
+            bool firstSpace = false; // Start false to trim the beginning
             XmlCharType xmlCharType = XmlCharType.Instance;
-            while (count < str1.Length)
+
+            for (int comparePos = 0; comparePos < chars.Length; comparePos++)
             {
-                if (!xmlCharType.IsWhiteSpace(str1[count]))
+                if (!xmlCharType.IsWhiteSpace(chars[comparePos]))
                 {
-                    FirstSpace = true;
-                    str2.Append(str1[count]);
+                    firstSpace = true;
+                    modifyPos++;
+                    chars[modifyPos] = chars[comparePos];
                 }
-                else if (FirstSpace)
+                else if (firstSpace)
                 {
-                    FirstSpace = false;
-                    str2.Append(' ');
+                    firstSpace = false;
+                    modifyPos++;
+                    chars[modifyPos] = ' ';
                 }
-                count++;
             }
-            return str2.ToString();
+
+            // Trim end
+            if (modifyPos > -1 && chars[modifyPos] == ' ')
+                modifyPos--;
+
+            return new string(chars, 0, modifyPos + 1);
         }
+
         private string Translate(XPathNodeIterator nodeIterator)
         {
-            string str1 = _argList[0].Evaluate(nodeIterator).ToString();
-            string str2 = _argList[1].Evaluate(nodeIterator).ToString();
-            string str3 = _argList[2].Evaluate(nodeIterator).ToString();
-            int count = 0, index;
-            StringBuilder str = new StringBuilder();
-            while (count < str1.Length)
+            string value = _argList[0].Evaluate(nodeIterator).ToString();
+            string mapFrom = _argList[1].Evaluate(nodeIterator).ToString();
+            string mapTo = _argList[2].Evaluate(nodeIterator).ToString();
+            int modifyPos = -1;
+            char[] chars = value.ToCharArray();
+
+            for (int comparePos = 0; comparePos < chars.Length; comparePos++)
             {
-                index = str2.IndexOf(str1[count]);
+                int index = mapFrom.IndexOf(chars[comparePos]);
                 if (index != -1)
                 {
-                    if (index < str3.Length)
+                    if (index < mapTo.Length)
                     {
-                        str.Append(str3[index]);
+                        modifyPos++;
+                        chars[modifyPos] = mapTo[index];
                     }
                 }
                 else
                 {
-                    str.Append(str1[count]);
+                    modifyPos++;
+                    chars[modifyPos] = chars[comparePos];
                 }
-                count++;
             }
-            return str.ToString();
+
+            return new string(chars, 0, modifyPos + 1);
         }
 
         public override XPathNodeIterator Clone() { return new StringFunctions(this); }


### PR DESCRIPTION
Improve Translate perf by ~20% and allocations by around 50% (dependant on string)
Improve Normalize perf by ~30% and allocations by around 55% (dependant on string)

General:
We are always iterating through every char so we can get them all in one go and use that as our temporary buffer instead of the StringBuilder.
Because these functions can remove chars there is a read point in the buffer and an update point. The update point is always the same place or less than the read point.

Normalize:
No need for XmlConvertEx.TrimString as we can start "firstSpace" as false to trim the start and all trailing whitespace at the end is combined into one space. We can just check that at the end which avoids a trim string creation.