### PR TITLE
Fix Dataflow ETW provider

### DIFF
--- a/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
+++ b/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.Diagnostics.Tracing
+{
+    /// <summary>Simple event listener than invokes a callback for each event received.</summary>
+    internal sealed class TestEventListener : EventListener
+    {
+        private readonly Guid _targetSourceGuid;
+        private readonly EventLevel _level;
+
+        private Action<EventWrittenEventArgs> _eventWritten;
+        private List<EventSource> _tmpEventSourceList = new List<EventSource>();
+
+        public TestEventListener(Guid targetSourceGuid, EventLevel level)
+        {
+            // Store the arguments
+            _targetSourceGuid = targetSourceGuid;
+            _level = level;
+
+            // The base constructor, which is called before this constructor,
+            // will invoke the virtual OnEventSourceCreated method for each
+            // existing EventSource, which means OnEventSourceCreated will be
+            // called before _targetSourceGuid and _level have been set.  As such,
+            // we store a temporary list that just exists from the moment this instance
+            // is created (instance field initializers run before the base constructor)
+            // and until we finish construction... in that window, OnEventSourceCreated
+            // will store the sources into the list rather than try to enable them directly,
+            // and then here we can enumerate that list, then clear it out.
+            foreach (var source in _tmpEventSourceList)
+            {
+                EnableSourceIfMatch(source);
+            }
+            _tmpEventSourceList = null;
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (_tmpEventSourceList != null)
+            {
+                _tmpEventSourceList.Add(eventSource);
+            }
+            else
+            {
+                EnableSourceIfMatch(eventSource);
+            }
+        }
+
+        private void EnableSourceIfMatch(EventSource source)
+        {
+            if (source.Guid.Equals(_targetSourceGuid))
+            {
+                EnableEvents(source, _level);
+            }
+        }
+
+        public void RunWithCallback(Action<EventWrittenEventArgs> handler, Action body)
+        {
+            _eventWritten = handler;
+            try { body(); }
+            finally { _eventWritten = null; }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            Action<EventWrittenEventArgs> callback = _eventWritten;
+            if (callback != null)
+            {
+                callback(eventData);
+            }
+        }
+    }
+
+}

