### PR TITLE
Call TryGetValue in overload of ConcurrentDictionary.GetOrAdd to avoid acquiring lock

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -991,8 +991,13 @@ namespace System.Collections.Concurrent
         {
             if (key == null) throw new ArgumentNullException("key");
 
+            int hashcode = _comparer.GetHashCode(key);
+
             TValue resultingValue;
-            TryAddInternal(key, _comparer.GetHashCode(key), value, false, true, out resultingValue);
+            if (!TryGetValueInternal(key, hashcode, out resultingValue))
+            {
+                TryAddInternal(key, hashcode, value, false, true, out resultingValue);
+            }
             return resultingValue;
         }
 


### PR DESCRIPTION
There are two overloads of ConcurrentDictionary.GetOrAdd. One accepts a factory
method to generate the value if the key is not found, and calls TryGetValue for
the existence check which is a lock-free operation.

The other overload, however, does not call TryGetValue - it simply calls
straight through to TryAddInternal, which will obtain a bucket lock *before it
does the existence check*. This violates the documented claim of
ConcurrentDictionary of lock-free reads. This commit simply adds the same
TryGetValue check, making the two overloads consistent.