### PR TITLE
Fix VS build by adjusting relative path to packages folder

### DIFF
--- a/src/Common/tests/Tests.props
+++ b/src/Common/tests/Tests.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildThisFileDirectory)..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props" Condition="'$(BuildingInsideVisualStudio)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props" Condition="'$(BuildingInsideVisualStudio)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <CommonPath>$(MSBuildThisFileDirectory)</CommonPath>
   </PropertyGroup>
@@ -8,6 +8,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
 </Project>


### PR DESCRIPTION
This was caused by PR #474, which moved the nuget packages
folder up one level. There were still two places conditioned on
$(BuildingInsideVisualStudio) that had the old path.

Note that the VS xunit runner isn't working at the moment, so
we don't even need this import at all, but keeping it in place
as a reference for how things last worked when running tests
on desktop. We may need to do it differently in the end. This
is just the minimal fix to unblock things.