### PR TITLE
System.ObjectModel: Add System.Threading to packages.config for tests

### DIFF
--- a/src/System.ObjectModel/tests/packages.config
+++ b/src/System.ObjectModel/tests/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Collections" version="4.0.10-beta-22605" />
   <package id="System.ObjectModel" version="4.0.10-beta-22605" />
   <package id="System.Runtime" version="4.0.20-beta-22605" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />


### PR DESCRIPTION
Needed for the Mono mcs compiler, see #774.