### PR TITLE
Fix DirectoryInfo.Exists for search results

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemObject.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemObject.cs
@@ -29,6 +29,7 @@ namespace System.IO
 
             public Win32FileSystemObject(string fullPath, Interop.WIN32_FIND_DATA findData, bool asDirectory)
             {
+                _asDirectory = asDirectory;
                 _fullPath = fullPath;
                 // Copy the information to data
                 _data.fileAttributes = (int)findData.dwFileAttributes;

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    public partial class DirectoryInfo_Exists : FileSystemTest
+    {
+        [Fact]
+        public void TrueForCreatedDirectory()
+        {
+            DirectoryInfo di = Directory.CreateDirectory(GetTestFilePath());
+            Assert.True(di.Exists);
+        }
+
+        [Fact]
+        public void TrueForNewDirectoryInfo()
+        {
+            string dirName = GetTestFilePath();
+            Directory.CreateDirectory(dirName);
+
+            DirectoryInfo di = new DirectoryInfo(dirName);
+            Assert.True(di.Exists);
+        }
+
+        [Fact]
+        public void TrueForEnumeratedDir()
+        {
+            string dirName = GetTestFilePath();
+            DirectoryInfo parent = Directory.CreateDirectory(dirName);
+            parent.CreateSubdirectory("subDir");
+
+            var dirs = parent.GetDirectories();
+            Assert.Equal(1, dirs.Length);
+            Assert.True(dirs[0].Exists);
+
+            var fsis = parent.GetFileSystemInfos();
+            Assert.Equal(1, fsis.Length);
+            Assert.IsType<DirectoryInfo>(fsis[0]);
+            Assert.True(fsis[0].Exists);
+
+            var dirsEnum = parent.EnumerateDirectories();
+            DirectoryInfo di = dirsEnum.FirstOrDefault();
+            Assert.NotNull(di);
+            Assert.True(di.Exists);
+
+
+            var fsisEnum = parent.EnumerateFileSystemInfos();
+            FileSystemInfo fsi = fsisEnum.FirstOrDefault();
+            Assert.NotNull(fsi);
+            Assert.IsType<DirectoryInfo>(fsi);
+            Assert.True(fsi.Exists);
+        }
+
+        [Fact]
+        public void ExistsBehaviorWithRefresh()
+        {
+            string dirName = GetTestFilePath();
+            DirectoryInfo di = new DirectoryInfo(dirName);
+            // don't check it, data has not yet been init'ed
+            Directory.CreateDirectory(dirName);
+            // data will be init'ed at the time of calling exists
+            Assert.True(di.Exists);
+
+            dirName = GetTestFilePath();
+            di = new DirectoryInfo(dirName);
+
+            Assert.False(di.Exists);
+            Directory.CreateDirectory(dirName);
+
+            // data should be stale
+            Assert.False(di.Exists);
+
+            // force refresh
+            di.Refresh();
+            Assert.True(di.Exists);
+        }
+
+        [Fact]
+        public void FalseForFile()
+        {
+            string fileName = GetTestFilePath();
+            File.Create(fileName);
+            DirectoryInfo di = new DirectoryInfo(fileName);
+            Assert.False(di.Exists);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -39,6 +39,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DirectoryInfo\Exists.cs" />
     <Compile Include="FileStream\Flush.Sharing.cs" />
     <Compile Include="FileStream\Flush_toDisk.cs" />
     <Compile Include="FileStream\SafeFileHandle.cs" />
@@ -80,7 +81,6 @@
     <Compile Include="FileSystemTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="DirectoryInfo\" />
     <Folder Include="Directory\" />
     <Folder Include="FileInfo\" />
     <Folder Include="File\" />


### PR DESCRIPTION
We have a seperate codepath for initializing DirectoryInfos when they are the result of
search.  We do this as a performance optimization since we already have the filesystem
data for the directory/file.  I was missing the flag that set the internal field as directory/file
in this codepath, which resulted in DirectoryInfo.Exists treating the item as a file and
returning false since it had the Directory attribute set.

I've fixed this omission and added some tests for DirectoryInfo.Exists.  Fixes #616