### PR TITLE
Add back some Xunits attributes that got dropped

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Registry\Registry_Getvalue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj_valuekind.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Microsoft.Win32.Registry/tests/XunitAssemblyAttributes.cs
+++ b/src/Microsoft.Win32.Registry/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+// Registry tests can conflict with each other due to accessing the same keys/values in the registry
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="UnionIntersectDistinctTests.cs" />
     <Compile Include="WhereTests.cs" />
     <Compile Include="WithCancellationTests.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="ZipJoinGroupJoinTests.cs" />
   </ItemGroup>
   <!-- Common or Common-branched source files -->

--- a/src/System.Linq.Parallel/tests/XunitAssemblyAttributes.cs
+++ b/src/System.Linq.Parallel/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+// Tests could run slower if PLINQ itself is run in parallel, especially as concurrent
+// queries compete for thread pool resources
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+


### PR DESCRIPTION
As part of #771, we redid how AssemblyAttributes were generated, this
caused us to lose some Xunit directives for some of our test
assemblies. This change just adds them back in.