### PR TITLE
Remove/fix/mark as bug tests which are skipped or printing failures

### DIFF
--- a/src/System.Xml.XDocument/tests/Properties/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/Properties/FunctionalTests.cs
@@ -55,7 +55,6 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new XElementName() { Attribute = new TestCaseAttribute() { Name = "XElement.Name with Events", Params = new object[] { true } } });
                 this.AddChild(new XElementName() { Attribute = new TestCaseAttribute() { Name = "XElement.Name", Params = new object[] { false } } });
                 this.AddChild(new XElementValue() { Attribute = new TestCaseAttribute() { Name = "XElement.Value", Params = new object[] { false } } });
-                this.AddChild(new XElementValue() { Attribute = new TestCaseAttribute() { Name = "XElement.Value with Events", Params = new object[] { true } } });
             }
             public partial class DeepEqualsTests : XLinqTestCase
             {

--- a/src/System.Xml.XDocument/tests/Properties/ImplicitConversionsRoundTrip.cs
+++ b/src/System.Xml.XDocument/tests/Properties/ImplicitConversionsRoundTrip.cs
@@ -230,13 +230,6 @@ namespace CoreXml.Test.XLinq
                     Decimal.One,
                     Decimal.Zero,
 
-                    // date  
-                    DateTime.MaxValue,
-                    DateTime.MinValue,
-                    DateTime.UtcNow,
-                    DateTime.Today,
-                    DateTime.Now,
-
                     //// DateTimeOffset
                     DateTimeOffset.Now,
                     DateTimeOffset.MaxValue,

--- a/src/System.Xml.XDocument/tests/xNodeReader/CXMLGeneralTest.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/CXMLGeneralTest.cs
@@ -1226,9 +1226,7 @@ namespace CoreXml.Test.XLinq
                 //[Variation("Call Skip in while read loop", Priority = 0)]
                 public void skip307543()
                 {
-                    TestLog.Skip("Utf16 encoding");
-                    string fileName = Path.Combine(XLinqTestCase.RootPath, @"TestData\XmlReader\Common\skip307543.xml");
-                    XmlReader DataReader = GetReader(fileName);
+                    XmlReader DataReader = GetReader(@"TestData\XmlReader\Common\skip307543.xml");
                     while (DataReader.Read())
                         DataReader.Skip();
                 }
@@ -1303,12 +1301,6 @@ namespace CoreXml.Test.XLinq
                 public void TestSkip10()
                 {
                     BoolToLTMResult(VerifySkipOnNodeType(XmlNodeType.Comment));
-                }
-
-                //[Variation("Call Skip on Document Type")]
-                public void TestSkip11()
-                {
-                    BoolToLTMResult(VerifySkipOnNodeType(XmlNodeType.DocumentType));
                 }
 
                 //[Variation("Call Skip on Whitespace", Priority = 0)]
@@ -1440,16 +1432,6 @@ namespace CoreXml.Test.XLinq
                     bool bPassed = false;
                     XmlReader DataReader = GetReader();
                     PositionOnNodeType(DataReader, XmlNodeType.Comment);
-                    bPassed = TestLog.Equals(DataReader.BaseURI, String.Empty, Variation.Desc);
-                    BoolToLTMResult(bPassed);
-                }
-
-                //[Variation("BaseURI for DTD node")]
-                public void TestBaseURI8()
-                {
-                    bool bPassed = false;
-                    XmlReader DataReader = GetReader();
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
                     bPassed = TestLog.Equals(DataReader.BaseURI, String.Empty, Variation.Desc);
                     BoolToLTMResult(bPassed);
                 }

--- a/src/System.Xml.XDocument/tests/xNodeReader/CXMLReaderAttrTest.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/CXMLReaderAttrTest.cs
@@ -1353,27 +1353,6 @@ namespace CoreXml.Test.XLinq
                 }
             }
 
