### PR TITLE
Add System.Threading to packages.config in test projects

### DIFF
--- a/src/Common/tests/SystemXml/XmlCoreTest/packages.config
+++ b/src/Common/tests/SystemXml/XmlCoreTest/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
   <package id="System.IO" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Linq" version="4.0.0-beta-22512" />

--- a/src/System.Globalization.Extensions/tests/packages.config
+++ b/src/System.Globalization.Extensions/tests/packages.config
@@ -9,6 +9,7 @@
   <package id="System.Runtime.Handles" version="4.0.0-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Runtime.InteropServices" version="4.0.20-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />
+  <package id="System.Threading" version="4.0.0-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />

--- a/src/System.Xml.XDocument/tests/Properties/packages.config
+++ b/src/System.Xml.XDocument/tests/Properties/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Collections" version="4.0.10-beta-22512" />

--- a/src/System.Xml.XDocument/tests/Streaming/packages.config
+++ b/src/System.Xml.XDocument/tests/Streaming/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.IO" version="4.0.10-beta-22512" />

--- a/src/System.Xml.XDocument/tests/TreeManipulation/packages.config
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22512" />

--- a/src/System.Xml.XDocument/tests/XDocument.Common/packages.config
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22512" />

--- a/src/System.Xml.XDocument/tests/misc/packages.config
+++ b/src/System.Xml.XDocument/tests/misc/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Collections" version="4.0.10-beta-22512" />

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/packages.config
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.IO" version="4.0.10-beta-22512" />


### PR DESCRIPTION
This would otherwise make the Mono mcs compiler fail with:
"error CS0518: The predefined type `System.Threading.Interlocked' is defined in an assembly that is not referenced."

It's the same change as in https://github.com/dotnet/corefx/pull/328