### PR TITLE
Disable parallelization of Registry tests

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/AssemblyInfo.cs
+++ b/src/Microsoft.Win32.Registry/tests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+// Registry tests can conflict with each other due to accessing the same keys/values in the registry
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{20a2ba2c-5517-483f-8ffe-643441a59852}</ProjectGuid>
+    <ProjectGuid>{20A2BA2C-5517-483F-8FFE-643441A59852}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Win32.Registry.Tests</RootNamespace>
     <AssemblyName>Microsoft.Win32.Registry.Tests</AssemblyName>
@@ -15,6 +15,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="RegistryKey\RegistryKeyTypes.cs" />
     <Compile Include="RegistryKey\RegistryKey_CreateSubKey_str.cs" />
     <Compile Include="RegistryKey\RegistryKey_CreateSubKey_str_rkpc.cs" />


### PR DESCRIPTION
As currently written, tests can conflict with each other in the state they access in the registry.  For example, tt appears that lots of tests use the "" subkey and then try to operate on different values using a interlocked counter to append a number to the test key name, but rather than using a shared static counter, each test class has its own static counter, so multiple tests from different classes running in parallel could get the same key name.

The registry tests in generall look like they could use some cleanup, both in general and specifically to avoid this kind of shared state.  But in the meantime, this commit disables the parallelization to avoid these random conflicts.