### PR TITLE
Add IsInnerLoopTestProject and IsOuterLoopTestProject property support during the build

### DIFF
--- a/src/Common/tests/XunitTraitsDiscoverers/OuterLoopTestsDiscoverer.cs
+++ b/src/Common/tests/XunitTraitsDiscoverers/OuterLoopTestsDiscoverer.cs
@@ -20,7 +20,7 @@ namespace Xunit.TraitDiscoverers
         /// <returns>The trait values.</returns>
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            yield return new KeyValuePair<string, string>("category", "outerloop");
+            yield return new KeyValuePair<string, string>("category", "OuterLoop");
         }
     }
 }

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Concurrent.Tests</AssemblyName>
     <RootNamespace>System.Collections.Concurrent.Tests</RootNamespace>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Console.Tests</AssemblyName>
     <RootNamespace>System.Console.Tests</RootNamespace>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -13,6 +13,7 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>System.Numerics.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Numerics.Tests</AssemblyName>
     <ProjectGuid>{28AE24F8-BEF4-4358-B612-ADD9D587C8E1}</ProjectGuid>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>System.Threading.Tasks.Dataflow.Tests</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>bcca2a00</NuGetPackageImportStamp>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -9,6 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Parallel.Tests</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Parallel.Tests</AssemblyName>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Xml.XDocument/tests/Properties/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/Properties/FunctionalTests.cs
