### PR TITLE
Fix build break caused by using defected version of the product

### DIFF
--- a/src/System.Xml.XPath.XDocument.sln
+++ b/src/System.Xml.XPath.XDocument.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22310.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XDocument", "System.Xml.XPath.XDocument\src\System.Xml.XPath.XDocument.csproj", "{DAA1EA56-C318-4D2E-AB8D-1AB87D9F98F5}"
 EndProject
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DAB
 	ProjectSection(SolutionItems) = preProject
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XmlDocument", "System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj", "{17CB2E3C-2904-4241-94DB-3894D24F35DA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +33,10 @@ Global
 		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -212,6 +212,10 @@
       <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
       <Name>XunitTraitsDiscoverers</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj">
+      <Project>{17cb2e3c-2904-4241-94db-3894d24f35da}</Project>
+      <Name>System.Xml.XPath.XmlDocument</Name>
+    </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.XDocument.csproj">
       <Project>{daa1ea56-c318-4d2e-ab8d-1ab87d9f98f5}</Project>
       <Name>System.Xml.XPath.XDocument</Name>

--- a/src/System.Xml.XPath.XDocument/tests/packages.config
+++ b/src/System.Xml.XPath.XDocument/tests/packages.config
@@ -12,7 +12,6 @@
   <package id="System.Xml.XDocument" version="4.0.0-beta-22605" targetFramework="portable-net45+win" />
   <package id="System.Xml.XmlDocument" version="4.0.0-beta-22605" targetFramework="portable-net45+win" />
   <package id="System.Xml.XPath" version="4.0.0-beta-22605" targetFramework="portable-net45+win" />
-  <package id="System.Xml.XPath.XmlDocument" version="4.0.0-beta-22605" targetFramework="portable-net45+win" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
The build break is caused by using binary from the nuget package which doesn't have the newest changes from github.

Issue was fixed here: https://github.com/dotnet/corefx/pull/209

Fixes following issue: https://github.com/dotnet/corefx/issues/949