### PR TITLE
FileVersionInfo test: Get expected values using VerLanguageName call #617

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
@@ -97,7 +97,7 @@ public class FileVersionInfoTest
         TestStringProperty("SpecialBuild", fvi.SpecialBuild, expected.SpecialBuild);
 
         //ToString
-        String nl = "\r\n";
+        String nl = Environment.NewLine;
         TestStringProperty("ToString()", fvi.ToString(),
                  "File:             " + fvi.FileName + nl +
                  "InternalName:     " + fvi.InternalName + nl +

--- a/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
@@ -167,7 +167,7 @@ public class FileVersionInfoTest
         s_fviNativeConsoleApp.IsPrivateBuild = false;
         s_fviNativeConsoleApp.IsPreRelease = true;
         s_fviNativeConsoleApp.IsSpecialBuild = true;
-        s_fviNativeConsoleApp.Language = "English (United States)";
+        s_fviNativeConsoleApp.Language = GetFileVersionLanguage(0x0409);//English (United States)
         s_fviNativeConsoleApp.LegalCopyright = "Copyright (C) 2050";
         s_fviNativeConsoleApp.LegalTrademarks = "";
         s_fviNativeConsoleApp.OriginalFilename = "NativeConsoleApp.exe";
@@ -197,8 +197,8 @@ public class FileVersionInfoTest
         s_fviNativeLibrary.IsPrivateBuild = false;
         s_fviNativeLibrary.IsPreRelease = true;
         s_fviNativeLibrary.IsSpecialBuild = false;
-        s_fviNativeLibrary.Language = "Chinese (Simplified)";
-        s_fviNativeLibrary.Language2 = "Chinese (Simplified, PRC)"; // changed, but not yet on all platforms
+        s_fviNativeLibrary.Language = GetFileVersionLanguage(0x0004);//Chinese (Simplified)
+        s_fviNativeLibrary.Language2 = GetFileVersionLanguage(0x0804);//Chinese (Simplified, PRC) - changed, but not yet on all platforms
         s_fviNativeLibrary.LegalCopyright = "None";
         s_fviNativeLibrary.LegalTrademarks = "";
         s_fviNativeLibrary.OriginalFilename = "NativeLi.dll";
@@ -228,7 +228,7 @@ public class FileVersionInfoTest
         s_fviSecondNativeLibrary.IsPrivateBuild = false;
         s_fviSecondNativeLibrary.IsPreRelease = false;
         s_fviSecondNativeLibrary.IsSpecialBuild = false;
-        s_fviSecondNativeLibrary.Language = "Process Default Language";
+        s_fviSecondNativeLibrary.Language = GetFileVersionLanguage(0x0400);//Process Default Language
         s_fviSecondNativeLibrary.LegalCopyright = "Copyright (C) 1 - 2014";
         s_fviSecondNativeLibrary.LegalTrademarks = "";
         s_fviSecondNativeLibrary.OriginalFilename = "SecondNa.dll";
@@ -258,7 +258,7 @@ public class FileVersionInfoTest
         s_fviAssembly1.IsPrivateBuild = false;
         s_fviAssembly1.IsPreRelease = false;
         s_fviAssembly1.IsSpecialBuild = false;
-        s_fviAssembly1.Language = "Language Neutral";
+        s_fviAssembly1.Language = GetFileVersionLanguage(0x0000);//Language Neutral
         s_fviAssembly1.LegalCopyright = "Copyright, you betcha!";
         s_fviAssembly1.LegalTrademarks = "TM";
         s_fviAssembly1.OriginalFilename = "Assembly1.dll";
@@ -376,5 +376,12 @@ public class FileVersionInfoTest
         }
         buffer.Append("\"");
         return (buffer.ToString());
+    }
+
+    private static string GetFileVersionLanguage(uint langid)
+    {
+        var lang = new StringBuilder(256);
+        Interop.mincore.VerLanguageName(langid, lang, (uint)lang.Capacity);
+        return lang.ToString();
     }
 }

--- a/src/System.Diagnostics.FileVersionInfo/tests/Interop/Interop.Windows.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/Interop/Interop.Windows.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, EntryPoint = "VerLanguageNameW")]
+        public static extern int VerLanguageName(uint langID, StringBuilder lpBuffer, uint nSize);
+    }
+}

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -36,6 +36,7 @@
   <!-- References are resolved from packages.config -->
   <ItemGroup>
     <Compile Include="FileVersionInfoTest.cs" />
+    <Compile Include="Interop\Interop.Windows.cs" />
   </ItemGroup>
   <!-- References used -->
   <ItemGroup>

--- a/src/System.Diagnostics.FileVersionInfo/tests/packages.config
+++ b/src/System.Diagnostics.FileVersionInfo/tests/packages.config
@@ -7,6 +7,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Runtime" version="4.0.20-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Runtime.Handles" version="4.0.0-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />


### PR DESCRIPTION
It seems that VerLanguageName returns value in Windows locale no matter what thread locale is set, so must get expected values using that function. Fixes  #617
Also, as really minor addition - change newline from \r\n to Environment.NewLine to match with same change in FileVersionInfo class (since it now uses AppendLine)