-            public partial class TCAttributeDocType : BridgeHelpers
-            {
-                //[Variation("AttributeCount and HasAttributes", Priority = 0)]
-                public void TADocType_1()
-                {
-                    XmlReader DataReader = GetReader();
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
-                    TestLog.Compare(DataReader.AttributeCount, 0, "Checking AttributeCount");
-                    TestLog.Compare(DataReader.HasAttributes, false, "Checking HasAttributes");
-                }
-
-                //[Variation("HasValue and Value on DocumentType")]
-                public void TADocType_2()
-                {
-                    XmlReader DataReader = GetReader(new StringReader("<!DOCTYPE dt [<!ENTITY e 'eee'>]><ROOT/>"));
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
-                    TestLog.Compare(DataReader.HasValue, true, "HasValue");
-                    TestLog.Compare(DataReader.Value, "<!ENTITY e 'eee'>", "Value");
-                }
-            }
-
             //[TestCase(Name = "ReadURI", Desc = "Read URI")]
             public partial class TATextReaderDocType : BridgeHelpers
             {

--- a/src/System.Xml.XDocument/tests/xNodeReader/CXmlReaderReadEtc.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/CXmlReaderReadEtc.cs
@@ -5,6 +5,7 @@ using System;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Test.ModuleCore;
+using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
@@ -316,20 +317,6 @@ namespace CoreXml.Test.XLinq
                     TestLog.Compare(DataReader.ReadInnerXml(), String.Empty, Variation.Desc);
                 }
 
-                //[Variation("ReadInnerXml on DocumentType attributes")]
-                public void TestTextReadInnerXml17()
-                {
-                    XmlReader DataReader = GetReader();
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
-                    try
-                    {
-                        DataReader.MoveToAttribute(DataReader.AttributeCount / 2);
-                        throw new TestException(TestResult.Failed, "");
-                    }
-                    catch (ArgumentOutOfRangeException) { }
-                    TestLog.Compare(DataReader.ReadInnerXml(), String.Empty, "inner");
-                }
-
                 //[Variation("One large element")]
                 public void TestTextReadInnerXml18()
                 {
@@ -363,15 +350,6 @@ namespace CoreXml.Test.XLinq
                 public void TestMoveToContent1()
                 {
                     XmlReader DataReader = GetReader();
-                    TestLog.Compare(DataReader.MoveToContent(), XmlNodeType.Element, Variation.Desc);
-                    TestLog.Compare(DataReader.Name, "PLAY", Variation.Desc);
-                }
-
-                //[Variation("MoveToContent on Skip DocumentType")]
-                public void TestMoveToContent1x()
-                {
-                    XmlReader DataReader = GetReader();
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
                     TestLog.Compare(DataReader.MoveToContent(), XmlNodeType.Element, Variation.Desc);
                     TestLog.Compare(DataReader.Name, "PLAY", Variation.Desc);
                 }
@@ -580,15 +558,6 @@ namespace CoreXml.Test.XLinq
                 {
                     XmlReader DataReader = GetReader();
                     PositionOnNodeType(DataReader, XmlNodeType.Comment);
-                    TestLog.Compare(DataReader.IsStartElement(), true, Variation.Desc);
-                    TestLog.Compare(DataReader.NodeType, XmlNodeType.Element, Variation.Desc);
-                }
-
-                //[Variation("IsStartElement on DocumentType")]
-                public void TestIsStartElement14()
-                {
-                    XmlReader DataReader = GetReader();
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
                     TestLog.Compare(DataReader.IsStartElement(), true, Variation.Desc);
                     TestLog.Compare(DataReader.NodeType, XmlNodeType.Element, Variation.Desc);
                 }
@@ -873,25 +842,27 @@ namespace CoreXml.Test.XLinq
                 private const String ST_TEST_ELEM_NS = "NAMESPACE1";
                 private const String ST_TEST_EMPTY_ELEM_NS = "EMPTY_NAMESPACE1";
 
-                //[Variation("ReadEndElement() on EndElement, no namespace", Priority = 0)]
-                public void TestReadEndElement1()
+                [Fact]
+                [ActiveIssue(641)]
+                public void TestReadEndElementOnEndElementWithoutNamespace()
                 {
                     XmlReader DataReader = GetReader();
                     PositionOnElement(DataReader, "NONAMESPACE");
                     PositionOnNodeType(DataReader, XmlNodeType.EndElement);
                     DataReader.ReadEndElement();
-                    VerifyNode(DataReader, XmlNodeType.EndElement, "NONAMESPACE", String.Empty);
+                    Assert.True(VerifyNode(DataReader, XmlNodeType.EndElement, "NONAMESPACE", String.Empty));
                 }
 
-                //[Variation("ReadEndElement() on EndElement, with namespace", Priority = 0)]
-                public void TestReadEndElement2()
+                [Fact]
+                [ActiveIssue(641)]
+                public void TestReadEndElementOnEndElementWithNamespace()
                 {
                     XmlReader DataReader = GetReader();
                     PositionOnElement(DataReader, ST_TEST_ELEM_NS);
                     PositionOnElement(DataReader, "bar:check");
                     PositionOnNodeType(DataReader, XmlNodeType.EndElement);
                     DataReader.ReadEndElement();
-                    VerifyNode(DataReader, XmlNodeType.EndElement, "bar:check", String.Empty);
+                    Assert.True(VerifyNode(DataReader, XmlNodeType.EndElement, "bar:check", String.Empty));
                 }
 
                 //[Variation("ReadEndElement on Start Element, no namespace")]
@@ -1023,22 +994,6 @@ namespace CoreXml.Test.XLinq
                     throw new TestException(TestResult.Failed, "");
                 }
 