--- a/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
+++ b/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
@@ -8,11 +8,21 @@ namespace System.Diagnostics.Tracing
     /// <summary>Simple event listener than invokes a callback for each event received.</summary>
     internal sealed class TestEventListener : EventListener
     {
+        private readonly string _targetSourceName;
         private readonly Guid _targetSourceGuid;
         private readonly EventLevel _level;
 
         private Action<EventWrittenEventArgs> _eventWritten;
         private List<EventSource> _tmpEventSourceList = new List<EventSource>();
+
+        public TestEventListener(string taretSourceName, EventLevel level)
+        {
+            // Store the arguments
+            _targetSourceName = taretSourceName;
+            _level = level;
+
+            LoadSourceList();
+        }
 
         public TestEventListener(Guid targetSourceGuid, EventLevel level)
         {
@@ -20,6 +30,11 @@ namespace System.Diagnostics.Tracing
             _targetSourceGuid = targetSourceGuid;
             _level = level;
 
+            LoadSourceList();
+        }
+
+        private void LoadSourceList()
+        {
             // The base constructor, which is called before this constructor,
             // will invoke the virtual OnEventSourceCreated method for each
             // existing EventSource, which means OnEventSourceCreated will be
@@ -50,7 +65,8 @@ namespace System.Diagnostics.Tracing
 
         private void EnableSourceIfMatch(EventSource source)
         {
-            if (source.Guid.Equals(_targetSourceGuid))
+            if (source.Name.Equals(_targetSourceName) || 
+                source.Guid.Equals(_targetSourceGuid))
             {
                 EnableEvents(source, _level);
             }

--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
     <RootNamespace>System.Collections.Concurrent</RootNamespace>
+    <DefineConstants>FEATURE_TRACING</DefineConstants>
   </PropertyGroup>
     <!-- Default configurations to help VS understand the configurations -->
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections.Concurrent/tests/EtwTests.cs
+++ b/src/System.Collections.Concurrent/tests/EtwTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Concurrent.Tests
+{
+    public class EtwTests
+    {
+        [Fact]
+        public void TestEtw()
+        {
+            using (var listener = new TestEventListener("System.Collections.Concurrent.ConcurrentCollectionsEventSource", EventLevel.Verbose))
+            {
+                var events = new ConcurrentQueue<int>();
+
+                const int AcquiringAllLocksEventId = 3;
+                Clear(events);
+                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                {
+                    var cd = new ConcurrentDictionary<int, int>();
+                    cd.TryAdd(1, 1);
+                    cd.Clear();
+                });
+                Assert.True(events.Count(i => i == AcquiringAllLocksEventId) > 0);
+
+                const int TryTakeStealsEventId = 4;
+                const int TryPeekStealsEventId = 5;
+                Clear(events);
+                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                {
+                    var cb = new ConcurrentBag<int>();
+                    int item;
+                    cb.TryPeek(out item);
+                    cb.TryTake(out item);
+                });
+                Assert.True(events.Count(i => i == TryPeekStealsEventId) > 0);
+                Assert.True(events.Count(i => i == TryTakeStealsEventId) > 0);
+
+                // No tests for:
+                //      CONCURRENTSTACK_FASTPUSHFAILED_ID
+                //      CONCURRENTSTACK_FASTPOPFAILED_ID
+                // These require certain race condition interleavings in order to fire.
+            }
+        }
+
+        private static void Clear<T>(ConcurrentQueue<T> queue)
+        {
+            T item;
+            while (queue.TryDequeue(out item)) ;
+        }
+    }
+}

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -15,12 +15,16 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
     <Compile Include="BlockingCollectionCancellationTests.cs" />
     <Compile Include="BlockingCollectionTests.cs" />
     <Compile Include="ConcurrentBagTests.cs" />
     <Compile Include="ConcurrentDictionaryTests.cs" />
     <Compile Include="ConcurrentQueueTests.cs" />
     <Compile Include="ConcurrentStackTests.cs" />
+    <Compile Include="EtwTests.cs" />
     <Compile Include="IntRangePartitionerTests.cs" />
     <Compile Include="LongRangePartitionerTests.cs" />
     <Compile Include="PartitionerStaticTests.cs" />

--- a/src/System.Collections.Concurrent/tests/packages.config
+++ b/src/System.Collections.Concurrent/tests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Console" version="4.0.0-beta-22512" />
+  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22512" />
+  <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
   <package id="System.Threading" version="4.0.0-beta-22512" />

--- a/src/System.Linq.Parallel/tests/EtwTests.cs
+++ b/src/System.Linq.Parallel/tests/EtwTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using Xunit;
+
+namespace Test
+{
+    public class EtwTests
+    {
+        [Fact]
+        public void TestEtw()
+        {
+            using (var listener = new TestEventListener(new Guid("159eeeec-4a14-4418-a8fe-faabcd987887"), EventLevel.Verbose))
+            {
+                var events = new ConcurrentQueue<int>();
+                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () => {
+                    Enumerable.Range(0, 10000).AsParallel().Select(i => i).ToArray();
+                });
+
+                const int BeginEventId = 1;
+                Assert.Equal(expected: 1, actual: events.Count(i => i == BeginEventId));
+
+                const int EndEventId = 2;
+                Assert.Equal(expected: 1, actual: events.Count(i => i == EndEventId));
+
+                const int ForkEventId = 3;
+                const int JoinEventId = 4;
+                Assert.True(events.Count(i => i == ForkEventId) > 0);
+                Assert.Equal(events.Count(i => i == ForkEventId), events.Count(i => i == JoinEventId));
+            }
+        }
+
+    }
+}

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -21,6 +21,9 @@
   </PropertyGroup>
   <!-- Compiled Source Files -->
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
     <Compile Include="AggregateTests.cs" />
     <Compile Include="AllAnyTests.cs" />
     <Compile Include="AverageMaxMinTests.cs" />
@@ -29,6 +32,7 @@
     <Compile Include="CountTests.cs" />
     <Compile Include="DegreeOfParallelismTests.cs" />
     <Compile Include="ElementAtPartitionerTests.cs" />
+    <Compile Include="EtwTests.cs" />
     <Compile Include="ExceptConcatReverseTests.cs" />
     <Compile Include="ExceptionAndParallelEnumerableExceptionTests.cs" />
     <Compile Include="ExchangeTests.cs" />
