### PR TITLE
Update the Environment tests to harden them against changes in the environment while they are running

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.ExpandEnvironmentVariables.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ExpandEnvironmentVariables.cs
@@ -22,29 +22,30 @@ public class ExpandEnvironmentVariables
     }
 
     [Fact]
-    public void ExpansionOfAllVariablesReturnedByGetEnvironmentVariablesSucceeds()
+    public void ExpansionOfVariableSucceeds()
     {
-        bool atLeastOne = false;
-        StringBuilder input = new StringBuilder();
-        StringBuilder expected = new StringBuilder();
+        // The test is going to test that we can correctly expand variables.
+        // We are going to do:
+        // envvar1=animal;
+        // and we are going to check that the expanded %envvar1% is animal.
 
-        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        Random r = new Random();
+        string envVar1 = "TestVariable_ExpansionOfVariableSucceeds_" + r.Next().ToString();
+        string expectedValue = "animal";
+
+        try
         {
-            string key = (string)entry.Key;
-            if (key.IndexOf('%') >= 0)
-            {
-                continue;
-            }
+            Environment.SetEnvironmentVariable(envVar1, expectedValue);
 
-            input.Append('%');
-            input.Append(key);
-            input.Append('%');
-            expected.Append((string)entry.Value);
-            atLeastOne = true;
+            string result = Environment.ExpandEnvironmentVariables("%" + envVar1 + "%");
+
+            Assert.Equal(expectedValue, result);
         }
-
-        Assert.True(atLeastOne);
-        Assert.Equal(expected.ToString(), Environment.ExpandEnvironmentVariables(input.ToString()));
+        finally
+        {
+            // Clear the variables we just set
+            Environment.SetEnvironmentVariable(envVar1, null);
+        }
     }
 
     [Fact]

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -78,19 +78,35 @@ public class GetEnvironmentVariable
     [Fact]
     public void CanGetAllVariablesIndividually()
     {
-        bool atLeastOne = false;
+        Random r = new Random();
+        string envVar1 = "TestVariable_CanGetVariablesIndividually_" + r.Next().ToString();
+        string envVar2 = "TestVariable_CanGetVariablesIndividually_" + r.Next().ToString();
 
-        IDictionary envBlock = Environment.GetEnvironmentVariables();
-
-        foreach (DictionaryEntry envEntry in envBlock)
+        try
         {
-            string name = (string)envEntry.Key;
-            string value = Environment.GetEnvironmentVariable(name);
-            Assert.Equal(envEntry.Value, value);
-            atLeastOne = true;
-        }
+            Environment.SetEnvironmentVariable(envVar1, envVar1);
+            Environment.SetEnvironmentVariable(envVar2, envVar2);
 
-        Assert.True(atLeastOne);
+            IDictionary envBlock = Environment.GetEnvironmentVariables();
+
+            // Make sure the environment variables we set are part of the dictionary returned.
+            Assert.True(envBlock.Contains(envVar1));
+            Assert.True(envBlock.Contains(envVar1));
+
+            // Make sure the values match the expected ones.
+            Assert.Equal(envVar1, envBlock[envVar1]);
+            Assert.Equal(envVar2, envBlock[envVar2]);
+
+            // Make sure we can read the individual variables as well
+            Assert.Equal(envVar1, Environment.GetEnvironmentVariable(envVar1));
+            Assert.Equal(envVar2, Environment.GetEnvironmentVariable(envVar2));
+        }
+        finally
+        {
+            // Clear the variables we just set
+            Environment.SetEnvironmentVariable(envVar1, null);
+            Environment.SetEnvironmentVariable(envVar2, null);
+        }
     }
 
     [DllImport("api-ms-win-core-processenvironment-l1-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]


### PR DESCRIPTION
The test can fail if an environment variable is set while it is trying to
enumerate the environment variables.

This change updates the test by explicitly setting and then checking for a fixed
set of environment variables.