-                //[Variation("ReadEndElement on DocumentType")]
-                public void TestReadEndElement12()
-                {
-                    XmlReader DataReader = GetReader();
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
-                    try
-                    {
-                        DataReader.ReadEndElement();
-                    }
-                    catch (XmlException)
-                    {
-                        return;
-                    }
-                    throw new TestException(TestResult.Failed, "");
-                }
-
                 //[Variation("ReadEndElement on XmlDeclaration")]
                 public void TestReadEndElement13()
                 {
@@ -1106,16 +1061,6 @@ namespace CoreXml.Test.XLinq
                     PositionOnElement(DataReader, "elem2");
                     TestLog.Compare(!DataReader.MoveToElement(), "MTE on elem2 failed");
                     TestLog.Compare(VerifyNode(DataReader, XmlNodeType.Element, "elem2", String.Empty), "MTE moved on wrong node");
-                }
-
-                //[Variation("Doctype node")]
-                public void v4()
-                {
-                    XmlReader DataReader = GetReader();
-
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
-                    TestLog.Compare(!DataReader.MoveToElement(), "MTE on doctype failed");
-                    TestLog.Compare(DataReader.NodeType, XmlNodeType.DocumentType, "doctype");
                 }
 
                 //[Variation("Comment node")]

--- a/src/System.Xml.XDocument/tests/xNodeReader/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/FunctionalTests.cs
@@ -55,7 +55,6 @@ namespace CoreXml.Test.XLinq
                 this.AddChild(new TCMoveToFirstAttribute() { Attribute = new TestCaseAttribute() { Name = "MoveToFirstAtribute", Desc = "MoveToFirstAttribute" } });
                 this.AddChild(new TCMoveToNextAttribute() { Attribute = new TestCaseAttribute() { Name = "MoveToNextAttribute", Desc = "MoveToNextAttribute" } });
                 this.AddChild(new TCAttributeTest() { Attribute = new TestCaseAttribute() { Name = "AttributeTest", Desc = "AttributeTest" } });
-                this.AddChild(new TCAttributeDocType() { Attribute = new TestCaseAttribute() { Name = "AttributeDocType", Desc = "AttributeDocType" } });
                 this.AddChild(new TCXmlns() { Attribute = new TestCaseAttribute() { Name = "Xlmns", Desc = "Xlmns" } });
                 this.AddChild(new TCXmlnsPrefix() { Attribute = new TestCaseAttribute() { Name = "XlmnsPrefix", Desc = "XlmnsPrefix" } });
                 this.AddChild(new TCReadState() { Attribute = new TestCaseAttribute() { Name = "ReadState", Desc = "ReadState" } });
@@ -226,19 +225,10 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestSkip8) { Attribute = new VariationAttribute("Call Skip on CDATA") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestSkip9) { Attribute = new VariationAttribute("Call Skip on Processing Instruction") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestSkip10) { Attribute = new VariationAttribute("Call Skip on Comment") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestSkip11) { Attribute = new VariationAttribute("Call Skip on Document Type") });
                     this.AddChild(new TestVariation(TestSkip12) { Attribute = new VariationAttribute("Call Skip on Whitespace") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestSkip13) { Attribute = new VariationAttribute("Call Skip on EndElement") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestSkip14) { Attribute = new VariationAttribute("Call Skip on root Element") });
                     this.AddChild(new TestVariation(XmlTextReaderDoesNotThrowWhenHandlingAmpersands) { Attribute = new VariationAttribute("XmlTextReader ArgumentOutOfRangeException when handling ampersands") });
