### PR TITLE
Update Array.SetValue calls to use added-back overload

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -352,16 +352,9 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
-                if (_count == 0)
-                {
-                    return;
-                }
-
-                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var item in this)
                 {
-                    indices[0] = arrayIndex++;
-                    array.SetValue(new DictionaryEntry(item.Key, item.Value), indices);
+                    array.SetValue(new DictionaryEntry(item.Key, item.Value), arrayIndex++);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -788,16 +788,9 @@ namespace System.Collections.Immutable
             Requires.Range(arrayIndex >= 0, "arrayIndex");
             Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
-            if (_count == 0)
-            {
-                return;
-            }
-
-            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             foreach (var item in this)
             {
-                indices[0] = arrayIndex++;
-                array.SetValue(new DictionaryEntry(item.Key, item.Value), indices);
+                array.SetValue(new DictionaryEntry(item.Key, item.Value), arrayIndex++);
             }
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
@@ -573,16 +573,9 @@ namespace System.Collections.Immutable
             Requires.Range(arrayIndex >= 0, "arrayIndex");
             Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
-            if (_count == 0)
-            {
-                return;
-            }
-
-            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             foreach (T item in this)
             {
-                indices[0] = arrayIndex++;
-                array.SetValue(item, indices);
+                array.SetValue(item, arrayIndex++);
             }
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -2651,16 +2651,9 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
-                if (_count == 0)
-                {
-                    return;
-                }
-
-                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var element in this)
                 {
-                    indices[0] = arrayIndex++;
-                    array.SetValue(element, indices);
+                    array.SetValue(element, arrayIndex++);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -1400,16 +1400,9 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + dictionarySize, "arrayIndex");
 
-                if (this.IsEmpty)
-                {
-                    return;
-                }
-
-                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var item in this)
                 {
-                    indices[0] = arrayIndex++;
-                    array.SetValue(new DictionaryEntry(item.Key, item.Value), indices);
+                    array.SetValue(new DictionaryEntry(item.Key, item.Value), arrayIndex++);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -1716,16 +1716,9 @@ namespace System.Collections.Immutable
                 Requires.Range(arrayIndex >= 0, "arrayIndex");
                 Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
-                if (this.IsEmpty)
-                {
-                    return;
-                }
-
-                int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
                 foreach (var item in this)
                 {
-                    indices[0] = arrayIndex++;
-                    array.SetValue(item, indices);
+                    array.SetValue(item, arrayIndex++);
                 }
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
@@ -135,16 +135,9 @@ namespace System.Collections.Immutable
             Requires.Range(arrayIndex >= 0, "arrayIndex");
             Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
 
-            if (this.Count == 0)
-            {
-                return;
-            }
-
-            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             foreach (T item in this)
             {
-                indices[0] = arrayIndex++;
-                array.SetValue(item, indices);
+                array.SetValue(item, arrayIndex++);
             }
         }
 

--- a/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs
+++ b/src/System.Xml.XmlDocument/src/System/Xml/Dom/XmlAttributeCollection.cs
@@ -248,16 +248,9 @@ namespace System.Xml
 
         void ICollection.CopyTo(Array array, int index)
         {
-            if (Count == 0)
-            {
-                return;
-            }
-
-            int[] indices = new int[1]; // SetValue takes a params array; lifting out the implicit allocation from the loop
             for (int i = 0, max = Count; i < max; i++, index++)
             {
-                indices[0] = index;
-                array.SetValue(nodes[i], indices);
+                array.SetValue(nodes[i], index);
             }
         }
 


### PR DESCRIPTION
Array.SetValue(object, int) was missing from the .NET Core surface area, but Array.SetValue(object, int[]) was still there.  This meant that code which had been calling the former silently changed to calling the latter, resulting in an extra array allocation.  This was most common in ICollection.CopyTo implementations, inside of a loop.  As such, we previously changed a bunch of these to allocate an array outside of the loop so as to ammortize its cost across all iterations, rather than having one allocation per iteration.

Instead, we've added the SetValue(object, int) overload back to the .NET Core profile; that method is able to set the value without incurring an allocation.  As such, this commit scrubs back through the places where we introducing the array allocation, removes it, and reverts back to using the SetValue(object, int) overload (once we actually compile against the updated contracts).