### PR TITLE
System.ComponentModel.Annotations : fix unit tests arrange value for double depending on culture

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
@@ -117,9 +117,9 @@ namespace System.ComponentModel.DataAnnotations
         {
             var attribute = new RangeAttribute(typeof(double), (1.0).ToString("F1"), (3.0).ToString("F1"));
             Assert.Throws<ValidationException>(() => attribute.Validate(0.9999999, s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate((0.9999999).ToString("F7"), s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate((0.9999999).ToString(), s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate(3.0000001, s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate((3.0000001).ToString("F7"), s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate((3.0000001).ToString(), s_testValidationContext));
         }
 
         [Fact]

--- a/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
@@ -101,25 +101,25 @@ namespace System.ComponentModel.DataAnnotations
         [Fact]
         public static void Can_validate_valid_values_for_doubles_using_type_and_strings_constructor()
         {
-            var attribute = new RangeAttribute(typeof(double), "1.0", "3.0");
+            var attribute = new RangeAttribute(typeof(double), (1.0).ToString("F1"), (3.0).ToString("F1"));
             AssertEx.DoesNotThrow(() => attribute.Validate(null, s_testValidationContext)); // null is valid
             AssertEx.DoesNotThrow(() => attribute.Validate(string.Empty, s_testValidationContext)); // empty string is valid
             AssertEx.DoesNotThrow(() => attribute.Validate(1.0, s_testValidationContext));
-            AssertEx.DoesNotThrow(() => attribute.Validate("1.0", s_testValidationContext));
+            AssertEx.DoesNotThrow(() => attribute.Validate((1.0).ToString("F1"), s_testValidationContext));
             AssertEx.DoesNotThrow(() => attribute.Validate(2.0, s_testValidationContext));
-            AssertEx.DoesNotThrow(() => attribute.Validate("2.0", s_testValidationContext));
+            AssertEx.DoesNotThrow(() => attribute.Validate((2.0).ToString("F1"), s_testValidationContext));
             AssertEx.DoesNotThrow(() => attribute.Validate(3.0, s_testValidationContext));
-            AssertEx.DoesNotThrow(() => attribute.Validate("3.0", s_testValidationContext));
+            AssertEx.DoesNotThrow(() => attribute.Validate((3.0).ToString("F1"), s_testValidationContext));
         }
 
         [Fact]
         public static void Can_validate_invalid_values_for_doubles_using_type_and_strings_constructor()
         {
-            var attribute = new RangeAttribute(typeof(double), "1.0", "3.0");
+            var attribute = new RangeAttribute(typeof(double), (1.0).ToString("F1"), (3.0).ToString("F1"));
             Assert.Throws<ValidationException>(() => attribute.Validate(0.9999999, s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate("0.9999999", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate((0.9999999).ToString("F7"), s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate(3.0000001, s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate("3.0000001", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate((3.0000001).ToString("F7"), s_testValidationContext));
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace System.ComponentModel.DataAnnotations
             Assert.Throws<InvalidOperationException>(
                 () => attribute.Validate("Does not matter - minimum > maximum", s_testValidationContext));
 
-            attribute = new RangeAttribute(typeof(double), "3.0", "1.0");
+            attribute = new RangeAttribute(typeof(double), (3.0).ToString("F1"), (1.0).ToString("F1"));
             Assert.Throws<InvalidOperationException>(
                 () => attribute.Validate("Does not matter - minimum > maximum", s_testValidationContext));
 
@@ -191,11 +191,11 @@ namespace System.ComponentModel.DataAnnotations
         [Fact]
         public static void Validation_throws_Exception_if_min_and_max_values_cannot_be_converted_to_double_OperandType()
         {
-            var attribute = new RangeAttribute(typeof(double), "Cannot Convert", "3.0");
+            var attribute = new RangeAttribute(typeof(double), "Cannot Convert", (3.0).ToString("F1"));
             Assert.Throws<FormatException>(
                 () => attribute.Validate("Does not matter - cannot convert minimum to double", s_testValidationContext));
 
-            attribute = new RangeAttribute(typeof(double), "1.0", "Cannot Convert");
+            attribute = new RangeAttribute(typeof(double), (1.0).ToString("F1"), "Cannot Convert");
             Assert.Throws<FormatException>(
                 () => attribute.Validate("Does not matter - cannot convert maximum to double", s_testValidationContext));
         }

--- a/src/System.Runtime/tests/System/Byte.cs
+++ b/src/System.Runtime/tests/System/Byte.cs
@@ -123,7 +123,7 @@ public static class ByteTests
         Assert.Equal("82", i2.ToString("g"));
 
         Byte i3 = 246;
-        Assert.Equal("246.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", 246.00), i3.ToString("N"));
 
         Byte i4 = 0x24;
         Assert.Equal("24", i4.ToString("x"));
@@ -143,6 +143,7 @@ public static class ByteTests
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
+        numberFormat.NumberDecimalSeparator = ".";
         Byte i3 = 24;
         Assert.Equal("24.00", i3.ToString("N", numberFormat));
     }
@@ -195,10 +196,10 @@ public static class ByteTests
         Assert.True(Byte.TryParse(" 67 ", out i));   // Leading/Trailing whitespace
         Assert.Equal<Byte>(67, i);
 
-        Assert.False(Byte.TryParse("$100", out i));  // Currency
-        Assert.False(Byte.TryParse("1,000", out i));  // Thousands
+        Assert.False(Byte.TryParse((100).ToString("C0"), out i));  // Currency
+        Assert.False(Byte.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(Byte.TryParse("ab", out i));    // Hex digits
-        Assert.False(Byte.TryParse("67.90", out i)); // Decimal
+        Assert.False(Byte.TryParse((67.90).ToString("F2"), out i)); // Decimal
         Assert.False(Byte.TryParse("(135)", out i));  // Parentheses
         Assert.False(Byte.TryParse("1E23", out i));   // Exponent
     }
@@ -222,6 +223,7 @@ public static class ByteTests
         Assert.True(Byte.TryParse("ab", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal<Byte>(0xab, i);
 
+        nfi.NumberDecimalSeparator = ".";
         Assert.False(Byte.TryParse("67.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(Byte.TryParse(" 67 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 

--- a/src/System.Runtime/tests/System/Decimal.cs
+++ b/src/System.Runtime/tests/System/Decimal.cs
@@ -489,8 +489,8 @@ public static class DecimalTests
         // Boolean Decimal.TryParse(String, NumberStyles, IFormatProvider, Decimal)
         Assert.Equal(123, Decimal.Parse("123"));
         Assert.Equal(-123, Decimal.Parse("-123"));
-        Assert.Equal(123.123m, Decimal.Parse("123.123"));
-        Assert.Equal(-123.123m, Decimal.Parse("-123.123"));
+        Assert.Equal(123.123m, Decimal.Parse((123.123).ToString()));
+        Assert.Equal(-123.123m, Decimal.Parse((-123.123).ToString()));
 
         Decimal d;
         Assert.True(Decimal.TryParse("79228162514264337593543950335", out d));
@@ -499,7 +499,8 @@ public static class DecimalTests
         Assert.True(Decimal.TryParse("-79228162514264337593543950335", out d));
         Assert.Equal(Decimal.MinValue, d);
 
-        Assert.True(Decimal.TryParse("79,228,162,514,264,337,593,543,950,335", NumberStyles.AllowThousands, NumberFormatInfo.CurrentInfo, out d));
+        var nfi = new NumberFormatInfo() { NumberGroupSeparator = "," };
+        Assert.True(Decimal.TryParse("79,228,162,514,264,337,593,543,950,335", NumberStyles.AllowThousands, nfi, out d));
         Assert.Equal(Decimal.MaxValue, d);
 
         Assert.False(Decimal.TryParse("ysaidufljasdf", out d));
@@ -801,10 +802,10 @@ public static class DecimalTests
     {
         // String Decimal.ToString()
         Decimal d1 = 6310.23m;
-        Assert.Equal("6310.23", d1.ToString());
+        Assert.Equal(string.Format("{0}", 6310.23), d1.ToString());
 
         Decimal d2 = -8249.000003m;
-        Assert.Equal("-8249.000003", d2.ToString());
+        Assert.Equal(string.Format("{0}", -8249.000003), d2.ToString());
 
         Assert.Equal("79228162514264337593543950335", Decimal.MaxValue.ToString());
         Assert.Equal("-79228162514264337593543950335", Decimal.MinValue.ToString());
@@ -855,7 +856,8 @@ public static class DecimalTests
     {
         Decimal dE = 1234567890123456789012345.6785m;
         string s1 = "1234567890123456789012345.678456";
-        Decimal d1 = Decimal.Parse(s1);
+        var nfi = new NumberFormatInfo() { NumberDecimalSeparator = "." };
+        Decimal d1 = Decimal.Parse(s1, nfi);
         Assert.Equal(d1, dE);
         return;
     }

--- a/src/System.Runtime/tests/System/Double.cs
+++ b/src/System.Runtime/tests/System/Double.cs
@@ -210,7 +210,7 @@ public static class DoubleTests
         Assert.Equal("-8249", i2.ToString("g"));
 
         Double i3 = -2468;
-        Assert.Equal("-2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
     }
 
     [Fact]
@@ -242,8 +242,8 @@ public static class DoubleTests
     [Fact]
     public static void TestParseNumberStyle()
     {
-        Assert.Equal<Double>((Double)123.1, Double.Parse("123.1", NumberStyles.AllowDecimalPoint));
-        Assert.Equal(1000, Double.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal<Double>((Double)123.1, Double.Parse(string.Format("{0}", 123.1), NumberStyles.AllowDecimalPoint));
+        Assert.Equal(1000, Double.Parse(string.Format("{0}", 1000), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -260,9 +260,11 @@ public static class DoubleTests
     public static void TestParseNumberStyleFormatProvider()
     {
         var nfi = new NumberFormatInfo();
+        nfi.NumberDecimalSeparator = ".";
         Assert.Equal<Double>((Double)123.123, Double.Parse("123.123", NumberStyles.Float, nfi));
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.Equal(1000, Double.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
@@ -282,16 +284,17 @@ public static class DoubleTests
         Assert.True(Double.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.True(Double.TryParse("678.90", out i)); // Decimal
+        Assert.True(Double.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.Equal((Double)678.90, i);
 
         Assert.True(Double.TryParse("1E23", out i));   // Exponent
         Assert.Equal((Double)1E23, i);
 
-        Assert.True(Double.TryParse("1,000", out i));  // Thousands
+        Assert.True(Double.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.Equal(1000, i);
 
-        Assert.False(Double.TryParse("$1000", out i));  // Currency
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(Double.TryParse((1000).ToString("C0", nfi), out i));  // Currency
         Assert.False(Double.TryParse("abc", out i));    // Hex digits
         Assert.False(Double.TryParse("(135)", out i));  // Parentheses
     }
@@ -301,6 +304,7 @@ public static class DoubleTests
     {
         Double i;
         var nfi = new NumberFormatInfo();
+        nfi.NumberDecimalSeparator = ".";
         Assert.True(Double.TryParse("123.123", NumberStyles.Any, nfi, out i));   // Simple positive
         Assert.Equal((Double)123.123, i);
 
@@ -308,6 +312,7 @@ public static class DoubleTests
         Assert.Equal(123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(Double.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal(1000, i);
 

--- a/src/System.Runtime/tests/System/Int16.cs
+++ b/src/System.Runtime/tests/System/Int16.cs
@@ -141,7 +141,7 @@ public static class Int16Tests
         Assert.Equal("-8249", i2.ToString("g"));
 
         Int16 i3 = -2468;
-        Assert.Equal("-2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
 
         Int16 i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
@@ -177,7 +177,7 @@ public static class Int16Tests
     public static void TestParseNumberStyle()
     {
         Assert.Equal(0x123, Int16.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal(1000, Int16.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal(1000, Int16.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -197,6 +197,7 @@ public static class Int16Tests
         Assert.Equal(0x123, Int16.Parse("123", NumberStyles.HexNumber, nfi));
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.Equal(1000, Int16.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
@@ -216,10 +217,11 @@ public static class Int16Tests
         Assert.True(Int16.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.False(Int16.TryParse("$1000", out i));  // Currency
-        Assert.False(Int16.TryParse("1,000", out i));  // Thousands
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(Int16.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(Int16.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(Int16.TryParse("abc", out i));    // Hex digits
-        Assert.False(Int16.TryParse("678.90", out i)); // Decimal
+        Assert.False(Int16.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.False(Int16.TryParse("(135)", out i));  // Parentheses
         Assert.False(Int16.TryParse("1E23", out i));   // Exponent
     }

--- a/src/System.Runtime/tests/System/Int32.cs
+++ b/src/System.Runtime/tests/System/Int32.cs
@@ -141,7 +141,7 @@ public static class Int32Tests
         Assert.Equal("-8249", i2.ToString("g"));
 
         Int32 i3 = -2468;
-        Assert.Equal("-2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
 
         Int32 i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
@@ -176,8 +176,8 @@ public static class Int32Tests
     [Fact]
     public static void TestParseNumberStyle()
     {
-        Assert.Equal(0x123, Int32.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal(1000, Int32.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal(0x123, Int64.Parse("123", NumberStyles.HexNumber));
+        Assert.Equal(1000, Int32.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -197,6 +197,7 @@ public static class Int32Tests
         Assert.Equal(0x123, Int32.Parse("123", NumberStyles.HexNumber, nfi));
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.Equal(1000, Int32.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
@@ -216,10 +217,11 @@ public static class Int32Tests
         Assert.True(Int32.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.False(Int32.TryParse("$1000", out i));  // Currency
-        Assert.False(Int32.TryParse("1,000", out i));  // Thousands
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(Int32.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(Int32.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(Int32.TryParse("abc", out i));    // Hex digits
-        Assert.False(Int32.TryParse("678.90", out i)); // Decimal
+        Assert.False(Int32.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.False(Int32.TryParse("(135)", out i));  // Parentheses
         Assert.False(Int32.TryParse("1E23", out i));   // Exponent
     }
@@ -236,6 +238,7 @@ public static class Int32Tests
         Assert.Equal(0x123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(Int32.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal(1000, i);
 
@@ -243,6 +246,7 @@ public static class Int32Tests
         Assert.True(Int32.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal(0xabc, i);
 
+        nfi.CurrencyGroupSeparator = ".";
         Assert.False(Int32.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(Int32.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 

--- a/src/System.Runtime/tests/System/Int64.cs
+++ b/src/System.Runtime/tests/System/Int64.cs
@@ -144,7 +144,7 @@ public static class Int64Tests
         Assert.Equal("-8249", i2.ToString("g"));
 
         Int64 i3 = -2468;
-        Assert.Equal("-2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
 
         Int64 i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
@@ -183,7 +183,7 @@ public static class Int64Tests
     public static void TestParseNumberStyle()
     {
         Assert.Equal(0x123, Int64.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal(1000, Int64.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal(1000, Int64.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -203,6 +203,7 @@ public static class Int64Tests
         Assert.Equal(0x123, Int64.Parse("123", NumberStyles.HexNumber, nfi));
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.Equal(1000, Int64.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
@@ -222,10 +223,11 @@ public static class Int64Tests
         Assert.True(Int64.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.False(Int64.TryParse("$1000", out i));  // Currency
-        Assert.False(Int64.TryParse("1,000", out i));  // Thousands
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(Int64.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(Int64.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(Int64.TryParse("abc", out i));    // Hex digits
-        Assert.False(Int64.TryParse("678.90", out i)); // Decimal
+        Assert.False(Int64.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.False(Int64.TryParse("(135)", out i));  // Parentheses
         Assert.False(Int64.TryParse("1E23", out i));   // Exponent
     }
@@ -242,6 +244,7 @@ public static class Int64Tests
         Assert.Equal(0x123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(Int64.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal(1000, i);
 
@@ -249,6 +252,7 @@ public static class Int64Tests
         Assert.True(Int64.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal(0xabc, i);
 
+        nfi.NumberDecimalSeparator = ".";
         Assert.False(Int64.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(Int64.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 

--- a/src/System.Runtime/tests/System/SByte.cs
+++ b/src/System.Runtime/tests/System/SByte.cs
@@ -123,7 +123,7 @@ public static class SByteTests
         Assert.Equal("82", i2.ToString("g"));
 
         SByte i3 = 46;
-        Assert.Equal("46.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", 46.00), i3.ToString("N"));
 
         SByte i4 = 0x24;
         Assert.Equal("24", i4.ToString("x"));
@@ -143,6 +143,7 @@ public static class SByteTests
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
+        numberFormat.NumberDecimalSeparator = ".";
         SByte i3 = 24;
         Assert.Equal("24.00", i3.ToString("N", numberFormat));
     }
@@ -196,10 +197,10 @@ public static class SByteTests
         Assert.True(SByte.TryParse(" 67 ", out i));   // Leading/Trailing whitespace
         Assert.Equal<SByte>(67, i);
 
-        Assert.False(SByte.TryParse("$100", out i));  // Currency
-        Assert.False(SByte.TryParse("1,000", out i));  // Thousands
+        Assert.False(SByte.TryParse((100).ToString("C0"), out i));  // Currency
+        Assert.False(SByte.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(SByte.TryParse("ab", out i));    // Hex digits
-        Assert.False(SByte.TryParse("67.90", out i)); // Decimal
+        Assert.False(SByte.TryParse((67.90).ToString("F2"), out i)); // Decimal
         Assert.False(SByte.TryParse("(35)", out i));  // Parentheses
         Assert.False(SByte.TryParse("1E23", out i));   // Exponent
     }
@@ -223,6 +224,7 @@ public static class SByteTests
         Assert.True(SByte.TryParse("2b", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal<SByte>(0x2b, i);
 
+        nfi.NumberDecimalSeparator = ".";
         Assert.False(SByte.TryParse("67.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(SByte.TryParse(" 67 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 

--- a/src/System.Runtime/tests/System/Single.cs
+++ b/src/System.Runtime/tests/System/Single.cs
@@ -210,7 +210,7 @@ public static class SingleTests
         Assert.Equal("-8249", i2.ToString("g"));
 
         Single i3 = -2468;
-        Assert.Equal("-2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
     }
 
     [Fact]
@@ -242,8 +242,8 @@ public static class SingleTests
     [Fact]
     public static void TestParseNumberStyle()
     {
-        Assert.Equal<Single>(123.1f, Single.Parse("123.1", NumberStyles.AllowDecimalPoint));
-        Assert.Equal(1000, Single.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal<Single>(123.1f, Single.Parse((123.1).ToString("F"), NumberStyles.AllowDecimalPoint));
+        Assert.Equal(1000, Single.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -260,9 +260,11 @@ public static class SingleTests
     public static void TestParseNumberStyleFormatProvider()
     {
         var nfi = new NumberFormatInfo();
+        nfi.NumberDecimalSeparator = ".";
         Assert.Equal<Single>(123.123f, Single.Parse("123.123", NumberStyles.Float, nfi));
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.Equal(1000, Single.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
@@ -282,16 +284,17 @@ public static class SingleTests
         Assert.True(Single.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.True(Single.TryParse("678.90", out i)); // Decimal
+        Assert.True(Single.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.Equal((Single)678.90, i);
 
         Assert.True(Single.TryParse("1E23", out i));   // Exponent
         Assert.Equal((Single)1E23, i);
 
-        Assert.True(Single.TryParse("1,000", out i));  // Thousands
+        Assert.True(Single.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.Equal(1000, i);
 
-        Assert.False(Single.TryParse("$1000", out i));  // Currency
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(Single.TryParse((1000).ToString("C0", nfi), out i));  // Currency
         Assert.False(Single.TryParse("abc", out i));    // Hex digits
         Assert.False(Single.TryParse("(135)", out i));  // Parentheses
     }
@@ -301,6 +304,7 @@ public static class SingleTests
     {
         Single i;
         var nfi = new NumberFormatInfo();
+        nfi.NumberDecimalSeparator = ".";
         Assert.True(Single.TryParse("123.123", NumberStyles.Any, nfi, out i));   // Simple positive
         Assert.Equal(123.123f, i);
 
@@ -308,6 +312,7 @@ public static class SingleTests
         Assert.Equal(123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(Single.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal(1000, i);
 

--- a/src/System.Runtime/tests/System/UInt16.cs
+++ b/src/System.Runtime/tests/System/UInt16.cs
@@ -123,7 +123,7 @@ public static class UInt16Tests
         Assert.Equal("8249", i2.ToString("g"));
 
         UInt16 i3 = 2468;
-        Assert.Equal("2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
 
         UInt16 i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
@@ -158,7 +158,8 @@ public static class UInt16Tests
     public static void TestParseNumberStyle()
     {
         Assert.Equal<UInt16>(0x123, UInt16.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal<UInt16>(1000, UInt16.Parse("1,000", NumberStyles.AllowThousands));
+
+        Assert.Equal<UInt16>(1000, UInt16.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -177,6 +178,7 @@ public static class UInt16Tests
         Assert.Equal<UInt16>(0x123, UInt16.Parse("123", NumberStyles.HexNumber, nfi));
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.Equal<UInt16>(1000, UInt16.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
@@ -195,10 +197,11 @@ public static class UInt16Tests
         Assert.True(UInt16.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal<UInt16>(678, i);
 
-        Assert.False(UInt16.TryParse("$1000", out i));  // Currency
-        Assert.False(UInt16.TryParse("1,000", out i));  // Thousands
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(UInt16.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(UInt16.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(UInt16.TryParse("abc", out i));    // Hex digits
-        Assert.False(UInt16.TryParse("678.90", out i)); // Decimal
+        Assert.False(UInt16.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.False(UInt16.TryParse("(135)", out i));  // Parentheses
         Assert.False(UInt16.TryParse("1E23", out i));   // Exponent
     }
@@ -215,6 +218,7 @@ public static class UInt16Tests
         Assert.Equal<UInt16>(0x123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(UInt16.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal<UInt16>(1000, i);
 
@@ -222,6 +226,7 @@ public static class UInt16Tests
         Assert.True(UInt16.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal<UInt16>(0xabc, i);
 
+        nfi.NumberDecimalSeparator = ".";
         Assert.False(UInt16.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(UInt16.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 

--- a/src/System.Runtime/tests/System/UInt32.cs
+++ b/src/System.Runtime/tests/System/UInt32.cs
@@ -123,7 +123,7 @@ public static class UInt32Tests
         Assert.Equal("8249", i2.ToString("g"));
 
         UInt32 i3 = 2468;
-        Assert.Equal("2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
 
         UInt32 i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
@@ -158,7 +158,7 @@ public static class UInt32Tests
     public static void TestParseNumberStyle()
     {
         Assert.Equal<UInt32>(0x123, UInt32.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal<UInt32>(1000, UInt32.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal<UInt32>(1000, UInt32.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -195,10 +195,11 @@ public static class UInt32Tests
         Assert.True(UInt32.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal<UInt32>(678, i);
 
-        Assert.False(UInt32.TryParse("$1000", out i));  // Currency
-        Assert.False(UInt32.TryParse("1,000", out i));  // Thousands
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(UInt32.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(UInt32.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(UInt32.TryParse("abc", out i));    // Hex digits
-        Assert.False(UInt32.TryParse("678.90", out i)); // Decimal
+        Assert.False(UInt32.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.False(UInt32.TryParse("(135)", out i));  // Parentheses
         Assert.False(UInt32.TryParse("1E23", out i));   // Exponent
     }
@@ -215,6 +216,7 @@ public static class UInt32Tests
         Assert.Equal<UInt32>(0x123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(UInt32.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal<UInt32>(1000, i);
 
@@ -222,6 +224,7 @@ public static class UInt32Tests
         Assert.True(UInt32.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal<UInt32>(0xabc, i);
 
+        nfi.NumberDecimalSeparator = ".";
         Assert.False(UInt32.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(UInt32.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 

--- a/src/System.Runtime/tests/System/UInt64.cs
+++ b/src/System.Runtime/tests/System/UInt64.cs
@@ -123,7 +123,7 @@ public static class UInt64Tests
         Assert.Equal("8249", i2.ToString("g"));
 
         UInt64 i3 = 2468;
-        Assert.Equal("2,468.00", i3.ToString("N"));
+        Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
 
         UInt64 i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
@@ -158,7 +158,7 @@ public static class UInt64Tests
     public static void TestParseNumberStyle()
     {
         Assert.Equal<UInt64>(0x123, UInt64.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal<UInt64>(1000, UInt64.Parse("1,000", NumberStyles.AllowThousands));
+        Assert.Equal<UInt64>(1000, UInt64.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -195,10 +195,11 @@ public static class UInt64Tests
         Assert.True(UInt64.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal<UInt64>(678, i);
 
-        Assert.False(UInt64.TryParse("$1000", out i));  // Currency
-        Assert.False(UInt64.TryParse("1,000", out i));  // Thousands
+        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
+        Assert.False(UInt64.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(UInt64.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.False(UInt64.TryParse("abc", out i));    // Hex digits
-        Assert.False(UInt64.TryParse("678.90", out i)); // Decimal
+        Assert.False(UInt64.TryParse((678.90).ToString("F2"), out i)); // Decimal
         Assert.False(UInt64.TryParse("(135)", out i));  // Parentheses
         Assert.False(UInt64.TryParse("1E23", out i));   // Exponent
     }
@@ -215,6 +216,7 @@ public static class UInt64Tests
         Assert.Equal<UInt64>(0x123, i);
 
         nfi.CurrencySymbol = "$";
+        nfi.CurrencyGroupSeparator = ",";
         Assert.True(UInt64.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal<UInt64>(1000, i);
 
@@ -222,6 +224,7 @@ public static class UInt64Tests
         Assert.True(UInt64.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
         Assert.Equal<UInt64>(0xabc, i);
 
+        nfi.NumberDecimalSeparator = ".";
         Assert.False(UInt64.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
         Assert.False(UInt64.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 


### PR DESCRIPTION
The decimal separator is obviously different depending on culture. So  three unit tests in System.ComponentModel.Annotations.Tests failed on a machine with an fr-FR culture.  

    System.ComponentModel.DataAnnotations.RangeAttributeTests.Validation_throw
    s_InvalidOperationException_if_minimum_is_greater_than_maximum [FAIL]
        Assert.Throws() Failure
            Expected: typeof(System.InvalidOperationException)
            Actual:   typeof(System.FormatException): Input string was not in a correct format.
        Stack Trace:
              at System.Number.ParseDouble(String value, NumberStyles options, NumberFormatInfo numfmt)
              at System.String.System.IConvertible.ToDouble(IFormatProvider provider)
              at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)

Actually "#.#" (string) is sent to RangeAttribue.validate() method as double type. (A call to Convert.ChangeType() fails)
I suggest (#.#).ToString("F") to format the double respecting the culture.

The test involves to validate 3.0 value for en-US and 3,0 value for fr-FR doesn't it ?