### PR TITLE
MemoryMappedFile tests now usually create unique file and map names

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateFromFile.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateFromFile.cs
@@ -9,6 +9,12 @@ using Xunit;
 [Collection("CreateFromFile")]
 public class CreateFromFile : MMFTestBase
 {
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
+    private readonly static string s_fileNameTest1 = "CreateFromFile_test1_" + s_uniquifier + ".txt";
+    private readonly static string s_fileNameTest2 = "CreateFromFile_test2_" + s_uniquifier + ".txt";
+    private readonly static string s_fileNameTest3 = "CreateFromFile_test3_" + s_uniquifier + ".txt";
+    private readonly static string s_fileNameNonexistent = "CreateFromFile_nonexistent_" + s_uniquifier + ".txt";
+
     [Fact]
     public static void CreateFromFileTestCases()
     {
@@ -32,13 +38,13 @@ public class CreateFromFile : MMFTestBase
     {
         try
         {
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
 
-            if (File.Exists("CreateFromFile_test2.txt"))
-                File.Delete("CreateFromFile_test2.txt");
+            if (File.Exists(s_fileNameTest2))
+                File.Delete(s_fileNameTest2);
             String fileText = "Non-empty file for MMF testing.";
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
+            File.WriteAllText(s_fileNameTest2, fileText);
 
             ////////////////////////////////////////////////////////////////////////
             // CreateFromFile(String)
@@ -50,34 +56,34 @@ public class CreateFromFile : MMFTestBase
             VerifyCreateFromFileException<ArgumentNullException>("Loc001", null);
 
             // existing file
-            VerifyCreateFromFile("Loc002", "CreateFromFile_test2.txt");
+            VerifyCreateFromFile("Loc002", s_fileNameTest2);
 
             // nonexistent file
-            if (File.Exists("nonexistent.txt"))
-                File.Delete("nonexistent.txt");
-            VerifyCreateFromFileException<FileNotFoundException>("Loc003", "nonexistent.txt");
+            if (File.Exists(s_fileNameNonexistent))
+                File.Delete(s_fileNameNonexistent);
+            VerifyCreateFromFileException<FileNotFoundException>("Loc003", s_fileNameNonexistent);
 
             // FS open
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
-                VerifyCreateFromFileException<IOException>("Loc004a", "CreateFromFile_test2.txt");
+                VerifyCreateFromFileException<IOException>("Loc004a", s_fileNameTest2);
             }
 
             // same file - not allowed
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("CreateFromFile_test2.txt"))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest2))
             {
-                VerifyCreateFromFileException<IOException>("Loc004b", "CreateFromFile_test2.txt");
+                VerifyCreateFromFileException<IOException>("Loc004b", s_fileNameTest2);
             }
 
             ////////////////////////////////////////////////////////////////////////
             // CreateFromFile(String, FileMode)
             ////////////////////////////////////////////////////////////////////////
 
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
-            if (File.Exists("CreateFromFile_test2.txt"))
-                File.Delete("CreateFromFile_test2.txt");
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
+            if (File.Exists(s_fileNameTest2))
+                File.Delete(s_fileNameTest2);
+            File.WriteAllText(s_fileNameTest2, fileText);
 
             // [] fileName
 
@@ -85,53 +91,53 @@ public class CreateFromFile : MMFTestBase
             VerifyCreateFromFileException<ArgumentNullException>("Loc101", null, FileMode.Open);
 
             // existing file - open
-            VerifyCreateFromFile("Loc102a", "CreateFromFile_test2.txt", FileMode.Open);
-            VerifyCreateFromFile("Loc102b", "CreateFromFile_test2.txt", FileMode.OpenOrCreate);
+            VerifyCreateFromFile("Loc102a", s_fileNameTest2, FileMode.Open);
+            VerifyCreateFromFile("Loc102b", s_fileNameTest2, FileMode.OpenOrCreate);
             // existing file - create
             // can't create new since it exists
-            VerifyCreateFromFileException<IOException>("Loc102d", "CreateFromFile_test2.txt", FileMode.CreateNew);
+            VerifyCreateFromFileException<IOException>("Loc102d", s_fileNameTest2, FileMode.CreateNew);
             // newly created file - exception with default capacity
-            VerifyCreateFromFileException<ArgumentException>("Loc102c", "CreateFromFile_test2.txt", FileMode.Create);
-            VerifyCreateFromFileException<ArgumentException>("Loc102f", "CreateFromFile_test2.txt", FileMode.Truncate);
+            VerifyCreateFromFileException<ArgumentException>("Loc102c", s_fileNameTest2, FileMode.Create);
+            VerifyCreateFromFileException<ArgumentException>("Loc102f", s_fileNameTest2, FileMode.Truncate);
             // append not allowed
-            VerifyCreateFromFileException<ArgumentException>("Loc102e", "CreateFromFile_test2.txt", FileMode.Append);
+            VerifyCreateFromFileException<ArgumentException>("Loc102e", s_fileNameTest2, FileMode.Append);
 
             // nonexistent file - error
-            if (File.Exists("nonexistent.txt"))
-                File.Delete("nonexistent.txt");
-            VerifyCreateFromFileException<FileNotFoundException>("Loc103a", "nonexistent.txt", FileMode.Open);
+            if (File.Exists(s_fileNameNonexistent))
+                File.Delete(s_fileNameNonexistent);
+            VerifyCreateFromFileException<FileNotFoundException>("Loc103a", s_fileNameNonexistent, FileMode.Open);
             // newly created file - exception with default capacity
-            VerifyCreateFromFileException<ArgumentException>("Loc103b", "CreateFromFile_test1.txt", FileMode.OpenOrCreate);
-            VerifyCreateFromFileException<ArgumentException>("Loc103c", "CreateFromFile_test1.txt", FileMode.CreateNew);
-            VerifyCreateFromFileException<ArgumentException>("Loc103d", "CreateFromFile_test1.txt", FileMode.Create);
-            VerifyCreateFromFileException<ArgumentException>("Loc103e", "CreateFromFile_test2.txt", FileMode.Truncate);
+            VerifyCreateFromFileException<ArgumentException>("Loc103b", s_fileNameTest1, FileMode.OpenOrCreate);
+            VerifyCreateFromFileException<ArgumentException>("Loc103c", s_fileNameTest1, FileMode.CreateNew);
+            VerifyCreateFromFileException<ArgumentException>("Loc103d", s_fileNameTest1, FileMode.Create);
+            VerifyCreateFromFileException<ArgumentException>("Loc103e", s_fileNameTest2, FileMode.Truncate);
             // append not allowed
-            VerifyCreateFromFileException<ArgumentException>("Loc103f", "CreateFromFile_test2.txt", FileMode.Append);
+            VerifyCreateFromFileException<ArgumentException>("Loc103f", s_fileNameTest2, FileMode.Append);
 
             // empty file - exception with default capacity
-            using (FileStream fs = new FileStream("CreateFromFile_test1.txt", FileMode.Create))
+            using (FileStream fs = new FileStream(s_fileNameTest1, FileMode.Create))
             {
             }
-            VerifyCreateFromFileException<ArgumentException>("Loc104a", "CreateFromFile_test1.txt", FileMode.Open);
-            VerifyCreateFromFileException<ArgumentException>("Loc104b", "CreateFromFile_test1.txt", FileMode.OpenOrCreate);
-            VerifyCreateFromFileException<ArgumentException>("Loc104c", "CreateFromFile_test1.txt", FileMode.Create);
-            VerifyCreateFromFileException<ArgumentException>("Loc104d", "CreateFromFile_test1.txt", FileMode.Truncate);
+            VerifyCreateFromFileException<ArgumentException>("Loc104a", s_fileNameTest1, FileMode.Open);
+            VerifyCreateFromFileException<ArgumentException>("Loc104b", s_fileNameTest1, FileMode.OpenOrCreate);
+            VerifyCreateFromFileException<ArgumentException>("Loc104c", s_fileNameTest1, FileMode.Create);
+            VerifyCreateFromFileException<ArgumentException>("Loc104d", s_fileNameTest1, FileMode.Truncate);
             // can't create new since it exists
-            VerifyCreateFromFileException<IOException>("Loc104e", "CreateFromFile_test1.txt", FileMode.CreateNew);
+            VerifyCreateFromFileException<IOException>("Loc104e", s_fileNameTest1, FileMode.CreateNew);
             // append not allowed
-            VerifyCreateFromFileException<ArgumentException>("Loc104f", "CreateFromFile_test1.txt", FileMode.Append);
+            VerifyCreateFromFileException<ArgumentException>("Loc104f", s_fileNameTest1, FileMode.Append);
 
             // FS open
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
-                VerifyCreateFromFileException<IOException>("Loc105a", "CreateFromFile_test2.txt", FileMode.Open);
+                VerifyCreateFromFileException<IOException>("Loc105a", s_fileNameTest2, FileMode.Open);
             }
 
             // same file - not allowed
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("CreateFromFile_test2.txt"))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest2))
             {
-                VerifyCreateFromFileException<IOException>("Loc105b", "CreateFromFile_test2.txt", FileMode.Open);
+                VerifyCreateFromFileException<IOException>("Loc105b", s_fileNameTest2, FileMode.Open);
             }
 
 
@@ -139,12 +145,12 @@ public class CreateFromFile : MMFTestBase
             // CreateFromFile(String, FileMode, String)
             ////////////////////////////////////////////////////////////////////////
 
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
-            if (File.Exists("CreateFromFile_test2.txt"))
-                File.Delete("CreateFromFile_test2.txt");
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            File.WriteAllText("test3.txt", fileText + fileText);
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
+            if (File.Exists(s_fileNameTest2))
+                File.Delete(s_fileNameTest2);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            File.WriteAllText(s_fileNameTest3, fileText + fileText);
 
             // [] fileName
 
