### PR TITLE
Fix filename casing in System.Console.Tests.csproj

### DIFF
--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Include="NegativeTesting.cs" />
     <Compile Include="Timeout.cs" />
     <Compile Include="ThreadSafety.cs" />
-    <Compile Include="XUnitAssemblyAttributes.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">


### PR DESCRIPTION
It is named differently on disk, make it consistent.