### PR TITLE
System.Reflection.Metadata: fix project ref to Immutable collections

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -177,11 +177,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -41,10 +41,6 @@
       <Project>{f3e433c8-352f-4944-bf7f-765ce435370d}</Project>
       <Name>System.Reflection.Metadata</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.Collections.Immutable\src\System.Collections.Immutable.csproj">
-      <Project>{1DD0FF15-6234-4BD6-850A-317F05479554}</Project>
-      <Name>System.Collections.Immutable</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Metadata\ClassLayoutRow.cs" />

--- a/src/System.Reflection.Metadata/tests/packages.config
+++ b/src/System.Reflection.Metadata/tests/packages.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />
+  <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
It should use the proper NuGet reference instead of a project reference.