### PR TITLE
Fix race in AsyncOperation Cancel() test

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
+++ b/src/System.ComponentModel.EventBasedAsync/tests/AsyncOperationTests.cs
@@ -206,9 +206,12 @@ namespace System.ComponentModel.EventBasedAsync
 
                 Exception = e.Error;
 
-                _completeEvent.Set();
+                // Make sure to set _cancelEvent before _completeEvent so that anyone waiting on
+                // _completeEvent will not be at risk of reading Cancelled before it is set.
                 if (e.Cancelled)
                     _cancelEvent.Set();
+
+                _completeEvent.Set();
             }
         }
 


### PR DESCRIPTION
Makes sure _cancelEvent is set before _completeEvent in
TestAsyncOperation.OnOperationCompleted() so that threads waiting on
_completeEvent don't risk reading Cancelled before it is set.
Fixes #666