-                }
-            }
-            public partial class TCIsDefault : BridgeHelpers
-            {
-                // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCIsDefault
-                // Test Case
-                public override void AddChildren()
-                {
                 }
             }
             public partial class TCBaseURI : BridgeHelpers
@@ -253,7 +243,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestBaseURI4) { Attribute = new VariationAttribute("BaseURI for CDATA node") });
                     this.AddChild(new TestVariation(TestBaseURI6) { Attribute = new VariationAttribute("BaseURI for PI node") });
                     this.AddChild(new TestVariation(TestBaseURI7) { Attribute = new VariationAttribute("BaseURI for Comment node") });
-                    this.AddChild(new TestVariation(TestBaseURI8) { Attribute = new VariationAttribute("BaseURI for DTD node") });
                     this.AddChild(new TestVariation(TestBaseURI9) { Attribute = new VariationAttribute("BaseURI for Whitespace node PreserveWhitespaces = true") });
                     this.AddChild(new TestVariation(TestBaseURI10) { Attribute = new VariationAttribute("BaseURI for EndElement node") });
                     this.AddChild(new TestVariation(TestTextReaderBaseURI4) { Attribute = new VariationAttribute("BaseURI for external General Entity") });
@@ -427,16 +416,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestAttributeTestNodeType_EndEntity) { Attribute = new VariationAttribute("AttributeTest On EndEntity") });
                 }
             }
-            public partial class TCAttributeDocType : BridgeHelpers
-            {
-                // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCAttributeDocType
-                // Test Case
-                public override void AddChildren()
-                {
-                    this.AddChild(new TestVariation(TADocType_1) { Attribute = new VariationAttribute("AttributeCount and HasAttributes") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TADocType_2) { Attribute = new VariationAttribute("HasValue and Value on DocumentType") });
-                }
-            }
             public partial class TCXmlns : BridgeHelpers
             {
                 // Type is CoreXml.Test.XLinq.FunctionalTests+XNodeReaderTests+TCXmlns
@@ -502,7 +481,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestTextReadInnerXml2) { Attribute = new VariationAttribute("ReadInnerXml with with entity references, EntityHandling = ExpandCharEntites") });
                     this.AddChild(new TestVariation(TestTextReadInnerXml4) { Attribute = new VariationAttribute("ReadInnerXml on EntityReference") });
                     this.AddChild(new TestVariation(TestTextReadInnerXml5) { Attribute = new VariationAttribute("ReadInnerXml on EndEntity") });
-                    this.AddChild(new TestVariation(TestTextReadInnerXml17) { Attribute = new VariationAttribute("ReadInnerXml on DocumentType attributes") });
                     this.AddChild(new TestVariation(TestTextReadInnerXml18) { Attribute = new VariationAttribute("One large element") });
                 }
             }
@@ -513,7 +491,6 @@ namespace CoreXml.Test.XLinq
                 public override void AddChildren()
                 {
                     this.AddChild(new TestVariation(TestMoveToContent1) { Attribute = new VariationAttribute("MoveToContent on Skip XmlDeclaration") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestMoveToContent1x) { Attribute = new VariationAttribute("MoveToContent on Skip DocumentType") });
                     this.AddChild(new TestVariation(TestMoveToContent2) { Attribute = new VariationAttribute("MoveToContent on Read through All valid Content Node(Element, Text, CDATA, and EndElement)") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestMoveToContent3) { Attribute = new VariationAttribute("MoveToContent on Read through All invalid Content Node(PI, Comment and whitespace)") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestMoveToContent4) { Attribute = new VariationAttribute("MoveToContent on Read through Mix valid and Invalid Content Node") });
@@ -539,7 +516,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestIsStartElement11) { Attribute = new VariationAttribute("IsStartElement on Text") });
                     this.AddChild(new TestVariation(TestIsStartElement12) { Attribute = new VariationAttribute("IsStartElement on ProcessingInstruction") });
                     this.AddChild(new TestVariation(TestIsStartElement13) { Attribute = new VariationAttribute("IsStartElement on Comment") });
