### PR TITLE
Switch package restore to happen as part of each project build.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -2,48 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
-  <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
-  <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
-    <ParameterGroup>
-      <Address ParameterType="System.String" Required="true"/>
-      <FileName ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="System" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-           var directory = System.IO.Path.GetDirectoryName(FileName);
-           System.IO.Directory.CreateDirectory(directory);
-           var client = new System.Net.WebClient();
-           client.Proxy = System.Net.WebRequest.DefaultWebProxy;
-           client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
-           client.DownloadFile(Address, FileName);
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <Target Name="_RestoreBuildTools"
-    BeforeTargets="BuildAllProjects"
-    Inputs="$(BuildToolsTargetInputs)"
-    Outputs="$(BuildToolsTargetOutputs)"
-    >
-    <Message Importance="High" Text="Restoring build tools..." />
-
-    <!-- Download latest nuget.exe -->
-    <DownloadFile
-      Condition="!Exists($(NuGetToolPath))"
-      Address="http://nuget.org/nuget.exe"
-      FileName="$(NuGetToolPath)" />
-
-    <!-- Restore build tools -->
-    <Exec
-      StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; install &quot; $(SourceDir).nuget\packages.config &quot;  -o &quot; $(PackagesDir) &quot; $(NuGetConfigCommandLine)" />
-
-    <Touch Files="$(BuildToolsInstallSemaphore)" AlwaysCreate="true" />
-  </Target>
-
   <ItemGroup>
     <Project Include="src\dirs.proj" />
   </ItemGroup>

--- a/dir.props
+++ b/dir.props
@@ -16,18 +16,14 @@
 
   <!-- Common nuget properties -->
   <PropertyGroup>
-    <NuGetToolPath>$(ToolsDir)NuGet.exe</NuGetToolPath>
+    <NuGetToolPath>$(PackagesDir)NuGet.exe</NuGetToolPath>
     <NuGetConfigFile>$(SourceDir)NuGet.Config</NuGetConfigFile>
-    <NuGetConfigCommandLine
-      Condition="Exists('$(NuGetConfigFile)')">-ConfigFile &quot;$(NuGetConfigFile)&quot;</NuGetConfigCommandLine>
-  </PropertyGroup>
+    <NuGetConfigCommandLine>-ConfigFile "$(NuGetConfigFile)"</NuGetConfigCommandLine>
 
-  <!-- Common build tool properties -->
-  <PropertyGroup>
-    <BuildToolsInstallSemaphore>$(ToolsDir)BuildTools.$(BuildToolsVersion).installed.semaphore</BuildToolsInstallSemaphore>
-
-    <BuildToolsTargetInputs>$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)build.proj</BuildToolsTargetInputs>
-    <BuildToolsTargetOutputs>$(BuildToolsInstallSemaphore)</BuildToolsTargetOutputs>
+    <NugetRestoreCommand>"$(NuGetToolPath)"</NugetRestoreCommand>
+    <NugetRestoreCommand>$(NugetRestoreCommand) install</NugetRestoreCommand>
+    <NugetRestoreCommand>$(NugetRestoreCommand) -OutputDirectory "$(PackagesDir.TrimEnd('\'))"</NugetRestoreCommand>
+    <NugetRestoreCommand>$(NugetRestoreCommand) $(NuGetConfigCommandLine)</NugetRestoreCommand>
   </PropertyGroup>
   
   <!-- Coverage options -->

--- a/dir.targets
+++ b/dir.targets
@@ -9,14 +9,28 @@
     </ParameterGroup>
     <Task>
       <Reference Include="System" />
+      <Reference Include="System.IO" />
       <Code Type="Fragment" Language="cs">
         <![CDATA[
-           var directory = System.IO.Path.GetDirectoryName(FileName);
-           System.IO.Directory.CreateDirectory(directory);
-           var client = new System.Net.WebClient();
-           client.Proxy = System.Net.WebRequest.DefaultWebProxy;
-           client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
-           client.DownloadFile(Address, FileName);
+            var directory = System.IO.Path.GetDirectoryName(FileName);
+            Directory.CreateDirectory(directory);
+
+            var tempFile = Path.Combine(directory, Path.GetRandomFileName());
+            var client = new System.Net.WebClient();
+            client.Proxy = System.Net.WebRequest.DefaultWebProxy;
+            client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+            client.DownloadFile(Address, tempFile);
+
+            try
+            {
+                if (!File.Exists(FileName))
+                   File.Move(tempFile, FileName);
+            }
+            finally
+            {
+              if (File.Exists(tempFile))
+                  File.Delete(tempFile);
+            }
         ]]>
       </Code>
     </Task>

