### PR TITLE
Incremental build tweaks

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -6,6 +6,8 @@
     <Project Include="src\dirs.proj" />
   </ItemGroup>
 
+  <Import Project="dir.targets" />
+
   <Import Project="dir.traversal.targets" />
 
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
@@ -28,7 +30,7 @@
     <Exec
       Command="$(ReportGeneratorCommandLine) $(ReportGeneratorOptions)"
       ContinueOnError="ErrorAndContinue" />
-    
+
   </Target>
   
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -10,9 +10,9 @@
 
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="Clean">
-    <RemoveDir Directories="$(BinDir);$(PackagesDir)" />
+    <RemoveDir Directories="$(BinDir)" />
   </Target>
-  
+
   <Target Name="GenerateCoverageReport"
     AfterTargets="Build"
     Inputs="$(CoverageReportDir)\*.coverage.xml"

--- a/dir.targets
+++ b/dir.targets
@@ -24,12 +24,12 @@
             try
             {
                 if (!File.Exists(FileName))
-                   File.Move(tempFile, FileName);
+                    File.Move(tempFile, FileName);
             }
             finally
             {
-              if (File.Exists(tempFile))
-                  File.Delete(tempFile);
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
             }
         ]]>
       </Code>
@@ -43,7 +43,7 @@
   <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
 
   <Target Name="_RestoreBuildTools"
-          Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
+          Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget\packages.config"
           Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
     <Message Importance="High" Text="Restoring build tools..." />
 
@@ -57,6 +57,14 @@
     
     <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
+
+    <!--
+      There are cases where the inputs could be newer than the outputs but the
+      download or restore may not need to update. In such cases we need to touch
+      these files otherwise we continually run this target over and over for
+      every project until these files are cleaned (if the are ever cleaned).
+    -->
+    <Touch Files="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)" />
   </Target>
 
 </Project>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -13,6 +13,13 @@
   <PropertyGroup>
     <!-- Explicity set the OutDir as it is used by the packaging targets -->
     <OutDir Condition="'$(OutDir)'==''">$(BaseOutputPathWithConfig)</OutDir>
+    
+    <!--
+      Producing packages is currently broken after the recent buildtools update
+      because the GetPackageVersion task gets an incorrect version number.
+      Git hub issue: https://github.com/dotnet/corefx/issues/758
+    -->
+    <SkipBuildPackages>true</SkipBuildPackages>
   </PropertyGroup>
   
   <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />


### PR DESCRIPTION
Update Clean target to no longer delete PackagesDir, to address #529. 

Fixed an issue with the _RestoreBuildTools target where we sometimes get into a never ending running of that target in cases where your dir.props or pacakges.config is newer than the tools. This showed its head while I had edits to that file and was no longer cleaning my Packages directory. To address I always ensure the outputs are newer by touching them at the end of the target whenever it is ran.

Also realized that our BuildPackages target was not being run any longer on clean builds and only on incremental builds. This showed that it is recently broken by the latest build tools update and I filed #758 for that but for now I'm disabling the building of the packaging. I also started importing dir.targets in build.proj so the tools were restored in time for them to be used in src\dir.proj even on clean builds.