### PR TITLE
Switch to running tests with new BuildAndTest target.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
   <ItemGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -67,4 +67,9 @@
     <Touch Files="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)" />
   </Target>
 
+  <!-- Provide default empty targets for BuildAndTest and Test which can be hooked onto or overridden as necessary -->
+  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
+
+  <Target Name="Test" />
+
 </Project>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -1,18 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="BuildAllProjects">
+    <PropertyGroup>
+      <DefaultBuildAllTarget Condition="'$(DefaultBuildAllTarget)'==''">$(MSBuildProjectDefaultTargets)</DefaultBuildAllTarget>
+    </PropertyGroup>
+
     <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity 
          however since the project names are unique it will essentially force each to run in its own batch -->
-    <MSBuild Targets="Build" Projects="@(Project)" Condition="'$(SerializeProjects)'=='true'" Properties="Dummy=%(Identity)"/>
-    <MSBuild Targets="Build" Projects="@(Project)" Condition="'$(SerializeProjects)'!='true'" BuildInParallel="true" />
+    <MSBuild Targets="$(DefaultBuildAllTarget)"
+             Projects="@(Project)"
+             Condition="'$(SerializeProjects)'=='true'"
+             Properties="Dummy=%(Identity);DefaultBuildAllTarget=$(DefaultBuildAllTarget)"
+             ContinueOnError="ErrorAndContinue" />
+
+    <MSBuild Targets="$(DefaultBuildAllTarget)"
+             Projects="@(Project)"
+             Condition="'$(SerializeProjects)'!='true'"
+             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget)"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue" />
+
   </Target>
 
   <Target Name="CleanAllProjects">
+    <PropertyGroup>
+      <DefaultCleanAllTarget Condition="'$(DefaultCleanAllTarget)'==''">Clean</DefaultCleanAllTarget>
+    </PropertyGroup>
+
     <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity 
          however since the project names are unique it will essentially force each to run in its own batch -->
-    <MSBuild Targets="Clean" Projects="@(Project)" Condition="'$(SerializeProjects)'=='true'" Properties="Dummy=%(Identity)"/>
-    <MSBuild Targets="Clean" Projects="@(Project)" Condition="'$(SerializeProjects)'!='true'" BuildInParallel="true" />
+    <MSBuild Targets="$(DefaultCleanAllTarget)"
+             Projects="@(Project)"
+             Condition="'$(SerializeProjects)'=='true'"
+             Properties="Dummy=%(Identity)"
+             ContinueOnError="ErrorAndContinue" />
+
+    <MSBuild Targets="$(DefaultCleanAllTarget)"
+             Projects="@(Project)"
+             Condition="'$(SerializeProjects)'!='true'"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue" />
   </Target>
 
   <PropertyGroup>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -92,14 +92,11 @@
   <Import Project="$(ToolsDir)sign.targets" Condition="Exists('$(ToolsDir)sign.targets')" />
 
   <Import Project="$(ToolsDir)publishtest.targets" Condition="Exists('$(ToolsDir)publishtest.targets')" />
-  
+
   <PropertyGroup>
     <IsTestProject Condition="'$(IsTestProject)'=='' And $([System.String]::new('$(MSBuildProjectName)').EndsWith('.Tests'))">True</IsTestProject>
     <RunTestsForProject Condition="'$(RunTestsForProject)'=='' and '$(IsTestProject)'=='True'">True</RunTestsForProject>
     <RunTestsForProject Condition="'$(SkipTests)'=='True'">False</RunTestsForProject>
-    
-    <!-- Don't run unit tests as post-build in VS, use F5 on test project instead (see below). -->
-    <RunTestsForProject Condition="'$(BuildingInsideVisualStudio)' == 'True'">False</RunTestsForProject>
 
     <CLSCompliant Condition="'$(IsTestProject)'=='true'">false</CLSCompliant>
   </PropertyGroup>
@@ -162,7 +159,7 @@
 
   <!-- On command line: run unit tests on CoreCLR as post-build step. -->
   <Target Name="RunTestsForProject"
-          AfterTargets="PrepareForRun"
+          AfterTargets="Test"
           Condition="'$(RunTestsForProject)'=='True'">
 
     <MakeDir Condition="$(CoverageEnabledForDir)" Directories="$(CoverageReportDir)" />

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
   <ItemGroup>


### PR DESCRIPTION
An attempt to address #679

This change adds a BuildAndTest and Test target to our default dir.targets file and hooks RunTestsForProject off the Test target so that by default if you build an individual project from the command line or in an IDE like VS it will just do the build and not run the tests. If people want to run the tests then they need to execute the BuildAndTest target (or just the Test target). This prevents the need for us to use special conditions like BuildingInsideVisualStudio in our targets. 

I've also changed the DefaultTargets for our build.proj and dirs.proj files to be BuildAndTest so if you run the build for them it will stil do the build and test run.

cc @eatdrinksleepcode @nguerrera 