@@ -152,83 +158,83 @@ public class CreateFromFile : MMFTestBase
             VerifyCreateFromFileException<ArgumentNullException>("Loc201", null, FileMode.Open);
 
             // existing file - open
-            VerifyCreateFromFile("Loc202a", "CreateFromFile_test2.txt", FileMode.Open);
-            VerifyCreateFromFile("Loc202b", "CreateFromFile_test2.txt", FileMode.OpenOrCreate);
+            VerifyCreateFromFile("Loc202a", s_fileNameTest2, FileMode.Open);
+            VerifyCreateFromFile("Loc202b", s_fileNameTest2, FileMode.OpenOrCreate);
             // existing file - create
             // can't create new since it exists
-            VerifyCreateFromFileException<IOException>("Loc202d", "CreateFromFile_test2.txt", FileMode.CreateNew);
+            VerifyCreateFromFileException<IOException>("Loc202d", s_fileNameTest2, FileMode.CreateNew);
             // newly created file - exception with default capacity
-            VerifyCreateFromFileException<ArgumentException>("Loc202c", "CreateFromFile_test2.txt", FileMode.Create);
-            VerifyCreateFromFileException<ArgumentException>("Loc202f", "CreateFromFile_test2.txt", FileMode.Truncate);
+            VerifyCreateFromFileException<ArgumentException>("Loc202c", s_fileNameTest2, FileMode.Create);
+            VerifyCreateFromFileException<ArgumentException>("Loc202f", s_fileNameTest2, FileMode.Truncate);
             // append not allowed
-            VerifyCreateFromFileException<ArgumentException>("Loc202e", "CreateFromFile_test2.txt", FileMode.Append);
+            VerifyCreateFromFileException<ArgumentException>("Loc202e", s_fileNameTest2, FileMode.Append);
 
             // nonexistent file - error
-            if (File.Exists("nonexistent.txt"))
-                File.Delete("nonexistent.txt");
-            VerifyCreateFromFileException<FileNotFoundException>("Loc203a", "nonexistent.txt", FileMode.Open);
+            if (File.Exists(s_fileNameNonexistent))
+                File.Delete(s_fileNameNonexistent);
+            VerifyCreateFromFileException<FileNotFoundException>("Loc203a", s_fileNameNonexistent, FileMode.Open);
             // newly created file - exception with default capacity
-            VerifyCreateFromFileException<ArgumentException>("Loc203b", "CreateFromFile_test1.txt", FileMode.OpenOrCreate);
-            VerifyCreateFromFileException<ArgumentException>("Loc203c", "CreateFromFile_test1.txt", FileMode.CreateNew);
-            VerifyCreateFromFileException<ArgumentException>("Loc203d", "CreateFromFile_test1.txt", FileMode.Create);
-            VerifyCreateFromFileException<ArgumentException>("Loc203e", "CreateFromFile_test2.txt", FileMode.Truncate);
+            VerifyCreateFromFileException<ArgumentException>("Loc203b", s_fileNameTest1, FileMode.OpenOrCreate);
+            VerifyCreateFromFileException<ArgumentException>("Loc203c", s_fileNameTest1, FileMode.CreateNew);
+            VerifyCreateFromFileException<ArgumentException>("Loc203d", s_fileNameTest1, FileMode.Create);
+            VerifyCreateFromFileException<ArgumentException>("Loc203e", s_fileNameTest2, FileMode.Truncate);
             // append not allowed
-            VerifyCreateFromFileException<ArgumentException>("Loc203f", "CreateFromFile_test2.txt", FileMode.Append);
+            VerifyCreateFromFileException<ArgumentException>("Loc203f", s_fileNameTest2, FileMode.Append);
 
             // empty file - exception with default capacity
-            using (FileStream fs = new FileStream("CreateFromFile_test1.txt", FileMode.Create))
+            using (FileStream fs = new FileStream(s_fileNameTest1, FileMode.Create))
             {
             }
-            VerifyCreateFromFileException<ArgumentException>("Loc204a", "CreateFromFile_test1.txt", FileMode.Open);
-            VerifyCreateFromFileException<ArgumentException>("Loc204b", "CreateFromFile_test1.txt", FileMode.OpenOrCreate);
-            VerifyCreateFromFileException<ArgumentException>("Loc204c", "CreateFromFile_test1.txt", FileMode.Create);
-            VerifyCreateFromFileException<ArgumentException>("Loc204d", "CreateFromFile_test1.txt", FileMode.Truncate);
+            VerifyCreateFromFileException<ArgumentException>("Loc204a", s_fileNameTest1, FileMode.Open);
+            VerifyCreateFromFileException<ArgumentException>("Loc204b", s_fileNameTest1, FileMode.OpenOrCreate);
+            VerifyCreateFromFileException<ArgumentException>("Loc204c", s_fileNameTest1, FileMode.Create);
+            VerifyCreateFromFileException<ArgumentException>("Loc204d", s_fileNameTest1, FileMode.Truncate);
             // can't create new since it exists
-            VerifyCreateFromFileException<IOException>("Loc204e", "CreateFromFile_test1.txt", FileMode.CreateNew);
+            VerifyCreateFromFileException<IOException>("Loc204e", s_fileNameTest1, FileMode.CreateNew);
             // append not allowed
-            VerifyCreateFromFileException<ArgumentException>("Loc204f", "CreateFromFile_test1.txt", FileMode.Append);
+            VerifyCreateFromFileException<ArgumentException>("Loc204f", s_fileNameTest1, FileMode.Append);
 
             // FS open
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
-                VerifyCreateFromFileException<IOException>("Loc205a", "CreateFromFile_test2.txt", FileMode.Open);
+                VerifyCreateFromFileException<IOException>("Loc205a", s_fileNameTest2, FileMode.Open);
             }
 
             // same file - not allowed
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("CreateFromFile_test2.txt"))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest2))
             {
-                VerifyCreateFromFileException<IOException>("Loc205b", "CreateFromFile_test2.txt", FileMode.Open);
+                VerifyCreateFromFileException<IOException>("Loc205b", s_fileNameTest2, FileMode.Open);
             }
 
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreateFromFile("Loc211", "CreateFromFile_test2.txt", FileMode.Open, "CreateFromFile2" + new String('a', 1000));
+            VerifyCreateFromFile("Loc211", s_fileNameTest2, FileMode.Open, "CreateFromFile2" + new String('a', 1000) + s_uniquifier);
 
             // null
-            VerifyCreateFromFile("Loc212", "CreateFromFile_test2.txt", FileMode.Open, null);
+            VerifyCreateFromFile("Loc212", s_fileNameTest2, FileMode.Open, null);
 
             // empty string disallowed
-            VerifyCreateFromFileException<ArgumentException>("Loc213", "CreateFromFile_test2.txt", FileMode.Open, String.Empty);
+            VerifyCreateFromFileException<ArgumentException>("Loc213", s_fileNameTest2, FileMode.Open, String.Empty);
 
             // all whitespace
-            VerifyCreateFromFile("Loc214", "CreateFromFile_test2.txt", FileMode.Open, "\t \n\u00A0");
+            VerifyCreateFromFile("Loc214", s_fileNameTest2, FileMode.Open, "\t \n\u00A0");
 
             // MMF with this mapname already exists
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("test3.txt", FileMode.Open, "map215"))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest3, FileMode.Open, "map215" + s_uniquifier))
             {
-                VerifyCreateFromFileException<IOException>("Loc215", "CreateFromFile_test2.txt", FileMode.Open, "map215");
+                VerifyCreateFromFileException<IOException>("Loc215", s_fileNameTest2, FileMode.Open, "map215" + s_uniquifier);
             }
 
             // MMF with this mapname existed, but was closed
-            VerifyCreateFromFile("Loc216", "CreateFromFile_test2.txt", FileMode.Open, "map215");
+            VerifyCreateFromFile("Loc216", s_fileNameTest2, FileMode.Open, "map215" + s_uniquifier);
 
             // "global/" prefix
-            VerifyCreateFromFile("Loc217", "CreateFromFile_test2.txt", FileMode.Open, "global/CFF_0");
+            VerifyCreateFromFile("Loc217", s_fileNameTest2, FileMode.Open, "global/CFF_0" + s_uniquifier);
 
             // "local/" prefix
-            VerifyCreateFromFile("Loc218", "CreateFromFile_test2.txt", FileMode.Open, "local/CFF_1");
+            VerifyCreateFromFile("Loc218", s_fileNameTest2, FileMode.Open, "local/CFF_1" + s_uniquifier);
 
 
             ////////////////////////////////////////////////////////////////////////
@@ -238,42 +244,42 @@ public class CreateFromFile : MMFTestBase
             // [] fileName
 
             // null fileName
-            VerifyCreateFromFileException<ArgumentNullException>("Loc301", null, FileMode.Open, "CFF_mapname", 0);
+            VerifyCreateFromFileException<ArgumentNullException>("Loc301", null, FileMode.Open, "CFF_mapname" + s_uniquifier, 0);
 
             // [] capacity
 
             // newly created file - exception with default capacity
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
-            VerifyCreateFromFileException<ArgumentException>("Loc311", "CreateFromFile_test1.txt", FileMode.CreateNew, "CFF_mapname211", 0);
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
+            VerifyCreateFromFileException<ArgumentException>("Loc311", s_fileNameTest1, FileMode.CreateNew, "CFF_mapname211" + s_uniquifier, 0);
 
             // newly created file - valid with >0 capacity
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
-            VerifyCreateFromFile("Loc312", "CreateFromFile_test1.txt", FileMode.CreateNew, "CFF_mapname312", 1);
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
+            VerifyCreateFromFile("Loc312", s_fileNameTest1, FileMode.CreateNew, "CFF_mapname312" + s_uniquifier, 1);
 
             // existing file, default capacity
