### PR TITLE
Fixes a failure in UMS tests

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -30,8 +30,6 @@ public class UmsSecurityTests
                         //change via PositionPointer
                         fixed (byte* invalidbytePtr = positionPointerByteArrays[positionLoop])
                         {
-                            // This depends on the layout of pinned memory
-                            Assert.True((long)invalidbytePtr > ((long)bytePtr + data.Length), String.Format("{0} > {1} + {2}", (long)invalidbytePtr, (long)bytePtr, data.Length));
                             // not throw currently
                             stream.PositionPointer = invalidbytePtr;
                             VerifyNothingCanBeReadOrWritten(stream, data);


### PR DESCRIPTION
The test was assuming arrays are alocated in memory address order.
This is not the case.