### PR TITLE
Change sync File helpers to use sync FileStreams

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -381,7 +381,7 @@ namespace System.IO
             Contract.Requires(encoding != null);
             Contract.Requires(path.Length > 0);
 
-            Stream stream = FileStream.InternalOpen(path);
+            Stream stream = FileStream.InternalOpen(path, useAsync: false);
 
             using (StreamReader sr = new StreamReader(stream, encoding, true))
                 return sr.ReadToEnd();
@@ -420,7 +420,7 @@ namespace System.IO
             Contract.Requires(encoding != null);
             Contract.Requires(path.Length > 0);
 
-            Stream stream = FileStream.InternalCreate(path);
+            Stream stream = FileStream.InternalCreate(path, useAsync: false);
 
             using (StreamWriter sw = new StreamWriter(stream, encoding))
                 sw.Write(contents);
@@ -436,7 +436,7 @@ namespace System.IO
         private static byte[] InternalReadAllBytes(String path)
         {
             // bufferSize == 1 used to avoid unnecessary buffer in FileStream
-            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1))
+            using (FileStream fs = FileStream.InternalOpen(path, bufferSize: 1, useAsync: false))
             {
                 long fileLength = fs.Length;
                 if (fileLength > Int32.MaxValue)
@@ -478,7 +478,7 @@ namespace System.IO
             Contract.Requires(path.Length != 0);
             Contract.Requires(bytes != null);
 
-            using (FileStream fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+            using (FileStream fs = FileStream.InternalCreate(path, useAsync: false))
             {
                 fs.Write(bytes, 0, bytes.Length);
             }
@@ -516,7 +516,7 @@ namespace System.IO
             String line;
             List<String> lines = new List<String>();
 
-            Stream stream = FileStream.InternalOpen(path);
+            Stream stream = FileStream.InternalOpen(path, useAsync: false);
 
             using (StreamReader sr = new StreamReader(stream, encoding))
                 while ((line = sr.ReadLine()) != null)
@@ -559,7 +559,7 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyPath);
             Contract.EndContractBlock();
 
-            Stream stream = FileStream.InternalCreate(path);
+            Stream stream = FileStream.InternalCreate(path, useAsync: false);
 
             InternalWriteAllLines(new StreamWriter(stream, UTF8NoBOM), contents);
         }
@@ -576,7 +576,7 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyPath);
             Contract.EndContractBlock();
 
-            Stream stream = FileStream.InternalCreate(path);
+            Stream stream = FileStream.InternalCreate(path, useAsync: false);
 
             InternalWriteAllLines(new StreamWriter(stream, encoding), contents);
         }
@@ -626,7 +626,7 @@ namespace System.IO
             Contract.Requires(encoding != null);
             Contract.Requires(path.Length > 0);
 
-            Stream stream = FileStream.InternalAppend(path);
+            Stream stream = FileStream.InternalAppend(path, useAsync: false);
 
             using (StreamWriter sw = new StreamWriter(stream, encoding))
                 sw.Write(contents);
@@ -642,7 +642,7 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyPath);
             Contract.EndContractBlock();
 
-            Stream stream = FileStream.InternalAppend(path);
+            Stream stream = FileStream.InternalAppend(path, useAsync: false);
 
             InternalWriteAllLines(new StreamWriter(stream, UTF8NoBOM), contents);
         }
@@ -659,7 +659,7 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyPath);
             Contract.EndContractBlock();
 
-            Stream stream = FileStream.InternalAppend(path);
+            Stream stream = FileStream.InternalAppend(path, useAsync: false);
 
             InternalWriteAllLines(new StreamWriter(stream, encoding), contents);
         }

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.cs
@@ -134,19 +134,19 @@ namespace System.IO
         // InternalOpen, InternalCreate, and InternalAppend:
         // Factory methods for FileStream used by File, FileInfo, and ReadLinesIterator
         // Specifies default access and sharing options for FileStreams created by those classes
-        internal static FileStream InternalOpen(String path)
+        internal static FileStream InternalOpen(String path, int bufferSize = DefaultBufferSize, bool useAsync = DefaultUseAsync)
         {
-            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, DefaultUseAsync);
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, useAsync);
         }
 
-        internal static FileStream InternalCreate(String path)
+        internal static FileStream InternalCreate(String path, int bufferSize = DefaultBufferSize, bool useAsync = DefaultUseAsync)
         {
-            return new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, DefaultBufferSize, DefaultUseAsync);
+            return new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, bufferSize, useAsync);
         }
 
-        internal static FileStream InternalAppend(String path)
+        internal static FileStream InternalAppend(String path, int bufferSize = DefaultBufferSize, bool useAsync = DefaultUseAsync)
         {
-            return new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, DefaultBufferSize, DefaultUseAsync);
+            return new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, bufferSize, useAsync);
         }
 
         #region FileStream members

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -49,8 +49,10 @@ namespace System.IO
             // has varying degrees of support on different systems.
 
             // Copy the contents of the file from the source to the destination, creating the destination in the process
-            using (Stream src = File.OpenRead(sourceFullPath))
-            using (Stream dst = File.Open(destFullPath, overwrite ? FileMode.CreateNew : FileMode.Create))
+            const int bufferSize = FileStream.DefaultBufferSize;
+            const bool useAsync = false;
+            using (Stream src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, useAsync))
+            using (Stream dst = new FileStream(destFullPath, overwrite ? FileMode.CreateNew : FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, useAsync))
             {
                 src.CopyTo(dst);
             }


### PR DESCRIPTION
.NET Core currently uses a default of useAsync=true for FileStreams.  But File has several synchronous helpers, e.g. ReadAllBytes, which create FileStreams using the default, don't hand the FileStream out externally, and only perform synchronous operations.  This means there's unnecessary overhead related to setting up and executing the underlying asynchronous operations.  This commit simply changes those helpers (ReadAllBytes, WriteAllText, etc.) to specify that the file should be opened for synchronous rather than asynchronous I/O.

The performance improvement depends on a variety of factors, including the size of the file being read/written, the number of operations involved in reading/writing the file, etc.  I tried a bunch of combinations and contents, and didn't see any regressions.  In a variety of cases though I did see measurable improvements, e.g.

- ReadAllBytes on a 1K file improved throughput by ~30%.
- ReadAllText on a 10MB file improved throughput by ~20%
- WriteAllBytes on a 4K file improved throughput by ~18%

Note that these were all microbenchmarks, executing these operations repeatedly in order to make them more easily measurable.