-            VerifyCreateFromFile("Loc313", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname313", 0);
+            VerifyCreateFromFile("Loc313", s_fileNameTest2, FileMode.Open, "CFF_mapname313" + s_uniquifier, 0);
 
             // existing file, capacity less than file size
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc314", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname314", 6);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc314", s_fileNameTest2, FileMode.Open, "CFF_mapname314" + s_uniquifier, 6);
 
             // existing file, capacity equal to file size
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            VerifyCreateFromFile("Loc315", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname315", fileText.Length);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            VerifyCreateFromFile("Loc315", s_fileNameTest2, FileMode.Open, "CFF_mapname315" + s_uniquifier, fileText.Length);
 
             // existing file, capacity greater than file size
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            VerifyCreateFromFile("Loc316", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname316", 6000);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            VerifyCreateFromFile("Loc316", s_fileNameTest2, FileMode.Open, "CFF_mapname316" + s_uniquifier, 6000);
 
             // negative
-            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc317", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname317", -1);
+            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc317", s_fileNameTest2, FileMode.Open, "CFF_mapname317" + s_uniquifier, -1);
 
             // negative
-            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc318", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname318", -4096);
+            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc318", s_fileNameTest2, FileMode.Open, "CFF_mapname318" + s_uniquifier, -4096);
 
-            VerifyCreateFromFileException<IOException>("Loc319b", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname319", Int64.MaxValue);  // valid but too large
+            VerifyCreateFromFileException<IOException>("Loc319b", s_fileNameTest2, FileMode.Open, "CFF_mapname319" + s_uniquifier, Int64.MaxValue);  // valid but too large
 
 
             ////////////////////////////////////////////////////////////////////////
@@ -283,199 +289,199 @@ public class CreateFromFile : MMFTestBase
             // [] capacity
 
             // existing file, capacity less than file size, MemoryMappedFileAccess.Read
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc414", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname414", 6, MemoryMappedFileAccess.Read);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc414", s_fileNameTest2, FileMode.Open, "CFF_mapname414" + s_uniquifier, 6, MemoryMappedFileAccess.Read);
 
             // existing file, capacity equal to file size, MemoryMappedFileAccess.Read
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            VerifyCreateFromFile("Loc415", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname415", fileText.Length, MemoryMappedFileAccess.Read);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            VerifyCreateFromFile("Loc415", s_fileNameTest2, FileMode.Open, "CFF_mapname415" + s_uniquifier, fileText.Length, MemoryMappedFileAccess.Read);
 
             // existing file, capacity greater than file size, MemoryMappedFileAccess.Read
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            VerifyCreateFromFileException<ArgumentException>("Loc416", "CreateFromFile_test2.txt", FileMode.Open, "CFF_mapname416", 6000, MemoryMappedFileAccess.Read);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            VerifyCreateFromFileException<ArgumentException>("Loc416", s_fileNameTest2, FileMode.Open, "CFF_mapname416" + s_uniquifier, 6000, MemoryMappedFileAccess.Read);
 
             ////////////////////////////////////////////////////////////////////////
             // CreateFromFile(FileStream, String, long, MemoryMappedFileAccess,
             //    MemoryMappedFileSecurity, HandleInheritability, bool)
             ////////////////////////////////////////////////////////////////////////
 
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
 
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            File.WriteAllText("test3.txt", fileText + fileText);
+            File.WriteAllText(s_fileNameTest2, fileText);
+            File.WriteAllText(s_fileNameTest3, fileText + fileText);
 
             // [] fileStream
 
             // null filestream
-            VerifyCreateFromFileException<ArgumentNullException>("Loc401", null, "map401", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+            VerifyCreateFromFileException<ArgumentNullException>("Loc401", null, "map401" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
 
             // existing file
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc402", fs, "map402", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc402", fs, "map402" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // same FS
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "map403a", 8192, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "map403a" + s_uniquifier, 8192, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
                 {
-                    VerifyCreateFromFile("Loc403", fs, "map403", 8192, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                    VerifyCreateFromFile("Loc403", fs, "map403" + s_uniquifier, 8192, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
                 }
             }
 
             // closed FS
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
                 fs.Dispose();
-                VerifyCreateFromFileException<ObjectDisposedException>("Loc404", fs, "map404", 4096, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ObjectDisposedException>("Loc404", fs, "map404" + s_uniquifier, 4096, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
             }
 
             // newly created file - exception with default capacity
-            using (FileStream fs = new FileStream("CreateFromFile_test1.txt", FileMode.CreateNew))
+            using (FileStream fs = new FileStream(s_fileNameTest1, FileMode.CreateNew))
             {
-                VerifyCreateFromFileException<ArgumentException>("Loc405", fs, "map405", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentException>("Loc405", fs, "map405" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // empty file - exception with default capacity
-            using (FileStream fs = new FileStream("CreateFromFile_test1.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest1, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentException>("Loc406", fs, "map406", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentException>("Loc406", fs, "map406" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // [] mapName
 
             // mapname > 260 chars
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc411", fs, "CreateFromFile" + new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc411", fs, "CreateFromFile" + new String('a', 1000) + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // null
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
                 VerifyCreateFromFile("Loc412", fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // empty string disallowed
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
                 VerifyCreateFromFileException<ArgumentException>("Loc413", fs, String.Empty, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // all whitespace
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
                 VerifyCreateFromFile("Loc414", fs, "\t \n\u00A0", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // MMF with this mapname already exists
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("test3.txt", FileMode.Open, "map415"))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest3, FileMode.Open, "map415" + s_uniquifier))
             {
-                using (FileStream fs2 = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+                using (FileStream fs2 = new FileStream(s_fileNameTest2, FileMode.Open))
                 {
-                    VerifyCreateFromFileException<IOException>("Loc415", fs2, "map415", 4096, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
+                    VerifyCreateFromFileException<IOException>("Loc415", fs2, "map415" + s_uniquifier, 4096, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
                 }
             }
 
             // MMF with this mapname existed, but was closed
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc416", fs, "map415", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc416", fs, "map415" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // "global/" prefix
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc417", fs, "global/CFF_2", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc417", fs, "global/CFF_2" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // "local/" prefix
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc418", fs, "local/CFF_3", 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc418", fs, "local/CFF_3" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // [] capacity
 
             // newly created file - exception with default capacity
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
-            using (FileStream fs = new FileStream("CreateFromFile_test1.txt", FileMode.CreateNew))
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
+            using (FileStream fs = new FileStream(s_fileNameTest1, FileMode.CreateNew))
             {
-                VerifyCreateFromFileException<ArgumentException>("Loc421", fs, "CFF_mapname421", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentException>("Loc421", fs, "CFF_mapname421" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // newly created file - valid with >0 capacity
-            if (File.Exists("CreateFromFile_test1.txt"))
-                File.Delete("CreateFromFile_test1.txt");
-            using (FileStream fs = new FileStream("CreateFromFile_test1.txt", FileMode.CreateNew))
+            if (File.Exists(s_fileNameTest1))
+                File.Delete(s_fileNameTest1);
+            using (FileStream fs = new FileStream(s_fileNameTest1, FileMode.CreateNew))
             {
-                VerifyCreateFromFile("Loc422", fs, "CFF_mapname422", 1, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc422", fs, "CFF_mapname422" + s_uniquifier, 1, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // existing file, default capacity
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc423", fs, "CFF_mapname423", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc423", fs, "CFF_mapname423" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // existing file, capacity less than file size
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc424", fs, "CFF_mapname424", 6, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc424", fs, "CFF_mapname424" + s_uniquifier, 6, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // existing file, capacity equal to file size
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc425", fs, "CFF_mapname425", fileText.Length, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc425", fs, "CFF_mapname425" + s_uniquifier, fileText.Length, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // existing file, capacity greater than file size
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc426", fs, "CFF_mapname426", 6000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc426", fs, "CFF_mapname426" + s_uniquifier, 6000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // existing file, capacity greater than file size & access = Read only
-            File.WriteAllText("CreateFromFile_test2.txt", fileText);
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            File.WriteAllText(s_fileNameTest2, fileText);
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentException>("Loc426a", fs, "CFF_mapname426a", 6000, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentException>("Loc426a", fs, "CFF_mapname426a" + s_uniquifier, 6000, MemoryMappedFileAccess.Read, HandleInheritability.None, false);
             }
 
             // negative
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc427", fs, "CFF_mapname427", -1, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc427", fs, "CFF_mapname427" + s_uniquifier, -1, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // negative
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc428", fs, "CFF_mapname428", -4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc428", fs, "CFF_mapname428" + s_uniquifier, -4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // Int64.MaxValue - cannot exceed local address space
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<IOException>("Loc429", fs, "CFF_mapname429", Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);  // valid but too large
+                VerifyCreateFromFileException<IOException>("Loc429", fs, "CFF_mapname429" + s_uniquifier, Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);  // valid but too large
             }
 
             // [] access
 
             // Write is disallowed
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite))
             {
-                VerifyCreateFromFileException<ArgumentException>("Loc430", fs, "CFF_mapname430", 0, MemoryMappedFileAccess.Write, HandleInheritability.None, false);
+                VerifyCreateFromFileException<ArgumentException>("Loc430", fs, "CFF_mapname430" + s_uniquifier, 0, MemoryMappedFileAccess.Write, HandleInheritability.None, false);
             }
 
             // valid access (filestream is ReadWrite)
@@ -486,9 +492,9 @@ public class CreateFromFile : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite))
+                using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    VerifyCreateFromFile("Loc431_" + access, fs, "CFF_mapname431_" + access, 0, access, HandleInheritability.None, false);
+                    VerifyCreateFromFile("Loc431_" + access, fs, "CFF_mapname431_" + access + s_uniquifier, 0, access, HandleInheritability.None, false);
                 }
             }
 
@@ -499,9 +505,9 @@ public class CreateFromFile : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite))
+                using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    VerifyCreateFromFileException<UnauthorizedAccessException>("Loc432_" + access, fs, "CFF_mapname432_" + access, 0, access, HandleInheritability.None, false);
+                    VerifyCreateFromFileException<UnauthorizedAccessException>("Loc432_" + access, fs, "CFF_mapname432_" + access + s_uniquifier, 0, access, HandleInheritability.None, false);
                 }
             }
 
@@ -512,9 +518,9 @@ public class CreateFromFile : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.Read))
+                using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.Read))
                 {
-                    VerifyCreateFromFile("Loc433_" + access, fs, "CFF_mapname433_" + access, 0, access, HandleInheritability.None, false);
+                    VerifyCreateFromFile("Loc433_" + access, fs, "CFF_mapname433_" + access + s_uniquifier, 0, access, HandleInheritability.None, false);
                 }
             }
 
@@ -526,9 +532,9 @@ public class CreateFromFile : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.Read))
+                using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.Read))
                 {
-                    VerifyCreateFromFileException<UnauthorizedAccessException>("Loc434_" + access, fs, "CFF_mapname434_" + access, 0, access, HandleInheritability.None, false);
+                    VerifyCreateFromFileException<UnauthorizedAccessException>("Loc434_" + access, fs, "CFF_mapname434_" + access + s_uniquifier, 0, access, HandleInheritability.None, false);
                 }
             }
 
