### PR TITLE
Use lseek instead of lseek64 in Unix I/O

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.lseek.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.lseek.cs
@@ -4,14 +4,14 @@
 using System;
 using System.Runtime.InteropServices;
 
-using off64_t = System.Int64;
+using off_t = System.Int64; // Assuming either 64-bit machine or _FILE_OFFSET_BITS == 64
 
 internal static partial class Interop
 {
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern long lseek64(int fd, off64_t offset, SeekWhence whence);
+        internal static extern off_t lseek(int fd, off_t offset, SeekWhence whence);
 
         internal enum SeekWhence
         {

--- a/src/Common/src/Interop/Unix/libc/Interop.posix_fadvise.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.posix_fadvise.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-using off_t = System.IntPtr;
+using off_t = System.Int64; // Assuming either 64-bit machine or _FILE_OFFSET_BITS == 64
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/Unix/libc/Interop.readdir.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.readdir.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 
 using ino_t = System.IntPtr;
-using off_t = System.IntPtr;
+using off_t = System.Int64; // Assuming either 64-bit machine or _FILE_OFFSET_BITS == 64
 
 internal static partial class Interop
 {

--- a/src/Common/src/Interop/Unix/libc/Interop.stat.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.stat.cs
@@ -11,7 +11,7 @@ using mode_t = System.Int32;
 using nlink_t = System.IntPtr;
 using uid_t = System.Int32;
 using gid_t = System.Int32;
-using off_t = System.IntPtr;
+using off_t = System.Int64; // Assuming either 64-bit machine or _FILE_OFFSET_BITS == 64
 using off64_t = System.Int64;
 using blksize_t = System.IntPtr;
 using blkcnt_t = System.IntPtr;
@@ -134,7 +134,7 @@ internal static partial class Interop
             dst.st_uid = src.st_uid;
             dst.st_gid = src.st_gid;
             dst.st_rdev = src.st_rdev;
-            dst.st_size = (long)src.st_size;
+            dst.st_size = src.st_size;
             dst.st_blksize = src.st_blksize;
             dst.st_blocks = (long)src.st_blocks;
             dst.st_atime = src.st_atime;

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -72,7 +72,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getenv.cs">
       <Link>Common\Interop\Interop.getenv.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek64.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek.cs">
       <Link>Common\Interop\Interop.lseek64.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -462,8 +462,8 @@ namespace System
                     {
                         // Read in all of the terminfo data
                         long termInfoLength;
-                        while (Interop.CheckIo(termInfoLength = Interop.libc.lseek64(fd, 0, Interop.libc.SeekWhence.SEEK_END))) ; // jump to the end to get the file length
-                        while (Interop.CheckIo(Interop.libc.lseek64(fd, 0, Interop.libc.SeekWhence.SEEK_SET))) ; // reset back to beginning
+                        while (Interop.CheckIo(termInfoLength = Interop.libc.lseek(fd, 0, Interop.libc.SeekWhence.SEEK_END))) ; // jump to the end to get the file length
+                        while (Interop.CheckIo(Interop.libc.lseek(fd, 0, Interop.libc.SeekWhence.SEEK_SET))) ; // reset back to beginning
                         const int MaxTermInfoLength = 4096; // according to the term and tic man pages, 4096 is the terminfo file size max
                         const int HeaderLength = 12;
                         if (termInfoLength <= HeaderLength || termInfoLength > MaxTermInfoLength)

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -159,7 +159,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
       <Link>Common\Interop\Interop.open.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek64.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek.cs">
       <Link>Common\Interop\Interop.lseek64.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mkdir.cs">

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -112,7 +112,7 @@ namespace System.IO
                 0;
             if (fadv != 0)
             {
-                SysCall<Interop.libc.Advice, int>((fd, advice, _) => Interop.libc.posix_fadvise(fd, IntPtr.Zero, IntPtr.Zero, advice), fadv);
+                SysCall<Interop.libc.Advice, int>((fd, advice, _) => Interop.libc.posix_fadvise(fd, 0, 0, advice), fadv);
             }
 
             // Jump to the end of the file if opened as Append.
@@ -252,7 +252,7 @@ namespace System.IO
                 if (!_canSeek.HasValue)
                 {
                     // Lazily-initialize whether we're able to seek, tested by seeking to our current location.
-                    _canSeek = SysCall<int, int>((fd, _, __) => Interop.libc.lseek64(fd, 0, Interop.libc.SeekWhence.SEEK_CUR), throwOnError: false) >= 0;
+                    _canSeek = SysCall<int, int>((fd, _, __) => Interop.libc.lseek(fd, 0, Interop.libc.SeekWhence.SEEK_CUR), throwOnError: false) >= 0;
                 }
                 return _canSeek.Value;
             }
@@ -960,7 +960,7 @@ namespace System.IO
             Contract.Assert(!_fileHandle.IsClosed && CanSeek);
             Contract.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End);
 
-            long pos = SysCall((fd, off, or) => Interop.libc.lseek64(fd, off, or), offset, (Interop.libc.SeekWhence)(int)origin); // SeekOrigin values are the same as Interop.libc.SeekWhence values
+            long pos = SysCall((fd, off, or) => Interop.libc.lseek(fd, off, or), offset, (Interop.libc.SeekWhence)(int)origin); // SeekOrigin values are the same as Interop.libc.SeekWhence values
             _filePosition = pos;
             return pos;
         }


### PR DESCRIPTION
As part of this, changed interop definitions of off_t to be Int64 rather than IntPtr.  For now we're assuming that we'll run either on 64-bit systems and/or where _FILE_OFFSET_BITS == 64.  We can revisit this if that assumption fails.

Fixes #733