### PR TITLE
Using shared CloseHandle interop

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -6,5 +6,6 @@ internal static partial class Interop
     private static class Libraries
     {
         internal const string Localization = "api-ms-win-core-localization-l1-2-0.dll";
+        internal const string Handle = "api-ms-win-core-handle-l1-1-0.dll";
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.CloseHandle.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CloseHandle.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.Handle, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [SecurityCritical]
+        internal static extern bool CloseHandle(IntPtr handle);
+    }
+}

--- a/src/System.Diagnostics.Process/src/Interop/Interop.Windows.cs
+++ b/src/System.Diagnostics.Process/src/Interop/Interop.Windows.cs
@@ -255,10 +255,6 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-wow64-l1-1-0", SetLastError = true)]
         public static extern bool IsWow64Process(SafeProcessHandle hProcess, ref bool Wow64Process);
 
-        [SecurityCritical]
-        [DllImport("api-ms-win-core-handle-l1-1-0", ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
-        public static extern bool CloseHandle(IntPtr handle);
-
         public static string GetComputerName()
         {
             char[] buffer = new char[256];

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -48,6 +48,12 @@
     <Compile Include="System\Diagnostics\ThreadWaitReason.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.CloseHandle.cs">
+      <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
+    </Compile>
     <Compile Include="Interop\Interop.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeProcessHandle.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadHandle.cs" />

--- a/src/System.IO.FileSystem/src/Interop/Interop.Windows.cs
+++ b/src/System.IO.FileSystem/src/Interop/Interop.Windows.cs
@@ -373,9 +373,6 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "RemoveDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal static extern bool RemoveDirectory(String path);
 
-        [DllImport("api-ms-win-core-handle-l1-1-0.dll", SetLastError = true)]
-        internal static extern bool CloseHandle(IntPtr handle);
-
         [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "FindFirstFileExW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal static extern SafeFindHandle FindFirstFileEx(String lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, ref WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
 

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -71,6 +71,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.CloseHandle.cs">
+      <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\Interop.FormatMessage.cs</Link>
     </Compile>

--- a/src/System.IO.MemoryMappedFiles/src/Interop/Interop.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/Interop/Interop.Windows.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 internal static partial class Interop
 {
-    private const string HANDLEDLL = "api-ms-win-core-handle-l1-1-0.dll";
     private const string MEMORYDLL = "api-ms-win-core-memory-l1-1-0.dll";
     private const string SYSINFODLL = "api-ms-win-core-sysinfo-l1-1-0.dll";
     //
@@ -234,10 +233,5 @@ internal static partial class Interop
                         UIntPtr dwSize,
                         int flAllocationType,
                         int flProtect);
-
-        [DllImport(HANDLEDLL, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [SecurityCritical]
-        internal static extern bool CloseHandle(IntPtr handle);
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -43,6 +43,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.CloseHandle.cs">
+      <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\Interop.FormatMessage.cs</Link>
     </Compile>

--- a/src/System.IO.Pipes/src/Interop/Interop.Windows.cs
+++ b/src/System.IO.Pipes/src/Interop/Interop.Windows.cs
@@ -143,11 +143,6 @@ internal static partial class Interop
         // Pipe
         //
 
-        [DllImport(HANDLEDLL, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [SecurityCritical]
-        internal static extern bool CloseHandle(IntPtr handle);
-
         [DllImport(PROCESSTHREADSDLL, SetLastError = true)]
         [SecurityCritical]
         internal static extern IntPtr GetCurrentProcess();

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -48,6 +48,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.CloseHandle.cs">
+      <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\Interop.FormatMessage.cs</Link>
     </Compile>


### PR DESCRIPTION
Some projects was using its own definition of `CloseHandle` interops. This commit changes it to use the shared definition from Common folder.