### PR TITLE
Fix faulty BlockingCollection test

### DIFF
--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
@@ -801,7 +801,6 @@ namespace System.Collections.Concurrent.Tests
             Assert.True(dictionary.IsEmpty, "TestClear: FAILED.  IsEmpty returned false after Clear");
         }
 
-        [Fact(Skip = "Issue #387")] // Require TaskCreationOptions.LongRunning which will cause deadlock when running under xUnit
         public static void TestTryUpdate()
         {
             var dictionary = new ConcurrentDictionary<string, int>();


### PR DESCRIPTION
In looking at a failed PR, I noticed a BlockingCollection test had failed.  I looked at the test, and it was very strange, in no way testing what the test name implied (wasn't even calling the relevant method) and with a race that would easily cause the test to fail.  These collection tests probably need a solid overhaul, but in the meantime I've rewritten this test and another one with the same race.