### PR TITLE
Enable [OuterLoop] tests

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
@@ -18,6 +18,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
         [Fact]
         [OuterLoop]
+        [ActiveIssue(614)]
         public void RunHardeningTests1()
         {
             // OfferMessage: All single-target source blocks
@@ -48,6 +49,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
         [Fact]
         [OuterLoop]
+        [ActiveIssue(614)]
         public void RunHardeningTests2()
         {
             // OfferMessage: All single-target source blocks
@@ -246,12 +248,12 @@ namespace System.Threading.Tasks.Dataflow.Tests
             {
                 bool localPassed = true;
                 var displayClassesFound = typeof(ActionBlock<>).GetTypeInfo().Assembly.GetTypes().Where(t => t.Name.Contains("DisplayClass"));
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.DataflowBlock")) == 2;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.ActionBlock")) == 2;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformBlock")) == 1;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformManyBlock")) == 1;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.BatchedJoinBlock")) == 2;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.Internal")) == 1;
+                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.DataflowBlock")) == 17;
+                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.ActionBlock")) == 4;
+                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformBlock")) == 3;
+                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformManyBlock")) == 3;
+                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.BatchedJoinBlock")) == 4;
+                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.Internal")) == 20;
                 Assert.True(localPassed, string.Format("Found {0} display classes, expected {1}, {2}", displayClassesFound.Count(), (isDebug ? 11 : 9), localPassed ? "Passed" : "FAILED"));
             }
         }

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
@@ -235,33 +235,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
             public override IDictionary Data { get { throw new InvalidOperationException(); } }
         }
 
-        // Tests to make sure we haven't inadvertently started using more closures, which typically
-        // means more allocations.  If we're able to eliminate some of these in the future,
-        // the test will fail, at which point we should update the numbers in the test accordingly
-        // to make the test pass again.
-        [Fact]
-        [OuterLoop]
-        public void TestClosureUsage()
-        {
-            bool isDebug = CheckAssemblyConfiguration(typeof(IDataflowBlock).GetTypeInfo().Assembly);
-
-            // Unfortunately, this test is influenced by changes in the compiler as much (or more than) it is
-            // influenced by changes in the code it is ostensibly testing.
-            // When these numbers get out of alignment again it might be a sign that the test should be retired.
-
-            {
-                bool localPassed = true;
-                var displayClassesFound = typeof(ActionBlock<>).GetTypeInfo().Assembly.GetTypes().Where(t => t.Name.Contains("DisplayClass"));
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.DataflowBlock")) == 17;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.ActionBlock")) == 4;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformBlock")) == 3;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformManyBlock")) == 3;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.BatchedJoinBlock")) == 4;
-                localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.Internal")) == 20;
-                Assert.True(localPassed, string.Format("Found {0} display classes, expected {1}, {2}", displayClassesFound.Count(), (isDebug ? 11 : 67), localPassed ? "Passed" : "FAILED"));
-            }
-        }
-
         [Fact]
         [OuterLoop]
         public void TestFaultyTaskScheduler()

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/HardeningTests.cs
@@ -245,6 +245,10 @@ namespace System.Threading.Tasks.Dataflow.Tests
         {
             bool isDebug = CheckAssemblyConfiguration(typeof(IDataflowBlock).GetTypeInfo().Assembly);
 
+            // Unfortunately, this test is influenced by changes in the compiler as much (or more than) it is
+            // influenced by changes in the code it is ostensibly testing.
+            // When these numbers get out of alignment again it might be a sign that the test should be retired.
+
             {
                 bool localPassed = true;
                 var displayClassesFound = typeof(ActionBlock<>).GetTypeInfo().Assembly.GetTypes().Where(t => t.Name.Contains("DisplayClass"));
@@ -254,7 +258,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.TransformManyBlock")) == 3;
                 localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.BatchedJoinBlock")) == 4;
                 localPassed &= displayClassesFound.Count(t => t.FullName.Contains("Dataflow.Internal")) == 20;
-                Assert.True(localPassed, string.Format("Found {0} display classes, expected {1}, {2}", displayClassesFound.Count(), (isDebug ? 11 : 9), localPassed ? "Passed" : "FAILED"));
+                Assert.True(localPassed, string.Format("Found {0} display classes, expected {1}, {2}", displayClassesFound.Count(), (isDebug ? 11 : 67), localPassed ? "Passed" : "FAILED"));
             }
         }
 

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -60,7 +60,8 @@
   <PropertyGroup>
     <XunitHost>corerun.exe</XunitHost>
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
-    <XunitOptions>$(XunitOptions) -notrait category=outerloop</XunitOptions>
+    <RunOuterLoop Condition="'$(RunOuterLoop)' == ''">False</RunOuterLoop>
+    <XunitOptions Condition="'$(RunOuterLoop)'!='True'">$(XunitOptions) -notrait category=outerloop</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
   </PropertyGroup>
   


### PR DESCRIPTION
Defines the build parameter (RunOuterLoop) that can be set to True to enable the execution of the [OuterLoop] tests.  The current state of this PR has the tests passing on the newly configured project in Jenkins (http://dotnet-ci.cloudapp.net/job/dotnet_corefx_outerloop/4/).