### PR TITLE
Remove the issue stats badge from the ReadMe.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # .NET Core
 
-[![Build status][build-status-image]][build-status]  [![Issue Stats][pull-requests-image]][pull-requests]  [![Issue Stats][issues-closed-image]][issues-closed]
+[![Build status][build-status-image]][build-status]
 
 [build-status-image]: http://dotnet-ci.cloudapp.net/job/dotnet_corefx/badge/icon
 [build-status]: http://dotnet-ci.cloudapp.net/job/dotnet_corefx/
-[pull-requests-image]: http://www.issuestats.com/github/dotnet/corefx/badge/pr
-[pull-requests]: http://www.issuestats.com/github/dotnet/corefx
-[issues-closed-image]: http://www.issuestats.com/github/dotnet/corefx/badge/issue
-[issues-closed]: http://www.issuestats.com/github/dotnet/corefx
 
 This repository contains the class libraries for .NET Core. This is a
 work in progress, and does not currently contain the entire set of libraries


### PR DESCRIPTION
The consensus among the team is that having the issue stats displayed on the repo home page isn't helpful and causes people to focus on the wrong things. I agree and think it is analogous to measuring the quality of a developer based on the number of lines of code they write. So I'm removing the badges from the readme.md. 