@@ -16,6 +16,7 @@ namespace CoreXml.Test.XLinq
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         [Fact]
+        [OuterLoop]
         public static void RunTests()
         {
             TestInput.CommandLine = "";

--- a/src/System.Xml.XDocument/tests/Properties/Properties.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/Properties/Properties.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Properties.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/SDMSample/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/SDMSample/FunctionalTests.cs
@@ -12,6 +12,7 @@ namespace CoreXml.Test.XLinq
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         [Fact]
+        [OuterLoop]
         public static void RunTests()
         {
             TestInput.CommandLine = "";

--- a/src/System.Xml.XDocument/tests/SDMSample/SDMSample.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/SDMSample/SDMSample.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>SDMSample.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/Streaming/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/Streaming/FunctionalTests.cs
@@ -16,6 +16,7 @@ namespace CoreXml.Test.XLinq
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
         [Fact]
+        [OuterLoop]
         public static void RunTests()
         {
             TestInput.CommandLine = "";

--- a/src/System.Xml.XDocument/tests/Streaming/Streaming.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/Streaming/Streaming.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Streaming.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/TreeManipulation/TreeManipulation.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/TreeManipulation.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>TreeManipulation.Tests</AssemblyName>
     <RootNamespace>XLinqTests</RootNamespace>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/TreeManipulation/TreeManipulationTests.cs
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/TreeManipulationTests.cs
@@ -9,354 +9,413 @@ namespace XLinqTests
     public class TreeManipulationTests : TestModule
     {
         [Fact]
+        [OuterLoop]
         public static void ConstructorXDocument()
         {
             RunTestCase(new ParamsObjectsCreation { Attribute = new TestCaseAttribute { Name = "Constructors with params - XDocument" } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void ConstructorXElementArray()
         {
             RunTestCase(new ParamsObjectsCreationElem { Attribute = new TestCaseAttribute { Name = "Constructors with params - XElement - array", Param = 0 } }); //Param = InputParamStyle.Array
         }
 
         [Fact]
+        [OuterLoop]
         public static void ConstructorXElementIEnumerable()
         {
             RunTestCase(new ParamsObjectsCreationElem { Attribute = new TestCaseAttribute { Name = "Constructors with params - XElement - IEnumerable", Param = 2 } }); //InputParamStyle.IEnumerable
         }
 
         [Fact]
+        [OuterLoop]
         public static void ConstructorXElementNodeArray()
         {
             RunTestCase(new ParamsObjectsCreationElem { Attribute = new TestCaseAttribute { Name = "Constructors with params - XElement - node + array", Param = 1 } }); //InputParamStyle.SingleAndArray
         }
 
         [Fact]
+        [OuterLoop]
         public static void IEnumerableOfXAttributeRemove()
         {
             RunTestCase(new XAttributeEnumRemove { Attribute = new TestCaseAttribute { Name = "IEnumerable<XAttribute>.Remove()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void IEnumerableOfXAttributeRemoveWithRemove()
         {
             RunTestCase(new XAttributeEnumRemove { Attribute = new TestCaseAttribute { Name = "IEnumerable<XAttribute>.Remove() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void IEnumerableOfXNodeRemove()
         {
             RunTestCase(new XNodeSequenceRemove { Attribute = new TestCaseAttribute { Name = "IEnumerable<XNode>.Remove()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void IEnumerableOfXNodeRemoveWithEvents()
         {
             RunTestCase(new XNodeSequenceRemove { Attribute = new TestCaseAttribute { Name = "IEnumerable<XNode>.Remove() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void LoadFromReader()
         {
             RunTestCase(new LoadFromReader { Attribute = new TestCaseAttribute { Name = "Load from Reader" } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void LoadFromStreamSanity()
         {
             RunTestCase(new LoadFromStream { Attribute = new TestCaseAttribute { Name = "Load from Stream - sanity" } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void SaveWithWriter()
         {
             RunTestCase(new SaveWithWriter { Attribute = new TestCaseAttribute { Name = "Save with Writer" } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void SimpleConstructors()
         {
             RunTestCase(new SimpleObjectsCreation { Attribute = new TestCaseAttribute { Name = "Simple constructors" } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XAttributeRemove()
         {
             RunTestCase(new XAttributeRemove { Attribute = new TestCaseAttribute { Name = "XAttribute.Remove", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XAttributeRemoveWithEvents()
         {
             RunTestCase(new XAttributeRemove { Attribute = new TestCaseAttribute { Name = "XAttribute.Remove with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerAddIntoElement()
         {
             RunTestCase(new XContainerAddIntoElement { Attribute = new TestCaseAttribute { Name = "XContainer.Add1", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerAddIntoDocument()
         {
             RunTestCase(new XContainerAddIntoDocument { Attribute = new TestCaseAttribute { Name = "XContainer.Add2", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerAddFirstInvalidIntoXDocument()
         {
             RunTestCase(new AddFirstInvalidIntoXDocument { Attribute = new TestCaseAttribute { Name = "XContainer.AddFirst", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerAddFirstInvalidIntoXDocumentWithEvents()
         {
             RunTestCase(new AddFirstInvalidIntoXDocument { Attribute = new TestCaseAttribute { Name = "XContainer.AddFirst with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void AddFirstSingeNodeAddIntoElement()
         {
             RunTestCase(new AddFirstSingeNodeAddIntoElement { Attribute = new TestCaseAttribute { Name = "XContainer.AddFirstAddFirstSingeNodeAddIntoElement", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void AddFirstSingeNodeAddIntoElementWithEvents()
         {
             RunTestCase(new AddFirstSingeNodeAddIntoElement { Attribute = new TestCaseAttribute { Name = "XContainer.AddFirstAddFirstSingeNodeAddIntoElement with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void AddFirstAddFirstIntoDocument()
         {
             RunTestCase(new AddFirstAddFirstIntoDocument { Attribute = new TestCaseAttribute { Name = "XContainer.AddFirstAddFirstAddFirstIntoDocument", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void AddFirstAddFirstIntoDocumentWithEvents()
         {
             RunTestCase(new AddFirstAddFirstIntoDocument { Attribute = new TestCaseAttribute { Name = "XContainer.AddFirstAddFirstAddFirstIntoDocument with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerAddIntoElementWithEvents()
         {
             RunTestCase(new XContainerAddIntoElement { Attribute = new TestCaseAttribute { Name = "XContainer.Add with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerAddIntoDocumentWithEvents()
         {
             RunTestCase(new XContainerAddIntoDocument { Attribute = new TestCaseAttribute { Name = "XContainer.Add with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerFirstNode()
         {
             RunTestCase(new FirstNode { Attribute = new TestCaseAttribute { Name = "XContainer.FirstNode", Param = true } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerLastNode()
         {
             RunTestCase(new FirstNode { Attribute = new TestCaseAttribute { Name = "XContainer.LastNode", Param = false } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerNextPreviousNode()
         {
             RunTestCase(new NextNode { Attribute = new TestCaseAttribute { Name = "XContainer.Next/PreviousNode" } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerRemoveNodesOnXElement()
         {
             RunTestCase(new XContainerRemoveNodesOnXElement { Attribute = new TestCaseAttribute { Name = "XContainer.RemoveNodes()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerRemoveNodesOnXElementWithEvents()
         {
             RunTestCase(new XContainerRemoveNodesOnXElement { Attribute = new TestCaseAttribute { Name = "XContainer.RemoveNodes() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerRemoveNodesOnXDocument()
         {
             RunTestCase(new XContainerRemoveNodesOnXDocument { Attribute = new TestCaseAttribute { Name = "XContainer.RemoveNodes()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerRemoveNodesOnXDocumentWithEvents()
         {
             RunTestCase(new XContainerRemoveNodesOnXDocument { Attribute = new TestCaseAttribute { Name = "XContainer.RemoveNodes() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerReplaceNodesOnDocument()
         {
             RunTestCase(new XContainerReplaceNodesOnDocument { Attribute = new TestCaseAttribute { Name = "XContainer.ReplaceNodesOnXDocument()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerReplaceNodesOnDocumentWithEvents()
         {
             RunTestCase(new XContainerReplaceNodesOnDocument { Attribute = new TestCaseAttribute { Name = "XContainer.ReplaceNodesOnXDocument() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerReplaceNodesOnXElement()
         {
             RunTestCase(new XContainerReplaceNodesOnXElement { Attribute = new TestCaseAttribute { Name = "XContainer.ReplaceNodesOnXElement()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XContainerReplaceNodesOnXElementWithEvents()
         {
             RunTestCase(new XContainerReplaceNodesOnXElement { Attribute = new TestCaseAttribute { Name = "XContainer.ReplaceNodesOnXElement() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XElementRemoveAttributes()
         {
             RunTestCase(new RemoveAttributes { Attribute = new TestCaseAttribute { Name = "XElement.RemoveAttributes", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XElementRemoveAttributesWithEvents()
         {
             RunTestCase(new RemoveAttributes { Attribute = new TestCaseAttribute { Name = "XElement.RemoveAttributes with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XElementSetAttributeValue()
         {
             RunTestCase(new XElement_SetAttributeValue { Attribute = new TestCaseAttribute { Name = "XElement.SetAttributeValue()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XElementSetAttributeValueWithEvents()
         {
             RunTestCase(new XElement_SetAttributeValue { Attribute = new TestCaseAttribute { Name = "XElement.SetAttributeValue() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XElementSetElementValue()
         {
             RunTestCase(new XElement_SetElementValue { Attribute = new TestCaseAttribute { Name = "XElement.SetElementValue()", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XElementSetElementValueWithEvents()
         {
             RunTestCase(new XElement_SetElementValue { Attribute = new TestCaseAttribute { Name = "XElement.SetElementValue() with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeAddAfter()
         {
             RunTestCase(new AddNodeAfter { Attribute = new TestCaseAttribute { Name = "XNode.AddAfter", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeAddAfterWithEvents()
         {
             RunTestCase(new AddNodeAfter { Attribute = new TestCaseAttribute { Name = "XNode.AddAfter with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeAddBefore()
         {
             RunTestCase(new AddNodeBefore { Attribute = new TestCaseAttribute { Name = "XNode.AddBefore", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeAddBeforeWithEvents()
         {
             RunTestCase(new AddNodeBefore { Attribute = new TestCaseAttribute { Name = "XNode.AddBefore with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeRemoveNodeMisc()
         {
             RunTestCase(new XNodeRemoveNodeMisc { Attribute = new TestCaseAttribute { Name = "XNode.Remove", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeRemoveNodeMiscWithEvents()
         {
             RunTestCase(new XNodeRemoveNodeMisc { Attribute = new TestCaseAttribute { Name = "XNode.Remove with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeRemoveOnDocument()
         {
             RunTestCase(new XNodeRemoveOnDocument { Attribute = new TestCaseAttribute { Name = "XNode.Remove", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeRemoveOnDocumentWithEvents()
         {
             RunTestCase(new XNodeRemoveOnDocument { Attribute = new TestCaseAttribute { Name = "XNode.Remove with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeRemoveOnElement()
         {
             RunTestCase(new XNodeRemoveOnElement { Attribute = new TestCaseAttribute { Name = "XNode.Remove", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeRemoveOnElementWithEvents()
         {
             RunTestCase(new XNodeRemoveOnElement { Attribute = new TestCaseAttribute { Name = "XNode.Remove with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnDocument1()
         {
             RunTestCase(new XNodeReplaceOnDocument1 { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnDocument1WithEvents()
         {
             RunTestCase(new XNodeReplaceOnDocument1 { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnDocument2()
         {
             RunTestCase(new XNodeReplaceOnDocument2 { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnDocument2WithEvents()
         {
             RunTestCase(new XNodeReplaceOnDocument2 { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnDocument3()
         {
             RunTestCase(new XNodeReplaceOnDocument3 { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnDocument3WithEvents()
         {
             RunTestCase(new XNodeReplaceOnDocument3 { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith with Events", Params = new object[] { true } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnElement()
         {
             RunTestCase(new XNodeReplaceOnElement { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith", Params = new object[] { false } } });
         }
 
         [Fact]
+        [OuterLoop]
         public static void XNodeReplaceOnElementWithEvents()
         {
             RunTestCase(new XNodeReplaceOnElement { Attribute = new TestCaseAttribute { Name = "XNode.ReplaceWith with Events", Params = new object[] { true } } });

--- a/src/System.Xml.XDocument/tests/events/Events.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/events/Events.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Events.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
     <ProjectGuid>{C560E194-5B14-4112-ABC6-3208491E53E6}</ProjectGuid>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/events/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/events/FunctionalTests.cs
@@ -13,6 +13,7 @@ namespace CoreXml.Test.XLinq
     {
         // Type is CoreXml.Test.XLinq.FunctionalTests
         [Fact]
+        [OuterLoop]
         public static void RunTests()
         {
             TestInput.CommandLine = "";

--- a/src/System.Xml.XDocument/tests/misc/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/misc/FunctionalTests.cs
@@ -14,6 +14,7 @@ namespace CoreXml.Test.XLinq
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
         [Fact]
+        [OuterLoop]
         public static void RunTests()
         {
             TestInput.CommandLine = "";

--- a/src/System.Xml.XDocument/tests/misc/Misc.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/misc/Misc.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Misc.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/FunctionalTests.cs
@@ -17,6 +17,7 @@ namespace CoreXml.Test.XLinq
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
         [Fact]
+        [OuterLoop]
         [ActiveIssue(641)]
         public static void RunTests()
         {

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/xNodeBuilder.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/xNodeBuilder.Tests.csproj
@@ -13,6 +13,7 @@
       Disable running tests for this project as most of them are failing because of the infrastructure issue
       https://github.com/dotnet/corefx/issues/641
     -->
+    <TestCategories>OuterLoop</TestCategories>
     <RunTestsForProject>False</RunTestsForProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Xml.XDocument/tests/xNodeReader/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/xNodeReader/FunctionalTests.cs
@@ -16,6 +16,7 @@ namespace CoreXml.Test.XLinq
         // Type is CoreXml.Test.XLinq.FunctionalTests
         // Test Module
         [Fact]
+        [OuterLoop]
         public static void RunTests()
         {
             TestInput.CommandLine = "";

--- a/src/System.Xml.XDocument/tests/xNodeReader/xNodeReader.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/xNodeReader/xNodeReader.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>xNodeReader.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
+    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XDocument.Tests</RootNamespace>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XmlDocument.Tests</RootNamespace>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
+++ b/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.Tests</RootNamespace>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XmlDocument.UnitTests</RootNamespace>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -97,10 +97,7 @@
 
   <PropertyGroup>
     <IsTestProject Condition="'$(IsTestProject)'=='' And $(MSBuildProjectName.EndsWith('.Tests'))">True</IsTestProject>
-    <RunTestsForProject Condition="'$(RunTestsForProject)'=='' and '$(IsTestProject)'=='True'">True</RunTestsForProject>
-    <RunTestsForProject Condition="'$(SkipTests)'=='True'">False</RunTestsForProject>
-
-    <CLSCompliant Condition="'$(IsTestProject)'=='true'">false</CLSCompliant>
+    <CLSCompliant Condition="'$(IsTestProject)'=='True'">false</CLSCompliant>
   </PropertyGroup>
 
   <!-- VS does not evaluate the conditions when loading the projects and so we add this via a target file and import it with a condition -->
@@ -134,11 +131,25 @@
     <Copy SourceFiles="$(TestRuntimePackageConfig)" DestinationFiles="$(TestRuntimePackageSemaphore)" ContinueOnError="true" />
   </Target>
 
+  <!-- Which categories of tests to run by default -->
+  <PropertyGroup>
+    <RunTestsWithCategories Condition="'$(RunTestsWithCategories)' == '' And '$(RunTestsWithoutCategories)' == ''">InnerLoop</RunTestsWithCategories>
+    <TestCategories Condition="'$(TestCategories)'==''">InnerLoop</TestCategories>
+
+    <TestDisabled>False</TestDisabled>
+    <TestDisabled Condition="'$(IsTestProject)'!='True' Or '$(SkipTests)'=='True' Or '$(RunTestsForProject)'=='False'">True</TestDisabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Split semicolon separated lists -->
+    <TestCategoriesItems Include="$(TestCategories)" />
+    <RunTestsWithCategoriesItems Include="$(RunTestsWithCategories)" />
+    <RunTestsWithoutCategoriesItems Include="$(RunTestsWithoutCategories)" />
+  </ItemGroup>
+
   <!-- General xunit options -->
   <PropertyGroup>
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
-    <RunOuterLoop Condition="'$(RunOuterLoop)' == ''">False</RunOuterLoop>
-    <XunitOptions Condition="'$(RunOuterLoop)'!='True'">$(XunitOptions) -notrait category=outerloop</XunitOptions>
     <XunitOptions>$(XunitOptions) -xml .\testResults.xml</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
   </PropertyGroup>
@@ -146,24 +157,11 @@
   <!-- Directory specific coverage options -->
   <PropertyGroup>
     <CoverageEnabledForProject Condition="'$(CoverageEnabledForProject)'=='' and '$(IsTestProject)'=='true'">$(_CoverageEnabled)</CoverageEnabledForProject>
-  </PropertyGroup>
-
-  <!-- xUnit command line without coverage enabled -->
-  <PropertyGroup>
     <XunitHost>corerun.exe</XunitHost>
-    <TestHost>$(XunitHost)</TestHost>
-    <TestCommandLine>$(XunitCommandLine) $(XunitOptions)</TestCommandLine>
-  </PropertyGroup>
-  
-  <!-- xUnit command line with coverage enabled -->
-  <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">
     <CoverageHost>$(CoverageToolPath)</CoverageHost>
     <CoverageOutputFilePath>$(CoverageReportDir)$(MSBuildProjectName).coverage.xml</CoverageOutputFilePath>
     <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All -threshold:1</CoverageOptions>
     <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user -target:$(XunitHost) -output:$(CoverageOutputFilePath)</CoverageCommandLine>
-    <TestHost>$(CoverageHost)</TestHost>
-    <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>
-    <TestCommandLine>$(CoverageCommandLine) -targetargs:"$(TestCommandLine)"</TestCommandLine>
   </PropertyGroup>
   
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
@@ -178,8 +176,26 @@
 
   <!-- On command line run unit tests on CoreCLR after the Test target -->
   <Target Name="RunTestsForProject"
-          AfterTargets="Test"
-          Condition="'$(RunTestsForProject)'=='true'">
+          AfterTargets="CheckTestCategories"
+          Condition="'$(TestDisabled)'!='True'">
+
+    <PropertyGroup>
+      <XunitOptions Condition="'@(RunWithTraits)'!=''">$(XunitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitOptions>
+      <XunitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitOptions>
+    </PropertyGroup>
+
+    <!-- xUnit command line without coverage enabled -->
+    <PropertyGroup>
+      <TestHost>$(XunitHost)</TestHost>
+      <TestCommandLine>$(XunitCommandLine) $(XunitOptions)</TestCommandLine>
+    </PropertyGroup>
+    
+    <!-- xUnit command line with coverage enabled -->
+    <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">
+      <TestHost>$(CoverageHost)</TestHost>
+      <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>
+      <TestCommandLine>$(CoverageCommandLine) -targetargs:"$(TestCommandLine)"</TestCommandLine>
+    </PropertyGroup>
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
@@ -190,6 +206,35 @@
     </Exec>
 
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
+  </Target>
+
+  <Target Name="CheckTestCategories"
+          AfterTargets="Test"
+          Condition="'$(TestDisabled)'!='True'">
+
+    <Error Condition="'$(RunTestsWithCategories)' != '' And '$(RunTestsWithoutCategories)' != ''"
+           Text="Specifying both RunTestsWithCategories and RunTestsWithoutCategories is not supported please only specify one or the other." />
+
+    <ItemGroup Condition="'@(RunTestsWithCategoriesItems)'!=''">
+      <!-- Intersection of TestCategoriesItems and RunTestsWithCategoriesItems -->
+      <TestCategoriesToRun Include="@(TestCategoriesItems)" Condition="'@(RunTestsWithCategoriesItems)'=='%(Identity)'" />
+    </ItemGroup>
+    <ItemGroup Condition="'@(RunTestsWithoutCategoriesItems)'!=''">
+      <!-- Run all test categories except specified -->
+      <TestCategoriesToRun Include="@(TestCategoriesItems)" Exclude="@(RunTestsWithoutCategoriesItems)" />
+    </ItemGroup>
+    <ItemGroup>
+      <RunWithInnerLoopItems Include="@(TestCategoriesToRun)" Condition="'%(TestCategoriesToRun.Identity)'=='InnerLoop'" />
+      
+      <RunWithTraits Condition="'@(RunWithInnerLoopItems)'==''" Include="@(TestCategoriesToRun)" />
+
+      <RunWithoutTraits Condition="'@(RunWithInnerLoopItems)'!=''" Include="@(TestCategoriesItems)" />
+      <RunWithoutTraits Condition="'@(RunWithInnerLoopItems)'!=''" Remove="@(TestCategoriesToRun)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <!-- If there is nothing to run then disable the test -->
+      <TestDisabled Condition="'@(TestCategoriesToRun)'==''">True</TestDisabled>
+    </PropertyGroup>
   </Target>
 
   <!-- Generate coverage reports for individual projects. -->


### PR DESCRIPTION
Add properties to disable selected projects from Inner- or Outer- loop run. By default all projects are Inner-loop. You can disable it from particular run by explicitly setting TestCategories property

<!---
@huboard:{"order":843.25,"milestone_order":961}
-->
