### PR TITLE
Use xunit netcore package in XunitTraitsDiscoverers

### DIFF
--- a/src/Common/tests/XunitTraitsDiscoverers/packages.config
+++ b/src/Common/tests/XunitTraitsDiscoverers/packages.config
@@ -5,8 +5,8 @@
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
   <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
-  <package id="xunit.abstractions" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
-  <package id="xunit.core" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="xunit.core.netcore" version="1.0.0-prerelease" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
XunitTraitsDiscoverers used the original xunit.abstractions and xunit.core packages instead of the netcore version.
This causes a problem like https://github.com/dotnet/buildtools/pull/38 when compiling on Mono due to the unwanted xunit.runner.tdnet.dll