### PR TITLE
Remove more MemoryMappedFile test name collisions

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateNew.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateNew.cs
@@ -125,7 +125,7 @@ public class CreateNew : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreateNew("Loc411", new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc411", "CreateNew2" + new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // null
             VerifyCreateNew("Loc412", null, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateOrOpen.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateOrOpen.cs
@@ -39,7 +39,7 @@ public class CreateOrOpen : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreate("Loc111", new String('a', 1000), 4096);
+            VerifyCreate("Loc111", "CreateOrOpen" + new String('a', 1000), 4096);
 
             // null
             VerifyException<ArgumentNullException>("Loc112", null, 4096);
@@ -168,7 +168,7 @@ public class CreateOrOpen : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreate("Loc411", new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc411", "CreateOrOpen2" + new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // null
             VerifyException<ArgumentNullException>("Loc412", null, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);


### PR DESCRIPTION
This change removes yet another memory mapped file name collision in the tests. These ones were hiding behind a string constructor call.

Addresses #600.