### PR TITLE
Allow running build.cmd from a "clean" window

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -6,14 +6,23 @@ setlocal
 ::       means that that rebuilding cannot successfully delete the task
 ::       assembly. 
 
-:: Check prerequisites
-if not defined VS120COMNTOOLS (
-    if not defined VS140COMNTOOLS (
-        echo Error: build.cmd should be run from a Visual Studio 2013 or 2015 Command Prompt.  
-        echo        Please see https://github.com/dotnet/corefx/wiki/Developer-Guide for build instructions.
-        exit /b 1
+if not defined VisualStudioVersion (
+    if defined VS140COMNTOOLS (
+        call "%VS140COMNTOOLS%\VsDevCmd.bat"
+        goto :EnvSet
     )
+
+    if defined VS120COMNTOOLS (
+        call "%VS120COMNTOOLS%\VsDevCmd.bat"
+        goto :EnvSet
+    )
+
+    echo Error: build.cmd requires Visual Studio 2013 or 2015.  
+    echo        Please see https://github.com/dotnet/corefx/wiki/Developer-Guide for build instructions.
+    exit /b 1
 )
+
+:EnvSet
 
 :: Log build command line
 set _buildproj=%~dp0build.proj


### PR DESCRIPTION
Previouly, build.cmd had to be run from a "Developer Command Prompt"
window in order to find msbuild. This change removes that
requirement. If you are not in a Developer Command Promprt, we try to
load one for VS 2015 or VS 2013 (in that order) for the invocation of
build.cmd