@@ -55,9 +59,9 @@
   </ItemGroup>
   <!-- Common or Common-branched source files -->
   <ItemGroup>
-      <Compile Include="$(CommonTestPath)\System\Console.cs" />
+    <Compile Include="$(CommonTestPath)\System\Console.cs" />
   </ItemGroup>
- <!-- References are resolved from packages.config -->
+  <!-- References are resolved from packages.config -->
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">
       <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>

--- a/src/System.Linq.Parallel/tests/packages.config
+++ b/src/System.Linq.Parallel/tests/packages.config
@@ -4,6 +4,7 @@
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22512" />
   <package id="System.Diagnostics.Tools" version="4.0.0-beta-22512" />
+  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22512" />
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
@@ -26,7 +26,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
     [EventSource(
         Name = "System.Threading.Tasks.Dataflow.DataflowEventSource",
         Guid = "16F53577-E41D-43D4-B47E-C17025BF4025",
-        LocalizationResources = "System.Threading.Tasks.Dataflow.Resources")]
+        LocalizationResources = "System.Threading.Tasks.Dataflow.Resources.Strings")]
     internal sealed class DataflowEtwProvider : EventSource
     {
         /// <summary>

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using Xunit;
+
+namespace System.Threading.Tasks.Dataflow.Tests
+{
+    public class EtwTests
+    {
+        [Fact]
+        public void TestEtw()
+        {
+            using (var listener = new TestEventListener(new Guid("16F53577-E41D-43D4-B47E-C17025BF4025"), EventLevel.Verbose))
+            {
+                ActionBlock<int> ab = null;
+                BufferBlock<int> bb = null;
+                int remaining = 0;
+                CountdownEvent ce = new CountdownEvent(0);
+
+                // Check that block creation events fire
+                const int DataflowBlockCreatedId = 1;
+                remaining = 2;
+                listener.RunWithCallback(ev => {
+                        Assert.Equal(expected: DataflowBlockCreatedId, actual: ev.EventId);
+                        remaining--;
+                    },
+                    () => {
+                        ab = new ActionBlock<int>(i => { });
+                        bb = new BufferBlock<int>(); // trigger block creation event
+                        Assert.Equal(expected: 0, actual: remaining);
+                    });
+
+                // Check that linking events fire
+                const int BlockLinkedId = 4;
+                remaining = 1;
+                IDisposable link = null;
+                listener.RunWithCallback(ev => {
+                        Assert.Equal(expected: BlockLinkedId, actual: ev.EventId);
+                        remaining--;
+                    },
+                    () => {
+                        link = bb.LinkTo(ab);
+                        Assert.Equal(expected: 0, actual: remaining);
+                    });
+
+                // Check that unlinking events fire
+                const int BlockUnlinkedId = 5;
+                remaining = 1;
+                listener.RunWithCallback(ev => {
+                        Assert.Equal(expected: BlockUnlinkedId, actual: ev.EventId);
+                        remaining--;
+                    },
+                    () => {
+                        link.Dispose();
+                        Assert.Equal(expected: 0, actual: remaining);
+                    });
+
+                // Bug: It appears that private reflection problems are causing events with enum arguments
+                //      to fail to fire on .NET Core.  Needs further investigation.  The following
+                //      two tests are disabled as a result.
+
+                //// Check that task launched events fire
+                //const int TaskLaunchedId = 2;
+                //ce.Reset(1);
+                //listener.RunWithCallback(ev => {
+                //        Assert.Equal(expected: TaskLaunchedId, actual: ev.EventId);
+                //        ce.Signal();
+                //    },
+                //    () => {
+                //        ab.Post(42);
+                //        ce.Wait();
+                //        Assert.Equal(expected: 0, actual: ce.CurrentCount);
+                //    });
+
+                //// Check that completion events fire
+                //const int BlockCompletedId = 3;
+                //ce.Reset(2);
+                //listener.RunWithCallback(ev => {
+                //        Assert.Equal(expected: BlockCompletedId, actual: ev.EventId);
+                //        ce.Signal();
+                //    },
+                //    () => {
+                //        ab.Complete();
+                //        bb.Complete();
+                //        ce.Wait();
+                //        Assert.Equal(expected: 0, actual: ce.CurrentCount);
+                //    });
+
+            }
+        }
+
+    }
+}

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/XunitAssemblyAttributes.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/XunitAssemblyAttributes.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+// Disabling parallelization until xunit provides a more fine-grained mechanism for allowing
+// certain tests to not run in parallel with any others, while still allowing for those others
+// to run in parallel with each other.  This is required for the ETW tests, which interact with
+// global state and thus can't run concurrently with any other tests.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -19,6 +19,9 @@
   <!-- References are resolved from packages.config -->
   <ItemGroup>
     <Compile Include="Dataflow\*.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">

--- a/src/System.Threading.Tasks.Dataflow/tests/packages.config
+++ b/src/System.Threading.Tasks.Dataflow/tests/packages.config
@@ -6,6 +6,7 @@
   <package id="System.Console" version="4.0.0-beta-22512" />
   <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22512" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22512" />
+  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22512" />
   <package id="System.Dynamic.Runtime" version="4.0.0-beta-22512" />
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Reflection" version="4.0.10-beta-22512" />

--- a/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace System.Threading.Tasks.Test.Unit
+{
+    public class EtwTests
+    {
+        [Fact]
+        public void TestEtw()
+        {
+            using (var listener = new TestEventListener("System.Threading.Tasks.Parallel.EventSource", EventLevel.Verbose))
+            {
+                var events = new ConcurrentQueue<int>();
+                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () => {
+                    Parallel.For(0, 10000, i => { });
+
+                    var barrier = new Barrier(2);
+                    Parallel.Invoke(
+                        () => barrier.SignalAndWait(),
+                        () => barrier.SignalAndWait());
+                });
+
+                const int BeginLoopEventId = 1;
+                const int BeginInvokeEventId = 3;
+                Assert.Equal(expected: 1, actual: events.Count(i => i == BeginLoopEventId));
+                Assert.Equal(expected: 1, actual: events.Count(i => i == BeginInvokeEventId));
+
+                const int EndLoopEventId = 2;
+                const int EndInvokeEventId = 4;
+                Assert.Equal(expected: 1, actual: events.Count(i => i == EndLoopEventId));
+                Assert.Equal(expected: 1, actual: events.Count(i => i == EndInvokeEventId));
+
+                const int ForkEventId = 5;
+                const int JoinEventId = 6;
+                Assert.True(events.Count(i => i == ForkEventId) >= 1);
+                Assert.Equal(events.Count(i => i == ForkEventId), events.Count(i => i == JoinEventId));
+            }
+        }
+    }
+}

