### PR TITLE
Avoid caching incomplete task in DataflowBlock.NullTarget

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -2776,6 +2776,8 @@ namespace System.Threading.Tasks.Dataflow
         /// <typeparam name="TInput">The type of the messages this block can accept.</typeparam>
         private class NullTargetBlock<TInput> : ITargetBlock<TInput>
         {
+            private Task _completion;
+
             /// <include file='XmlDocs\CommonXmlDocComments.xml' path='CommonXmlDocComments/Targets/Member[@name="OfferMessage"]/*' />
             DataflowMessageStatus ITargetBlock<TInput>.OfferMessage(DataflowMessageHeader messageHeader, TInput messageValue, ISourceBlock<TInput> source, Boolean consumeToAccept)
             {
@@ -2802,7 +2804,10 @@ namespace System.Threading.Tasks.Dataflow
             /// <include file='XmlDocs\CommonXmlDocComments.xml' path='CommonXmlDocComments/Blocks/Member[@name="Fault"]/*' />
             void IDataflowBlock.Fault(Exception exception) { } // No-op
             /// <include file='XmlDocs\CommonXmlDocComments.xml' path='CommonXmlDocComments/Blocks/Member[@name="Completion"]/*' />
-            Task IDataflowBlock.Completion { get { return Common.NeverCompletingTask; } }
+            Task IDataflowBlock.Completion
+            {
+                get { return LazyInitializer.EnsureInitialized(ref _completion, () => new TaskCompletionSource<VoidResult>().Task); }
+            }
         }
         #endregion
     }

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -330,9 +330,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             else list.Add(exception);
         }
 
-        /// <summary>A task that never completes.</summary>
-        internal static readonly Task NeverCompletingTask = new TaskCompletionSource<VoidResult>().Task;
-
         /// <summary>Creates a task we can cache for the desired Boolean result.</summary>
         /// <param name="value">The value of the Boolean.</param>
         /// <returns>A task that may be cached.</returns>


### PR DESCRIPTION
In general, code should avoid caching incomplete Tasks in statically rooted locations or else risk a potentially serious memory leak.  Today in Dataflow, the Task returned by DataflowBlock.NullTarget<T>()'s Completion is a statically-cached, never-completing task, which means that any continuations created off of it will be leaked for the duration of the app.  This commit changes DataflowBlock.NullTarget<T>() to return a Task specific to that block rather than one statically used across all blocks.