### PR TITLE
Use Full NuGet address for NuGet.exe download

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -47,7 +47,7 @@
 
     <!-- Download latest nuget.exe -->
     <DownloadFile FileName="$(NuGetToolPath)"
-                  Address="http://nuget.org/nuget.exe" 
+                  Address="http://www.nuget.org/nuget.exe" 
                   Condition="!Exists('$(NuGetToolPath)')" />
 
     <!-- Restore build tools -->


### PR DESCRIPTION
Some folks and our internal build system have been having issues connecting to nuget.org in order to install nuget.exe. Fully specifying nuget's address seems to clear up these issues, at least in local tests. At the very worst, this should be a harmless change.

@terrajobst , @AlexGhiondea , @weshaggard 