--- a/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -18,7 +18,11 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
     <Compile Include="BreakTests.cs" />
+    <Compile Include="EtwTests.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="ParallelFor.cs" />
     <Compile Include="ParallelForBoundary.cs" />
@@ -32,6 +36,7 @@
     <Compile Include="RangePartitionerTests.cs" />
     <Compile Include="RangePartitionerThreadSafetyTests.cs" />
     <Compile Include="RespectParentCancellationTest.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">

--- a/src/System.Threading.Tasks.Parallel/tests/XunitAssemblyAttributes.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/XunitAssemblyAttributes.cs
@@ -3,8 +3,6 @@
 
 using Xunit;
 
-// Tests could run slower if PLINQ itself is run in parallel, especially as concurrent
-// queries compete for thread pool resources.  Further, the ETW tests must not be run
-// concurrently with any other tests.
+// Parallel loops are more likely to be serialized if tests are allowed to run in parallel.
+// Further, ETW tests must not be run concurrently with any other tests.
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]
-

--- a/src/System.Threading.Tasks.Parallel/tests/packages.config
+++ b/src/System.Threading.Tasks.Parallel/tests/packages.config
@@ -3,6 +3,7 @@
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22512" />
+  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22512" />
   <package id="System.Linq" version="4.0.0-beta-22512" />
   <package id="System.Runtime" version="4.0.20-beta-22512" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />


### PR DESCRIPTION
Dataflow's ETW provider is broken due to not having the correct localized resource name; attempting to enable ETW tracing will cause the library to fail with resource-related exceptions.

This commit fixes that and adds some basic ETW tests to ensure that the EventSource is properly tracing events.