### PR TITLE
Use standard build targets for ProcessTest_ConsoleApp

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.csproj
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.csproj
@@ -1,40 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <BinDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.cmd))\bin</BinDir>
     <ProjectGuid>{69E46A6F-9966-45A5-8945-2559FE337827}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>ProcessTest_ConsoleApp</RootNamespace>
     <AssemblyName>ProcessTest_ConsoleApp</AssemblyName>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>4.5</TargetFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BinDir)\$(Configuration)\System.Diagnostics.Process.Tests\</OutputPath>
+    <TargetFrameworkProfile />
   </PropertyGroup>
-  
+  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ProcessTest_ConsoleApp.cs" />
@@ -42,5 +24,5 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -32,6 +32,10 @@
       <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
       <Name>XunitTraitsDiscoverers</Name>
     </ProjectReference>
+    <ProjectReference Include="..\ProcessTest_ConsoleApp\ProcessTest_ConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>ProcessTest_ConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <!--  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -39,10 +43,5 @@
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
   </ItemGroup> -->
-  <ItemGroup>
-    <Reference Include="ProcessTest_ConsoleApp">
-      <HintPath>$(BaseOutputPath)\$(Configuration)\$(AssemblyName)\ProcessTest_ConsoleApp.exe</HintPath>
-    </Reference>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -1,18 +1,24 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(TargetFrameworkProfile)' != ''">
-    <TargetingPortable>true</TargetingPortable>
+  
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '' 
+                         and '$(TargetFrameworkVersion)'    == '' 
+                         and '$(TargetFrameworkProfile)'    == '' ">
+    <TargetingDefaultPlatform>true</TargetingDefaultPlatform>
   </PropertyGroup>
 
-  <!-- Setup the default target for projects not already explicitly targeting portable -->
-  <PropertyGroup Condition="'$(TargetingPortable)' != 'true'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+  </PropertyGroup>
+
+  <!-- Setup the default target for projects not already explicitly targeting another platform -->
+  <PropertyGroup Condition="'$(TargetingDefaultPlatform)' == 'true'">
     <!-- Setting a default portable profile, although nothing should resolve from there as we want to use the pacakge refs -->
     <TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile Condition="'$(TargetFrameworkProfile)' == ''">Profile7</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
-    <ImplicitlyExpandTargetFramework Condition="'$(ImplicitlyExpandTargetFramework)' == ''">false</ImplicitlyExpandTargetFramework>
+    <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
 
     <AssemblySearchPaths>
       {HintPathFromItem};
@@ -29,7 +35,7 @@
 
   <!-- Need to add references to the mscorlib design-time facade for some old-style portable dependencies like xunit -->
   <Target Name="AddDesignTimeFacadeReferences"
-      Condition="'$(TargetingPortable)' != 'true'"
+      Condition="'$(TargetingDefaultPlatform)' == 'true'"
       BeforeTargets="ResolveReferences"
       DependsOnTargets="GetReferenceAssemblyPaths"
   >
@@ -39,7 +45,11 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" 
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'" />
+          
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"
+          Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable'" />
 
   <Import Project="$(ToolsDir)packageresolve.targets" Condition="Exists('$(ToolsDir)packageresolve.targets')" />
 


### PR DESCRIPTION
Allow for projects in the tree to use dir.props and dir.targets
and target full .NET Framework

Fixes incorrect intermediate directory for ProcessTest_ConsoleApp.

Allows msbuild to see build-ordering relationship between the test
project and the console app. Should fix #633.