@@ -542,9 +548,9 @@ public class CreateFromFile : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.Write))
+                using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.Write))
                 {
-                    VerifyCreateFromFileException<UnauthorizedAccessException>("Loc435_" + access, fs, "CFF_mapname435_" + access, 0, access, HandleInheritability.None, false);
+                    VerifyCreateFromFileException<UnauthorizedAccessException>("Loc435_" + access, fs, "CFF_mapname435_" + access + s_uniquifier, 0, access, HandleInheritability.None, false);
                 }
             }
 
@@ -555,48 +561,48 @@ public class CreateFromFile : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open, FileAccess.ReadWrite))
+                using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc436_" + ((int)access), fs, "CFF_mapname436_" + ((int)access), 0, access, HandleInheritability.None, false);
+                    VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc436_" + ((int)access), fs, "CFF_mapname436_" + ((int)access) + s_uniquifier, 0, access, HandleInheritability.None, false);
                 }
             }
 
             // [] inheritability
 
             // None
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc461", fs, "CFF_mapname461", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc461", fs, "CFF_mapname461" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // Inheritable
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc462", fs, "CFF_mapname462", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false);
+                VerifyCreateFromFile("Loc462", fs, "CFF_mapname462" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false);
             }
 
             // invalid
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc463", fs, "CFF_mapname463", 0, MemoryMappedFileAccess.ReadWrite, (HandleInheritability)(-1), false);
+                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc463", fs, "CFF_mapname463" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, (HandleInheritability)(-1), false);
             }
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc464", fs, "CFF_mapname464", 0, MemoryMappedFileAccess.ReadWrite, (HandleInheritability)(2), false);
+                VerifyCreateFromFileException<ArgumentOutOfRangeException>("Loc464", fs, "CFF_mapname464" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, (HandleInheritability)(2), false);
             }
 
             // [] leaveOpen
 
             // false
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc471", fs, "CFF_mapname471", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+                VerifyCreateFromFile("Loc471", fs, "CFF_mapname471" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
             }
 
             // true
-            using (FileStream fs = new FileStream("CreateFromFile_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest2, FileMode.Open))
             {
-                VerifyCreateFromFile("Loc472", fs, "CFF_mapname472", 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);
+                VerifyCreateFromFile("Loc472", fs, "CFF_mapname472" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);
             }
 
             /// END TEST CASES

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateNew.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateNew.cs
@@ -9,6 +9,8 @@ using Xunit;
 [Collection("CreateNew")]
 public class CreateNew : MMFTestBase
 {
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
+
     [Fact]
     public static void CreateNewTestCases()
     {
@@ -39,7 +41,7 @@ public class CreateNew : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreateNew("Loc111", "CreateNew" + new String('a', 1000), 4096);
+            VerifyCreateNew("Loc111", "CreateNew" + new String('a', 1000) + s_uniquifier, 4096);
 
             // null
             VerifyCreateNew("Loc112", null, 4096);
@@ -51,39 +53,39 @@ public class CreateNew : MMFTestBase
             VerifyCreateNew("Loc114", "\t\t \n\u00A0", 4096);
 
             // MMF with this mapname already exists
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("map115", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("map115" + s_uniquifier, 1000))
             {
-                VerifyCreateNewException<IOException>("Loc115", "map115", 1000);
+                VerifyCreateNewException<IOException>("Loc115", "map115" + s_uniquifier, 1000);
             }
 
             // MMF with this mapname existed, but was closed
-            VerifyCreateNew("Loc116", "map115", 500);
+            VerifyCreateNew("Loc116", "map115" + s_uniquifier, 500);
 
             // "global/" prefix
-            VerifyCreateNew("Loc117", "global/CN_0", 4096);
+            VerifyCreateNew("Loc117", "global/CN_0" + s_uniquifier, 4096);
 
             // "local/" prefix
-            VerifyCreateNew("Loc118", "local/CN_1", 4096);
+            VerifyCreateNew("Loc118", "local/CN_1" + s_uniquifier, 4096);
 
             // [] capacity
 
             // >0 capacity
-            VerifyCreateNew("Loc211", "CN_mapname211", 50);
+            VerifyCreateNew("Loc211", "CN_mapname211" + s_uniquifier, 50);
 
             // 0 capacity
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc211", "CN_mapname211", 0);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc211", "CN_mapname211" + s_uniquifier, 0);
 
             // negative
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc213", "CN_mapname213", -1);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc213", "CN_mapname213" + s_uniquifier, -1);
 
             // negative
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc214", "CN_mapname214", -4096);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc214", "CN_mapname214" + s_uniquifier, -4096);
 
             // Int64.MaxValue - cannot exceed local address space
             if (IntPtr.Size == 4)
-                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc215", "CN_mapname215", Int64.MaxValue);
+                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc215", "CN_mapname215" + s_uniquifier, Int64.MaxValue);
             else // 64-bit machine
-                VerifyCreateNewException<IOException>("Loc215b", "CN_mapname215", Int64.MaxValue); // valid but too large
+                VerifyCreateNewException<IOException>("Loc215b", "CN_mapname215" + s_uniquifier, Int64.MaxValue); // valid but too large
 
             ////////////////////////////////////////////////////////////////////////
             // CreateNew(mapName, capcity, MemoryMappedFileAccess)
@@ -92,7 +94,7 @@ public class CreateNew : MMFTestBase
             // [] access
 
             // Write is disallowed
-            VerifyCreateNewException<ArgumentException>("Loc330", "CN_mapname330", 1000, MemoryMappedFileAccess.Write);
+            VerifyCreateNewException<ArgumentException>("Loc330", "CN_mapname330" + s_uniquifier, 1000, MemoryMappedFileAccess.Write);
 
             // valid access
             MemoryMappedFileAccess[] accessList = new MemoryMappedFileAccess[] {
@@ -104,7 +106,7 @@ public class CreateNew : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyCreateNew("Loc331_" + access, "CN_mapname331_" + access, 1000, access);
+                VerifyCreateNew("Loc331_" + access, "CN_mapname331_" + access + s_uniquifier, 1000, access);
             }
 
             // invalid enum value
@@ -114,7 +116,7 @@ public class CreateNew : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc332_" + ((int)access), "CN_mapname332_" + ((int)access), 1000, access);
+                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc332_" + ((int)access), "CN_mapname332_" + ((int)access) + s_uniquifier, 1000, access);
             }
 
             ////////////////////////////////////////////////////////////////////////
