### PR TITLE
Disable flakey AsyncOperation test

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
@@ -58,7 +58,7 @@ namespace System.ComponentModel.EventBasedAsync
                }).Wait();
         }
 
-        [Fact]
+        [Fact(Skip = "#666")]
         public static void Cancel()
         {
             // Test that cancellation gets passed all the way through PostOperationCompleted(callback, AsyncCompletedEventArgs)


### PR DESCRIPTION
This started failing in the CI build.  See #666.