### PR TITLE
Fix #320 - InvalidProgramException on .NET < 4.5.2 on x64

### DIFF
--- a/src/System.Collections.Immutable/src/Validation/Requires.cs
+++ b/src/System.Collections.Immutable/src/Validation/Requires.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Validation
 {
@@ -135,6 +136,7 @@ namespace Validation
         /// <typeparam name="TDisposed">Specifies the type of the disposed object.</typeparam>
         /// <param name="disposed">The disposed object.</param>
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.NoInlining)] // inlining this on .NET < 4.5.2 on x64 causes InvalidProgramException. 
         public static void FailObjectDisposed<TDisposed>(TDisposed disposed)
         {
             // separating out this throwing helps with inlining of the caller, especially


### PR DESCRIPTION
In .NET 4.5 and .NET 4.5.1 on x64, the JIT would attempt to inline a
particular generic method, which would cause it to bail with an
InvalidProgramException.

Workaround the issue by applying MethodImplOptions.NoInlining to the
method. There is no perf loss because the whole purpose of this method
is to throw in the failure case and it is factored out precisely to
help the inlining of its callers.

The JIT bug has already been fixed in .NET 4.5.2, but we support
immutable collections on .NET 4.5 and .NET 4.5.1 as well, which is
why we must workaround the issue.