@@ -125,7 +127,7 @@ public class CreateNew : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreateNew("Loc411", "CreateNew2" + new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc411", "CreateNew2" + new String('a', 1000) + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // null
             VerifyCreateNew("Loc412", null, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
@@ -137,44 +139,44 @@ public class CreateNew : MMFTestBase
             VerifyCreateNew("Loc414", "\t\t \n\u00A0", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // MMF with this mapname already exists
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("map415", 4096))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("map415" + s_uniquifier, 4096))
             {
-                VerifyCreateNewException<IOException>("Loc415", "map415", 4096, MemoryMappedFileAccess.Read, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyCreateNewException<IOException>("Loc415", "map415" + s_uniquifier, 4096, MemoryMappedFileAccess.Read, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             // MMF with this mapname existed, but was closed
-            VerifyCreateNew("Loc416", "map415", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc416", "map415" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // "global/" prefix
-            VerifyCreateNew("Loc417", "global/CN_2", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc417", "global/CN_2" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // "local/" prefix
-            VerifyCreateNew("Loc418", "local/CN_3", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc418", "local/CN_3" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // [] capacity
 
             // >0 capacity
-            VerifyCreateNew("Loc421", "CN_mapname421", 50, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc421", "CN_mapname421" + s_uniquifier, 50, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // 0 capacity
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc422", "CN_mapname422", 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc422", "CN_mapname422" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // negative
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc423", "CN_mapname423", -1, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc423", "CN_mapname423" + s_uniquifier, -1, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // negative
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc424", "CN_mapname424", -4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc424", "CN_mapname424" + s_uniquifier, -4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // Int64.MaxValue - cannot exceed local address space
             if (IntPtr.Size == 4)
-                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc425", "CN_mapname425", Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc425", "CN_mapname425" + s_uniquifier, Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
             else // 64-bit machine
-                VerifyCreateNewException<IOException>("Loc425b", "CN_mapname425", Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None); // valid but too large
+                VerifyCreateNewException<IOException>("Loc425b", "CN_mapname425" + s_uniquifier, Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None); // valid but too large
 
             // [] access
 
             // Write is disallowed
-            VerifyCreateNewException<ArgumentException>("Loc430", "CN_mapname430", 1000, MemoryMappedFileAccess.Write, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNewException<ArgumentException>("Loc430", "CN_mapname430" + s_uniquifier, 1000, MemoryMappedFileAccess.Write, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // valid access
             accessList = new MemoryMappedFileAccess[] {
@@ -186,7 +188,7 @@ public class CreateNew : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyCreateNew("Loc431_" + access, "CN_mapname431_" + access, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyCreateNew("Loc431_" + access, "CN_mapname431_" + access + s_uniquifier, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             // invalid enum value
@@ -196,7 +198,7 @@ public class CreateNew : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc432_" + ((int)access), "CN_mapname432_" + ((int)access), 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyCreateNewException<ArgumentOutOfRangeException>("Loc432_" + ((int)access), "CN_mapname432_" + ((int)access) + s_uniquifier, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             // [] options
@@ -206,13 +208,13 @@ public class CreateNew : MMFTestBase
             VerifyCreateNew("Loc440b", null, 4096 * 10000);
 
             // None
-            VerifyCreateNew("Loc441", "CN_mapname441", 4096 * 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreateNew("Loc441", "CN_mapname441" + s_uniquifier, 4096 * 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // DelayAllocatePages
-            VerifyCreateNew("Loc442", "CN_mapname442", 4096 * 10000, MemoryMappedFileAccess.Read, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None);
+            VerifyCreateNew("Loc442", "CN_mapname442" + s_uniquifier, 4096 * 10000, MemoryMappedFileAccess.Read, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None);
 
             // invalid
-            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc444", "CN_mapname444", 100, MemoryMappedFileAccess.ReadWrite, (MemoryMappedFileOptions)(-1), HandleInheritability.None);
+            VerifyCreateNewException<ArgumentOutOfRangeException>("Loc444", "CN_mapname444" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, (MemoryMappedFileOptions)(-1), HandleInheritability.None);
 
             /// END TEST CASES
 

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateOrOpen.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateOrOpen.cs
@@ -9,6 +9,9 @@ using Xunit;
 [Collection("CreateOrOpen")]
 public class CreateOrOpen : MMFTestBase
 {
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
+    private readonly static string s_fileNameTest = "CreateOrOpen_test_" + s_uniquifier + ".txt";
+
     [Fact]
     public static void CreateOrOpenTestCases()
     {
@@ -39,7 +42,7 @@ public class CreateOrOpen : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreate("Loc111", "CreateOrOpen" + new String('a', 1000), 4096);
+            VerifyCreate("Loc111", "CreateOrOpen" + new String('a', 1000) + s_uniquifier, 4096);
 
             // null
             VerifyException<ArgumentNullException>("Loc112", null, 4096);
@@ -51,64 +54,64 @@ public class CreateOrOpen : MMFTestBase
             VerifyCreate("Loc114", "\t \n\u00A0", 4096);
 
             // MMF with this mapname already exists (pagefile backed)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_map115a", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_map115a" + s_uniquifier, 1000))
             {
-                VerifyOpen("Loc115a", "COO_map115a", 1000, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc115a", "COO_map115a" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite);
             }
 
             // MMF with this mapname already exists (filesystem backed)
             String fileText = "Non-empty file for MMF testing.";
-            File.WriteAllText("CreateOrOpen_test2.txt", fileText);
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("CreateOrOpen_test2.txt", FileMode.Open, "COO_map115b"))
+            File.WriteAllText(s_fileNameTest, fileText);
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest, FileMode.Open, "COO_map115b" + s_uniquifier))
             {
-                VerifyOpen("Loc115b", "COO_map115b", 1000, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc115b", "COO_map115b" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite);
             }
 
             // MMF with this mapname existed, but was closed - new MMF
-            VerifyCreate("Loc116", "COO_map115a", 500);
+            VerifyCreate("Loc116", "COO_map115a" + s_uniquifier, 500);
 
             // "global/" prefix
-            VerifyCreate("Loc117", "global/COO_mapname", 4096);
+            VerifyCreate("Loc117", "global/COO_mapname" + s_uniquifier, 4096);
 
             // "local/" prefix
-            VerifyCreate("Loc118", "local/COO_mapname", 4096);
+            VerifyCreate("Loc118", "local/COO_mapname" + s_uniquifier, 4096);
 
             // [] capacity
 
             // >0 capacity
-            VerifyCreate("Loc211", "COO_mapname211", 50);
+            VerifyCreate("Loc211", "COO_mapname211" + s_uniquifier, 50);
 
             // 0 capacity
-            VerifyException<ArgumentOutOfRangeException>("Loc211", "COO_mapname211", 0);
+            VerifyException<ArgumentOutOfRangeException>("Loc211", "COO_mapname211" + s_uniquifier, 0);
 
             // negative
-            VerifyException<ArgumentOutOfRangeException>("Loc213", "COO_mapname213", -1);
+            VerifyException<ArgumentOutOfRangeException>("Loc213", "COO_mapname213" + s_uniquifier, -1);
 
             // negative
-            VerifyException<ArgumentOutOfRangeException>("Loc214", "COO_mapname214", -4096);
+            VerifyException<ArgumentOutOfRangeException>("Loc214", "COO_mapname214" + s_uniquifier, -4096);
 
             // Int64.MaxValue - cannot exceed local address space
             if (IntPtr.Size == 4)
-                VerifyException<ArgumentOutOfRangeException>("Loc215", "COO_mapname215", Int64.MaxValue);
+                VerifyException<ArgumentOutOfRangeException>("Loc215", "COO_mapname215" + s_uniquifier, Int64.MaxValue);
             else // 64-bit machine
-                VerifyException<IOException>("Loc215b", "COO_mapname215", Int64.MaxValue); // valid but too large
+                VerifyException<IOException>("Loc215b", "COO_mapname215" + s_uniquifier, Int64.MaxValue); // valid but too large
 
             // ignored for existing file (smaller)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname216", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname216" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpen("Loc216", "COO_mapname216", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc216", "COO_mapname216" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // ignored for existing file (larger)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname217", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname217" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpen("Loc217", "COO_mapname217", 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc217", "COO_mapname217" + s_uniquifier, 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // existing file - invalid - still exception
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname218", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname218" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyException<ArgumentOutOfRangeException>("Loc218", "COO_mapname218", 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyException<ArgumentOutOfRangeException>("Loc218", "COO_mapname218" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             ////////////////////////////////////////////////////////////////////////
@@ -118,7 +121,7 @@ public class CreateOrOpen : MMFTestBase
             // [] access
 
             // Write is disallowed
-            VerifyException<ArgumentException>("Loc330", "COO_mapname330", 1000, MemoryMappedFileAccess.Write);
+            VerifyException<ArgumentException>("Loc330", "COO_mapname330" + s_uniquifier, 1000, MemoryMappedFileAccess.Write);
 
             // valid access - new file
             MemoryMappedFileAccess[] accessList = new MemoryMappedFileAccess[] {
@@ -130,7 +133,7 @@ public class CreateOrOpen : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyCreate("Loc331_" + access, "COO_mapname331_" + access, 1000, access);
+                VerifyCreate("Loc331_" + access, "COO_mapname331_" + access + s_uniquifier, 1000, access);
             }
 
             // invalid enum value
@@ -140,11 +143,11 @@ public class CreateOrOpen : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyException<ArgumentOutOfRangeException>("Loc332_" + ((int)access), "COO_mapname332_" + ((int)access), 1000, access);
+                VerifyException<ArgumentOutOfRangeException>("Loc332_" + ((int)access), "COO_mapname332_" + ((int)access) + s_uniquifier, 1000, access);
             }
 
             // default security - all valid for existing file
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname333", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname333" + s_uniquifier, 1000))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.CopyOnWrite,
@@ -156,7 +159,7 @@ public class CreateOrOpen : MMFTestBase
                 };
                 foreach (MemoryMappedFileAccess access in accessList)
                 {
-                    VerifyOpen("Loc333_" + access, "COO_mapname333", 1000, access, access);
+                    VerifyOpen("Loc333_" + access, "COO_mapname333" + s_uniquifier, 1000, access, access);
                 }
             }
 
@@ -168,7 +171,7 @@ public class CreateOrOpen : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            VerifyCreate("Loc411", "CreateOrOpen2" + new String('a', 1000), 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc411", "CreateOrOpen2" + new String('a', 1000) + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // null
             VerifyException<ArgumentNullException>("Loc412", null, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
@@ -180,72 +183,72 @@ public class CreateOrOpen : MMFTestBase
             VerifyCreate("Loc414", "\t \n\u00A0", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // MMF with this mapname already exists (pagefile backed)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_map415a", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_map415a" + s_uniquifier, 1000))
             {
-                using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen("COO_map415a", 1000))
+                using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateOrOpen("COO_map415a" + s_uniquifier, 1000))
                 {
-                    VerifyOpen("Loc415a", "COO_map415a", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                    VerifyOpen("Loc415a", "COO_map415a" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
                 }
             }
 
             // MMF with this mapname already exists (filesystem backed)
-            File.WriteAllText("CreateOrOpen_test2.txt", fileText);
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("CreateOrOpen_test2.txt", FileMode.Open, "COO_map415b"))
+            File.WriteAllText(s_fileNameTest, fileText);
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest, FileMode.Open, "COO_map415b"))
             {
-                VerifyOpen("Loc415b", "COO_map415b", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc415b", "COO_map415b" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // MMF with this mapname existed, but was closed - new MMF
-            VerifyCreate("Loc416", "COO_map415a", 500, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc416", "COO_map415a" + s_uniquifier, 500, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // "global/" prefix
-            VerifyCreate("Loc417", "global/COO_mapname", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc417", "global/COO_mapname" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // "local/" prefix
-            VerifyCreate("Loc418", "local/COO_mapname", 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc418", "local/COO_mapname" + s_uniquifier, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // [] capacity
 
             // >0 capacity
-            VerifyCreate("Loc421", "COO_mapname421", 50, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc421", "COO_mapname421" + s_uniquifier, 50, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // 0 capacity
-            VerifyException<ArgumentOutOfRangeException>("Loc422", "COO_mapname422", 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyException<ArgumentOutOfRangeException>("Loc422", "COO_mapname422" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // negative
-            VerifyException<ArgumentOutOfRangeException>("Loc423", "COO_mapname423", -1, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyException<ArgumentOutOfRangeException>("Loc423", "COO_mapname423" + s_uniquifier, -1, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // negative
-            VerifyException<ArgumentOutOfRangeException>("Loc424", "COO_mapname424", -4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyException<ArgumentOutOfRangeException>("Loc424", "COO_mapname424" + s_uniquifier, -4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // Int64.MaxValue - cannot exceed local address space
             if (IntPtr.Size == 4)
-                VerifyException<ArgumentOutOfRangeException>("Loc425", "COO_mapname425", Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyException<ArgumentOutOfRangeException>("Loc425", "COO_mapname425" + s_uniquifier, Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
             else // 64-bit machine
-                VerifyException<IOException>("Loc425b", "COO_mapname425", Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None); // valid but too large
+                VerifyException<IOException>("Loc425b", "COO_mapname425" + s_uniquifier, Int64.MaxValue, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None); // valid but too large
 
             // ignored for existing file (smaller)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname426", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname426" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpen("Loc426", "COO_mapname426", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc426", "COO_mapname426" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // ignored for existing file (larger)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname427", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname427" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpen("Loc427", "COO_mapname427", 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc427", "COO_mapname427" + s_uniquifier, 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // existing file - invalid - still exception
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname428", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname428" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyException<ArgumentOutOfRangeException>("Loc428", "COO_mapname428", 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyException<ArgumentOutOfRangeException>("Loc428", "COO_mapname428" + s_uniquifier, 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             // [] access
 
             // Write is disallowed for new file
-            VerifyException<ArgumentException>("Loc430", "COO_mapname430", 1000, MemoryMappedFileAccess.Write, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyException<ArgumentException>("Loc430", "COO_mapname430" + s_uniquifier, 1000, MemoryMappedFileAccess.Write, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // valid access for a new file
             accessList = new MemoryMappedFileAccess[] {
@@ -257,7 +260,7 @@ public class CreateOrOpen : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyCreate("Loc431_" + access, "COO_mapname431_" + access, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyCreate("Loc431_" + access, "COO_mapname431_" + access + s_uniquifier, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             // invalid enum value
@@ -267,11 +270,11 @@ public class CreateOrOpen : MMFTestBase
             };
             foreach (MemoryMappedFileAccess access in accessList)
             {
-                VerifyException<ArgumentOutOfRangeException>("Loc432_" + ((int)access), "COO_mapname432_" + ((int)access), 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
+                VerifyException<ArgumentOutOfRangeException>("Loc432_" + ((int)access), "COO_mapname432_" + ((int)access) + s_uniquifier, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None);
             }
 
             // default security - all valid
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname433", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname433" + s_uniquifier, 1000))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.CopyOnWrite,
@@ -283,12 +286,12 @@ public class CreateOrOpen : MMFTestBase
                 };
                 foreach (MemoryMappedFileAccess access in accessList)
                 {
-                    VerifyOpen("Loc433_" + access, "COO_mapname433", 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None, access);
+                    VerifyOpen("Loc433_" + access, "COO_mapname433" + s_uniquifier, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None, access);
                 }
             }
 
             // default security, original (lesser) viewAccess is respected
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname434", 1000, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname434" + s_uniquifier, 1000, MemoryMappedFileAccess.Read))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.CopyOnWrite,
@@ -299,30 +302,30 @@ public class CreateOrOpen : MMFTestBase
                 };
                 foreach (MemoryMappedFileAccess access in accessList)
                 {
-                    VerifyOpen("Loc434_" + access, "COO_mapname434", 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.Read);
+                    VerifyOpen("Loc434_" + access, "COO_mapname434" + s_uniquifier, 1000, access, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.Read);
                 }
-                VerifyOpen("Loc434_Write", "COO_mapname434", 1000, MemoryMappedFileAccess.Write, MemoryMappedFileOptions.None, HandleInheritability.None, (MemoryMappedFileAccess)(-1));  // for current architecture, rights=Write implies ReadWrite access but not Read, so no expected access here
+                VerifyOpen("Loc434_Write", "COO_mapname434" + s_uniquifier, 1000, MemoryMappedFileAccess.Write, MemoryMappedFileOptions.None, HandleInheritability.None, (MemoryMappedFileAccess)(-1));  // for current architecture, rights=Write implies ReadWrite access but not Read, so no expected access here
             }
 
             // [] options
 
             // Default
-            VerifyCreate("Loc440a", "COO_mapname440a", 4096 * 1000);
-            VerifyCreate("Loc440b", "COO_mapname440b", 4096 * 10000);
+            VerifyCreate("Loc440a", "COO_mapname440a" + s_uniquifier, 4096 * 1000);
+            VerifyCreate("Loc440b", "COO_mapname440b" + s_uniquifier, 4096 * 10000);
 
             // None - new file
-            VerifyCreate("Loc441", "COO_mapname441", 4096 * 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc441", "COO_mapname441" + s_uniquifier, 4096 * 10000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // DelayAllocatePages - new file
-            VerifyCreate("Loc442", "COO_mapname442", 4096 * 10000, MemoryMappedFileAccess.Read, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None);
+            VerifyCreate("Loc442", "COO_mapname442" + s_uniquifier, 4096 * 10000, MemoryMappedFileAccess.Read, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None);
 
             // invalid
-            VerifyException<ArgumentOutOfRangeException>("Loc443", "COO_mapname443", 100, MemoryMappedFileAccess.ReadWrite, (MemoryMappedFileOptions)(-1), HandleInheritability.None);
+            VerifyException<ArgumentOutOfRangeException>("Loc443", "COO_mapname443" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, (MemoryMappedFileOptions)(-1), HandleInheritability.None);
 
             // ignored for existing file
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname444", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname444" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpen("Loc444", "COO_mapname444", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc444", "COO_mapname444" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // [] memoryMappedFileSecurity
@@ -330,40 +333,40 @@ public class CreateOrOpen : MMFTestBase
             // null, tested throughout this file
 
             // valid non-null
-            VerifyCreate("Loc451", "COO_mapname451", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc451", "COO_mapname451" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // ignored for existing
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen("COO_mapname452", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateOrOpen("COO_mapname452" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpen("Loc452", "COO_mapname452", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc452", "COO_mapname452" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // [] inheritability
 
             // None - new file
-            VerifyCreate("Loc461", "COO_mapname461", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
+            VerifyCreate("Loc461", "COO_mapname461" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None);
 
             // Inheritable - new file
-            VerifyCreate("Loc462", "COO_mapname462", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable);
+            VerifyCreate("Loc462", "COO_mapname462" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable);
 
             // Mix and match: None - existing file w/Inheritable
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname464", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("COO_mapname464" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable))
             {
-                VerifyOpen("Loc464a", "COO_mapname464", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
+                VerifyOpen("Loc464a", "COO_mapname464" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None, MemoryMappedFileAccess.ReadWrite);
             }
 
             // Mix and match: Inheritable - existing file w/None
-            using (FileStream fs = new FileStream("CreateOrOpen_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest, FileMode.Open))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "COO_mapname465", 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "COO_mapname465" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
                 {
-                    VerifyOpen("Loc465b", "COO_mapname465", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWrite);
+                    VerifyOpen("Loc465b", "COO_mapname465" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWrite);
                 }
             }
 
             // invalid
-            VerifyException<ArgumentOutOfRangeException>("Loc467", "COO_mapname467", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, (HandleInheritability)(-1));
-            VerifyException<ArgumentOutOfRangeException>("Loc468", "COO_mapname468", 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, (HandleInheritability)(2));
+            VerifyException<ArgumentOutOfRangeException>("Loc467", "COO_mapname467" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, (HandleInheritability)(-1));
+            VerifyException<ArgumentOutOfRangeException>("Loc468", "COO_mapname468" + s_uniquifier, 100, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, (HandleInheritability)(2));
 
 
             /// END TEST CASES

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateViewAccessor.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateViewAccessor.cs
@@ -11,7 +11,8 @@ using System.Runtime.InteropServices;
 [Collection("CreateViewAccessor")]
 public class CreateViewAccessor : MMFTestBase
 {
-    private static readonly String s_fileNameForLargeCapacity = "CreateViewAccessor_MMF_ForLargeCapacity.txt";
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
+    private readonly static string s_fileNameForLargeCapacity = "CreateViewAccessor_MMF_ForLargeCapacity_" + s_uniquifier + ".txt";
 
     [Fact]
     public static void CreateViewAccessorTestCases()
@@ -45,19 +46,19 @@ public class CreateViewAccessor : MMFTestBase
             String fileContents = String.Empty;
 
             // Verify default values
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname101", 100))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname101" + s_uniquifier, 100))
             {
                 VerifyCreateViewAccessor("Loc101", mmf, defaultCapacity, defaultAccess, fileContents);
             }
 
             // default length is full MMF
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname102", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname102" + s_uniquifier, defaultCapacity * 2))
             {
                 VerifyCreateViewAccessor("Loc102", mmf, defaultCapacity * 2, defaultAccess, fileContents);
             }
 
             // if MMF is read-only, default access throws
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname103", 100, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname103" + s_uniquifier, 100, MemoryMappedFileAccess.Read))
             {
                 VerifyCreateViewAccessorException<UnauthorizedAccessException>("Loc103", mmf);
             }
@@ -66,7 +67,7 @@ public class CreateViewAccessor : MMFTestBase
             // CreateViewAccessor(long, long)
             ////////////////////////////////////////////////////////////////////////
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname200", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname200" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewAccessor("Loc201", mmf, 0, 0, defaultCapacity * 2, defaultAccess, fileContents);
@@ -89,7 +90,7 @@ public class CreateViewAccessor : MMFTestBase
 
             // size
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname410", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname410" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewAccessor("Loc211", mmf, 1000, 0, defaultCapacity * 2 - 1000, defaultAccess, fileContents);
@@ -132,7 +133,7 @@ public class CreateViewAccessor : MMFTestBase
 
             // [] offset
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname400", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname400" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewAccessor("Loc401", mmf, 0, 0, defaultAccess, defaultCapacity * 2, defaultAccess, fileContents);
@@ -155,7 +156,7 @@ public class CreateViewAccessor : MMFTestBase
 
             // size
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname410", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname410" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewAccessor("Loc411", mmf, 1000, 0, defaultAccess, defaultCapacity * 2 - 1000, defaultAccess, fileContents);
@@ -197,7 +198,7 @@ public class CreateViewAccessor : MMFTestBase
             MemoryMappedFileAccess[] accessList;
 
             // existing file is ReadWriteExecute
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname431", 1000, MemoryMappedFileAccess.ReadWriteExecute))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname431" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWriteExecute))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -214,7 +215,7 @@ public class CreateViewAccessor : MMFTestBase
             }
 
             // existing file is ReadExecute
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname432", 1000, MemoryMappedFileAccess.ReadExecute))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname432" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadExecute))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -237,7 +238,7 @@ public class CreateViewAccessor : MMFTestBase
             }
 
             // existing file is CopyOnWrite
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname433", 1000, MemoryMappedFileAccess.CopyOnWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname433" + s_uniquifier, 1000, MemoryMappedFileAccess.CopyOnWrite))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -260,7 +261,7 @@ public class CreateViewAccessor : MMFTestBase
             }
 
             // existing file is ReadWrite
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname434", 1000, MemoryMappedFileAccess.ReadWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname434" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -283,7 +284,7 @@ public class CreateViewAccessor : MMFTestBase
             }
 
             // existing file is Read
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname435", 1000, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname435" + s_uniquifier, 1000, MemoryMappedFileAccess.Read))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -306,7 +307,7 @@ public class CreateViewAccessor : MMFTestBase
             }
 
             // invalid enum value
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname436", 1000, MemoryMappedFileAccess.ReadWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVA_mapname436" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     (MemoryMappedFileAccess)(-1),
@@ -375,7 +376,7 @@ public class CreateViewAccessor : MMFTestBase
         iCountTestcases++;
         try
         {
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameForLargeCapacity, FileMode.Open, "CVA_RunTestLargeCapacity", capacity))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameForLargeCapacity, FileMode.Open, "CVA_RunTestLargeCapacity" + s_uniquifier, capacity))
             {
                 try
                 {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateViewStream.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/CreateViewStream.cs
@@ -10,7 +10,8 @@ using Xunit;
 [Collection("CreateViewStream")]
 public class CreateViewStream : MMFTestBase
 {
-    private static readonly String s_fileNameForLargeCapacity = "CreateViewStream_MMF_ForLargeCapacity.txt";
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
+    private readonly static string s_fileNameForLargeCapacity = "CreateViewStream_MMF_ForLargeCapacity_" + s_uniquifier + ".txt";
 
     [Fact]
     public static void CreateViewStreamTestCases()
@@ -44,19 +45,19 @@ public class CreateViewStream : MMFTestBase
             String fileContents = String.Empty;
 
             // Verify default values
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname101", 100))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname101" + s_uniquifier, 100))
             {
                 VerifyCreateViewStream("Loc101", mmf, defaultCapacity, defaultAccess, fileContents);
             }
 
             // default length is full MMF
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname102", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname102" + s_uniquifier, defaultCapacity * 2))
             {
                 VerifyCreateViewStream("Loc102", mmf, defaultCapacity * 2, defaultAccess, fileContents);
             }
 
             // if MMF is read-only, default access throws
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname103", 100, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname103" + s_uniquifier, 100, MemoryMappedFileAccess.Read))
             {
                 VerifyCreateViewStreamException<UnauthorizedAccessException>("Loc103", mmf);
             }
@@ -66,7 +67,7 @@ public class CreateViewStream : MMFTestBase
             ////////////////////////////////////////////////////////////////////////
 
             // capacity
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname200", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname200" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewStream("Loc201", mmf, 0, 0, defaultCapacity * 2, defaultAccess, fileContents);
@@ -131,7 +132,7 @@ public class CreateViewStream : MMFTestBase
 
             // [] offset
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname400", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname400" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewStream("Loc401", mmf, 0, 0, defaultAccess, defaultCapacity * 2, defaultAccess, fileContents);
@@ -154,7 +155,7 @@ public class CreateViewStream : MMFTestBase
 
             // size
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname410", defaultCapacity * 2))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname410" + s_uniquifier, defaultCapacity * 2))
             {
                 // 0
                 VerifyCreateViewStream("Loc411", mmf, 1000, 0, defaultAccess, defaultCapacity * 2 - 1000, defaultAccess, fileContents);
@@ -196,7 +197,7 @@ public class CreateViewStream : MMFTestBase
             MemoryMappedFileAccess[] accessList;
 
             // existing file is ReadWriteExecute
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname431", 1000, MemoryMappedFileAccess.ReadWriteExecute))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname431" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWriteExecute))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -213,7 +214,7 @@ public class CreateViewStream : MMFTestBase
             }
 
             // existing file is ReadExecute
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname432", 1000, MemoryMappedFileAccess.ReadExecute))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname432" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadExecute))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -236,7 +237,7 @@ public class CreateViewStream : MMFTestBase
             }
 
             // existing file is CopyOnWrite
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname433", 1000, MemoryMappedFileAccess.CopyOnWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname433" + s_uniquifier, 1000, MemoryMappedFileAccess.CopyOnWrite))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -259,7 +260,7 @@ public class CreateViewStream : MMFTestBase
             }
 
             // existing file is ReadWrite
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname434", 1000, MemoryMappedFileAccess.ReadWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname434" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -282,7 +283,7 @@ public class CreateViewStream : MMFTestBase
             }
 
             // existing file is Read
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname435", 1000, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname435" + s_uniquifier, 1000, MemoryMappedFileAccess.Read))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     MemoryMappedFileAccess.Read,
@@ -305,7 +306,7 @@ public class CreateViewStream : MMFTestBase
             }
 
             // invalid enum value
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname436", 1000, MemoryMappedFileAccess.ReadWrite))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("CVS_mapname436" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite))
             {
                 accessList = new MemoryMappedFileAccess[] {
                     (MemoryMappedFileAccess)(-1),
@@ -374,7 +375,7 @@ public class CreateViewStream : MMFTestBase
         iCountTestcases++;
         try
         {
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameForLargeCapacity, FileMode.Open, "RunTestLargeCapacity", capacity))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameForLargeCapacity, FileMode.Open, "RunTestLargeCapacity" + s_uniquifier, capacity))
             {
                 try
                 {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/Dispose.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/Dispose.cs
@@ -9,6 +9,7 @@ using Xunit;
 [Collection("Dispose")]
 public class MMF_Dispose
 {
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
     private int _iCountErrors = 0;
     private int _iCountTestcases = 0;
 
@@ -39,7 +40,7 @@ public class MMF_Dispose
             // Dispose()
             ////////////////////////////////////////////////////////////////////////
 
-            MemoryMappedFile mmf = MemoryMappedFile.CreateNew("Dispose_mapname101", 100);
+            MemoryMappedFile mmf = MemoryMappedFile.CreateNew("Dispose_mapname101" + s_uniquifier, 100);
             MemoryMappedViewStream viewStream = mmf.CreateViewStream();
             MemoryMappedViewAccessor viewAccessor = mmf.CreateViewAccessor();
             mmf.Dispose();

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/OpenExisting.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/OpenExisting.cs
@@ -11,6 +11,9 @@ using Xunit;
 [Collection("OpenExisting")]
 public class OpenExisting : MMFTestBase
 {
+    private readonly static string s_uniquifier = Guid.NewGuid().ToString();
+    private readonly static string s_fileNameTest = "OpenExisting_test_" + s_uniquifier + ".txt";
+
     [Fact]
     public static void OpenExistingTestCases()
     {
@@ -41,9 +44,9 @@ public class OpenExisting : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("OpenExisting_" + new String('a', 1000), 4096))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("OpenExisting_" + new String('a', 1000) + s_uniquifier, 4096))
             {
-                VerifyOpenExisting("Loc111", "OpenExisting_" + new String('a', 1000), MemoryMappedFileAccess.ReadWrite);
+                VerifyOpenExisting("Loc111", "OpenExisting_" + new String('a', 1000) + s_uniquifier, MemoryMappedFileAccess.ReadWrite);
             }
 
             // null
@@ -62,21 +65,21 @@ public class OpenExisting : MMFTestBase
             }
 
             // MMF with this mapname already exists (pagefile backed)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("OpenExisting_map115a", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("OpenExisting_map115a" + s_uniquifier, 1000))
             {
-                VerifyOpenExisting("Loc115a", "OpenExisting_map115a", MemoryMappedFileAccess.ReadWrite);
+                VerifyOpenExisting("Loc115a", "OpenExisting_map115a" + s_uniquifier, MemoryMappedFileAccess.ReadWrite);
             }
 
             // MMF with this mapname already exists (filesystem backed)
             String fileText = "Non-empty file for MMF testing.";
-            File.WriteAllText("OpenExisting_test2.txt", fileText);
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("OpenExisting_test2.txt", FileMode.Open, "map115b"))
+            File.WriteAllText(s_fileNameTest, fileText);
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest, FileMode.Open, "map115b" + s_uniquifier))
             {
-                VerifyOpenExisting("Loc115b", "map115b", MemoryMappedFileAccess.ReadWrite);
+                VerifyOpenExisting("Loc115b", "map115b" + s_uniquifier, MemoryMappedFileAccess.ReadWrite);
             }
 
             // MMF with this mapname existed, but was closed - new MMF