--- a/dir.targets
+++ b/dir.targets
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" InitialTargets="_RestoreBuildToolsWrapper" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
+  <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <Address ParameterType="System.String" Required="true"/>
+      <FileName ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+           var directory = System.IO.Path.GetDirectoryName(FileName);
+           System.IO.Directory.CreateDirectory(directory);
+           var client = new System.Net.WebClient();
+           client.Proxy = System.Net.WebRequest.DefaultWebProxy;
+           client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+           client.DownloadFile(Address, FileName);
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- 
+    Needed to avoid the IntialTargets from having an Output which ends up getting
+    added to the output references when you have a project to project reference.
+  -->
+  <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
+
+  <Target Name="_RestoreBuildTools"
+          Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
+          Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
+    <Message Importance="High" Text="Restoring build tools..." />
+
+    <!-- Download latest nuget.exe -->
+    <DownloadFile FileName="$(NuGetToolPath)"
+                  Address="http://nuget.org/nuget.exe" 
+                  Condition="!Exists($(NuGetToolPath))" />
+
+    <!-- Restore build tools -->
+    <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget\packages.config&quot;" StandardOutputImportance="Low" />
+    
+    <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
+           Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
+  </Target>
+
+</Project>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,37 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.24-prerelease" />
-  <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
   <package id="OpenCover" version="4.5.3522" />
   <package id="ReportGenerator" version="2.0.4.0" />
-  <package id="System.Collections" version="4.0.10-beta-22512" />
-  <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
-  <package id="System.Console" version="4.0.0-beta-22512" />
-  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22512" />
-  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22512" />
-  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22512" />
-  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22512" />
-  <package id="System.Globalization" version="4.0.10-beta-22512" />
-  <package id="System.IO" version="4.0.10-beta-22512" />
-  <package id="System.IO.FileSystem" version="4.0.0-beta-22512" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22512" />
-  <package id="System.Linq" version="4.0.0-beta-22512" />
-  <package id="System.Reflection" version="4.0.10-beta-22512" />
-  <package id="System.Reflection.Extensions" version="4.0.0-beta-22512" />
-  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22512" />
-  <package id="System.Runtime" version="4.0.20-beta-22512" />
-  <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
-  <package id="System.Runtime.Handles" version="4.0.0-beta-22512" />
-  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22512" />
-  <package id="System.Text.Encoding" version="4.0.10-beta-22512" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22512" />
-  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22512" />
-  <package id="System.Threading" version="4.0.0-beta-22512" />
-  <package id="System.Threading.ThreadPool" version="4.0.10-beta-22512" />
-  <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
-  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
-  <package id="System.Xml.XDocument" version="4.0.0-beta-22512" />
-  <package id="xunit.console.netcore" version="1.0.2-prerelease" />
-  <package id="xunit.runner.dependencies.netcore" version="1.0.0-prerelease" />
-  <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -1,5 +1,10 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+  <PropertyGroup>
+    <ErrorIfBuildToolsRestoredFromIndividualProject Condition="!Exists('$(ToolsDir)')">true</ErrorIfBuildToolsRestoredFromIndividualProject>
+  </PropertyGroup>
+  
+  <Import Project="..\dir.targets" />
+  
   <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '' 
                          and '$(TargetFrameworkVersion)'    == '' 
                          and '$(TargetFrameworkProfile)'    == '' ">
@@ -51,10 +56,26 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"
           Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable'" />
 
