### PR TITLE
Fixes #54 (Remove always true "if" and unreachable code in System.Xml.Linq.XObject.SkipNotify method.)

### DIFF
--- a/src/System.Xml.XDocument/src/Properties/AssemblyInfo.cs
+++ b/src/System.Xml.XDocument/src/Properties/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -23,6 +24,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
+[assembly: InternalsVisibleTo("System.Xml.XDocument.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
 
 
 

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XObject.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XObject.cs
@@ -479,7 +479,7 @@ namespace System.Xml.Linq
                     o = o.parent;
                 }
                 if (o == null) return true;
-                if (o.Annotations<XObjectChangeAnnotation>() != null) return false;
+                if (o.Annotation<XObjectChangeAnnotation>() != null) return false;
                 o = o.parent;
             }
         }

--- a/src/System.Xml.XDocument/tests/System.Xml.XDocument.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/System.Xml.XDocument.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="axes\AxisOrderValidation.cs" />
     <Compile Include="axes\TestData.cs" />
     <Compile Include="axes\InvalidParamValidation.cs" />
+    <Compile Include="System\Xml\XObjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">

--- a/src/System.Xml.XDocument/tests/System/Xml/XObjectTests.cs
+++ b/src/System.Xml.XDocument/tests/System/Xml/XObjectTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Xml.Linq.Tests
+{
+    //////////////////////////////////////////////////////////////////////////////////////////////////////
+    /// <summary>
+    /// Tests for XObject class.
+    /// </summary>
+    //////////////////////////////////////////////////////////////////////////////////////////////////////
+    public class XObjectTests
+    {
+        public class SkipNotifyTests
+        {
+            [Fact]
+            public void NoXObjectChangeAnnotation()
+            {
+                var sut = new FakeXObject();
+                sut.AddAnnotation(new object());
+                sut.AddAnnotation(new object());
+                Assert.True(sut.SkipNotify());
+            }
+
+            [Fact]
+            public void XObjectChangeAnnotation()
+            {
+                var sut = new FakeXObject();
+                sut.AddAnnotation(new object());
+                sut.AddAnnotation(new object());
+                sut.AddAnnotation(new XObjectChangeAnnotation());
+                Assert.False(sut.SkipNotify());
+            }
+        }
+
+        private class FakeXObject : XObject
+        {
+            public override XmlNodeType NodeType
+            {
+                get
+                {
+                    return XmlNodeType.None;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #54 (Remove always true "if" and unreachable code in System.Xml.Linq.XObject.SkipNotify method.)

Uses `XObject.Annotation<T>()` method to check `XObjectChangeAnnotation` is present in `XObject.annotations` list.