-            VerifyOpenExistingException<FileNotFoundException>("Loc116", "OpenExisting_map115a");
+            VerifyOpenExistingException<FileNotFoundException>("Loc116", "OpenExisting_map115a" + s_uniquifier);
 
 
             ////////////////////////////////////////////////////////////////////////
@@ -86,10 +89,10 @@ public class OpenExisting : MMFTestBase
             // [] rights
             MemoryMappedFileRights[] rightsList;
 
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname334", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname334" + s_uniquifier, 1000))
             {
                 // default security - AccessSystemSecurity fails
-                VerifyOpenExistingException<IOException>("Loc333", "mapname334", MemoryMappedFileRights.AccessSystemSecurity);
+                VerifyOpenExistingException<IOException>("Loc333", "mapname334" + s_uniquifier, MemoryMappedFileRights.AccessSystemSecurity);
 
                 // default security - all others valid
                 rightsList = new MemoryMappedFileRights[] {
@@ -110,7 +113,7 @@ public class OpenExisting : MMFTestBase
                 {
                     //Console.WriteLine("{0}  {1}", rights, RightsToMinAccess(rights));
                     // include ReadPermissions or we won't be able to verify the security object
-                    VerifyOpenExisting("Loc334_" + rights, "mapname334", rights | MemoryMappedFileRights.ReadPermissions, RightsToMinAccess(rights));
+                    VerifyOpenExisting("Loc334_" + rights, "mapname334" + s_uniquifier, rights | MemoryMappedFileRights.ReadPermissions, RightsToMinAccess(rights));
                 }
 
                 // invalid enum value
@@ -120,7 +123,7 @@ public class OpenExisting : MMFTestBase
                 };
                 foreach (MemoryMappedFileRights rights in rightsList)
                 {
-                    VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc335_" + ((int)rights), "mapname334", rights);
+                    VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc335_" + ((int)rights), "mapname334" + s_uniquifier, rights);
                 }
             }
 
