### PR TITLE
Fix project reference

### DIFF
--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -22,7 +22,10 @@
       <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
       <Name>XunitTraitsDiscoverers</Name>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Runtime.Numerics.csproj" />
+    <ProjectReference Include="..\src\System.Runtime.Numerics.csproj">
+      <Project>{d2c99d27-0bef-4319-adb3-05cbeba8f69b}</Project>
+      <Name>System.Runtime.Numerics</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">


### PR DESCRIPTION
Just fix project reference

~~Considered scenario: just forked or just cleaned repo.~~
~~Test projects of these solutions:~~
~~System.Collections.sln~~
~~System.ComponentModel.EventBasedAsync.sln~~
~~System.ComponentModel.sln~~
~~System.Console.sln~~
~~System.Diagnostics.Process.sln~~
~~System.IO.FileSystem.DriveInfo.sln~~
~~System.Runtime.Numerics.sln~~
~~System.Text.Encoding.CodePages.sln~~

~~depends on XunitTraitsDiscoverers project but solutions itself doesn't includes XunitTraitsDiscoverers~~
~~so building whole solution in VS will fail.~~