### PR TITLE
Pass -wait to xunit to pause after test run from VS

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.22-prerelease</BuildToolsVersion>
+    <BuildToolsVersion>1.0.23-prerelease</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.22-prerelease" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.23-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
@@ -28,7 +28,7 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22512" />
-  <package id="xunit.console.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.console.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.0-prerelease" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -81,7 +81,7 @@
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
     <StartAction Condition="'$(StartAction)' == ''">Program</StartAction>
     <StartProgram Condition="'$(StartProgram)' == ''">$(StartWorkingDirectory)\$(XunitHost)</StartProgram>
-    <StartArguments Condition="'$(StartArguments)' == ''">$(XunitCommandLine) $(XunitOptions)</StartArguments>
+    <StartArguments Condition="'$(StartArguments)' == ''">$(XunitCommandLine) $(XunitOptions) -wait</StartArguments>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 


### PR DESCRIPTION
Allows tests to be run using Ctrl+F5 with a pause to
keep the window open so that the results can be seen.

This was previously blocked by missing -wait support
in the .NET Core xunit console runner, but that was
added with dotnet/buildtools@cc6a4b00b4fe4ceaf659c91.

Bump dependency version on xunit and buildtools to
pick it up.