### PR TITLE
CA2002: Do not lock on objects with weak identity

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -64,6 +64,9 @@ namespace System.Diagnostics
 
         private static object s_createProcessLock = new object();
 
+        // lockable object only instance is knowledgeable about
+        private readonly object _lockable = new object();
+
         private StreamReadMode _outputStreamReadMode;
         private StreamReadMode _errorStreamReadMode;
 
@@ -832,7 +835,7 @@ namespace System.Diagnostics
         {
             if (!_watchingForExit)
             {
-                lock (this)
+                lock (_lockable)
                 {
                     if (!_watchingForExit)
                     {
@@ -1023,7 +1026,7 @@ namespace System.Diagnostics
         {
             if (!_raisedOnExited)
             {
-                lock (this)
+                lock (_lockable)
                 {
                     if (!_raisedOnExited)
                     {
@@ -1200,7 +1203,7 @@ namespace System.Diagnostics
         {
             if (_watchingForExit)
             {
-                lock (this)
+                lock (_lockable)
                 {
                     if (_watchingForExit)
                     {

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
@@ -88,6 +88,9 @@ namespace System.Linq.Parallel
         private volatile int _consumerIsWaiting;
         private CancellationToken _cancellationToken;
 
+        // lockable object only instance is knowledgeable about
+        private readonly object _lockable = new object();
+
         //-----------------------------------------------------------------------------------
         // Initializes a new channel with the specific capacity and chunk size.
         //
@@ -231,7 +234,7 @@ namespace System.Linq.Parallel
             // Update 8/2/2011: Dispose() should never be called with SetDone() concurrently,
             // but in order to reduce churn late in the product cycle, we decided not to 
             // remove the lock.
-            lock (this)
+            lock (_lockable)
             {
                 if (_consumerEvent != null)
                 {
@@ -659,7 +662,7 @@ namespace System.Linq.Parallel
             // Update 8/2/2011: Dispose() should never be called with SetDone() concurrently,
             // but in order to reduce churn late in the product cycle, we decided not to 
             // remove the lock.
-            lock (this)
+            lock (_lockable)
             {
                 Contract.Assert(_done, "Expected channel to be done before disposing");
                 Contract.Assert(_producerEvent != null);

--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
@@ -63,6 +63,9 @@ namespace System.Xml.Linq
 
         private const int StartingHash = (5381 << 16) + 5381;   // Starting hash code value for string keys to be hashed
 
+        // lockable object only instance is knowledgeable about
+        private readonly object _lockable = new object();
+
         /// <summary>
         /// Prototype of function which is called to extract a string key value from a hashed value.
         /// Returns null if the hashed value is invalid (e.g. value has been released due to a WeakReference TValue being cleaned up).
@@ -105,7 +108,7 @@ namespace System.Xml.Linq
                 // We only want one thread to perform a resize, as it is an expensive operation
                 // First thread will perform resize; waiting threads will call Resize(), but should immediately
                 // return since there will almost always be space in the hash table resized by the first thread.
-                lock (this)
+                lock (_lockable)
                 {
                     XHashtableState newState = _state.Resize();
 

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlElementList.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlElementList.cs
@@ -350,6 +350,9 @@ namespace System.Xml
         private XmlDocument _doc;
         private XmlNodeChangedEventHandler _nodeChangeHandler = null;
 
+        // lockable object only instance is knowledgeable about
+        private readonly object _lockable = new object();
+
         internal XmlElementListListener(XmlDocument doc, XmlElementList elemList)
         {
             _doc = doc;
@@ -361,7 +364,7 @@ namespace System.Xml
 
         private void OnListChanged(object sender, XmlNodeChangedEventArgs args)
         {
-            lock (this)
+            lock (_lockable)
             {
                 if (_elemList != null)
                 {
@@ -383,7 +386,7 @@ namespace System.Xml
         // This method is called from the finalizer of XmlElementList
         internal void Unregister()
         {
-            lock (this)
+            lock (_lockable)
             {
                 if (_elemList != null)
                 {


### PR DESCRIPTION
This commit changes 'lock (this)' usage into a lock on a private
object which only instance is knowledgeable about.