+  <!-- Restore packages -->
+  <PropertyGroup>
+    <PackagesConfig Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfig>
+    <RestorePackages Condition="'$(RestorePackages)' == '' and Exists('$(PackagesConfig)')">true</RestorePackages>
+    <RestorePackagesSemaphore>$(PackagesDir)$(MSBuildProjectFile).package.restored</RestorePackagesSemaphore>
+  </PropertyGroup>
+
+  <Target Name="RestorePackages" 
+          BeforeTargets="ResolveNuGetPackages"
+          Inputs="$(PackagesConfig)"
+          Outputs="$(RestorePackagesSemaphore)"
+          Condition="'$(RestorePackages)' == 'true'">
+    <Exec Command="$(NugetRestoreCommand) &quot;$(PackagesConfig)&quot;" StandardOutputImportance="Low" />
+    <Touch Files="$(RestorePackagesSemaphore)" AlwaysCreate="true" />
+  </Target>
+
   <Import Project="$(ToolsDir)packageresolve.targets" Condition="Exists('$(ToolsDir)packageresolve.targets')" />
 
   <Import Project="$(ToolsDir)sign.targets" Condition="Exists('$(ToolsDir)sign.targets')" />
-  
+
   <Import Project="$(ToolsDir)publishtest.targets" Condition="Exists('$(ToolsDir)publishtest.targets')" />
   
   <PropertyGroup>
@@ -65,6 +86,20 @@
     <!-- Don't run unit tests as post-build in VS, use F5 on test project instead (see below). -->
     <RunTestsForProject Condition="'$(BuildingInsideVisualStudio)' == 'True'">False</RunTestsForProject>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <TestRuntimePackageConfig>$(ToolsDir)test-runtime\packages.config</TestRuntimePackageConfig>
+    <TestRuntimePackageSemaphore>$(PackagesDir)Test-Runtime.package.restored</TestRuntimePackageSemaphore>
+  </PropertyGroup>
+
+  <Target Name="RestoreTestRuntimePackage" 
+          BeforeTargets="ResolveNuGetPackages"
+          Inputs="$(TestRuntimePackageConfig)"
+          Outputs="$(TestRuntimePackageSemaphore)"
+          Condition="'$(IsTestProject)' == 'true'">
+    <Exec Command="$(NugetRestoreCommand) &quot;$(TestRuntimePackageConfig)&quot;" StandardOutputImportance="Low" />
+    <Touch Files="$(TestRuntimePackageSemaphore)" AlwaysCreate="true" />
+  </Target>
 
   <!-- General xunit options -->
   <PropertyGroup>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,32 +1,12 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="RestoreAllPackages;VerifyBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
-
-  <Target Name="VerifyBuildTools" 
-    Inputs="$(BuildToolsTargetInputs)"
-    Outputs="$(BuildToolsTargetOutputs)"
-    >
-    <Error Condition="!Exists('$(BuildToolsInstallSemaphore)')" 
-      Text="The build tools have not been installed. Please run build.cmd from the root of the repo at least once to get the tools installed." />
-
-    <!-- If we enter this target at all then the inputs are newer then the outputs so give a warning. -->
-    <Warning Text="Looks like there may be an update to the build tools. Please run build.cmd from the root of the repo to refresh the build tools." /> 
-  </Target>
-
-  <ItemGroup>
-    <!-- Include test runtime when restoring packages in EnsureDependencies -->
-    <PackageConfigs Include="$(ToolsDir)test-runtime\packages.config" />
-  </ItemGroup>
-  
-  <Import Project="$(ToolsDir)depending.targets" Condition="Exists('$(ToolsDir)depending.targets')" />
-  <Target Name="RestoreAllPackages">
-    <Message Importance="High" Text="Restoring all package dependencies..." />
-    <CallTarget Targets="EnsureDependencies" />
-  </Target>
 
   <ItemGroup>
     <Project Include="*\src\*.csproj" />
     <Project Include="*\tests\**\*.csproj" />
   </ItemGroup>
+
+  <Import Project="..\dir.targets" />
 
   <Import Project="..\dir.traversal.targets" />
   


### PR DESCRIPTION
This change switches from running package restore all at once
in a command line build to doing it for each project one at a time.
This allows individual projects to be built successfully from VS and the
command line without requring full build of the repo.

It also allows the nuget installs to happen in parellel while
running a full build as well as makes them respect incremental builds and
only restore packages if the packages.config file has changed or the
packages folder doesn't exist.

One limitation to this model is in some cases when building an individual
project from the command line you may hit an error if it is the first to
restore the build tools package. The error will tell you retry the build
and it will succeed on the second try. This only happens if you build
leaf node individual projects from the command line, it will work if you
build them in VS or the entire repo from build.cmd/proj first. This is
just a limitation of restoring packages in the same msbuild session that
is trying to import targets from that restored package.