### PR TITLE
Update the native vcxproj to use DefaultPlatformToolset instead of v120.

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/NativeTestService/NativeTestService.vcxproj
+++ b/src/System.ServiceProcess.ServiceController/tests/NativeTestService/NativeTestService.vcxproj
@@ -16,18 +16,20 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>NativeTestService</RootNamespace>
     <OutDir>$(OutputPath)</OutDir>
+    <!-- Defaulting to v120 but if we have higher tools it will be overridden in Microsoft.Cpp.Default.props -->
+    <DefaultPlatformToolset>v120</DefaultPlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
This should address #735. @stephentoub would you mind verifying this on with your VS 2015 builds with Unix options? I don't have the right setup to verify that but I believe this should fix it. I know we could also just disable this project for Unix but if this work we can keep it building for now, as we don't have a good way of filtering out entire projects based on OS at this moment.