### PR TITLE
Significantly improve code coverage performance

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -140,7 +140,7 @@
   <!-- xUnit command line with coverage enabled -->
   <PropertyGroup Condition="$(CoverageEnabledForDir)">
     <CoverageHost>$(CoverageToolPath)</CoverageHost>
-    <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All</CoverageOptions>
+    <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All -threshold:1</CoverageOptions>
     <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user  -target:corerun.exe -output:$(CoverageReportDir)$(TargetFileName).coverage.xml</CoverageCommandLine>
     <TestHost>$(CoverageHost)</TestHost>
     <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>


### PR DESCRIPTION
Our lab code coverage runs are currently taking over an hour.  With this change, they take closer to 15 minutes.

OpenCover supports a threshold on the tracking of how many times a given sequence/branch point is hit (by default, there's no limit). Each time a point is hit, it requires synchronized communication between the profiled app and the profiler host, which causes significant contention when the app has lots of parallelism, e.g. our PLINQ tests.

This change just makes the threshold 1 instead of unlimited, meaning we now only track whether each point is hit, not how many times it's hit.  We can of course revisit this in the future should we start to care about hit counts.

(Thanks to @sawilde for the suggestion.)