### PR TITLE
Update the references to the Microsoft.DotNet.TestHost package.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.24-prerelease</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-4</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.24-prerelease" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-4" />
   <package id="OpenCover" version="4.5.3522" />
   <package id="ReportGenerator" version="2.0.4.0" />
 </packages>

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -648,6 +648,8 @@ namespace Test
             }
             catch (Exception ex)
             {
+                // This is not going to be the case since we changed the behavior of WithCancellation
+                // to not throw when called on disposed cancellationtokens.
                 ae1 = (ArgumentException)ex;
             }
 
@@ -659,6 +661,8 @@ namespace Test
             }
             catch (Exception ex)
             {
+                // This is not going to be the case since we changed the behavior of WithCancellation
+                // to not throw when called on disposed cancellationtokens.
                 ae2 = (ArgumentException)ex;
             }
 
@@ -671,12 +675,14 @@ namespace Test
             }
             catch (Exception ex)
             {
+                // This is not going to be the case since we changed the behavior of WithCancellation
+                // to not throw when called on disposed cancellationtokens.
                 ae3 = (ArgumentException)ex;
             }
 
-            Assert.NotNull(ae1);
-            Assert.NotNull(ae2);
-            Assert.NotNull(ae3);
+            Assert.Null(ae1); 
+            Assert.Null(ae2);
+            Assert.Null(ae3);
         }
 
         public static void SimulateThreadSleep(int milliseconds)


### PR DESCRIPTION
The Microsoft.DotNet.TestHost package was split into 2 packages:
- One that can be produced from the CoreCLR repo (CoreClr package)
- One that contains additional file that are not build by the CoreCLR repo (TestHost package)

This is the first step towards enabling the CoreFx repo to consume binaries
produced from the CoreCLR repo.