### PR TITLE
Fix Single & Double parse tests when not en-US

### DIFF
--- a/src/System.Runtime/tests/System/Double.cs
+++ b/src/System.Runtime/tests/System/Double.cs
@@ -176,10 +176,6 @@ public static class DoubleTests
 
         Double i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
-
-        Assert.Equal("NaN", Double.NaN.ToString());
-        Assert.Equal("Infinity", Double.PositiveInfinity.ToString());
-        Assert.Equal("-Infinity", Double.NegativeInfinity.ToString());
     }
 
     [Fact]
@@ -198,6 +194,10 @@ public static class DoubleTests
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
         Assert.Equal("-2468", i3.ToString(numberFormat));
+
+        Assert.Equal("NaN", Double.NaN.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("Infinity", Double.PositiveInfinity.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("-Infinity", Double.NegativeInfinity.ToString(NumberFormatInfo.InvariantInfo));
     }
 
     [Fact]
@@ -291,15 +291,6 @@ public static class DoubleTests
         Assert.True(Double.TryParse("1,000", out i));  // Thousands
         Assert.Equal(1000, i);
 
-        Assert.True(Double.TryParse("Infinity", out i));
-        Assert.True(Double.IsPositiveInfinity(i));
-
-        Assert.True(Double.TryParse("-Infinity", out i));
-        Assert.True(Double.IsNegativeInfinity(i));
-
-        Assert.True(Double.TryParse("NaN", out i));
-        Assert.True(Double.IsNaN(i));
-
         Assert.False(Double.TryParse("$1000", out i));  // Currency
         Assert.False(Double.TryParse("abc", out i));    // Hex digits
         Assert.False(Double.TryParse("(135)", out i));  // Parentheses
@@ -327,6 +318,15 @@ public static class DoubleTests
 
         Assert.True(Double.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
         Assert.Equal(-135, i);
+
+        Assert.True(Double.TryParse("Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(Double.IsPositiveInfinity(i));
+
+        Assert.True(Double.TryParse("-Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(Double.IsNegativeInfinity(i));
+
+        Assert.True(Double.TryParse("NaN", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(Double.IsNaN(i));
     }
 }
 

--- a/src/System.Runtime/tests/System/Single.cs
+++ b/src/System.Runtime/tests/System/Single.cs
@@ -176,10 +176,6 @@ public static class SingleTests
 
         Single i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
-
-        Assert.Equal("NaN", Single.NaN.ToString());
-        Assert.Equal("Infinity", Single.PositiveInfinity.ToString());
-        Assert.Equal("-Infinity", Single.NegativeInfinity.ToString());
     }
 
     [Fact]
@@ -198,6 +194,10 @@ public static class SingleTests
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
         Assert.Equal("-2468", i3.ToString(numberFormat));
+
+        Assert.Equal("NaN", Single.NaN.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("Infinity", Single.PositiveInfinity.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("-Infinity", Single.NegativeInfinity.ToString(NumberFormatInfo.InvariantInfo));
     }
 
     [Fact]
@@ -291,15 +291,6 @@ public static class SingleTests
         Assert.True(Single.TryParse("1,000", out i));  // Thousands
         Assert.Equal(1000, i);
 
-        Assert.True(Single.TryParse("Infinity", out i));
-        Assert.True(Single.IsPositiveInfinity(i));
-
-        Assert.True(Single.TryParse("-Infinity", out i));
-        Assert.True(Single.IsNegativeInfinity(i));
-
-        Assert.True(Single.TryParse("NaN", out i));
-        Assert.True(Single.IsNaN(i));
-
         Assert.False(Single.TryParse("$1000", out i));  // Currency
         Assert.False(Single.TryParse("abc", out i));    // Hex digits
         Assert.False(Single.TryParse("(135)", out i));  // Parentheses
@@ -327,6 +318,15 @@ public static class SingleTests
 
         Assert.True(Single.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
         Assert.Equal(-135, i);
+
+        Assert.True(Single.TryParse("Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(Single.IsPositiveInfinity(i));
+
+        Assert.True(Single.TryParse("-Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(Single.IsNegativeInfinity(i));
+
+        Assert.True(Single.TryParse("NaN", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(Single.IsNaN(i));
     }
 }
 


### PR DESCRIPTION
Fixes #657. Modifies Single & Double parse tests for Infinity and NaN
to use NumberFormatInfo.InvariantInfo so that they pass under non-en-US
cultures. This should also fix the tests for Windows 10.