### PR TITLE
Replace open64 usage with open in Unix libs

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.open.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.open.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern int open64(string filename, OpenFlags flags, mode_t mode);
+        internal static extern int open(string filename, OpenFlags flags, mode_t mode);
 
         [Flags]
         internal enum OpenFlags
@@ -23,7 +23,8 @@ internal static partial class Interop
             O_EXCL = 0x80,
             O_TRUNC = 0x200,
             O_SYNC = 0x1000,
-            O_ASYNC = 0x2000
+            O_ASYNC = 0x2000,
+            O_LARGEFILE = 0x8000
         }
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Diagnostics.Contracts;
-using System.Security;
 using System.Runtime.InteropServices;
-using Microsoft.Win32;
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -38,7 +36,7 @@ namespace Microsoft.Win32.SafeHandles
             try { } finally
             {
                 int fd;
-                while (Interop.CheckIo(fd = Interop.libc.open64(path, flags, mode))) ;
+                while (Interop.CheckIo(fd = Interop.libc.open(path, flags, mode))) ;
                 Contract.Assert(fd >= 0);
                 handle.SetHandle((IntPtr)fd);
             }

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -75,8 +75,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek64.cs">
       <Link>Common\Interop\Interop.lseek64.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open64.cs">
-      <Link>Common\Interop\Interop.open64.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
+      <Link>Common\Interop\Interop.open.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.read.cs">
       <Link>Common\Interop\Interop.read.cs</Link>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -448,7 +448,7 @@ namespace System
                     string filePath = directoryPath + "/" + term[0] + "/" + term; // filePath == /directory/termFirstLetter/term
 
                     int fd;
-                    while ((fd = Interop.libc.open64(filePath, Interop.libc.OpenFlags.O_RDONLY, 0)) < 0)
+                    while ((fd = Interop.libc.open(filePath, Interop.libc.OpenFlags.O_RDONLY, 0)) < 0)
                     {
                         // Don't throw in this case, as we'll be polling multiple locations looking for the file.
                         // But we still want to retry if the open is interrupted by a signal.

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -156,8 +156,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getcwd.cs">
       <Link>Common\Interop\Interop.getcwd.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open64.cs">
-      <Link>Common\Interop\Interop.open64.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
+      <Link>Common\Interop\Interop.open.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek64.cs">
       <Link>Common\Interop\Interop.lseek64.cs</Link>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -165,8 +165,8 @@ namespace System.IO
         /// <returns>The flags value to be passed to the open system call.</returns>
         private static Interop.libc.OpenFlags PreOpenConfigurationFromOptions(FileMode mode, FileAccess access, FileOptions options)
         {
-            // Translate FileMode.  Most of the values map cleanly to one or more options for open/open64.
-            Interop.libc.OpenFlags flags = 0;
+            // Translate FileMode.  Most of the values map cleanly to one or more options for open.
+            Interop.libc.OpenFlags flags = Interop.libc.OpenFlags.O_LARGEFILE;
             switch (mode)
             {
                 default:
@@ -191,7 +191,7 @@ namespace System.IO
                     break;
             }
 
-            // Translate FileAccess.  All possible values map cleanly to corresponding values for open/open64.
+            // Translate FileAccess.  All possible values map cleanly to corresponding values for open.
             switch (access)
             {
                 case FileAccess.Read:


### PR DESCRIPTION
Use the POSIX-compliant open function instead of open64.

Fixes #715