### PR TITLE
Call Dispose in Finalizer; remove unnecessary Null check

### DIFF
--- a/src/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/BackgroundWorker.cs
+++ b/src/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/BackgroundWorker.cs
@@ -23,6 +23,11 @@ namespace System.ComponentModel
             _operationCompleted = new SendOrPostCallback(AsyncOperationCompleted);
             _progressReporter = new SendOrPostCallback(ProgressReporter);
         }
+        
+        ~BackgroundWorker()
+        {
+            Dispose(false);
+        }
 
         private void AsyncOperationCompleted(object arg)
         {
@@ -200,14 +205,7 @@ namespace System.ComponentModel
             RunWorkerCompletedEventArgs e =
                 new RunWorkerCompletedEventArgs(workerResult, error, cancelled);
 
-            if (_asyncOperation != null)
-            {
-                _asyncOperation.PostOperationCompleted(_operationCompleted, e);
-            }
-            else
-            {
-                _operationCompleted(e);
-            }
+            _asyncOperation.PostOperationCompleted(_operationCompleted, e);
         }
 
         public void Dispose()


### PR DESCRIPTION
Please compare with the original implementation which behaves identical to my changes: http://referencesource.microsoft.com/#System/compmod/system/componentmodel/BackgroundWorker.cs,85d60b0d93a826fa