### PR TITLE
Enable code coverage for the corefx repo

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -54,4 +54,23 @@
   <Target Name="Clean">
     <RemoveDir Directories="$(BinDir);$(PackagesDir)" />
   </Target>
+  
+  <Target Name="GenerateCoverageReport"
+    AfterTargets="Build"
+    Inputs="$(CoverageReportDir)\*.coverage.xml"
+    Outputs="$(CoverageReportDir)*.*"
+    Condition="$(_CoverageEnabled)">
+    
+    <PropertyGroup>
+      <ReportGeneratorVersion>2.0.4.0</ReportGeneratorVersion>
+      <ReportGeneratorCommandLine>$(PackagesDir)ReportGenerator.$(ReportGeneratorVersion)\ReportGenerator.exe</ReportGeneratorCommandLine>
+      <ReportGeneratorOptions>-reports:$(CoverageReportDir)\*.coverage.xml -targetdir:$(CoverageReportDir) -reporttypes:Html</ReportGeneratorOptions>
+    </PropertyGroup>
+    
+    <Exec
+      Command="$(ReportGeneratorCommandLine) $(ReportGeneratorOptions)"
+      ContinueOnError="ErrorAndContinue" />
+    
+  </Target>
+  
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -30,6 +30,18 @@
     <BuildToolsTargetOutputs>$(BuildToolsInstallSemaphore)</BuildToolsTargetOutputs>
   </PropertyGroup>
   
+  <!-- Coverage options -->
+  <PropertyGroup>
+    <_CoverageEnabled>false</_CoverageEnabled>
+    <_CoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(OS)' == 'Windows_NT' and '$(Coverage)' == 'true'">true</_CoverageEnabled>
+    <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(BinDir)\tests\coverage\</CoverageReportDir>
+    <CoverageVersion>4.5.3522</CoverageVersion>
+    <CoverageToolPath>$(PackagesDir)OpenCover.$(CoverageVersion)\OpenCover.Console.exe</CoverageToolPath>
+    <!-- When coverage is enabled, we disallow building projects in parallel. There appear to be issues with the OpenCover tool
+         in these scenarios. -->
+    <SerializeProjects>true</SerializeProjects>
+  </PropertyGroup>
+  
   <!-- Set default Configuration and Platform -->
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' ==''">Debug</Configuration>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.22-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
+  <package id="OpenCover" version="4.5.3522" />
+  <package id="ReportGenerator" version="2.0.4.0" />
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
   <package id="System.Console" version="4.0.0-beta-22512" />

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>System.Diagnostics.Process.Tests</RootNamespace>
     <AssemblyName>System.Diagnostics.Process.Tests</AssemblyName>
     <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
+    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -7,6 +7,7 @@
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
+    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -13,6 +13,7 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>
+    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>System.Threading.Tasks.Dataflow.Tests</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>bcca2a00</NuGetPackageImportStamp>
+    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XDocument.Tests</RootNamespace>
+    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XmlDocument.Tests</RootNamespace>
+    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -55,14 +55,36 @@
     <!-- Don't run unit tests as post-build in VS, use F5 on test project instead (see below). -->
     <RunTestsForProject Condition="'$(BuildingInsideVisualStudio)' == 'True'">False</RunTestsForProject>
   </PropertyGroup>
-
-  <!-- xUnit command line -->
+  
+  <!-- General xunit options -->
   <PropertyGroup>
-    <XunitHost>corerun.exe</XunitHost>
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
     <RunOuterLoop Condition="'$(RunOuterLoop)' == ''">False</RunOuterLoop>
     <XunitOptions Condition="'$(RunOuterLoop)'!='True'">$(XunitOptions) -notrait category=outerloop</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+  </PropertyGroup>
+  
+  <!-- Directory specific coverage options -->
+  <PropertyGroup>
+    <CoverageEnabledForDir>$(_CoverageEnabled)</CoverageEnabledForDir>
+    <CoverageEnabledForDir Condition="'$(CoverageEnabledForProject)' == 'false'">false</CoverageEnabledForDir>
+  </PropertyGroup>
+
+  <!-- xUnit command line without coverage enabled -->
+  <PropertyGroup Condition="!$(CoverageEnabledForDir)">
+    <XunitHost>corerun.exe</XunitHost>
+    <TestHost>$(XunitHost)</TestHost>
+    <TestCommandLine>$(XunitCommandLine) $(XunitOptions)</TestCommandLine>
+  </PropertyGroup>
+  
+  <!-- xUnit command line with coverage enabled -->
+  <PropertyGroup Condition="$(CoverageEnabledForDir)">
+    <CoverageHost>$(CoverageToolPath)</CoverageHost>
+    <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -nodefaultfilters</CoverageOptions>
+    <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user  -target:corerun.exe -output:$(CoverageReportDir)$(TargetFileName).coverage.xml</CoverageCommandLine>
+    <TestHost>$(CoverageHost)</TestHost>
+    <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>
+    <TestCommandLine>$(CoverageCommandLine) -targetargs:"$(XunitCommandLine) $(XunitOptions)"</TestCommandLine>
   </PropertyGroup>
   
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
@@ -70,8 +92,8 @@
     <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
     <StartAction Condition="'$(StartAction)' == ''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)' == ''">$(StartWorkingDirectory)\$(XunitHost)</StartProgram>
-    <StartArguments Condition="'$(StartArguments)' == ''">$(XunitCommandLine) $(XunitOptions)</StartArguments>
+    <StartProgram Condition="'$(StartProgram)' == ''">$(StartWorkingDirectory)\$(TestHost)</StartProgram>
+    <StartArguments Condition="'$(StartArguments)' == ''">$(TestCommandLine)</StartArguments>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
@@ -80,7 +102,9 @@
           AfterTargets="PrepareForRun"
           Condition="'$(RunTestsForProject)'=='True'">
 
-    <Exec Command="$(XunitHost) $(XunitCommandLine) $(XunitOptions)"
+    <MakeDir Condition="$(CoverageEnabledForDir)" Directories="$(CoverageReportDir)" />
+          
+    <Exec Command="$(TestHost) $(TestCommandLine)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
           ContinueOnError="True">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />


### PR DESCRIPTION
This change enables code coverage for the corefx project using OpenCover.

 * When /p:Coverage=true is passed, we wrap the xunit call in the OpenCover command.
 * OpenCover filters test assemblies but no other default filters.
 * We disable parallel execution of tests within xunit and parallel project building when running coverage. This appears to cause issues with OpenCover (I see spurious failures in tests) and is actually slower than just running execution serially.
 * A few assemblies still have issues even after this.  These have coverage disabled with CoverageEnabledForProject.  Will open an issue for future investigation.
 * After execution is complete, we run the ReportGenerator tool over the set of generated coverage data, creating a full report in bin\tests\coverage.