### PR TITLE
Switch from Touch to Copy for the restore semaphore files

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -62,7 +62,7 @@
   <PropertyGroup>
     <PackagesConfig Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfig>
     <RestorePackages Condition="'$(RestorePackages)' == '' and Exists('$(PackagesConfig)')">true</RestorePackages>
-    <RestorePackagesSemaphore>$(PackagesDir)$(MSBuildProjectFile).package.restored</RestorePackagesSemaphore>
+    <RestorePackagesSemaphore>$(PackagesDir)$(MSBuildProjectFile)-packages.config</RestorePackagesSemaphore>
   </PropertyGroup>
 
   <Target Name="RestorePackages" 
@@ -71,7 +71,7 @@
           Outputs="$(RestorePackagesSemaphore)"
           Condition="'$(RestorePackages)' == 'true'">
     <Exec Command="$(NugetRestoreCommand) &quot;$(PackagesConfig)&quot;" StandardOutputImportance="Low" />
-    <Touch Files="$(RestorePackagesSemaphore)" AlwaysCreate="true" />
+    <Copy SourceFiles="$(PackagesConfig)" DestinationFiles="$(RestorePackagesSemaphore)" ContinueOnError="True" />
   </Target>
 
   <Import Project="$(ToolsDir)packageresolve.targets" Condition="Exists('$(ToolsDir)packageresolve.targets')" />
@@ -103,7 +103,7 @@
 
   <PropertyGroup>
     <TestRuntimePackageConfig>$(ToolsDir)test-runtime\packages.config</TestRuntimePackageConfig>
-    <TestRuntimePackageSemaphore>$(PackagesDir)Test-Runtime.package.restored</TestRuntimePackageSemaphore>
+    <TestRuntimePackageSemaphore>$(PackagesDir)Test-Runtime-packages.config</TestRuntimePackageSemaphore>
   </PropertyGroup>
 
   <Target Name="RestoreTestRuntimePackage" 
@@ -112,7 +112,7 @@
           Outputs="$(TestRuntimePackageSemaphore)"
           Condition="'$(IsTestProject)' == 'true'">
     <Exec Command="$(NugetRestoreCommand) &quot;$(TestRuntimePackageConfig)&quot;" StandardOutputImportance="Low" />
-    <Touch Files="$(TestRuntimePackageSemaphore)" AlwaysCreate="true" />
+    <Copy SourceFiles="$(TestRuntimePackageConfig)" DestinationFiles="$(TestRuntimePackageSemaphore)" ContinueOnError="true" />
   </Target>
 
   <!-- General xunit options -->


### PR DESCRIPTION
There have been a couple failures due to the race condition for
restoring the test-runtime.packages.confg file. When two or more
tasks are trying to Touch the semaphore file at the same time it
errors out. This commit switches to using Copy with ignore errors
because that is more resilient and it is OK if we restore the
packages more than once.

It is also now copying the actual packages.config file as well
so it leaves a trail of which projects restored which packages.