@@ -131,9 +134,9 @@ public class OpenExisting : MMFTestBase
             // [] mapName
 
             // mapname > 260 chars
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(new String('a', 1000), 4096))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(new String('a', 1000) + s_uniquifier, 4096))
             {
-                VerifyOpenExisting("Loc411", new String('a', 1000), MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc411", new String('a', 1000) + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
             // null
@@ -152,25 +155,25 @@ public class OpenExisting : MMFTestBase
             }
 
             // MMF with this mapname already exists (pagefile backed)
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("map415a", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("map415a" + s_uniquifier, 1000))
             {
-                VerifyOpenExisting("Loc415a", "map415a", MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc415a", "map415a" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
             // MMF with this mapname already exists (filesystem backed)
-            File.WriteAllText("OpenExisting_test2.txt", fileText);
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile("OpenExisting_test2.txt", FileMode.Open, "map415b"))
+            File.WriteAllText(s_fileNameTest, fileText);
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(s_fileNameTest, FileMode.Open, "map415b" + s_uniquifier))
             {
-                VerifyOpenExisting("Loc415b", "map415b", MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc415b", "map415b" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
             // MMF with this mapname existed, but was closed
-            VerifyOpenExistingException<FileNotFoundException>("Loc416", "map415a", MemoryMappedFileRights.FullControl, HandleInheritability.None);
+            VerifyOpenExistingException<FileNotFoundException>("Loc416", "map415a" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None);
 
             // [] rights
 
             // invalid enum value
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname432", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname432" + s_uniquifier, 1000))
             {
                 rightsList = new MemoryMappedFileRights[] {
                     (MemoryMappedFileRights)(-1),
@@ -178,12 +181,12 @@ public class OpenExisting : MMFTestBase
                 };
                 foreach (MemoryMappedFileRights rights in rightsList)
                 {
-                    VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc432_" + ((int)rights), "mapname432", rights, HandleInheritability.None);
+                    VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc432_" + ((int)rights), "mapname432" + s_uniquifier, rights, HandleInheritability.None);
                 }
             }
 
             // default security - all valid
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname433", 1000))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname433" + s_uniquifier, 1000))
             {
                 rightsList = new MemoryMappedFileRights[] {
                     MemoryMappedFileRights.CopyOnWrite,
@@ -202,15 +205,15 @@ public class OpenExisting : MMFTestBase
                 foreach (MemoryMappedFileRights rights in rightsList)
                 {
                     // include ReadPermissions or we won't be able to verify the security object
-                    VerifyOpenExisting("Loc433_" + rights, "mapname433", rights | MemoryMappedFileRights.ReadPermissions, HandleInheritability.None, RightsToMinAccess(rights));
+                    VerifyOpenExisting("Loc433_" + rights, "mapname433" + s_uniquifier, rights | MemoryMappedFileRights.ReadPermissions, HandleInheritability.None, RightsToMinAccess(rights));
                 }
 
                 // default security - AccessSystemSecurity fails
-                VerifyOpenExistingException<IOException>("Loc433b", "mapname433", MemoryMappedFileRights.AccessSystemSecurity);
+                VerifyOpenExistingException<IOException>("Loc433b", "mapname433" + s_uniquifier, MemoryMappedFileRights.AccessSystemSecurity);
             }
 
             // default security, original (lesser) viewAccess is respected
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname434", 1000, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname434" + s_uniquifier, 1000, MemoryMappedFileAccess.Read))
             {
                 rightsList = new MemoryMappedFileRights[] {
                     MemoryMappedFileRights.CopyOnWrite,
@@ -229,71 +232,71 @@ public class OpenExisting : MMFTestBase
                 foreach (MemoryMappedFileRights rights in rightsList)
                 {
                     // include ReadPermissions or we won't be able to verify the security object
-                    VerifyOpenExisting("Loc434_" + rights, "mapname434", rights | MemoryMappedFileRights.ReadPermissions, HandleInheritability.None, RightsToMinAccess(rights & ~MemoryMappedFileRights.Write));
+                    VerifyOpenExisting("Loc434_" + rights, "mapname434" + s_uniquifier, rights | MemoryMappedFileRights.ReadPermissions, HandleInheritability.None, RightsToMinAccess(rights & ~MemoryMappedFileRights.Write));
                 }
             }
 
             // [] inheritability
 
             // None - existing file w/None
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname463", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname463" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpenExisting("Loc463a", "mapname463", MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc463a", "mapname463" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
-            using (FileStream fs = new FileStream("OpenExisting_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest, FileMode.Open))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname463", 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname463" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
                 {
-                    VerifyOpenExisting("Loc463b", "mapname463", MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                    VerifyOpenExisting("Loc463b", "mapname463" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
                 }
             }
 
             // None - existing file w/Inheritable
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname464", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname464" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable))
             {
-                VerifyOpenExisting("Loc464a", "mapname464", MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc464a", "mapname464" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
-            using (FileStream fs = new FileStream("OpenExisting_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest, FileMode.Open))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname464", 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname464" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false))
                 {
-                    VerifyOpenExisting("Loc464b", "mapname464", MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
+                    VerifyOpenExisting("Loc464b", "mapname464" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.None, MemoryMappedFileAccess.ReadWriteExecute);
                 }
             }
 
             // Inheritable - existing file w/None
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname465", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname465" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None))
             {
-                VerifyOpenExisting("Loc465a", "mapname465", MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc465a", "mapname465" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
-            using (FileStream fs = new FileStream("OpenExisting_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest, FileMode.Open))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname465", 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname465" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
                 {
-                    VerifyOpenExisting("Loc465b", "mapname465", MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
+                    VerifyOpenExisting("Loc465b", "mapname465" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
                 }
             }
 
             // Inheritable - existing file w/Inheritable
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname466", 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew("mapname466" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.Inheritable))
             {
-                VerifyOpenExisting("Loc466a", "mapname466", MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
+                VerifyOpenExisting("Loc466a", "mapname466" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
             }
 
-            using (FileStream fs = new FileStream("OpenExisting_test2.txt", FileMode.Open))
+            using (FileStream fs = new FileStream(s_fileNameTest, FileMode.Open))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname466", 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false))
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, "mapname466" + s_uniquifier, 1000, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false))
                 {
-                    VerifyOpenExisting("Loc466b", "mapname466", MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
+                    VerifyOpenExisting("Loc466b", "mapname466" + s_uniquifier, MemoryMappedFileRights.FullControl, HandleInheritability.Inheritable, MemoryMappedFileAccess.ReadWriteExecute);
                 }
             }
 
             // invalid
-            VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc467", "mapname467", MemoryMappedFileRights.FullControl, (HandleInheritability)(-1));
-            VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc468", "mapname468", MemoryMappedFileRights.FullControl, (HandleInheritability)(2));
+            VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc467", "mapname467" + s_uniquifier, MemoryMappedFileRights.FullControl, (HandleInheritability)(-1));
+            VerifyOpenExistingException<ArgumentOutOfRangeException>("Loc468", "mapname468" + s_uniquifier, MemoryMappedFileRights.FullControl, (HandleInheritability)(2));
 
             /// END TEST CASES
 


### PR DESCRIPTION
Except for tests that test names with just whitespace, all file and
map names now have a uniquifier guid as part of the name that is
different per class and per test run.