-                    this.AddChild(new TestVariation(TestIsStartElement14) { Attribute = new VariationAttribute("IsStartElement on DocumentType") });
                 }
             }
             public partial class TCReadStartElement : BridgeHelpers
@@ -572,8 +548,6 @@ namespace CoreXml.Test.XLinq
                 // Test Case
                 public override void AddChildren()
                 {
-                    this.AddChild(new TestVariation(TestReadEndElement1) { Attribute = new VariationAttribute("ReadEndElement() on EndElement, no namespace") { Priority = 0 } });
-                    this.AddChild(new TestVariation(TestReadEndElement2) { Attribute = new VariationAttribute("ReadEndElement() on EndElement, with namespace") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestReadEndElement3) { Attribute = new VariationAttribute("ReadEndElement on Start Element, no namespace") });
                     this.AddChild(new TestVariation(TestReadEndElement4) { Attribute = new VariationAttribute("ReadEndElement on Empty Element, no namespace") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestReadEndElement5) { Attribute = new VariationAttribute("ReadEndElement on regular Element, with namespace") { Priority = 0 } });
@@ -582,7 +556,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestReadEndElement9) { Attribute = new VariationAttribute("ReadEndElement on Text") });
                     this.AddChild(new TestVariation(TestReadEndElement10) { Attribute = new VariationAttribute("ReadEndElement on ProcessingInstruction") });
                     this.AddChild(new TestVariation(TestReadEndElement11) { Attribute = new VariationAttribute("ReadEndElement on Comment") });
-                    this.AddChild(new TestVariation(TestReadEndElement12) { Attribute = new VariationAttribute("ReadEndElement on DocumentType") });
                     this.AddChild(new TestVariation(TestReadEndElement13) { Attribute = new VariationAttribute("ReadEndElement on XmlDeclaration") });
                     this.AddChild(new TestVariation(TestTextReadEndElement1) { Attribute = new VariationAttribute("ReadEndElement on EntityReference") });
                     this.AddChild(new TestVariation(TestTextReadEndElement2) { Attribute = new VariationAttribute("ReadEndElement on EndEntity") });
@@ -597,7 +570,6 @@ namespace CoreXml.Test.XLinq
                 {
                     this.AddChild(new TestVariation(v1) { Attribute = new VariationAttribute("Attribute node") });
                     this.AddChild(new TestVariation(v2) { Attribute = new VariationAttribute("Element node") });
-                    this.AddChild(new TestVariation(v4) { Attribute = new VariationAttribute("Doctype node") });
                     this.AddChild(new TestVariation(v5) { Attribute = new VariationAttribute("Comment node") });
                 }
             }
@@ -759,7 +731,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(TestReadBase64_15) { Attribute = new VariationAttribute("ReadBase64 after failure") });
                     this.AddChild(new TestVariation(TestReadBase64_16) { Attribute = new VariationAttribute("Read after partial ReadBase64") { Priority = 0 } });
                     this.AddChild(new TestVariation(TestReadBase64_17) { Attribute = new VariationAttribute("Current node on multiple calls") });
-                    this.AddChild(new TestVariation(TestReadBase64_18) { Attribute = new VariationAttribute("No op node types") });
                     this.AddChild(new TestVariation(TestTextReadBase64_23) { Attribute = new VariationAttribute("ReadBase64 with incomplete sequence") });
                     this.AddChild(new TestVariation(TestTextReadBase64_24) { Attribute = new VariationAttribute("ReadBase64 when end tag doesn't exist") });
                     this.AddChild(new TestVariation(TestTextReadBase64_26) { Attribute = new VariationAttribute("ReadBase64 with whitespaces in the mIddle") });
