### PR TITLE
Acquire comparers for default collections through helper

### DIFF
--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-  <CodeAnalysisRuleSet>System.Collections.Immutable.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>System.Collections.Immutable.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -100,6 +100,7 @@
     <Compile Include="System\Collections\Immutable\KeysOrValuesCollectionAccessor.cs" />
     <Compile Include="System\Collections\Immutable\RefAsValueType.cs" />
     <Compile Include="System\Collections\Immutable\SecureObjectPool.cs" />
+    <Compile Include="System\Collections\Immutable\Utilities.cs" />
     <Compile Include="System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs" />
     <Compile Include="System\Linq\ImmutableArrayExtensions.cs" />
     <Compile Include="Strings.Designer.cs">

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Comparers.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Comparers.cs
@@ -24,7 +24,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The default instance to use when all the comparers used are their default values.
             /// </summary>
-            internal static readonly Comparers Default = new Comparers(EqualityComparer<TKey>.Default, EqualityComparer<TValue>.Default);
+            internal static readonly Comparers Default = new Comparers(Utilities.GetDefaultEqualityComparer<TKey>(), Utilities.GetDefaultEqualityComparer<TValue>());
 
             /// <summary>
             /// The equality comparer to use for the key.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -23,7 +23,7 @@ namespace System.Collections.Immutable
         /// An empty immutable dictionary with default equality comparers.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly ImmutableDictionary<TKey, TValue> Empty = new ImmutableDictionary<TKey, TValue>();
+        public static readonly ImmutableDictionary<TKey, TValue> Empty = new ImmutableDictionary<TKey, TValue>(Comparers.Get(Utilities.GetDefaultEqualityComparer<TKey>(), Utilities.GetDefaultEqualityComparer<TValue>()));
 
         /// <summary>
         /// The singleton delegate that freezes the contents of hash buckets when the root of the data structure is frozen.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Immutable
         /// An empty immutable hash set with the default comparer for <typeparamref name="T"/>.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly ImmutableHashSet<T> Empty = new ImmutableHashSet<T>(SortedInt32KeyNode<HashBucket>.EmptyNode, EqualityComparer<T>.Default, 0);
+        public static readonly ImmutableHashSet<T> Empty = new ImmutableHashSet<T>(SortedInt32KeyNode<HashBucket>.EmptyNode, Utilities.GetDefaultEqualityComparer<T>(), 0);
 
         /// <summary>
         /// The singleton delegate that freezes the contents of hash buckets when the root of the data structure is frozen.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -25,7 +25,7 @@ namespace System.Collections.Immutable
         /// An empty sorted dictionary with default sort and equality comparers.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty = new ImmutableSortedDictionary<TKey, TValue>();
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty = new ImmutableSortedDictionary<TKey, TValue>(Utilities.GetDefaultComparer<TKey>(), Utilities.GetDefaultEqualityComparer<TValue>());
 
         /// <summary>
         /// The root node of the AVL tree that stores this map.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -34,7 +34,7 @@ namespace System.Collections.Immutable
         /// An empty sorted set with the default sort comparer.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly ImmutableSortedSet<T> Empty = new ImmutableSortedSet<T>();
+        public static readonly ImmutableSortedSet<T> Empty = new ImmutableSortedSet<T>(Utilities.GetDefaultComparer<T>());
 
         /// <summary>
         /// The root node of the AVL tree that stores this set.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/Utilities.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/Utilities.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.Collections.Immutable
+{
+    internal static class Utilities
+    {
+        /// <summary>
+        /// Gets the default comparer to use for a given type, guarding against a race in lazy initialization of the value.
+        /// </summary>
+        /// <typeparam name="T">The type of value to be compared.</typeparam>
+        /// <returns>The comparer instance.</returns>
+        internal static Comparer<T> GetDefaultComparer<T>()
+        {
+            // Protect against a race when .NET initializes its Comparer<T>.Default instance
+            // that can lead to us getting a different instance than everyone else will get later.
+            // This is important because if our Empty static collection instance is based on the 
+            // odd instance of the default comparer, then forever after anyone asking for an instance
+            // of the collection with the default comparer will experience another allocation.
+            var dummy = Comparer<T>.Default;
+            return Comparer<T>.Default;
+        }
+
+        /// <summary>
+        /// Gets the default comparer to use for a given type, guarding against a race in lazy initialization of the value.
+        /// </summary>
+        /// <typeparam name="T">The type of value to be compared.</typeparam>
+        /// <returns>The comparer instance.</returns>
+        internal static EqualityComparer<T> GetDefaultEqualityComparer<T>()
+        {
+            // Protect against a race when .NET initializes its EqualityComparer<T>.Default instance
+            // that can lead to us getting a different instance than everyone else will get later.
+            // This is important because if our Empty static collection instance is based on the 
+            // odd instance of the default comparer, then forever after anyone asking for an instance
+            // of the collection with the default comparer will experience another allocation.
+            var dummy = EqualityComparer<T>.Default;
+            return EqualityComparer<T>.Default;
+        }
+    }
+}


### PR DESCRIPTION
EqualityComparer<T>.Default and Comparer<T>.Default do not guarantee to return the same instance every time. In particular when they are being lazily initialized, there is a race where they could return different values to different threads.
This can be costly to immutable collections because we have optimizations around folks who change collections' comparers. And if they want to compare a collection's comparer to Comparer<T>.Default, and it is already the default, it should just "return this" instead of allocate a new collection. But that optimization will fail if Empty was initialized with a different instance that future callers will see.

At the moment, we still don't eliminate the race condition, but at least we've centralized the problem in this commit. 

The present form of this pull request is not ready to be merged.

Eventually will fix #780 