### PR TITLE
Fix PLINQ concat ordering bug

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
@@ -377,7 +377,7 @@ namespace System.Linq.Parallel
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
                         ConcatKey key =
-                            ConcatKey.MakeLeft<TLeftKey, TRightKey>(_rightOrdered ? rightKey : default(TRightKey));
+                            ConcatKey.MakeRight<TLeftKey, TRightKey>(_rightOrdered ? rightKey : default(TRightKey));
                         Pair oldEntry;
                         Wrapper<TInputOutput> wrappedElem = new Wrapper<TInputOutput>((TInputOutput)elem.First);
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ConcatQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ConcatQueryOperator.cs
@@ -205,7 +205,7 @@ namespace System.Linq.Parallel
                 TRightKey rightKey = default(TRightKey);
                 if (_secondSource.MoveNext(ref currentElement, ref rightKey))
                 {
-                    currentKey = ConcatKey.MakeLeft<TLeftKey, TRightKey>(rightKey);
+                    currentKey = ConcatKey.MakeRight<TLeftKey, TRightKey>(rightKey);
                     return true;
                 }
 

--- a/src/System.Linq.Parallel/tests/ParallelQueryTests.cs
+++ b/src/System.Linq.Parallel/tests/ParallelQueryTests.cs
@@ -11,7 +11,6 @@ namespace Test
     public static class ParallelQueryTests
     {
         [Fact]
-        [ActiveIssue(235)]
         public static void RunTests()
         {
             LeftOperator[] leftOps = new LeftOperator[] {


### PR DESCRIPTION
For .NET Core, some (temporary) changes were made to PLINQ to remove some of its usage of generics in order to workaround some (temporary) constraints of the runtime.  In doing so, this bug slipped in, with the wrong concat key being created for an element in the sequence, causing erroneous results.  This PR fixes the bug and adds a test case that fails before and succeeds after the fix. (Fixes #584)