@@ -863,8 +834,6 @@ namespace CoreXml.Test.XLinq
                     this.AddChild(new TestVariation(ReadOuterXml15) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandEntities") { Priority = 0 } });
                     this.AddChild(new TestVariation(ReadOuterXml17) { Attribute = new VariationAttribute("ReadOuterXml on ProcessingInstruction") });
                     this.AddChild(new TestVariation(ReadOuterXml24) { Attribute = new VariationAttribute("ReadOuterXml on CDATA") });
-                    this.AddChild(new TestVariation(ReadOuterXml25) { Attribute = new VariationAttribute("ReadOuterXml on XmlDeclaration attributes") });
-                    this.AddChild(new TestVariation(ReadOuterXml26) { Attribute = new VariationAttribute("ReadOuterXml on DocumentType attributes") });
                     this.AddChild(new TestVariation(TRReadOuterXml27) { Attribute = new VariationAttribute("ReadOuterXml on element with entities, EntityHandling = ExpandCharEntities") });
                     this.AddChild(new TestVariation(TRReadOuterXml28) { Attribute = new VariationAttribute("ReadOuterXml on attribute with entities, EntityHandling = ExpandCharEntites") });
                     this.AddChild(new TestVariation(TestTextReadOuterXml29) { Attribute = new VariationAttribute("One large element") });

--- a/src/System.Xml.XDocument/tests/xNodeReader/ReadBase64.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/ReadBase64.cs
@@ -367,7 +367,6 @@ namespace CoreXml.Test.XLinq
                 //[Variation("No op node types")]
                 public void TestReadBase64_18()
                 {
-                    TestOnInvalidNodeType(XmlNodeType.DocumentType);
                     TestOnInvalidNodeType(XmlNodeType.EndElement);
                 }
 
@@ -834,12 +833,6 @@ namespace CoreXml.Test.XLinq
 
                     TestLog.Compare(DataReader.NodeType, XmlNodeType.EndElement, "Nodetype not end element");
                     TestLog.Compare(DataReader.Name, "ElemNum", "Nodetype not end element");
-                }
-
-                //[Variation("No op node types")]
-                public void TestReadBase64_18()
-                {
-                    TestOnInvalidNodeType(XmlNodeType.DocumentType);
                 }
 
                 //[Variation("ReadBase64 with incomplete sequence")]

--- a/src/System.Xml.XDocument/tests/xNodeReader/ReadOuterXml.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/ReadOuterXml.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Xml;
 using Microsoft.Test.ModuleCore;
+using Xunit;
 
 namespace CoreXml.Test.XLinq
 {
@@ -206,8 +207,9 @@ namespace CoreXml.Test.XLinq
                     TestOuterOnNodeType(XmlNodeType.CDATA);
                 }
 
-                //[Variation("ReadOuterXml on XmlDeclaration attributes")]
-                public void ReadOuterXml25()
+                [Fact]
+                [ActiveIssue(641)]
+                public void ReadOuterXmlOnXmlDeclarationAttributes()
                 {
                     XmlReader DataReader = GetReader();//GetReader(pGenericXml);
                     DataReader.Read();
@@ -217,24 +219,8 @@ namespace CoreXml.Test.XLinq
                         throw new TestException(TestResult.Failed, "");
                     }
                     catch (ArgumentOutOfRangeException) { }
-                    TestLog.Compare(DataReader.ReadOuterXml(), String.Empty, "outer");
-                    TestLog.Compare(VerifyNode(DataReader, XmlNodeType.Attribute, String.Empty, "UTF-8"), false, "vn");
-                }
-
-                //[Variation("ReadOuterXml on DocumentType attributes")]
-                public void ReadOuterXml26()
-                {
-                    XmlReader DataReader = GetReader();//GetReader(pGenericXml);
-                    PositionOnNodeType(DataReader, XmlNodeType.DocumentType);
-                    try
-                    {
-                        DataReader.MoveToAttribute(DataReader.AttributeCount / 2);
-                        throw new TestException(TestResult.Failed, "");
-                    }
-                    catch (ArgumentOutOfRangeException) { }
-
-                    TestLog.Compare(DataReader.ReadOuterXml(), String.Empty, "outer");
-                    TestLog.Compare(VerifyNode(DataReader, XmlNodeType.Attribute, "SYSTEM", String.Empty), false, "vn");
+                    Assert.True(TestLog.Compare(DataReader.ReadOuterXml(), String.Empty, "outer"));
+                    Assert.True(TestLog.Compare(VerifyNode(DataReader, XmlNodeType.Attribute, String.Empty, "UTF-8"), false, "vn"));
                 }
 
                 //[Variation("ReadOuterXml on element with entities, EntityHandling = ExpandCharEntities")]


### PR DESCRIPTION
This should remove all non-essential messages printed on the console (only number of tests passed and the test group name is displayed now)

<!---
@huboard:{"order":919.5,"milestone_order":769,"custom_state":""}
-->
