### PR TITLE
Enable code coverage on VS2015 and include more libraries

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -32,7 +32,7 @@
     <_CoverageEnabled>false</_CoverageEnabled>
     <_CoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(OS)' == 'Windows_NT' and '$(Coverage)' == 'true'">true</_CoverageEnabled>
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(BinDir)\tests\coverage\</CoverageReportDir>
-    <CoverageVersion>4.5.3522</CoverageVersion>
+    <CoverageVersion>4.5.3711-rc52</CoverageVersion>
     <CoverageToolPath>$(PackagesDir)OpenCover.$(CoverageVersion)\OpenCover.Console.exe</CoverageToolPath>
     <!-- When coverage is enabled, we disallow building projects in parallel. There appear to be issues with the OpenCover tool
          in these scenarios. -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-4" />
-  <package id="OpenCover" version="4.5.3522" />
+  <package id="OpenCover" version="4.5.3711-rc52" />
   <package id="ReportGenerator" version="2.0.4.0" />
 </packages>

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -7,7 +7,6 @@
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
-    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -13,7 +13,6 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>
-    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.Threading.Tasks.Dataflow.Tests</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>bcca2a00</NuGetPackageImportStamp>
-    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XDocument.Tests</RootNamespace>
-    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XmlDocument.Tests</RootNamespace>
-    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>


### PR DESCRIPTION
Two issues:
1) Code coverage doesn't work with VS2015.
2) Several of our libraries are disabled from code coverage.

For the first, the issue turned out to be a failure of the OpenCover code coverage tool to read the PDBs produced by Roslyn.  The library on which the tool depends for PDB reading has been updated to support Roslyn, and a more recent version of OpenCover than the one we're currently using pulls in that updated version of the PDB reader.  As such, the fix is just to upgrade which version of OpenCover we use.

For the second, whatever reason caused us to disable code coverage on several projects appear to have since been addressed, either by us or in the OpenCover update.  The fix then is to just re-enable code coverage on these libraries.

The only library that remains disabled for code coverage is System.Diagnostics.Process.dll.  It's either hanging or just taking a really, really long time (PLINQ takes about 10 minutes, but at least it completes).  Needs more investigation.