### PR TITLE
Remove faulty assert in ActionBlock test

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/ActionBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/ActionBlockTests.cs
@@ -380,7 +380,10 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     case 1: ab = new ActionBlock<int>(i => { thrower(); return Task.FromResult(0); }, options); break;
                     case 2: ab = new ActionBlock<int>(i => Task.Run(thrower), options); break;
                 }
-                ab.PostRange(0, 4);
+                for (int i = 0; i < 4; i++)
+                {
+                    ab.Post(i); // Post may return false, depending on race with ActionBlock faulting
+                }
 
                 try
                 {


### PR DESCRIPTION
The test was asserting that a Post would always be succesful (via usage of the PostRange helper method), but the test was purposefully faulting the block, which could (by design) cause Posts to fail.

Fixes #661.