### PR TITLE
Fix GetGroup never returning EmptyGroup

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -83,24 +83,18 @@ namespace System.Text.RegularExpressions
         {
             if (_captureMap != null)
             {
-                Object o;
-
-                o = _captureMap[groupnum];
-                if (o == null)
-                    return Group._emptygroup;
-                //throw new ArgumentOutOfRangeException("groupnum");
-
-                return GetGroupImpl((int)o);
+                int groupNumImpl;
+                if (_captureMap.TryGetValue(groupnum, out groupNumImpl))
+                {
+                    return GetGroupImpl(groupNumImpl);
+                }
             }
-            else
+            else if (groupnum < _match._matchcount.Length && groupnum >= 0)
             {
-                //if (groupnum >= _match._regex.CapSize || groupnum < 0)
-                //   throw new ArgumentOutOfRangeException("groupnum");
-                if (groupnum >= _match._matchcount.Length || groupnum < 0)
-                    return Group._emptygroup;
-
                 return GetGroupImpl(groupnum);
             }
+
+            return Group._emptygroup;
         }
 
 


### PR DESCRIPTION
This is like #253 with a minor change.  After talking things over internally, we decided we'll do the due diligence ourselves to write the test (the test he wrote is failing and debugging these things is still a big pain in the butt, so we'd rather face the pain ourselves).  So we're just going to take @alfaproject's code change.  I checked out his PR, removed the test addition and am submitting this PR.