### PR TITLE
Scrub [ComVisible] attribution from CoreFX library sources

### DIFF
--- a/src/Common/src/System/Text/NormalizationForm.cs
+++ b/src/Common/src/System/Text/NormalizationForm.cs
@@ -7,7 +7,6 @@ namespace System.Text
 #if INTERNAL_GLOBALIZATION_EXTENSIONS
     internal
 #else
-    [System.Runtime.InteropServices.ComVisible(true)]
     public
 #endif
     enum NormalizationForm

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Win32
      * @security(checkClassLinking=on)
      */
     //This class contains only static members and does not need to be serializable.
-    [ComVisible(true)]
     public static class Registry
     {
         [System.Security.SecuritySafeCritical]  

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Win32
     /**
      * Registry hive values.  Useful only for GetRemoteBaseKey
      */
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum RegistryHive
     {
         ClassesRoot = unchecked((int)0x80000000),
@@ -82,7 +81,6 @@ namespace Microsoft.Win32
      * @security(checkDllCalls=off)
      * @security(checkClassLinking=on)
      */
-    [ComVisible(true)]
     public sealed class RegistryKey : IDisposable
     {
         // We could use const here, if C# supported ELEMENT_TYPE_I fully.
@@ -274,20 +272,17 @@ namespace Microsoft.Win32
             return CreateSubKey(subkey, IsWritable());
         }
 
-        [ComVisible(false)]
         public RegistryKey CreateSubKey(String subkey, bool writable)
         {
             return CreateSubKeyInternal(subkey, writable, RegistryOptions.None);
         }
 
-        [ComVisible(false)]
         public RegistryKey CreateSubKey(String subkey, bool writable, RegistryOptions options)
         {
             return CreateSubKeyInternal(subkey, writable, options);
         }
 
         [System.Security.SecuritySafeCritical]  
-        [ComVisible(false)]
         private unsafe RegistryKey CreateSubKeyInternal(String subkey, bool writable, RegistryOptions registryOptions)
         {
             ValidateKeyOptions(registryOptions);
@@ -406,7 +401,6 @@ namespace Microsoft.Win32
         }
 
         [System.Security.SecuritySafeCritical]  
-        [ComVisible(false)]
         public void DeleteSubKeyTree(String subkey, Boolean throwOnMissingSubKey)
         {
             ValidateKeyName(subkey);
@@ -564,7 +558,6 @@ namespace Microsoft.Win32
 
 
         [System.Security.SecuritySafeCritical]  
-        [ComVisible(false)]
         public static RegistryKey OpenBaseKey(RegistryHive hKey, RegistryView view)
         {
             ValidateKeyView(view);
@@ -594,7 +587,6 @@ namespace Microsoft.Win32
         }
 
         [System.Security.SecuritySafeCritical]  
-        [ComVisible(false)]
         public static RegistryKey OpenRemoteBaseKey(RegistryHive hKey, String machineName, RegistryView view)
         {
             if (machineName == null)
@@ -725,7 +717,6 @@ namespace Microsoft.Win32
             }
         }
 
-        [ComVisible(false)]
         public RegistryView View
         {
             [System.Security.SecuritySafeCritical]
@@ -736,7 +727,6 @@ namespace Microsoft.Win32
             }
         }
 
-        [ComVisible(false)]
         public SafeRegistryHandle Handle
         {
             [System.Security.SecurityCritical]
@@ -797,14 +787,12 @@ namespace Microsoft.Win32
         }
 
         [System.Security.SecurityCritical]
-        [ComVisible(false)]
         public static RegistryKey FromHandle(SafeRegistryHandle handle)
         {
             return FromHandle(handle, RegistryView.Default);
         }
 
         [System.Security.SecurityCritical]
-        [ComVisible(false)]
         public static RegistryKey FromHandle(SafeRegistryHandle handle, RegistryView view)
         {
             if (handle == null) throw new ArgumentNullException("handle");
@@ -1009,7 +997,6 @@ namespace Microsoft.Win32
         }
 
         [System.Security.SecuritySafeCritical]
-        [ComVisible(false)]
         public Object GetValue(String name, Object defaultValue, RegistryValueOptions options)
         {
             if (options < RegistryValueOptions.None || options > RegistryValueOptions.DoNotExpandEnvironmentNames)
@@ -1276,7 +1263,6 @@ namespace Microsoft.Win32
         }
 
         [System.Security.SecuritySafeCritical]  
-        [ComVisible(false)]
         public RegistryValueKind GetValueKind(string name)
         {
             EnsureNotDisposed();
@@ -1349,7 +1335,6 @@ namespace Microsoft.Win32
         }
 
         [System.Security.SecuritySafeCritical] 
-        [ComVisible(false)]
         public unsafe void SetValue(String name, Object value, RegistryValueKind valueKind)
         {
             if (value == null)

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryValueKind.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryValueKind.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Win32
 {
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum RegistryValueKind
     {
         String = Interop.REG_SZ,
@@ -13,7 +12,6 @@ namespace Microsoft.Win32
         MultiString = Interop.REG_MULTI_SZ,
         QWord = Interop.REG_QWORD,
         Unknown = 0,                          // REG_NONE is defined as zero but BCL
-        [System.Runtime.InteropServices.ComVisible(false)]
         None = unchecked((int)0xFFFFFFFF), //  mistakingly overrode this value.  
     }   // Now instead of using Interop.REG_NONE we use "-1".
 }

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -38,7 +38,6 @@ namespace System.Collections.Concurrent
     /// away as an <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. 
     /// </remarks>
     /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
-    [ComVisible(false)]
     [DebuggerTypeProxy(typeof(BlockingCollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}, Type = {_collection}")]
     public class BlockingCollection<T> : IEnumerable<T>, ICollection, IDisposable, IReadOnlyCollection<T>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -34,7 +34,6 @@ namespace System.Collections.Concurrent
     /// concurrently from multiple threads.
     /// </para>
     /// </remarks>
-    [ComVisible(false)]
     [DebuggerTypeProxy(typeof(IProducerConsumerCollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     public class ConcurrentBag<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -29,7 +29,6 @@ namespace System.Collections.Concurrent
     /// All public and protected members of <see cref="ConcurrentDictionary{TKey,TValue}"/> are thread-safe and may be used
     /// concurrently from multiple threads.
     /// </remarks>
-    [ComVisible(false)]
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
     public class ConcurrentDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -24,7 +24,6 @@ namespace System.Collections.Concurrent
     /// All public  and protected members of <see cref="ConcurrentQueue{T}"/> are thread-safe and may be used
     /// concurrently from multiple threads.
     /// </remarks>
-    [ComVisible(false)]
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(IProducerConsumerCollectionDebugView<>))]
     public class ConcurrentQueue<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>

--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -34,7 +34,6 @@ namespace System.Collections
 #endif
     [DebuggerTypeProxy(typeof(System.Collections.ArrayList.ArrayListDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class ArrayList : IList
     {
         private Object[] _items;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
@@ -17,7 +17,6 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class CaseInsensitiveComparer : IComparer
     {
         private CompareInfo _compareInfo;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
@@ -15,7 +15,6 @@ using System.Diagnostics.Contracts;
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
-    [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class CollectionBase : IList
     {
         private ArrayList _list;
@@ -46,7 +45,6 @@ namespace System.Collections
             get { return (IList)this; }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public int Capacity
         {
             get

--- a/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
@@ -16,7 +16,6 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
-    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class Comparer : IComparer
     {
         private CompareInfo _compareInfo;

--- a/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
@@ -15,7 +15,6 @@ using System;
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
-    [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class DictionaryBase : IDictionary
     {
         private Hashtable _hashtable;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -56,7 +56,6 @@ namespace System.Collections
     //
     [DebuggerTypeProxy(typeof(System.Collections.Hashtable.HashtableDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class Hashtable : IDictionary
     {
         /*

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -20,7 +20,6 @@ namespace System.Collections
     // buffer, so Enqueue can be O(n).  Dequeue is O(1).
     [DebuggerTypeProxy(typeof(System.Collections.Queue.QueueDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class Queue : ICollection
     {
         private Object[] _array;

--- a/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
@@ -15,7 +15,6 @@ using System;
 namespace System.Collections
 {
     // Useful base class for typed readonly collections where items derive from object
-    [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class ReadOnlyCollectionBase : ICollection
     {
         private ArrayList _list;

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -60,7 +60,6 @@ namespace System.Collections
     // 
     [DebuggerTypeProxy(typeof(System.Collections.SortedList.SortedListDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
 #if FEATURE_CORECLR
     [Obsolete("Non-generic collections have been deprecated. Please use collections in System.Collections.Generic.")]
 #endif

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -22,7 +22,6 @@ namespace System.Collections
     // so Push can be O(n).  Pop is O(1).
     [DebuggerTypeProxy(typeof(System.Collections.Stack.StackDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class Stack : ICollection
     {
         private Object[] _array;     // Storage for stack elements

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
@@ -22,7 +22,6 @@ namespace System.ComponentModel
     /// <devdoc>
     ///    <para>Provides functionality required by all components.</para>
     /// </devdoc>
-    [ComVisible(true)]
     public interface IComponent : IDisposable
     {
         // The site of the component.

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/IContainer.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/IContainer.cs
@@ -18,7 +18,6 @@ namespace System.ComponentModel
     ///    <para>Provides
     ///       functionality for containers. Containers are objects that logically contain zero or more components.</para>
     /// </devdoc>
-    [ComVisible(true)]
     public interface IContainer : IDisposable
     {
         // Adds a component to the container.

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/ISite.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/ISite.cs
@@ -21,7 +21,6 @@ namespace System.ComponentModel
     ///       and enable communication between them, as well as provide a way
     ///       for the container to manage its components.</para>
     /// </devdoc>
-    [ComVisible(true)]
     public interface ISite : IServiceProvider
     {
         // The component sited by this component site.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ITypeDescriptorContext.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ITypeDescriptorContext.cs
@@ -10,7 +10,6 @@ namespace System.ComponentModel
     ///       Provides information about a context to a type converter or a value editor,
     ///       so that the type converter or editor can perform a conversion.</para>
     /// </devdoc>
-    [ComVisible(true)]
     public interface ITypeDescriptorContext : IServiceProvider
     {
         /// <devdoc>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -9,7 +9,6 @@ namespace System.ComponentModel
     /// <devdoc>
     ///    <para>Converts the value of an object into a different data type.</para>
     /// </devdoc>
-    [ComVisible(true)]
     public class TypeConverter
     {
         /// <devdoc>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -301,7 +301,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long NonpagedSystemMemorySize64
         {
             get
@@ -311,7 +310,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long PagedMemorySize64
         {
             get
@@ -321,7 +319,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long PagedSystemMemorySize64
         {
             get
@@ -331,7 +328,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long PeakPagedMemorySize64
         {
             get
@@ -341,7 +337,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long PeakWorkingSet64
         {
             get
@@ -351,7 +346,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long PeakVirtualMemorySize64
         {
             get
@@ -417,7 +411,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long PrivateMemorySize64
         {
             get
@@ -528,7 +521,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long VirtualMemorySize64
         {
             get
@@ -639,7 +631,6 @@ namespace System.Diagnostics
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public long WorkingSet64
         {
             get
@@ -1250,7 +1241,6 @@ namespace System.Diagnostics
         /// then the remaining information is returned. The user can add an event handler to OutputDataReceived.
         /// </para>
         /// </devdoc>
-        [System.Runtime.InteropServices.ComVisible(false)]
         public void BeginOutputReadLine()
         {
             if (_outputStreamReadMode == StreamReadMode.Undefined)
@@ -1289,7 +1279,6 @@ namespace System.Diagnostics
         /// then the remaining information is returned. The user can add an event handler to ErrorDataReceived.
         /// </para>
         /// </devdoc>
-        [System.Runtime.InteropServices.ComVisible(false)]
         public void BeginErrorReadLine()
         {
             if (_errorStreamReadMode == StreamReadMode.Undefined)
@@ -1327,7 +1316,6 @@ namespace System.Diagnostics
         /// specified by BeginOutputReadLine().
         /// </para>
         /// </devdoc>
-        [System.Runtime.InteropServices.ComVisible(false)]
         public void CancelOutputRead()
         {
             if (_output != null)
@@ -1348,7 +1336,6 @@ namespace System.Diagnostics
         /// specified by BeginErrorReadLine().
         /// </para>
         /// </devdoc>
-        [System.Runtime.InteropServices.ComVisible(false)]
         public void CancelErrorRead()
         {
             if (_error != null)

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
@@ -111,9 +111,6 @@ namespace System.Diagnostics
             }
         }
 
-        [
-        ComVisible(false)
-        ]
         public TraceFilter Filter
         {
             get
@@ -143,9 +140,6 @@ namespace System.Diagnostics
             }
         }
 
-        [
-        ComVisible(false)
-        ]
         public TraceOptions TraceOutputOptions
         {
             get { return _traceOptions; }
@@ -312,9 +306,6 @@ namespace System.Diagnostics
 
         // new write methods used by TraceSource
 
-        [
-        ComVisible(false)
-        ]
         public virtual void TraceData(TraceEventCache eventCache, String source, TraceEventType eventType, int id, object data)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, null, null, data))
@@ -329,9 +320,6 @@ namespace System.Diagnostics
             WriteFooter(eventCache);
         }
 
-        [
-        ComVisible(false)
-        ]
         public virtual void TraceData(TraceEventCache eventCache, String source, TraceEventType eventType, int id, params object[] data)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, null, null, null, data))
@@ -356,18 +344,12 @@ namespace System.Diagnostics
             WriteFooter(eventCache);
         }
 
-        [
-        ComVisible(false)
-        ]
         public virtual void TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, int id)
         {
             TraceEvent(eventCache, source, eventType, id, String.Empty);
         }
 
         // All other TraceEvent methods come through this one.
-        [
-        ComVisible(false)
-        ]
         public virtual void TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, int id, string message)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, message))
@@ -379,9 +361,6 @@ namespace System.Diagnostics
             WriteFooter(eventCache);
         }
 
-        [
-        ComVisible(false)
-        ]
         public virtual void TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, int id, string format, params object[] args)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, format, args))

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveNotFoundException.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveNotFoundException.cs
@@ -6,7 +6,6 @@ using System;
 namespace System.IO
 {
     //Thrown when trying to access a drive that is not availabe.
-    [System.Runtime.InteropServices.ComVisible(true)]
     public class DriveNotFoundException : IOException
     {
         public DriveNotFoundException()

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveType.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveType.cs
@@ -6,7 +6,6 @@ using System;
 namespace System.IO
 {
     // Matches Win32's DRIVE_XXX #defines from winbase.h
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum DriveType
     {
         Unknown = 0,

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileAccess.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileAccess.cs
@@ -10,7 +10,6 @@ namespace System.IO
     ///   access to a file.
     /// </devdoc>
     [Flags]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum FileAccess
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileAttributes.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileAttributes.cs
@@ -6,7 +6,6 @@ using System;
 namespace System.IO
 {
     [Flags]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum FileAttributes
     {
         ReadOnly = 0x0001,

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileMode.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileMode.cs
@@ -14,7 +14,6 @@ namespace System.IO
     ///   to the end of the file).  To truncate a file or create it if it doesn't
     ///   exist, use Create.
     /// </devdoc>
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum FileMode
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem.Primitives/src/System/IO/FileShare.cs
+++ b/src/System.IO.FileSystem.Primitives/src/System/IO/FileShare.cs
@@ -14,7 +14,6 @@ namespace System.IO
     ///   FILE_SHARE_WRITE, and FILE_SHARE_DELETE in winnt.h
     /// </devdoc>
     [Flags]
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum FileShare
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -16,7 +16,6 @@ using System.Threading;
 
 namespace System.IO
 {
-    [ComVisible(true)]
     public static class Directory
     {
         public static DirectoryInfo GetParent(String path)

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -16,7 +16,6 @@ using Microsoft.Win32;
 
 namespace System.IO
 {
-    [ComVisible(true)]
     public sealed class DirectoryInfo : FileSystemInfo
     {
         [System.Security.SecuritySafeCritical]

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -18,7 +18,6 @@ namespace System.IO
 {
     // Class for creating FileStream objects, and some basic file management
     // routines such as Delete, etc.
-    [ComVisible(true)]
     public static class File
     {
         public static StreamReader OpenText(String path)

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -13,7 +13,6 @@ namespace System.IO
 {
     // Class for creating FileStream objects, and some basic file management
     // routines such as Delete, etc.
-    [ComVisible(true)]
     public sealed class FileInfo : FileSystemInfo
     {
         private String _name;

--- a/src/System.IO.FileSystem/src/System/IO/FileOptions.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileOptions.cs
@@ -11,7 +11,6 @@ namespace System.IO
     // a number of them made sense in managed code, at least not yet.
 
     [Flags]
-    [ComVisible(true)]
     /// <devdoc>
     ///   Additional options to how to create a FileStream.
     /// </devdoc>

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
@@ -12,7 +12,6 @@ using System.Diagnostics.Contracts;
 
 namespace System.IO
 {
-    [ComVisible(true)]
     public abstract class FileSystemInfo
     {
         protected String FullPath;          // fully qualified path of the file or directory
@@ -101,7 +100,6 @@ namespace System.IO
             }
         }
 
-        [ComVisible(false)]
         public DateTime CreationTimeUtc
         {
             [System.Security.SecuritySafeCritical]
@@ -130,7 +128,6 @@ namespace System.IO
             }
         }
 
-        [ComVisible(false)]
         public DateTime LastAccessTimeUtc
         {
             [System.Security.SecuritySafeCritical]
@@ -159,7 +156,6 @@ namespace System.IO
             }
         }
 
-        [ComVisible(false)]
         public DateTime LastWriteTimeUtc
         {
             [System.Security.SecuritySafeCritical]

--- a/src/System.IO.FileSystem/src/System/IO/SearchOption.cs
+++ b/src/System.IO.FileSystem/src/System/IO/SearchOption.cs
@@ -10,7 +10,6 @@ namespace System.IO
     ///   retrieve files/directories from the current directory alone
     ///   or should include all the subdirectories also.
     /// </devdoc>
-    [System.Runtime.InteropServices.ComVisible(true)]
     public enum SearchOption
     {
         /// <devdoc>

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -45,7 +45,6 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.IO
 {
-    [ComVisible(true)]
     internal sealed partial class Win32FileStream : FileStreamBase
     {
         internal const int DefaultBufferSize = 4096;
@@ -1812,8 +1811,6 @@ namespace System.IO
             return numBytesWritten;
         }
 
-
-        [ComVisible(false)]
         [System.Security.SecuritySafeCritical]
         public override Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
@@ -1854,7 +1851,6 @@ namespace System.IO
 #endif
         }
 
-        [ComVisible(false)]
         [System.Security.SecuritySafeCritical]
         public override Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
@@ -2016,7 +2012,6 @@ namespace System.IO
         // Legend is that we chose not to flush the OS file buffers in Flush() in fear of 
         // perf problems with frequent, long running FlushFileBuffers() calls. But we don't 
         // have that problem with FlushAsync() because we will call FlushFileBuffers() in the background.
-        [ComVisible(false)]
         [System.Security.SecuritySafeCritical]
         public override Task FlushAsync(CancellationToken cancellationToken)
         {

--- a/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
@@ -341,7 +341,6 @@ namespace System.IO
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        [ComVisible(false)]
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -532,7 +531,6 @@ namespace System.IO
         /// <param name="count">Maximum number of bytes to read.</param>       
         /// <param name="cancellationToken">Token that can be used to cancell this operation.</param>
         /// <returns>Task that can be used to access the number of bytes actually read.</returns>
-        [ComVisible(false)]
         public override Task<Int32> ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
         {
             if (buffer == null)
@@ -778,7 +776,6 @@ namespace System.IO
         /// <param name="count">Number of bytes to write.</param>
         /// <param name="cancellationToken">Token that can be used to cancell the opetation.</param>
         /// <returns>Task that can be awaited </returns>
-        [ComVisible(false)]
         public override Task WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
         {
             if (buffer == null)

--- a/src/System.Resources.ResourceWriter/src/System/Resources/ResourceWriter.cs
+++ b/src/System.Resources.ResourceWriter/src/System/Resources/ResourceWriter.cs
@@ -36,7 +36,6 @@ namespace System.Resources
     // See the RuntimeResourceSet overview for details on the system 
     // default file format.
     // 
-    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class ResourceWriter : System.IDisposable
     {
         // An initial size for our internal sorted list, to avoid extra resizes.

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -57,7 +57,6 @@ namespace System.Text
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public new DecoderFallbackBuffer FallbackBuffer
         {
             get

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
@@ -52,7 +52,6 @@ namespace System.Text
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
         public new EncoderFallbackBuffer FallbackBuffer
         {
             get

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
@@ -31,7 +31,6 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
     /// All public  and protected members of <see cref="ConcurrentQueue{T}"/> are thread-safe and may be used
     /// concurrently from multiple threads.
     /// </remarks>
-    [ComVisible(false)]
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView<>))]
     internal class ConcurrentQueue<T> : IProducerConsumerCollection<T>


### PR DESCRIPTION
Per #779, this PR scrubs [ComVisible] attribute from the CoreFX library sources.

@jkotas, one thing I'm unsure of: since [ComVisible(true)] is the default for desktop, and since some of these libraries (e.g. immutable collections, dataflow, etc.) can be used with the desktop, should we actually be applying [ComVisible(false)] to every assembly?  Some of the assemblies already had this, and with the current commit I've removed those, but if they're needed I can put them back and make sure the other libraries have such attribution, too.