### PR TITLE
Fix condition in dir.targets

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -50,7 +50,7 @@
     <!-- Download latest nuget.exe -->
     <DownloadFile FileName="$(NuGetToolPath)"
                   Address="http://nuget.org/nuget.exe" 
-                  Condition="!Exists($(NuGetToolPath))" />
+                  Condition="!Exists('$(NuGetToolPath)')" />
 
     <!-- Restore build tools -->
     <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget\packages.config&quot;" StandardOutputImportance="Low" />


### PR DESCRIPTION
The value passed to Exists() should be enclosed in single quotes according to https://msdn.microsoft.com/en-us/library/7szfhaft.aspx