### PR TITLE
Remove useless Microsoft.Common.Targets import from dir.tarversal.targets

### DIFF
--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
   <Target Name="BuildAllProjects">
     <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity 


### PR DESCRIPTION
Remove useless Microsoft.Common.Targets import from dir.tarversal.targets, all it does is potentially cause errors in some cases like if you don't have Configuration\Platform set even though they aren't needed for a *.proj file that uses this.