### PR TITLE
Unskip ThrowAfterSynchronousComplete() test

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
@@ -43,7 +43,7 @@ namespace System.ComponentModel.EventBasedAsync
                 }).Wait();
         }
 
-        [Fact(Skip = "Bug 1092169")]
+        [Fact]
         public static void ThrowAfterSynchronousComplete()
         {
             Task.Run(() =>


### PR DESCRIPTION
The bug mentioned in the 'Skip' parameter has been resolved as
'Not Repro'.

@YingP99 @jhendrixMSFT 