### PR TITLE
Add the OS type to the output and intermediate paths

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -75,16 +75,16 @@
   <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
     <BaseOutputPath>$(ProjectDir)bin\</BaseOutputPath>
-    <BaseOutputPathWithConfig>$(BaseOutputPath)$(Configuration)\</BaseOutputPathWithConfig>
-    <BaseOutputPathWithConfig Condition="'$(Platform)' != 'AnyCPU'">$(BaseOutputPath)$(Platform)\$(Configuration)\</BaseOutputPathWithConfig>
+    <BaseOutputPathWithConfig>$(BaseOutputPath)$(OS)\$(Configuration)\</BaseOutputPathWithConfig>
+    <BaseOutputPathWithConfig Condition="'$(Platform)' != 'AnyCPU'">$(BaseOutputPath)$(Platform)\$(OS)\$(Configuration)\</BaseOutputPathWithConfig>
     <OutputPath>$(BaseOutputPathWithConfig)$(MSBuildProjectName)\</OutputPath>
 
     <BaseIntermediateOutputPath>$(BaseOutputPath)obj\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(MSBuildProjectName)\$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(Platform)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(MSBuildProjectName)\$(OS)\$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(Platform)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(MSBuildProjectName)\$(Platform)\$(OS)\$(Configuration)\</IntermediateOutputPath>
     
-    <TestPath>$(TestWorkingDir)$(MSBuildProjectName)\$(Configuration)\</TestPath>
-    <TestPath Condition="'$(Platform)' != 'AnyCPU'">$(TestWorkingDir)$(MSBuildProjectName)\$(Configuration)\$(Platform)\</TestPath>
+    <TestPath>$(TestWorkingDir)$(MSBuildProjectName)\$(OS)\$(Configuration)\</TestPath>
+    <TestPath Condition="'$(Platform)' != 'AnyCPU'">$(TestWorkingDir)$(MSBuildProjectName)\$(Platform)\$(OS)\$(Configuration)\</TestPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This avoids issues where switching between Unix and Windows_NT causes rebuild problems