### PR TITLE
Build log filename variable

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,7 +3,7 @@ setlocal
 
 :: Note: We've disabled node reuse because it causes file locking issues.
 ::       The issue is that we extend the build with our own targets which
-::       means that that rebuilding cannot successully delete the task
+::       means that that rebuilding cannot successfully delete the task
 ::       assembly. 
 
 :: Check prerequisites
@@ -16,8 +16,10 @@ if not defined VS120COMNTOOLS (
 )
 
 :: Log build command line
+set _buildproj=%~dp0build.proj
+set _buildlog=%~dp0msbuild.log
 set _buildprefix=echo
-set _buildpostfix=^> "%~dp0msbuild.log"
+set _buildpostfix=^> "%_buildlog%"
 call :build %*
 
 :: Build
@@ -28,7 +30,7 @@ call :build %*
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%~dp0build.proj" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%_buildlog%";Append %* %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 
@@ -36,7 +38,7 @@ goto :eof
 
 echo.
 :: Pull the build summary from the log file
-findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%~dp0msbuild.log"
+findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"
 echo Build Exit Code = %BUILDERRORLEVEL%
 
 exit /b %BUILDERRORLEVEL%


### PR DESCRIPTION
- Set name of build log file and build project file into env variable so
they are more easily discoverable in the log output, and only defined
once.
- Fix minor typo in comments.
- This is equivalent change to PR buildtools#71 applied here as
suggested by @weshaggard   https://github.com/dotnet/buildtools/pull/71