### PR TITLE
Remove buffer allocation from File.ReadAllBytes

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -435,16 +435,16 @@ namespace System.IO
         [System.Security.SecurityCritical]
         private static byte[] InternalReadAllBytes(String path)
         {
-            byte[] bytes;
-            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            // bufferSize == 1 used to avoid unnecessary buffer in FileStream
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1))
             {
-                // Do a blocking read
-                int index = 0;
                 long fileLength = fs.Length;
                 if (fileLength > Int32.MaxValue)
                     throw new IOException(SR.IO_FileTooLong2GB);
+
+                int index = 0;
                 int count = (int)fileLength;
-                bytes = new byte[count];
+                byte[] bytes = new byte[count];
                 while (count > 0)
                 {
                     int n = fs.Read(bytes, index, count);
@@ -453,8 +453,8 @@ namespace System.IO
                     index += n;
                     count -= n;
                 }
+                return bytes;
             }
-            return bytes;
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated


### PR DESCRIPTION
(Fixes #580)

ReadAllBytes is creating a FileStream with the default buffer size of 4K.  Since we've already allocated a byte array large enough to hold the entire file, the internal buffer allocated in FileStream is pure overhead, both for the allocation itself and also for the extra copy of data through the buffer.

This commit fixes this simply by explicitly setting the bufferSize to 1.  FileStream lazily-allocates the buffer, only creating and using it if it needs it.  If a read comes in for a size greater than or equal to the bufferSize, it'll skip the buffer.  So, previously, when reading a file > 4K in size, the buffer would be avoided; now it's also avoided for files <= 4K in size.

A microbenchmark repeatedly caling ReadAllBytes showed that with this fix the number of gen0 GCs caused by its usage dropped anywhere from 0-10x, depending on the size of the file being read.  Throughput improved by a few percentage points as well.

(Note that I also tried this same change for WriteAllBytes.  While it did have a similar effect on gen0 GCs, it also caused a surprising regression in throughput, upwards of 20%, and I did not further dig into why.  I also noticed that at the moment FileStream in .NET Core is defaulting to useAsync=true, which is different from the desktop and doesn't make much sense for {Read/Write}AllBytes; if that default remains the default, we should explicitly set useAsync=false for these methods.)