### PR TITLE
Fix ProcessTest failures on non-US locale #619

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
@@ -42,7 +42,7 @@ namespace ProcessTest_ConsoleApp
                 // We're testing STDERR streams, not the JIT debugger. 
                 // This makes the process behave just like a crashing .NET app, but without the WER invocation
                 // nor the blocking dialog that comes with it, or the need to suppress that.
-                Console.Error.WriteLine(string.Format("Unhandled Exception: {0}", toLog.ToString()));
+                Console.Error.WriteLine(string.Format("Unhandled Exception: {0}", toLog.Message));
                 return 1;
             }
 

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using System.IO;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Diagnostics.ProcessTests
@@ -23,7 +22,7 @@ namespace System.Diagnostics.ProcessTests
 
                 s = s.Replace("\r", "").Replace("\n", "");
 
-                Assert.Contains("Unhandled Exception: System.Exception: Intentional Exception thrown   at ProcessTest_ConsoleApp.Program.Main(String[] args)", s);
+                Assert.Equal("Unhandled Exception: Intentional Exception thrown", s);
             }
         }
 
@@ -41,7 +40,7 @@ namespace System.Diagnostics.ProcessTests
             {
                 p.BeginErrorReadLine();
                 p.WaitForExit();
-                Assert.Contains(@"Unhandled Exception: System.Exception: Intentional Exception thrown   at ProcessTest_ConsoleApp.Program.Main(String[] args)", s_process_AsyncErrorStream_sb.ToString());
+                Assert.Equal("Unhandled Exception: Intentional Exception thrown", s_process_AsyncErrorStream_sb.ToString());
             }
         }
 


### PR DESCRIPTION
Set en-US locale in ProcessTest console app since ProcessTest expects error message from this locale. Fixes #619