### PR TITLE
Fill System.Runtime.Extensions test gaps

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -17,8 +17,11 @@
   </PropertyGroup>
   <!-- References are resolved from packages.config -->
   <ItemGroup>
+    <Compile Include="System\Diagnostics\Stopwatch.cs" />
+    <Compile Include="System\IO\Path.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
+    <Compile Include="System\BitConverter.cs" />
     <Compile Include="System\Convert.BoxedObjectCheck.cs" />
     <Compile Include="System\Convert.FromBase64.cs" />
     <Compile Include="System\Convert.TestBase.cs" />
@@ -42,6 +45,9 @@
     <Compile Include="System\Environment.ExpandEnvironmentVariables.cs" />
     <Compile Include="System\Environment.GetEnvironmentVariable.cs" />
     <Compile Include="System\Environment.SetEnvironmentVariable.cs" />
+    <Compile Include="System\Math.cs" />
+    <Compile Include="System\Random.cs" />
+    <Compile Include="System\StringComparer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">
@@ -56,3 +62,4 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
+

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -18,6 +18,7 @@
   <!-- References are resolved from packages.config -->
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
+    <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\Path.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
@@ -62,4 +63,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
-

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -2,157 +2,128 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
-public static unsafe class BitConverterTests
+public static class BitConverterTests
 {
     [Fact]
-    public static void TestBitConverter()
+    public static void DoubleToInt64Bits()
     {
+        Double input = 123456.3234;
+        Int64 result = BitConverter.DoubleToInt64Bits(input);
+        Assert.Equal(4683220267154373240L, result);
+        Double roundtripped = BitConverter.Int64BitsToDouble(result);
+        Assert.Equal(input, roundtripped);
+    }
+
+    [Fact]
+    public static void RoundtripBoolean()
+    {
+        Byte[] bytes = BitConverter.GetBytes(true);
+        Assert.Equal(1, bytes.Length);
+        Assert.Equal(1, bytes[0]);
+        Assert.True(BitConverter.ToBoolean(bytes, 0));
+
+        bytes = BitConverter.GetBytes(false);
+        Assert.Equal(1, bytes.Length);
+        Assert.Equal(0, bytes[0]);
+        Assert.False(BitConverter.ToBoolean(bytes, 0));
+    }
+
+    [Fact]
+    public static void RoundtripChar()
+    {
+        Char input = 'A';
+        Byte[] expected = { 0x41, 0 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToChar, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripDouble()
+    {
+        Double input = 123456.3234;
+        Byte[] expected = { 0x78, 0x7a, 0xa5, 0x2c, 0x05, 0x24, 0xfe, 0x40 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToDouble, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripSingle()
+    {
+        Single input = 8392.34f;
+        Byte[] expected = { 0x5c, 0x21, 0x03, 0x46 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToSingle, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripInt16()
+    {
+        Int16 input = 0x1234;
+        Byte[] expected = { 0x34, 0x12 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt16, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripInt32()
+    {
+        Int32 input = 0x12345678;
+        Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt32, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripInt64()
+    {
+        Int64 input = 0x0123456789abcdef;
+        Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt64, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripUInt16()
+    {
+        UInt16 input = 0x1234;
+        Byte[] expected = { 0x34, 0x12 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt16, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripUInt32()
+    {
+        UInt32 input = 0x12345678;
+        Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt32, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripUInt64()
+    {
+        UInt64 input = 0x0123456789abcdef;
+        Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt64, input, expected);
+    }
+
+    [Fact]
+    public static void RoundtripString()
+    {
+        Byte[] bytes = { 0x12, 0x34, 0x56, 0x78, 0x9a };
+
+        Assert.Equal("12-34-56-78-9A", BitConverter.ToString(bytes));
+        Assert.Equal("56-78-9A", BitConverter.ToString(bytes, 2));
+        Assert.Equal("56", BitConverter.ToString(bytes, 2, 1));
+        Assert.Equal(String.Empty, BitConverter.ToString(new byte[0]));
+    }
+
+    private static void VerifyRoundtrip<TInput>(Func<TInput, Byte[]> getBytes, Func<Byte[], int, TInput> convertBack, TInput input, Byte[] expectedBytes)
+    {
+        Byte[] bytes = getBytes(input);
+        Assert.Equal(expectedBytes.Length, bytes.Length);
+
         if (!BitConverter.IsLittleEndian)
         {
-            Console.WriteLine("Detected BigEndian platform. Tests not certified for big-endian systems.");
-            return;
+            Array.Reverse(expectedBytes);
         }
 
-        int i;
-
-        double d = 123456.3234;
-        Int64 i64;
-
-        i64 = BitConverter.DoubleToInt64Bits(d);
-        Assert.Equal(i64, 4683220267154373240L);
-        double d2 = BitConverter.Int64BitsToDouble(i64);
-        Assert.Equal(d, d2);
-
-        byte[] b;
-        bool bol;
-
-        b = BitConverter.GetBytes(true);
-        Assert.Equal(b.Length, 1);
-        Assert.Equal(b[0], 1);
-        bol = BitConverter.ToBoolean(b, 0);
-        Assert.True(bol);
-
-        b = BitConverter.GetBytes(false);
-        Assert.Equal(b.Length, 1);
-        Assert.Equal(b[0], 0);
-        bol = BitConverter.ToBoolean(b, 0);
-        Assert.False(bol);
-
-        b = BitConverter.GetBytes('A');
-        Assert.Equal(b.Length, 2);
-        Assert.Equal(b[0], 0x41);
-        Assert.Equal(b[1], 0);
-
-        char c = BitConverter.ToChar(b, 0);
-        Assert.Equal(c, 'A');
-
-        d = 123456.3234;
-        b = BitConverter.GetBytes(d);
-        Assert.Equal(b.Length, 8);
-        Assert.Equal(b[0], 0x78);
-        Assert.Equal(b[1], 0x7a);
-        Assert.Equal(b[2], 0xa5);
-        Assert.Equal(b[3], 0x2c);
-        Assert.Equal(b[4], 0x05);
-        Assert.Equal(b[5], 0x24);
-        Assert.Equal(b[6], 0xfe);
-        Assert.Equal(b[7], 0x40);
-        d = BitConverter.ToDouble(b, 0);
-        Assert.Equal(d, 123456.3234);
-
-        float f = 8392.34F;
-        b = BitConverter.GetBytes(f);
-        Assert.Equal(b.Length, 4);
-        Assert.Equal(b[0], 0x5c);
-        Assert.Equal(b[1], 0x21);
-        Assert.Equal(b[2], 0x03);
-        Assert.Equal(b[3], 0x46);
-
-        f = BitConverter.ToSingle(b, 0);
-        Assert.Equal(f, 8392.34F);
-
-        short sh = 0x1234;
-        b = BitConverter.GetBytes(sh);
-        Assert.Equal(b.Length, 2);
-        Assert.Equal(b[0], 0x34);
-        Assert.Equal(b[1], 0x12);
-        sh = BitConverter.ToInt16(b, 0);
-        Assert.Equal(sh, 0x1234);
-
-        ushort ush = 0x1234;
-        b = BitConverter.GetBytes(ush);
-        Assert.Equal(b.Length, 2);
-        Assert.Equal(b[0], 0x34);
-        Assert.Equal(b[1], 0x12);
-        ush = BitConverter.ToUInt16(b, 0);
-        Assert.Equal(ush, 0x1234);
-
-        i = 0x12345678;
-        b = BitConverter.GetBytes(i);
-        Assert.Equal(b.Length, 4);
-        Assert.Equal(b[0], 0x78);
-        Assert.Equal(b[1], 0x56);
-        Assert.Equal(b[2], 0x34);
-        Assert.Equal(b[3], 0x12);
-
-        i = BitConverter.ToInt32(b, 0);
-        Assert.Equal(i, 0x12345678);
-
-        uint u = 0x12345678u;
-        b = BitConverter.GetBytes(u);
-        Assert.Equal(b.Length, 4);
-        Assert.Equal(b[0], 0x78);
-        Assert.Equal(b[1], 0x56);
-        Assert.Equal(b[2], 0x34);
-        Assert.Equal(b[3], 0x12);
-
-        u = BitConverter.ToUInt32(b, 0);
-        Assert.Equal(u, 0x12345678u);
-
-        long l = 0x0123456789abcdef;
-        b = BitConverter.GetBytes(l);
-        Assert.Equal(b.Length, 8);
-        Assert.Equal(b[0], 0xef);
-        Assert.Equal(b[1], 0xcd);
-        Assert.Equal(b[2], 0xab);
-        Assert.Equal(b[3], 0x89);
-        Assert.Equal(b[4], 0x67);
-        Assert.Equal(b[5], 0x45);
-        Assert.Equal(b[6], 0x23);
-        Assert.Equal(b[7], 0x01);
-        l = BitConverter.ToInt64(b, 0);
-        Assert.Equal(l, 0x0123456789abcdef);
-
-        ulong ul = 0x0123456789abcdefu;
-        b = BitConverter.GetBytes(ul);
-        Assert.Equal(b.Length, 8);
-        Assert.Equal(b[0], 0xef);
-        Assert.Equal(b[1], 0xcd);
-        Assert.Equal(b[2], 0xab);
-        Assert.Equal(b[3], 0x89);
-        Assert.Equal(b[4], 0x67);
-        Assert.Equal(b[5], 0x45);
-        Assert.Equal(b[6], 0x23);
-        Assert.Equal(b[7], 0x01);
-        ul = BitConverter.ToUInt64(b, 0);
-        Assert.Equal(ul, 0x0123456789abcdefu);
-
-        b = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9a };
-        String s = BitConverter.ToString(b);
-        Assert.Equal(s, "12-34-56-78-9A");
-
-        s = BitConverter.ToString(b, 2);
-        Assert.Equal(s, "56-78-9A");
-
-        s = BitConverter.ToString(b, 2, 1);
-        Assert.Equal(s, "56");
-
-        s = BitConverter.ToString(new byte[0]);
-        Assert.Equal(s, String.Empty);
+        Assert.Equal(expectedBytes, bytes);
+        Assert.Equal(input, convertBack(bytes, 0));
     }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public static unsafe class BitConverterTests
+{
+    [Fact]
+    public static void TestBitConverter()
+    {
+        if (!BitConverter.IsLittleEndian)
+        {
+            Console.WriteLine("Detected BigEndian platform. Tests not certified for big-endian systems.");
+            return;
+        }
+
+        int i;
+
+        double d = 123456.3234;
+        Int64 i64;
+
+        i64 = BitConverter.DoubleToInt64Bits(d);
+        Assert.Equal(i64, 4683220267154373240L);
+        double d2 = BitConverter.Int64BitsToDouble(i64);
+        Assert.Equal(d, d2);
+
+        byte[] b;
+        bool bol;
+
+        b = BitConverter.GetBytes(true);
+        Assert.Equal(b.Length, 1);
+        Assert.Equal(b[0], 1);
+        bol = BitConverter.ToBoolean(b, 0);
+        Assert.True(bol);
+
+        b = BitConverter.GetBytes(false);
+        Assert.Equal(b.Length, 1);
+        Assert.Equal(b[0], 0);
+        bol = BitConverter.ToBoolean(b, 0);
+        Assert.False(bol);
+
+        b = BitConverter.GetBytes('A');
+        Assert.Equal(b.Length, 2);
+        Assert.Equal(b[0], 0x41);
+        Assert.Equal(b[1], 0);
+
+        char c = BitConverter.ToChar(b, 0);
+        Assert.Equal(c, 'A');
+
+        d = 123456.3234;
+        b = BitConverter.GetBytes(d);
+        Assert.Equal(b.Length, 8);
+        Assert.Equal(b[0], 0x78);
+        Assert.Equal(b[1], 0x7a);
+        Assert.Equal(b[2], 0xa5);
+        Assert.Equal(b[3], 0x2c);
+        Assert.Equal(b[4], 0x05);
+        Assert.Equal(b[5], 0x24);
+        Assert.Equal(b[6], 0xfe);
+        Assert.Equal(b[7], 0x40);
+        d = BitConverter.ToDouble(b, 0);
+        Assert.Equal(d, 123456.3234);
+
+        float f = 8392.34F;
+        b = BitConverter.GetBytes(f);
+        Assert.Equal(b.Length, 4);
+        Assert.Equal(b[0], 0x5c);
+        Assert.Equal(b[1], 0x21);
+        Assert.Equal(b[2], 0x03);
+        Assert.Equal(b[3], 0x46);
+
+        f = BitConverter.ToSingle(b, 0);
+        Assert.Equal(f, 8392.34F);
+
+        short sh = 0x1234;
+        b = BitConverter.GetBytes(sh);
+        Assert.Equal(b.Length, 2);
+        Assert.Equal(b[0], 0x34);
+        Assert.Equal(b[1], 0x12);
+        sh = BitConverter.ToInt16(b, 0);
+        Assert.Equal(sh, 0x1234);
+
+        ushort ush = 0x1234;
+        b = BitConverter.GetBytes(ush);
+        Assert.Equal(b.Length, 2);
+        Assert.Equal(b[0], 0x34);
+        Assert.Equal(b[1], 0x12);
+        ush = BitConverter.ToUInt16(b, 0);
+        Assert.Equal(ush, 0x1234);
+
+        i = 0x12345678;
+        b = BitConverter.GetBytes(i);
+        Assert.Equal(b.Length, 4);
+        Assert.Equal(b[0], 0x78);
+        Assert.Equal(b[1], 0x56);
+        Assert.Equal(b[2], 0x34);
+        Assert.Equal(b[3], 0x12);
+
+        i = BitConverter.ToInt32(b, 0);
+        Assert.Equal(i, 0x12345678);
+
+        uint u = 0x12345678u;
+        b = BitConverter.GetBytes(u);
+        Assert.Equal(b.Length, 4);
+        Assert.Equal(b[0], 0x78);
+        Assert.Equal(b[1], 0x56);
+        Assert.Equal(b[2], 0x34);
+        Assert.Equal(b[3], 0x12);
+
+        u = BitConverter.ToUInt32(b, 0);
+        Assert.Equal(u, 0x12345678u);
+
+        long l = 0x0123456789abcdef;
+        b = BitConverter.GetBytes(l);
+        Assert.Equal(b.Length, 8);
+        Assert.Equal(b[0], 0xef);
+        Assert.Equal(b[1], 0xcd);
+        Assert.Equal(b[2], 0xab);
+        Assert.Equal(b[3], 0x89);
+        Assert.Equal(b[4], 0x67);
+        Assert.Equal(b[5], 0x45);
+        Assert.Equal(b[6], 0x23);
+        Assert.Equal(b[7], 0x01);
+        l = BitConverter.ToInt64(b, 0);
+        Assert.Equal(l, 0x0123456789abcdef);
+
+        ulong ul = 0x0123456789abcdefu;
+        b = BitConverter.GetBytes(ul);
+        Assert.Equal(b.Length, 8);
+        Assert.Equal(b[0], 0xef);
+        Assert.Equal(b[1], 0xcd);
+        Assert.Equal(b[2], 0xab);
+        Assert.Equal(b[3], 0x89);
+        Assert.Equal(b[4], 0x67);
+        Assert.Equal(b[5], 0x45);
+        Assert.Equal(b[6], 0x23);
+        Assert.Equal(b[7], 0x01);
+        ul = BitConverter.ToUInt64(b, 0);
+        Assert.Equal(ul, 0x0123456789abcdefu);
+
+        b = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9a };
+        String s = BitConverter.ToString(b);
+        Assert.Equal(s, "12-34-56-78-9A");
+
+        s = BitConverter.ToString(b, 2);
+        Assert.Equal(s, "56-78-9A");
+
+        s = BitConverter.ToString(b, 2, 1);
+        Assert.Equal(s, "56");
+
+        s = BitConverter.ToString(new byte[0]);
+        Assert.Equal(s, String.Empty);
+    }
+}
+

--- a/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using Xunit;
+
+public static class StopwatchTests
+{
+    [Fact]
+    public static void TestGetTimestamp()
+    {
+        // Int64 Stopwatch.GetTimestamp()
+        long ts1 = Stopwatch.GetTimestamp();
+        Sleep();
+        long ts2 = Stopwatch.GetTimestamp();
+        Assert.NotEqual(ts1, ts2);
+    }
+
+    [Fact]
+    public static void TestStartNew()
+    {
+        Stopwatch watch = new Stopwatch();
+
+        Assert.False(watch.IsRunning);
+
+        watch.Start();
+
+        Sleep();
+        Assert.True(watch.IsRunning);
+        Assert.True(watch.Elapsed > TimeSpan.Zero);
+
+        watch.Stop();
+        var e1 = watch.Elapsed;
+        var e2 = watch.Elapsed;
+        Assert.Equal(e1, e2);
+
+        Assert.False(watch.IsRunning);
+    }
+
+    [Fact]
+    public static void Testctor()
+    {
+        Stopwatch watch = Stopwatch.StartNew();
+        Sleep();
+        Assert.True(watch.IsRunning);
+        watch.Start(); // should be no-op
+        Assert.True(watch.IsRunning);
+        Assert.True(watch.Elapsed > TimeSpan.Zero);
+
+        watch.Reset();
+        Assert.False(watch.IsRunning);
+        Assert.True(watch.Elapsed == TimeSpan.Zero);
+    }
+
+    private static void Sleep()
+    {
+        System.Threading.Tasks.Task.Delay(1).Wait();
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -25,8 +25,8 @@ public static class StopwatchTests
         Stopwatch watch = new Stopwatch();
         Assert.False(watch.IsRunning);
         watch.Start();
-        Sleep();
         Assert.True(watch.IsRunning);
+        Sleep();
         Assert.True(watch.Elapsed > TimeSpan.Zero);
 
         watch.Stop();
@@ -43,10 +43,10 @@ public static class StopwatchTests
     public static void StartNewAndReset()
     {
         Stopwatch watch = Stopwatch.StartNew();
-        Sleep();
         Assert.True(watch.IsRunning);
         watch.Start(); // should be no-op
         Assert.True(watch.IsRunning);
+        Sleep();
         Assert.True(watch.Elapsed > TimeSpan.Zero);
 
         watch.Reset();
@@ -54,8 +54,22 @@ public static class StopwatchTests
         Assert.Equal(TimeSpan.Zero, watch.Elapsed);
     }
 
-    private static void Sleep()
+    [Fact]
+    public static void StartNewAndRestart()
     {
-        s_sleepEvent.WaitOne(1);
+        Stopwatch watch = Stopwatch.StartNew();
+        Assert.True(watch.IsRunning);
+        Sleep(10);
+        TimeSpan elapsedSinceStart = watch.Elapsed;
+        Assert.True(elapsedSinceStart > TimeSpan.Zero);
+
+        watch.Restart();
+        Assert.True(watch.IsRunning);
+        Assert.True(watch.Elapsed < elapsedSinceStart);
+    }
+
+    private static void Sleep(int milliseconds = 1)
+    {
+        s_sleepEvent.WaitOne(milliseconds);
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -2,15 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Diagnostics;
 using Xunit;
 
 public static class StopwatchTests
 {
+    private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
+
     [Fact]
-    public static void TestGetTimestamp()
+    public static void GetTimestamp()
     {
-        // Int64 Stopwatch.GetTimestamp()
         long ts1 = Stopwatch.GetTimestamp();
         Sleep();
         long ts2 = Stopwatch.GetTimestamp();
@@ -18,28 +20,27 @@ public static class StopwatchTests
     }
 
     [Fact]
-    public static void TestStartNew()
+    public static void ConstructStartAndStop()
     {
         Stopwatch watch = new Stopwatch();
-
         Assert.False(watch.IsRunning);
-
         watch.Start();
-
         Sleep();
         Assert.True(watch.IsRunning);
         Assert.True(watch.Elapsed > TimeSpan.Zero);
 
         watch.Stop();
+        Assert.False(watch.IsRunning);
+
         var e1 = watch.Elapsed;
+        Sleep();
         var e2 = watch.Elapsed;
         Assert.Equal(e1, e2);
-
-        Assert.False(watch.IsRunning);
+        Assert.Equal((long)e1.TotalMilliseconds, watch.ElapsedMilliseconds);
     }
 
     [Fact]
-    public static void Testctor()
+    public static void StartNewAndReset()
     {
         Stopwatch watch = Stopwatch.StartNew();
         Sleep();
@@ -50,11 +51,11 @@ public static class StopwatchTests
 
         watch.Reset();
         Assert.False(watch.IsRunning);
-        Assert.True(watch.Elapsed == TimeSpan.Zero);
+        Assert.Equal(TimeSpan.Zero, watch.Elapsed);
     }
 
     private static void Sleep()
     {
-        System.Threading.Tasks.Task.Delay(1).Wait();
+        s_sleepEvent.WaitOne(1);
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -7,7 +7,8 @@ using Xunit;
 
 public class PathCombineTests
 {
-    private static String s_separator = "\\"; // Was Path.DirectorySeparatorChar
+    private static readonly char s_separator = Path.DirectorySeparatorChar;
+
     [Fact]
     public static void PathIsNull()
     {
@@ -41,12 +42,14 @@ public class PathCombineTests
         //paths has many elements
         Verify(new String[] { "abc" + s_separator + "def", "def", "ghi", "jkl", "mno" });
     }
+
     [Fact]
     public static void PathIsNullWihtoutRootedAfterArgumentNull()
     {
         //any path is null without rooted after (ANE)
         CommonCasesException<ArgumentNullException>(null);
     }
+
     [Fact]
     public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
     {
@@ -60,6 +63,7 @@ public class PathCombineTests
         CommonCasesException<ArgumentException>("ab\0cd");
         CommonCasesException<ArgumentException>("ab\tcd");
     }
+
     [Fact]
     public static void ContainsInvalidCharWithRootedAfterArgumentNull()
     {
@@ -188,43 +192,37 @@ public class PathCombineTests
 
     private static void VerifyException<T>(string[] paths) where T : Exception
     {
-        String rVal;
-        Assert.Throws<T>(() => { rVal = Path.Combine(paths); });
+        Assert.Throws<T>(() => Path.Combine(paths));
 
         //verify passed as elements case
         if (paths != null)
         {
-            if (paths.Length >= 1 && paths.Length <= 5)
+            Assert.InRange(paths.Length, 1, 5);
+
+            Assert.Throws<T>(() =>
             {
-                Assert.Throws<T>(() =>
+                switch (paths.Length)
                 {
-                    switch (paths.Length)
-                    {
-                        case 0:
-                            rVal = Path.Combine();
-                            break;
-                        case 1:
-                            rVal = Path.Combine(paths[0]);
-                            break;
-                        case 2:
-                            rVal = Path.Combine(paths[0], paths[1]);
-                            break;
-                        case 3:
-                            rVal = Path.Combine(paths[0], paths[1], paths[2]);
-                            break;
-                        case 4:
-                            rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3]);
-                            break;
-                        case 5:
-                            rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
-                            break;
-                    }
-                });
-            }
-            else
-            {
-                Assert.True(false, String.Format("Test doesn't cover case with {0} items passed seperately, add it.", paths.Length));
-            }
+                    case 0:
+                        Path.Combine();
+                        break;
+                    case 1:
+                        Path.Combine(paths[0]);
+                        break;
+                    case 2:
+                        Path.Combine(paths[0], paths[1]);
+                        break;
+                    case 3:
+                        Path.Combine(paths[0], paths[1], paths[2]);
+                        break;
+                    case 4:
+                        Path.Combine(paths[0], paths[1], paths[2], paths[3]);
+                        break;
+                    case 5:
+                        Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
+                        break;
+                }
+            });
         }
     }
 

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -5,279 +5,276 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace PathTests
+public class PathCombineTests
 {
-    public class CombineTests
+    private static String s_separator = "\\"; // Was Path.DirectorySeparatorChar
+    [Fact]
+    public static void PathIsNull()
     {
-        private static String s_separator = "\\"; // Was Path.DirectorySeparatorChar
-        [Fact]
-        public static void PathIsNull()
+        VerifyException<ArgumentNullException>(null);
+    }
+
+    [Fact]
+    public static void VerifyEmptyPath()
+    {
+        //paths is empty
+        Verify(new String[0]);
+    }
+
+    [Fact]
+    public static void VerifyPath1Element()
+    {
+        //paths has 1 element
+        Verify(new String[] { "abc" });
+    }
+
+    [Fact]
+    public static void VerifyPath2Elements()
+    {
+        //paths has 2 elements
+        Verify(new String[] { "abc", "def" });
+    }
+
+    [Fact]
+    public static void VerifyPathManyElements()
+    {
+        //paths has many elements
+        Verify(new String[] { "abc" + s_separator + "def", "def", "ghi", "jkl", "mno" });
+    }
+    [Fact]
+    public static void PathIsNullWihtoutRootedAfterArgumentNull()
+    {
+        //any path is null without rooted after (ANE)
+        CommonCasesException<ArgumentNullException>(null);
+    }
+    [Fact]
+    public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
+    {
+        //any path contains invalid character without rooted after (AE)
+        CommonCasesException<ArgumentException>("ab\"cd");
+        CommonCasesException<ArgumentException>("ab\"cd");
+        CommonCasesException<ArgumentException>("ab<cd");
+        CommonCasesException<ArgumentException>("ab>cd");
+        CommonCasesException<ArgumentException>("ab|cd");
+        CommonCasesException<ArgumentException>("ab\bcd");
+        CommonCasesException<ArgumentException>("ab\0cd");
+        CommonCasesException<ArgumentException>("ab\tcd");
+    }
+    [Fact]
+    public static void ContainsInvalidCharWithRootedAfterArgumentNull()
+    {
+        //any path contains invalid character with rooted after (AE)
+        CommonCasesException<ArgumentException>("ab\"cd", s_separator + "abc");
+        CommonCasesException<ArgumentException>("ab<cd", s_separator + "abc");
+        CommonCasesException<ArgumentException>("ab>cd", s_separator + "abc");
+        CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
+        CommonCasesException<ArgumentException>("ab\bcd", s_separator + "abc");
+        CommonCasesException<ArgumentException>("ab\0cd", s_separator + "abc");
+        CommonCasesException<ArgumentException>("ab\tcd", s_separator + "abc");
+    }
+
+    [Fact]
+    public static void PathIsRooted()
+    {
+        //any path is rooted (starts with \, \\, A:)
+        CommonCases(s_separator + "abc");
+        CommonCases(s_separator + s_separator + "abc");
+    }
+
+    [Fact]
+    public static void PathIsEmptyCommonCases()
+    {
+        //any path is empty (skipped)
+        CommonCases("");
+    }
+
+    [Fact]
+    public static void PathIsEmptyMultipleArguments()
+    {
+        //all paths are empty
+        Verify(new String[] { "" });
+        Verify(new String[] { "", "" });
+        Verify(new String[] { "", "", "" });
+        Verify(new String[] { "", "", "", "" });
+        Verify(new String[] { "", "", "", "", "" });
+    }
+
+    [Fact]
+    public static void PathIsSingleElement()
+    {
+        //any path is single element
+        CommonCases("abc");
+    }
+
+    [Fact]
+    public static void PathIsMultipleElements()
+    {
+        //any path is multiple element
+        CommonCases(Path.Combine("abc", Path.Combine("def", "ghi")));
+    }
+
+    public static void NoPathIsRooted()
+    {
+        //no path is rooted
+        CommonCases("abc");
+    }
+
+    private static void Verify(string[] paths)
+    {
+        String rVal;
+        String expected = String.Empty;
+        if (paths.Length > 0) expected = paths[0];
+        for (int i = 1; i < paths.Length; i++)
         {
-            VerifyException<ArgumentNullException>(null);
+            expected = Path.Combine(expected, paths[i]);
         }
 
-        [Fact]
-        public static void VerifyEmptyPath()
+        //verify passed as array case
+        rVal = Path.Combine(paths);
+
+        Assert.Equal(expected, rVal);
+
+        //verify passed as elements case
+        switch (paths.Length)
         {
-            //paths is empty
-            Verify(new String[0]);
+            case 0:
+                rVal = Path.Combine();
+                break;
+            case 1:
+                rVal = Path.Combine(paths[0]);
+                break;
+            case 2:
+                rVal = Path.Combine(paths[0], paths[1]);
+                break;
+            case 3:
+                rVal = Path.Combine(paths[0], paths[1], paths[2]);
+                break;
+            case 4:
+                rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3]);
+                break;
+            case 5:
+                rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
+                break;
+            default:
+                Assert.True(false, String.Format("Test doesn't cover case with {0} items passed seperately, add it.", paths.Length));
+                break;
         }
 
-        [Fact]
-        public static void VerifyPath1Element()
-        {
-            //paths has 1 element
-            Verify(new String[] { "abc" });
-        }
+        Assert.Equal(expected, rVal);
+    }
 
-        [Fact]
-        public static void VerifyPath2Elements()
-        {
-            //paths has 2 elements
-            Verify(new String[] { "abc", "def" });
-        }
+    public static void CommonCases(string testing)
+    {
+        Verify(new string[] { testing });
 
-        [Fact]
-        public static void VerifyPathManyElements()
-        {
-            //paths has many elements
-            Verify(new String[] { "abc" + s_separator + "def", "def", "ghi", "jkl", "mno" });
-        }
-        [Fact]
-        public static void PathIsNullWihtoutRootedAfterArgumentNull()
-        {
-            //any path is null without rooted after (ANE)
-            CommonCasesException<ArgumentNullException>(null);
-        }
-        [Fact]
-        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
-        {
-            //any path contains invalid character without rooted after (AE)
-            CommonCasesException<ArgumentException>("ab\"cd");
-            CommonCasesException<ArgumentException>("ab\"cd");
-            CommonCasesException<ArgumentException>("ab<cd");
-            CommonCasesException<ArgumentException>("ab>cd");
-            CommonCasesException<ArgumentException>("ab|cd");
-            CommonCasesException<ArgumentException>("ab\bcd");
-            CommonCasesException<ArgumentException>("ab\0cd");
-            CommonCasesException<ArgumentException>("ab\tcd");
-        }
-        [Fact]
-        public static void ContainsInvalidCharWithRootedAfterArgumentNull()
-        {
-            //any path contains invalid character with rooted after (AE)
-            CommonCasesException<ArgumentException>("ab\"cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab<cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab>cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab\bcd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab\0cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab\tcd", s_separator + "abc");
-        }
+        Verify(new string[] { "abc", testing });
+        Verify(new string[] { testing, "abc" });
 
-        [Fact]
-        public static void PathIsRooted()
-        {
-            //any path is rooted (starts with \, \\, A:)
-            CommonCases(s_separator + "abc");
-            CommonCases(s_separator + s_separator + "abc");
-        }
+        Verify(new string[] { "abc", "def", testing });
+        Verify(new string[] { "abc", testing, "def" });
+        Verify(new string[] { testing, "abc", "def" });
 
-        [Fact]
-        public static void PathIsEmptyCommonCases()
-        {
-            //any path is empty (skipped)
-            CommonCases("");
-        }
+        Verify(new string[] { "abc", "def", "ghi", testing });
+        Verify(new string[] { "abc", "def", testing, "ghi" });
+        Verify(new string[] { "abc", testing, "def", "ghi" });
+        Verify(new string[] { testing, "abc", "def", "ghi" });
 
-        [Fact]
-        public static void PathIsEmptyMultipleArguments()
-        {
-            //all paths are empty
-            Verify(new String[] { "" });
-            Verify(new String[] { "", "" });
-            Verify(new String[] { "", "", "" });
-            Verify(new String[] { "", "", "", "" });
-            Verify(new String[] { "", "", "", "", "" });
-        }
+        Verify(new string[] { "abc", "def", "ghi", "jkl", testing });
+        Verify(new string[] { "abc", "def", "ghi", testing, "jkl" });
+        Verify(new string[] { "abc", "def", testing, "ghi", "jkl" });
+        Verify(new string[] { "abc", testing, "def", "ghi", "jkl" });
+        Verify(new string[] { testing, "abc", "def", "ghi", "jkl" });
+    }
 
-        [Fact]
-        public static void PathIsSingleElement()
-        {
-            //any path is single element
-            CommonCases("abc");
-        }
+    private static void VerifyException<T>(string[] paths) where T : Exception
+    {
+        String rVal;
+        Assert.Throws<T>(() => { rVal = Path.Combine(paths); });
 
-        [Fact]
-        public static void PathIsMultipleElements()
+        //verify passed as elements case
+        if (paths != null)
         {
-            //any path is multiple element
-            CommonCases(Path.Combine("abc", Path.Combine("def", "ghi")));
-        }
-
-        public static void NoPathIsRooted()
-        {
-            //no path is rooted
-            CommonCases("abc");
-        }
-
-        private static void Verify(string[] paths)
-        {
-            String rVal;
-            String expected = String.Empty;
-            if (paths.Length > 0) expected = paths[0];
-            for (int i = 1; i < paths.Length; i++)
+            if (paths.Length >= 1 && paths.Length <= 5)
             {
-                expected = Path.Combine(expected, paths[i]);
-            }
-
-            //verify passed as array case
-            rVal = Path.Combine(paths);
-
-            Assert.Equal(expected, rVal);
-
-            //verify passed as elements case
-            switch (paths.Length)
-            {
-                case 0:
-                    rVal = Path.Combine();
-                    break;
-                case 1:
-                    rVal = Path.Combine(paths[0]);
-                    break;
-                case 2:
-                    rVal = Path.Combine(paths[0], paths[1]);
-                    break;
-                case 3:
-                    rVal = Path.Combine(paths[0], paths[1], paths[2]);
-                    break;
-                case 4:
-                    rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3]);
-                    break;
-                case 5:
-                    rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
-                    break;
-                default:
-                    Assert.True(false, String.Format("Test doesn't cover case with {0} items passed seperately, add it.", paths.Length));
-                    break;
-            }
-
-            Assert.Equal(expected, rVal);
-        }
-
-        public static void CommonCases(string testing)
-        {
-            Verify(new string[] { testing });
-
-            Verify(new string[] { "abc", testing });
-            Verify(new string[] { testing, "abc" });
-
-            Verify(new string[] { "abc", "def", testing });
-            Verify(new string[] { "abc", testing, "def" });
-            Verify(new string[] { testing, "abc", "def" });
-
-            Verify(new string[] { "abc", "def", "ghi", testing });
-            Verify(new string[] { "abc", "def", testing, "ghi" });
-            Verify(new string[] { "abc", testing, "def", "ghi" });
-            Verify(new string[] { testing, "abc", "def", "ghi" });
-
-            Verify(new string[] { "abc", "def", "ghi", "jkl", testing });
-            Verify(new string[] { "abc", "def", "ghi", testing, "jkl" });
-            Verify(new string[] { "abc", "def", testing, "ghi", "jkl" });
-            Verify(new string[] { "abc", testing, "def", "ghi", "jkl" });
-            Verify(new string[] { testing, "abc", "def", "ghi", "jkl" });
-        }
-
-        private static void VerifyException<T>(string[] paths) where T : Exception
-        {
-            String rVal;
-            Assert.Throws<T>(() => { rVal = Path.Combine(paths); });
-
-            //verify passed as elements case
-            if (paths != null)
-            {
-                if (paths.Length >= 1 && paths.Length <= 5)
+                Assert.Throws<T>(() =>
                 {
-                    Assert.Throws<T>(() =>
+                    switch (paths.Length)
                     {
-                        switch (paths.Length)
-                        {
-                            case 0:
-                                rVal = Path.Combine();
-                                break;
-                            case 1:
-                                rVal = Path.Combine(paths[0]);
-                                break;
-                            case 2:
-                                rVal = Path.Combine(paths[0], paths[1]);
-                                break;
-                            case 3:
-                                rVal = Path.Combine(paths[0], paths[1], paths[2]);
-                                break;
-                            case 4:
-                                rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3]);
-                                break;
-                            case 5:
-                                rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
-                                break;
-                        }
-                    });
-                }
-                else
-                {
-                    Assert.True(false, String.Format("Test doesn't cover case with {0} items passed seperately, add it.", paths.Length));
-                }
+                        case 0:
+                            rVal = Path.Combine();
+                            break;
+                        case 1:
+                            rVal = Path.Combine(paths[0]);
+                            break;
+                        case 2:
+                            rVal = Path.Combine(paths[0], paths[1]);
+                            break;
+                        case 3:
+                            rVal = Path.Combine(paths[0], paths[1], paths[2]);
+                            break;
+                        case 4:
+                            rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3]);
+                            break;
+                        case 5:
+                            rVal = Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
+                            break;
+                    }
+                });
+            }
+            else
+            {
+                Assert.True(false, String.Format("Test doesn't cover case with {0} items passed seperately, add it.", paths.Length));
             }
         }
+    }
 
-        private static void CommonCasesException<T>(string testing) where T : Exception
-        {
-            VerifyException<T>(new string[] { testing });
+    private static void CommonCasesException<T>(string testing) where T : Exception
+    {
+        VerifyException<T>(new string[] { testing });
 
-            VerifyException<T>(new string[] { "abc", testing });
-            VerifyException<T>(new string[] { testing, "abc" });
+        VerifyException<T>(new string[] { "abc", testing });
+        VerifyException<T>(new string[] { testing, "abc" });
 
-            VerifyException<T>(new string[] { "abc", "def", testing });
-            VerifyException<T>(new string[] { "abc", testing, "def" });
-            VerifyException<T>(new string[] { testing, "abc", "def" });
+        VerifyException<T>(new string[] { "abc", "def", testing });
+        VerifyException<T>(new string[] { "abc", testing, "def" });
+        VerifyException<T>(new string[] { testing, "abc", "def" });
 
-            VerifyException<T>(new string[] { "abc", "def", "ghi", testing });
-            VerifyException<T>(new string[] { "abc", "def", testing, "ghi" });
-            VerifyException<T>(new string[] { "abc", testing, "def", "ghi" });
-            VerifyException<T>(new string[] { testing, "abc", "def", "ghi" });
+        VerifyException<T>(new string[] { "abc", "def", "ghi", testing });
+        VerifyException<T>(new string[] { "abc", "def", testing, "ghi" });
+        VerifyException<T>(new string[] { "abc", testing, "def", "ghi" });
+        VerifyException<T>(new string[] { testing, "abc", "def", "ghi" });
 
-            VerifyException<T>(new string[] { "abc", "def", "ghi", "jkl", testing });
-            VerifyException<T>(new string[] { "abc", "def", "ghi", testing, "jkl" });
-            VerifyException<T>(new string[] { "abc", "def", testing, "ghi", "jkl" });
-            VerifyException<T>(new string[] { "abc", testing, "def", "ghi", "jkl" });
-            VerifyException<T>(new string[] { testing, "abc", "def", "ghi", "jkl" });
-        }
+        VerifyException<T>(new string[] { "abc", "def", "ghi", "jkl", testing });
+        VerifyException<T>(new string[] { "abc", "def", "ghi", testing, "jkl" });
+        VerifyException<T>(new string[] { "abc", "def", testing, "ghi", "jkl" });
+        VerifyException<T>(new string[] { "abc", testing, "def", "ghi", "jkl" });
+        VerifyException<T>(new string[] { testing, "abc", "def", "ghi", "jkl" });
+    }
 
-        private static void CommonCasesException<T>(string testing, string testing2) where T : Exception
-        {
-            VerifyException<T>(new string[] { testing, testing2 });
+    private static void CommonCasesException<T>(string testing, string testing2) where T : Exception
+    {
+        VerifyException<T>(new string[] { testing, testing2 });
 
-            VerifyException<T>(new string[] { "abc", testing, testing2 });
-            VerifyException<T>(new string[] { testing, "abc", testing2 });
-            VerifyException<T>(new string[] { testing, testing2, "def" });
+        VerifyException<T>(new string[] { "abc", testing, testing2 });
+        VerifyException<T>(new string[] { testing, "abc", testing2 });
+        VerifyException<T>(new string[] { testing, testing2, "def" });
 
-            VerifyException<T>(new string[] { "abc", "def", testing, testing2 });
-            VerifyException<T>(new string[] { "abc", testing, "def", testing2 });
-            VerifyException<T>(new string[] { "abc", testing, testing2, "ghi" });
-            VerifyException<T>(new string[] { testing, "abc", "def", testing2 });
-            VerifyException<T>(new string[] { testing, "abc", testing2, "ghi" });
-            VerifyException<T>(new string[] { testing, testing2, "def", "ghi" });
+        VerifyException<T>(new string[] { "abc", "def", testing, testing2 });
+        VerifyException<T>(new string[] { "abc", testing, "def", testing2 });
+        VerifyException<T>(new string[] { "abc", testing, testing2, "ghi" });
+        VerifyException<T>(new string[] { testing, "abc", "def", testing2 });
+        VerifyException<T>(new string[] { testing, "abc", testing2, "ghi" });
+        VerifyException<T>(new string[] { testing, testing2, "def", "ghi" });
 
-            VerifyException<T>(new string[] { "abc", "def", "ghi", testing, testing2 });
-            VerifyException<T>(new string[] { "abc", "def", testing, "ghi", testing2 });
-            VerifyException<T>(new string[] { "abc", "def", testing, testing2, "jkl" });
-            VerifyException<T>(new string[] { "abc", testing, "def", "ghi", testing2 });
-            VerifyException<T>(new string[] { "abc", testing, "def", testing2, "jkl" });
-            VerifyException<T>(new string[] { "abc", testing, testing2, "ghi", "jkl" });
-            VerifyException<T>(new string[] { testing, "abc", "def", "ghi", testing2 });
-            VerifyException<T>(new string[] { testing, "abc", "def", testing2, "jkl" });
-            VerifyException<T>(new string[] { testing, "abc", testing2, "ghi", "jkl" });
-            VerifyException<T>(new string[] { testing, testing2, "def", "ghi", "jkl" });
-        }
+        VerifyException<T>(new string[] { "abc", "def", "ghi", testing, testing2 });
+        VerifyException<T>(new string[] { "abc", "def", testing, "ghi", testing2 });
+        VerifyException<T>(new string[] { "abc", "def", testing, testing2, "jkl" });
+        VerifyException<T>(new string[] { "abc", testing, "def", "ghi", testing2 });
+        VerifyException<T>(new string[] { "abc", testing, "def", testing2, "jkl" });
+        VerifyException<T>(new string[] { "abc", testing, testing2, "ghi", "jkl" });
+        VerifyException<T>(new string[] { testing, "abc", "def", "ghi", testing2 });
+        VerifyException<T>(new string[] { testing, "abc", "def", testing2, "jkl" });
+        VerifyException<T>(new string[] { testing, "abc", testing2, "ghi", "jkl" });
+        VerifyException<T>(new string[] { testing, testing2, "def", "ghi", "jkl" });
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.cs
@@ -3,110 +3,57 @@
 
 using System;
 using System.IO;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
-public static unsafe class PathTests
+public static class PathTests
 {
     [Fact]
-    public static void TestChangeExtension()
+    public static void ChangeExtension()
     {
-        String s;
-
-        s = Path.ChangeExtension("foo.txt", "exe");
-        Assert.Equal(s, "foo.exe");
-        return;
+        Assert.Equal("file.exe", Path.ChangeExtension("file.txt", "exe"));
     }
 
     [Fact]
-    public static void TestCombine()
+    public static void GetDirectoryName()
     {
-        String s = Path.Combine(@"c:\", "foo", "bar", "baz.exe");
-        Assert.Equal(s, @"c:\foo\bar\baz.exe");
-
-        s = Path.Combine();
-        Assert.Equal(s, String.Empty);
+        Assert.Equal("dir", Path.GetDirectoryName(@"dir\baz"));
+        Assert.Equal(null, Path.GetDirectoryName(@"c:\"));
     }
 
     [Fact]
-    public static void TestGetDirectoryName()
+    public static void GetExtension()
     {
-        String s;
-
-        s = Path.GetDirectoryName(@"foo\baz");
-        Assert.Equal(s, @"foo");
-
-        s = Path.GetDirectoryName(@"c:\");
-        Assert.Equal(s, null);
+        Assert.Equal(".exe", Path.GetExtension("file.exe"));
+        Assert.True(Path.HasExtension("file.exe"));
+        Assert.Equal(string.Empty, Path.GetExtension("file"));
+        Assert.False(Path.HasExtension("file"));
     }
 
     [Fact]
-    public static void TestShortFileName()
+    public static void GetFileName()
     {
-        //@todo: Not implemented yet.
-        //String s = Path.GetDirectoryName(@"c:\x~x\yy\zz.txt");
-        //Console.WriteLine(s);
+        Assert.Equal("file.exe", Path.GetFileName(@"c:\bar\baz\file.exe"));
+        Assert.Equal(string.Empty, Path.GetFileName(@"c:\bar\baz\"));
     }
 
     [Fact]
-    public static void TestGetExtension()
+    public static void GetFileNameWithoutExtension()
     {
-        String s;
-        bool b;
-
-        s = Path.GetExtension("foo.exe");
-        Assert.Equal(s, ".exe");
-
-        b = Path.HasExtension("foo.exe");
-        Assert.True(b);
-
-        s = Path.GetExtension("foo");
-        Assert.Equal(s, "");
-
-        b = Path.HasExtension("foo");
-        Assert.False(b);
+        Assert.Equal("file", Path.GetFileNameWithoutExtension(@"c:\bar\baz\file.exe"));
+        Assert.Equal(string.Empty, Path.GetFileNameWithoutExtension(@"c:\bar\baz\"));
     }
 
     [Fact]
-    public static void TestGetFileName()
+    public static void GetPathRoot()
     {
-        String s;
-        s = Path.GetFileName(@"c:\bar\baz\foo.exe");
-        Assert.Equal(s, "foo.exe");
-
-        s = Path.GetFileName(@"c:\bar\baz\");
-        Assert.Equal(s, "");
+        Assert.Equal(@"c:\", Path.GetPathRoot(@"c:\x\y\z\"));
+        Assert.True(Path.IsPathRooted(@"c:\x\y\z\"));
+        Assert.Equal(string.Empty, Path.GetPathRoot(@"file.exe"));
+        Assert.False(Path.IsPathRooted("file.exe"));
     }
 
     [Fact]
-    public static void TestGetFileNameWithoutExtension()
-    {
-        String s;
-        s = Path.GetFileNameWithoutExtension(@"c:\bar\baz\foo.exe");
-        Assert.Equal(s, "foo");
-
-        s = Path.GetFileNameWithoutExtension(@"c:\bar\baz\");
-        Assert.Equal(s, "");
-    }
-
-    [Fact]
-    public static void TestGetPathRoot()
-    {
-        String s;
-        bool b;
-        s = Path.GetPathRoot(@"c:\foo\bar\bar\");
-        Assert.Equal(s, @"c:\");
-        b = Path.IsPathRooted(@"c:\foo\bar\bar\");
-        Assert.True(b);
-        s = Path.GetPathRoot(@"foo.exe");
-        Assert.Equal(s, @"");
-        b = Path.IsPathRooted(@"foo.exe");
-        Assert.False(b);
-    }
-
-    [Fact]
-    public static void TestGetRandomFileName()
+    public static void GetRandomFileName()
     {
         for (int i = 0; i < 100; i++)
         {
@@ -115,14 +62,4 @@ public static unsafe class PathTests
             Assert.Equal(s[8], '.');
         }
     }
-
-    [Fact]
-    public static void TestShortNamesExpansion()
-    {
-        // we are not sure if 'c:\Program Files' exist so the result should be 
-        // either 'PROGRA~1' or 'Program Files'
-        string s = Path.GetDirectoryName(@"C:\PROGRA~1\");
-        Assert.True(s.Equals(@"c:\PROGRA~1", StringComparison.OrdinalIgnoreCase) || s.Equals(@"c:\Program Files", StringComparison.OrdinalIgnoreCase));
-    }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public static unsafe class PathTests
+{
+    [Fact]
+    public static void TestChangeExtension()
+    {
+        String s;
+
+        s = Path.ChangeExtension("foo.txt", "exe");
+        Assert.Equal(s, "foo.exe");
+        return;
+    }
+
+    [Fact]
+    public static void TestCombine()
+    {
+        String s = Path.Combine(@"c:\", "foo", "bar", "baz.exe");
+        Assert.Equal(s, @"c:\foo\bar\baz.exe");
+
+        s = Path.Combine();
+        Assert.Equal(s, String.Empty);
+    }
+
+    [Fact]
+    public static void TestGetDirectoryName()
+    {
+        String s;
+
+        s = Path.GetDirectoryName(@"foo\baz");
+        Assert.Equal(s, @"foo");
+
+        s = Path.GetDirectoryName(@"c:\");
+        Assert.Equal(s, null);
+    }
+
+    [Fact]
+    public static void TestShortFileName()
+    {
+        //@todo: Not implemented yet.
+        //String s = Path.GetDirectoryName(@"c:\x~x\yy\zz.txt");
+        //Console.WriteLine(s);
+    }
+
+    [Fact]
+    public static void TestGetExtension()
+    {
+        String s;
+        bool b;
+
+        s = Path.GetExtension("foo.exe");
+        Assert.Equal(s, ".exe");
+
+        b = Path.HasExtension("foo.exe");
+        Assert.True(b);
+
+        s = Path.GetExtension("foo");
+        Assert.Equal(s, "");
+
+        b = Path.HasExtension("foo");
+        Assert.False(b);
+    }
+
+    [Fact]
+    public static void TestGetFileName()
+    {
+        String s;
+        s = Path.GetFileName(@"c:\bar\baz\foo.exe");
+        Assert.Equal(s, "foo.exe");
+
+        s = Path.GetFileName(@"c:\bar\baz\");
+        Assert.Equal(s, "");
+    }
+
+    [Fact]
+    public static void TestGetFileNameWithoutExtension()
+    {
+        String s;
+        s = Path.GetFileNameWithoutExtension(@"c:\bar\baz\foo.exe");
+        Assert.Equal(s, "foo");
+
+        s = Path.GetFileNameWithoutExtension(@"c:\bar\baz\");
+        Assert.Equal(s, "");
+    }
+
+    [Fact]
+    public static void TestGetPathRoot()
+    {
+        String s;
+        bool b;
+        s = Path.GetPathRoot(@"c:\foo\bar\bar\");
+        Assert.Equal(s, @"c:\");
+        b = Path.IsPathRooted(@"c:\foo\bar\bar\");
+        Assert.True(b);
+        s = Path.GetPathRoot(@"foo.exe");
+        Assert.Equal(s, @"");
+        b = Path.IsPathRooted(@"foo.exe");
+        Assert.False(b);
+    }
+
+    [Fact]
+    public static void TestGetRandomFileName()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            String s = Path.GetRandomFileName();
+            Assert.Equal(s.Length, 8 + 1 + 3);
+            Assert.Equal(s[8], '.');
+        }
+    }
+
+    [Fact]
+    public static void TestShortNamesExpansion()
+    {
+        // we are not sure if 'c:\Program Files' exist so the result should be 
+        // either 'PROGRA~1' or 'Program Files'
+        string s = Path.GetDirectoryName(@"C:\PROGRA~1\");
+        Assert.True(s.Equals(@"c:\PROGRA~1", StringComparison.OrdinalIgnoreCase) || s.Equals(@"c:\Program Files", StringComparison.OrdinalIgnoreCase));
+    }
+}
+

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -2,513 +2,636 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
-public static unsafe class MathTests
+public static class MathTests
 {
     [Fact]
-    public static void TestCos()
+    public static void Cos()
     {
-        double d;
-
-        d = Math.Cos(1.0);
-        IsEqual(d, 0.54030230586814);
-        d = Math.Cos(0.0);
-        IsEqual(d, 1.0);
-        d = Math.Cos(-1.0);
-        IsEqual(d, 0.54030230586814);
-        d = Math.Cos(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Cos(Double.PositiveInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Cos(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        AssertSimilar(0.54030230586814, Math.Cos(1.0));
+        Assert.Equal(1.0, Math.Cos(0.0));
+        AssertSimilar(0.54030230586814, Math.Cos(-1.0));
+        Assert.Equal(double.NaN, Math.Cos(double.NaN));
+        Assert.Equal(double.NaN, Math.Cos(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Cos(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestSin()
+    public static void Sin()
     {
-        double d;
-
-        d = Math.Sin(1.0);
-        IsEqual(d, 0.841470984807897);
-        d = Math.Sin(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Sin(-1.0);
-        IsEqual(d, -0.841470984807897);
-        d = Math.Sin(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Sin(Double.PositiveInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Sin(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        AssertSimilar(0.841470984807897, Math.Sin(1.0));
+        Assert.Equal(0.0, Math.Sin(0.0));
+        AssertSimilar(-0.841470984807897, Math.Sin(-1.0));
+        Assert.Equal(double.NaN, Math.Sin(double.NaN));
+        Assert.Equal(double.NaN, Math.Sin(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Sin(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestTan()
+    public static void Tan()
     {
-        double d;
-
-        d = Math.Tan(1.0);
-        IsEqual(d, 1.5574077246549);
-        d = Math.Tan(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Tan(-1.0);
-        IsEqual(d, -1.5574077246549);
-        d = Math.Tan(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Tan(Double.PositiveInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Tan(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        AssertSimilar(1.5574077246549, Math.Tan(1.0));
+        Assert.Equal(0.0, Math.Tan(0.0));
+        AssertSimilar(-1.5574077246549, Math.Tan(-1.0));
+        Assert.Equal(double.NaN, Math.Tan(double.NaN));
+        Assert.Equal(double.NaN, Math.Tan(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Tan(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestCosh()
+    public static void Cosh()
     {
-        double d;
-
-        d = Math.Cosh(1.0);
-        IsEqual(d, 1.54308063481524);
-        d = Math.Cosh(0.0);
-        IsEqual(d, 1.0);
-        d = Math.Cosh(-1.0);
-        IsEqual(d, 1.54308063481524);
-        d = Math.Cosh(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Cosh(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Cosh(Double.NegativeInfinity);
-        IsEqual(d, Double.PositiveInfinity);
+        AssertSimilar(1.54308063481524, Math.Cosh(1.0));
+        Assert.Equal(1.0, Math.Cosh(0.0));
+        AssertSimilar(1.54308063481524, Math.Cosh(-1.0));
+        Assert.Equal(double.NaN, Math.Cosh(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Cosh(double.PositiveInfinity));
+        Assert.Equal(double.PositiveInfinity, Math.Cosh(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestSinh()
+    public static void Sinh()
     {
-        double d;
-
-        d = Math.Sinh(1.0);
-        IsEqual(d, 1.1752011936438);
-        d = Math.Sinh(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Sinh(-1.0);
-        IsEqual(d, -1.1752011936438);
-        d = Math.Sinh(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Sinh(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Sinh(Double.NegativeInfinity);
-        IsEqual(d, Double.NegativeInfinity);
+        AssertSimilar(1.1752011936438, Math.Sinh(1.0));
+        Assert.Equal(0.0, Math.Sinh(0.0));
+        AssertSimilar(-1.1752011936438, Math.Sinh(-1.0));
+        Assert.Equal(double.NaN, Math.Sinh(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Sinh(double.PositiveInfinity));
+        Assert.Equal(double.NegativeInfinity, Math.Sinh(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestTanh()
+    public static void Tanh()
     {
-        double d;
-
-        d = Math.Tanh(1.0);
-        IsEqual(d, 0.761594155955765);
-        d = Math.Tanh(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Tanh(-1.0);
-        IsEqual(d, -0.761594155955765);
-        d = Math.Tanh(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Tanh(Double.PositiveInfinity);
-        IsEqual(d, 1.0);
-        d = Math.Tanh(Double.NegativeInfinity);
-        IsEqual(d, -1.0);
+        AssertSimilar(0.761594155955765, Math.Tanh(1.0));
+        Assert.Equal(0.0, Math.Tanh(0.0));
+        AssertSimilar(-0.761594155955765, Math.Tanh(-1.0));
+        Assert.Equal(double.NaN, Math.Tanh(double.NaN));
+        Assert.Equal(1.0, Math.Tanh(double.PositiveInfinity));
+        Assert.Equal(-1.0, Math.Tanh(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestACos()
+    public static void Acos()
     {
-        double d;
-
-        d = Math.Acos(1.0);
-        IsEqual(d, 0.0);
-        d = Math.Acos(0.0);
-        IsEqual(d, 1.5707963267949);
-        d = Math.Acos(-1.0);
-        IsEqual(d, 3.14159265358979);
-        d = Math.Acos(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Acos(Double.PositiveInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Acos(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        Assert.Equal(0.0, Math.Acos(1.0));
+        AssertSimilar(1.5707963267949, Math.Acos(0.0));
+        AssertSimilar(3.14159265358979, Math.Acos(-1.0));
+        Assert.Equal(double.NaN, Math.Acos(double.NaN));
+        Assert.Equal(double.NaN, Math.Acos(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Acos(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestASin()
+    public static void Asin()
     {
-        double d;
-
-        d = Math.Asin(1.0);
-        IsEqual(d, 1.5707963267949);
-        d = Math.Asin(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Asin(-1.0);
-        IsEqual(d, -1.5707963267949);
-        d = Math.Asin(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Asin(Double.PositiveInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Asin(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        AssertSimilar(1.5707963267949, Math.Asin(1.0));
+        Assert.Equal(0.0, Math.Asin(0.0));
+        AssertSimilar(-1.5707963267949, Math.Asin(-1.0));
+        Assert.Equal(double.NaN, Math.Asin(double.NaN));
+        Assert.Equal(double.NaN, Math.Asin(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Asin(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestATan()
+    public static void Atan()
     {
-        double d;
-
-        d = Math.Atan(1.0);
-        IsEqual(d, 0.785398163397448);
-        d = Math.Atan(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Atan(-1.0);
-        IsEqual(d, -0.785398163397448);
-        d = Math.Atan(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Atan(Double.PositiveInfinity);
-        IsEqual(d, 1.5707963267949);
-        d = Math.Atan(Double.NegativeInfinity);
-        IsEqual(d, -1.5707963267949);
+        AssertSimilar(0.785398163397448, Math.Atan(1.0));
+        Assert.Equal(0.0, Math.Atan(0.0));
+        AssertSimilar(-0.785398163397448, Math.Atan(-1.0));
+        Assert.Equal(double.NaN, Math.Atan(double.NaN));
+        AssertSimilar(1.5707963267949, Math.Atan(double.PositiveInfinity));
+        AssertSimilar(-1.5707963267949, Math.Atan(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestATan2()
+    public static void Atan2()
     {
-        double d;
-
-        d = Math.Atan2(0.0, 0.0);
-        IsEqual(d, 0.0);
-        d = Math.Atan2(1.0, 0.0);
-        IsEqual(d, 1.5707963267949);
-        d = Math.Atan2(2.0, 3.0);
-        IsEqual(d, 0.588002603547568);
-        d = Math.Atan2(0.0, 3.0);
-        IsEqual(d, 0.0);
-        d = Math.Atan2(-2.0, 3.0);
-        IsEqual(d, -0.588002603547568);
-        d = Math.Atan2(Double.NaN, 1.0);
-        IsEqual(d, Double.NaN);
-        d = Math.Atan2(1.0, Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Atan2(Double.PositiveInfinity, 1.0);
-        IsEqual(d, 1.5707963267949);
-        d = Math.Atan2(Double.NegativeInfinity, 1.0);
-        IsEqual(d, -1.5707963267949);
-        d = Math.Atan2(1.0, Double.PositiveInfinity);
-        IsEqual(d, 0.0);
-        d = Math.Atan2(1.0, Double.NegativeInfinity);
-        IsEqual(d, 3.14159265358979);
+        Assert.Equal(0.0, Math.Atan2(0.0, 0.0));
+        AssertSimilar(1.5707963267949, Math.Atan2(1.0, 0.0));
+        AssertSimilar(0.588002603547568, Math.Atan2(2.0, 3.0));
+        Assert.Equal(0.0, Math.Atan2(0.0, 3.0));
+        AssertSimilar(-0.588002603547568, Math.Atan2(-2.0, 3.0));
+        Assert.Equal(double.NaN, Math.Atan2(double.NaN, 1.0));
+        Assert.Equal(double.NaN, Math.Atan2(1.0, double.NaN));
+        AssertSimilar(1.5707963267949, Math.Atan2(double.PositiveInfinity, 1.0));
+        AssertSimilar(-1.5707963267949, Math.Atan2(double.NegativeInfinity, 1.0));
+        Assert.Equal(0.0, Math.Atan2(1.0, double.PositiveInfinity));
+        AssertSimilar(3.14159265358979, Math.Atan2(1.0, double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestCeiling()
+    public static void Ceiling_Decimal()
     {
-        double d;
-
-        d = Math.Ceiling(1.1);
-        IsEqual(d, 2.0);
-        d = Math.Ceiling(1.9);
-        IsEqual(d, 2.0);
-        d = Math.Ceiling(-1.1);
-        IsEqual(d, -1.0);
-        d = Math.Ceiling(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Ceiling(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Ceiling(Double.NaN);
-        IsEqual(d, Double.NaN);
+        Assert.Equal(2.0m, Math.Ceiling(1.1m));
+        Assert.Equal(2.0m, Math.Ceiling(1.9m));
+        Assert.Equal(-1.0m, Math.Ceiling(-1.1m));
     }
 
     [Fact]
-    public static void TestFloor()
+    public static void Ceiling_Double()
     {
-        double d;
-
-        d = Math.Floor(1.1);
-        IsEqual(d, 1.0);
-        d = Math.Floor(1.9);
-        IsEqual(d, 1.0);
-        d = Math.Floor(-1.1);
-        IsEqual(d, -2.0);
-        d = Math.Floor(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Floor(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Floor(Double.NaN);
-        IsEqual(d, Double.NaN);
+        Assert.Equal(2.0, Math.Ceiling(1.1));
+        Assert.Equal(2.0, Math.Ceiling(1.9));
+        Assert.Equal(-1.0, Math.Ceiling(-1.1));
+        Assert.Equal(double.NaN, Math.Ceiling(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Ceiling(double.PositiveInfinity));
+        Assert.Equal(double.NegativeInfinity, Math.Ceiling(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestRound()
+    public static void Floor_Decimal()
     {
-        double d;
-
-        d = Math.Round(0.0);
-        IsEqual(d, 0.0);
-
-        d = Math.Round(1.4);
-        IsEqual(d, 1.0);
-
-        d = Math.Round(1.5);
-        IsEqual(d, 2.0);
-
-        d = Math.Round(2e16);
-        IsEqual(d, 2e16);
-
-        d = Math.Round(-0.0);
-        IsEqual(d, 0.0);
-
-        d = Math.Round(-1.4);
-        IsEqual(d, -1.0);
-
-        d = Math.Round(-1.5);
-        IsEqual(d, -2.0);
-
-        d = Math.Round(-2e16);
-        IsEqual(d, -2e16);
+        Assert.Equal(1.0m, Math.Floor(1.1m));
+        Assert.Equal(1.0m, Math.Floor(1.9m));
+        Assert.Equal(-2.0m, Math.Floor(-1.1m));
     }
 
     [Fact]
-    public static void TestRoundDigits()
+    public static void Floor_Double()
     {
-        double d;
-
-        d = Math.Round(3.42156, 3, MidpointRounding.AwayFromZero);
-        IsEqual(d, 3.422);
-
-        d = Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero);
-        IsEqual(d, -3.422);
-
-        d = Math.Round(0.0, 3, MidpointRounding.AwayFromZero);
-        IsEqual(d, 0.0);
-
-        d = Math.Round(Double.NaN, 3, MidpointRounding.AwayFromZero);
-        IsEqual(d, Double.NaN);
-
-        d = Math.Round(Double.PositiveInfinity, 3, MidpointRounding.AwayFromZero);
-        IsEqual(d, Double.PositiveInfinity);
-
-        d = Math.Round(Double.NegativeInfinity, 3, MidpointRounding.AwayFromZero);
-        IsEqual(d, Double.NegativeInfinity);
-
-        Decimal dec;
-        dec = Math.Round((Decimal)3.42156, 3, MidpointRounding.AwayFromZero);
-        Assert.Equal(dec, (Decimal)3.422);
-
-        dec = Math.Round((Decimal)(-3.42156), 3, MidpointRounding.AwayFromZero);
-        Assert.Equal(dec, (Decimal)(-3.422));
-
-        dec = Math.Round(Decimal.Zero, 3, MidpointRounding.AwayFromZero);
-        Assert.Equal(dec, Decimal.Zero);
+        Assert.Equal(1.0, Math.Floor(1.1));
+        Assert.Equal(1.0, Math.Floor(1.9));
+        Assert.Equal(-2.0, Math.Floor(-1.1));
+        Assert.Equal(double.NaN, Math.Floor(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Floor(double.PositiveInfinity));
+        Assert.Equal(double.NegativeInfinity, Math.Floor(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestSqrt()
+    public static void Round_Decimal()
     {
-        double d;
-
-        d = Math.Sqrt(3.0);
-        IsEqual(d, 1.73205080756888);
-        d = Math.Sqrt(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Sqrt(-3.0);
-        IsEqual(d, Double.NaN);
-        d = Math.Sqrt(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Sqrt(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Sqrt(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        Assert.Equal(0.0m, Math.Round(0.0m));
+        Assert.Equal(1.0m, Math.Round(1.4m));
+        Assert.Equal(2.0m, Math.Round(1.5m));
+        Assert.Equal(2e16m, Math.Round(2e16m));
+        Assert.Equal(0.0m, Math.Round(-0.0m));
+        Assert.Equal(-1.0m, Math.Round(-1.4m));
+        Assert.Equal(-2.0m, Math.Round(-1.5m));
+        Assert.Equal(-2e16m, Math.Round(-2e16m));
     }
 
     [Fact]
-    public static void TestLog()
+    public static void Round_Decimal_Digits()
     {
-        double d;
-
-        d = Math.Log(3.0);
-        IsEqual(d, 1.09861228866811);
-        d = Math.Log(0.0);
-        IsEqual(d, Double.NegativeInfinity);
-        d = Math.Log(-3.0);
-        IsEqual(d, Double.NaN);
-        d = Math.Log(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Log(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Log(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        Assert.Equal(3.422m, Math.Round(3.42156m, 3, MidpointRounding.AwayFromZero));
+        Assert.Equal(-3.422m, Math.Round(-3.42156m, 3, MidpointRounding.AwayFromZero));
+        Assert.Equal(Decimal.Zero, Math.Round(Decimal.Zero, 3, MidpointRounding.AwayFromZero));
     }
 
     [Fact]
-    public static void TestLog10()
+    public static void Round_Double()
     {
-        double d;
-
-        d = Math.Log10(3.0);
-        IsEqual(d, 0.477121254719662);
-        d = Math.Log10(0.0);
-        IsEqual(d, Double.NegativeInfinity);
-        d = Math.Log10(-3.0);
-        IsEqual(d, Double.NaN);
-        d = Math.Log10(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Log10(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Log10(Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
+        Assert.Equal(0.0, Math.Round(0.0));
+        Assert.Equal(1.0, Math.Round(1.4));
+        Assert.Equal(2.0, Math.Round(1.5));
+        Assert.Equal(2e16, Math.Round(2e16));
+        Assert.Equal(0.0, Math.Round(-0.0));
+        Assert.Equal(-1.0, Math.Round(-1.4));
+        Assert.Equal(-2.0, Math.Round(-1.5));
+        Assert.Equal(-2e16, Math.Round(-2e16));
     }
 
     [Fact]
-    public static void TestPow()
+    public static void Round_Double_Digits()
     {
-        double d;
-
-        d = Math.Pow(0.0, 0.0);
-        IsEqual(d, 1.0);
-        d = Math.Pow(1.0, 0.0);
-        IsEqual(d, 1.0);
-        d = Math.Pow(2.0, 3.0);
-        IsEqual(d, 8.0);
-        d = Math.Pow(0.0, 3.0);
-        IsEqual(d, 0.0);
-        d = Math.Pow(-2.0, 3.0);
-        IsEqual(d, -8.0);
-        d = Math.Pow(Double.NaN, 1.0);
-        IsEqual(d, Double.NaN);
-        d = Math.Pow(1.0, Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Pow(Double.PositiveInfinity, 1.0);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Pow(Double.NegativeInfinity, 1.0);
-        IsEqual(d, Double.NegativeInfinity);
-        d = Math.Pow(1.0, Double.PositiveInfinity);
-        IsEqual(d, 1.0);
-        d = Math.Pow(1.0, Double.NegativeInfinity);
-        IsEqual(d, 1.0);
-        d = Math.Pow(-1.0, Double.PositiveInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Pow(-1.0, Double.NegativeInfinity);
-        IsEqual(d, Double.NaN);
-        d = Math.Pow(1.1, Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Pow(1.1, Double.NegativeInfinity);
-        IsEqual(d, 0.0);
+        AssertSimilar(3.422, Math.Round(3.42156, 3, MidpointRounding.AwayFromZero));
+        AssertSimilar(-3.422, Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero));
+        Assert.Equal(0.0, Math.Round(0.0, 3, MidpointRounding.AwayFromZero));
+        Assert.Equal(double.NaN, Math.Round(double.NaN, 3, MidpointRounding.AwayFromZero));
+        Assert.Equal(double.PositiveInfinity, Math.Round(double.PositiveInfinity, 3, MidpointRounding.AwayFromZero));
+        Assert.Equal(double.NegativeInfinity, Math.Round(double.NegativeInfinity, 3, MidpointRounding.AwayFromZero));
     }
 
     [Fact]
-    public static void TestFAbs()
+    public static void Sqrt()
     {
-        float d;
-
-        d = Math.Abs(3.0f);
-        IsEqual(d, 3.0);
-        d = Math.Abs(0.0f);
-        IsEqual(d, 0.0);
-        d = Math.Abs(-3.0f);
-        IsEqual(d, 3.0);
-        d = Math.Abs(Single.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Abs(Single.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Abs(Single.NegativeInfinity);
-        IsEqual(d, Double.PositiveInfinity);
+        AssertSimilar(1.73205080756888, Math.Sqrt(3.0));
+        Assert.Equal(0.0, Math.Sqrt(0.0));
+        Assert.Equal(double.NaN, Math.Sqrt(-3.0));
+        Assert.Equal(double.NaN, Math.Sqrt(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Sqrt(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Sqrt(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestAbs()
+    public static void Log()
     {
-        double d;
-
-        d = Math.Abs(3.0);
-        IsEqual(d, 3.0);
-        d = Math.Abs(0.0);
-        IsEqual(d, 0.0);
-        d = Math.Abs(-3.0);
-        IsEqual(d, 3.0);
-        d = Math.Abs(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Abs(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Abs(Double.NegativeInfinity);
-        IsEqual(d, Double.PositiveInfinity);
+        AssertSimilar(1.09861228866811, Math.Log(3.0));
+        Assert.Equal(double.NegativeInfinity, Math.Log(0.0));
+        Assert.Equal(double.NaN, Math.Log(-3.0));
+        Assert.Equal(double.NaN, Math.Log(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestExp()
+    public static void LogWithBase()
     {
-        double d;
-
-        d = Math.Exp(3.0);
-        IsEqual(d, 20.0855369231877);
-        d = Math.Exp(0.0);
-        IsEqual(d, 1.0);
-        d = Math.Exp(-3.0);
-        IsEqual(d, 0.0497870683678639);
-        d = Math.Exp(Double.NaN);
-        IsEqual(d, Double.NaN);
-        d = Math.Exp(Double.PositiveInfinity);
-        IsEqual(d, Double.PositiveInfinity);
-        d = Math.Exp(Double.NegativeInfinity);
-        IsEqual(d, 0.0);
+        Assert.Equal(1.0, Math.Log(3.0, 3.0));
+        AssertSimilar(2.40217350273, Math.Log(14, 3.0));
+        Assert.Equal(double.NegativeInfinity, Math.Log(0.0, 3.0));
+        Assert.Equal(double.NaN, Math.Log(-3.0, 3.0));
+        Assert.Equal(double.NaN, Math.Log(double.NaN, 3.0));
+        Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
+        Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
     }
 
     [Fact]
-    public static void TestDecimalAbs()
+    public static void Log10()
     {
-        Decimal d;
-
-        d = Math.Abs(new Decimal(3.0));
-        IsEqual(Decimal.ToDouble(d), 3.0);
-        d = Math.Abs(new Decimal(-3.0));
-        IsEqual(Decimal.ToDouble(d), 3.0);
+        AssertSimilar(0.477121254719662, Math.Log10(3.0));
+        Assert.Equal(double.NegativeInfinity, Math.Log10(0.0));
+        Assert.Equal(double.NaN, Math.Log10(-3.0));
+        Assert.Equal(double.NaN, Math.Log10(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Log10(double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestDecimalMin()
+    public static void Pow()
     {
-        Decimal d;
-
-        d = Math.Min(new Decimal(3.0), new Decimal(-2.0));
-        Assert.Equal(d, new Decimal(-2.0));
+        Assert.Equal(1.0, Math.Pow(0.0, 0.0));
+        Assert.Equal(1.0, Math.Pow(1.0, 0.0));
+        Assert.Equal(8.0, Math.Pow(2.0, 3.0));
+        Assert.Equal(0.0, Math.Pow(0.0, 3.0));
+        Assert.Equal(-8.0, Math.Pow(-2.0, 3.0));
+        Assert.Equal(double.NaN, Math.Pow(double.NaN, 1.0));
+        Assert.Equal(double.NaN, Math.Pow(1.0, double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Pow(double.PositiveInfinity, 1.0));
+        Assert.Equal(double.NegativeInfinity, Math.Pow(double.NegativeInfinity, 1.0));
+        Assert.Equal(1.0, Math.Pow(1.0, double.PositiveInfinity));
+        Assert.Equal(1.0, Math.Pow(1.0, double.NegativeInfinity));
+        Assert.Equal(double.NaN, Math.Pow(-1.0, double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Pow(-1.0, double.NegativeInfinity));
+        Assert.Equal(double.PositiveInfinity, Math.Pow(1.1, double.PositiveInfinity));
+        Assert.Equal(0.0, Math.Pow(1.1, double.NegativeInfinity));
     }
 
     [Fact]
-    public static void TestDecimalMax()
+    public static void Abs_Decimal()
     {
-        Decimal d;
-
-        d = Math.Max(new Decimal(3.0), new Decimal(-2.0));
-        Assert.Equal(d, new Decimal(3.0));
+        Assert.Equal(3.0m, Math.Abs(3.0m));
+        Assert.Equal(0.0m, Math.Abs(0.0m));
+        Assert.Equal(0.0m, Math.Abs(-0.0m));
+        Assert.Equal(3.0m, Math.Abs(-3.0m));
+        Assert.Equal(Decimal.MaxValue, Math.Abs(Decimal.MinValue));
     }
 
-    private static void IsEqual(double d1, double d2)
+    [Fact]
+    public static void Abs_Double()
     {
-        if (d1 == d2)
+        Assert.Equal(3.0, Math.Abs(3.0));
+        Assert.Equal(0.0, Math.Abs(0.0));
+        Assert.Equal(3.0, Math.Abs(-3.0));
+        Assert.Equal(double.NaN, Math.Abs(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Abs(double.PositiveInfinity));
+        Assert.Equal(double.PositiveInfinity, Math.Abs(double.NegativeInfinity));
+    }
+
+    [Fact]
+    public static void Abs_Short()
+    {
+        Assert.Equal((short)3, Math.Abs((short)3));
+        Assert.Equal((short)0, Math.Abs((short)0));
+        Assert.Equal((short)3, Math.Abs((short)(-3)));
+        Assert.Throws<OverflowException>(() => Math.Abs(short.MinValue));
+    }
+
+    [Fact]
+    public static void Abs_Int()
+    {
+        Assert.Equal(3, Math.Abs(3));
+        Assert.Equal(0, Math.Abs(0));
+        Assert.Equal(3, Math.Abs(-3));
+        Assert.Throws<OverflowException>(() => Math.Abs(int.MinValue));
+    }
+
+    [Fact]
+    public static void Abs_Long()
+    {
+        Assert.Equal(3L, Math.Abs(3L));
+        Assert.Equal(0L, Math.Abs(0L));
+        Assert.Equal(3L, Math.Abs(-3L));
+        Assert.Throws<OverflowException>(() => Math.Abs(long.MinValue));
+    }
+
+    [Fact]
+    public static void Abs_SByte()
+    {
+        Assert.Equal((sbyte)3, Math.Abs((sbyte)3));
+        Assert.Equal((sbyte)0, Math.Abs((sbyte)0));
+        Assert.Equal((sbyte)3, Math.Abs((sbyte)(-3)));
+        Assert.Throws<OverflowException>(() => Math.Abs(sbyte.MinValue));
+    }
+
+    [Fact]
+    public static void Abs_Float()
+    {
+        Assert.Equal(3.0, Math.Abs(3.0f));
+        Assert.Equal(0.0, Math.Abs(0.0f));
+        Assert.Equal(3.0, Math.Abs(-3.0f));
+        Assert.Equal(float.NaN, Math.Abs(float.NaN));
+        Assert.Equal(float.PositiveInfinity, Math.Abs(float.PositiveInfinity));
+        Assert.Equal(float.PositiveInfinity, Math.Abs(float.NegativeInfinity));
+    }
+
+    [Fact]
+    public static void Exp()
+    {
+        AssertSimilar(20.0855369231877, Math.Exp(3.0));
+        Assert.Equal(1.0, Math.Exp(0.0));
+        AssertSimilar(0.0497870683678639, Math.Exp(-3.0));
+        Assert.Equal(double.NaN, Math.Exp(double.NaN));
+        Assert.Equal(double.PositiveInfinity, Math.Exp(double.PositiveInfinity));
+        Assert.Equal(0.0, Math.Exp(double.NegativeInfinity));
+    }
+
+    [Fact]
+    public static void IEEERemainder()
+    {
+        AssertSimilar(-1.0, Math.IEEERemainder(3, 2));
+        AssertSimilar(0.0, Math.IEEERemainder(4, 2));
+        AssertSimilar(1.0, Math.IEEERemainder(10, 3));
+        AssertSimilar(-1.0, Math.IEEERemainder(11, 3));
+        AssertSimilar(-2.0, Math.IEEERemainder(28, 5));
+        AssertSimilar(1.8, Math.IEEERemainder(17.8, 4));
+        AssertSimilar(1.4, Math.IEEERemainder(17.8, 4.1));
+        AssertSimilar(0.0999999999999979, Math.IEEERemainder(-16.3, 4.1));
+        AssertSimilar(1.4, Math.IEEERemainder(17.8, -4.1));
+        AssertSimilar(-1.4, Math.IEEERemainder(-17.8, -4.1));
+    }
+
+    [Fact]
+    public static void Min_Byte()
+    {
+        Assert.Equal((byte)2, Math.Min((byte)3, (byte)2));
+        Assert.Equal(byte.MinValue, Math.Min(byte.MinValue, byte.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_Decimal()
+    {
+        Assert.Equal(-2.0m, Math.Min(3.0m, -2.0m));
+        Assert.Equal(decimal.MinValue, Math.Min(decimal.MinValue, decimal.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_Double()
+    {
+        Assert.Equal(-2.0, Math.Min(3.0, -2.0));
+        Assert.Equal(double.MinValue, Math.Min(double.MinValue, double.MaxValue));
+        Assert.Equal(double.NegativeInfinity, Math.Min(double.NegativeInfinity, double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Min(double.NegativeInfinity, double.NaN));
+        Assert.Equal(double.NaN, Math.Min(double.NaN, double.NaN));
+    }
+
+    [Fact]
+    public static void Min_Short()
+    {
+        Assert.Equal((short)(-2), Math.Min((short)3, (short)(-2)));
+        Assert.Equal(short.MinValue, Math.Min(short.MinValue, short.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_Int()
+    {
+        Assert.Equal(-2, Math.Min(3, -2));
+        Assert.Equal(int.MinValue, Math.Min(int.MinValue, int.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_Long()
+    {
+        Assert.Equal(-2L, Math.Min(3L, -2L));
+        Assert.Equal(long.MinValue, Math.Min(long.MinValue, long.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_SByte()
+    {
+        Assert.Equal((sbyte)(-2), Math.Min((sbyte)3, (sbyte)(-2)));
+        Assert.Equal(sbyte.MinValue, Math.Min(sbyte.MinValue, sbyte.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_Float()
+    {
+        Assert.Equal(-2.0f, Math.Min(3.0f, -2.0f));
+        Assert.Equal(float.MinValue, Math.Min(float.MinValue, float.MaxValue));
+        Assert.Equal(float.NegativeInfinity, Math.Min(float.NegativeInfinity, float.PositiveInfinity));
+        Assert.Equal(float.NaN, Math.Min(float.NegativeInfinity, float.NaN));
+        Assert.Equal(float.NaN, Math.Min(float.NaN, float.NaN));
+    }
+
+    [Fact]
+    public static void Min_UShort()
+    {
+        Assert.Equal((ushort)2, Math.Min((ushort)3, (ushort)2));
+        Assert.Equal(ushort.MinValue, Math.Min(ushort.MinValue, ushort.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_UInt()
+    {
+        Assert.Equal((uint)2, Math.Min((uint)3, (uint)2));
+        Assert.Equal(uint.MinValue, Math.Min(uint.MinValue, uint.MaxValue));
+    }
+
+    [Fact]
+    public static void Min_ULong()
+    {
+        Assert.Equal((ulong)2, Math.Min((ulong)3, (ulong)2));
+        Assert.Equal(ulong.MinValue, Math.Min(ulong.MinValue, ulong.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_Byte()
+    {
+        Assert.Equal((byte)3, Math.Max((byte)2, (byte)3));
+        Assert.Equal(byte.MaxValue, Math.Max(byte.MinValue, byte.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_Decimal()
+    {
+        Assert.Equal(3.0m, Math.Max(-2.0m, 3.0m));
+        Assert.Equal(decimal.MaxValue, Math.Max(decimal.MinValue, decimal.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_Double()
+    {
+        Assert.Equal(3.0, Math.Max(3.0, -2.0));
+        Assert.Equal(double.MaxValue, Math.Max(double.MinValue, double.MaxValue));
+        Assert.Equal(double.PositiveInfinity, Math.Max(double.NegativeInfinity, double.PositiveInfinity));
+        Assert.Equal(double.NaN, Math.Max(double.PositiveInfinity, double.NaN));
+        Assert.Equal(double.NaN, Math.Max(double.NaN, double.NaN));
+    }
+
+    [Fact]
+    public static void Max_Short()
+    {
+        Assert.Equal((short)3, Math.Max((short)(-2), (short)3));
+        Assert.Equal(short.MaxValue, Math.Max(short.MinValue, short.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_Int()
+    {
+        Assert.Equal(3, Math.Max(-2, 3));
+        Assert.Equal(int.MaxValue, Math.Max(int.MinValue, int.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_Long()
+    {
+        Assert.Equal(3L, Math.Max(-2L, 3L));
+        Assert.Equal(long.MaxValue, Math.Max(long.MinValue, long.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_SByte()
+    {
+        Assert.Equal((sbyte)3, Math.Max((sbyte)(-2), (sbyte)3));
+        Assert.Equal(sbyte.MaxValue, Math.Max(sbyte.MinValue, sbyte.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_Float()
+    {
+        Assert.Equal(3.0f, Math.Max(3.0f, -2.0f));
+        Assert.Equal(float.MaxValue, Math.Max(float.MinValue, float.MaxValue));
+        Assert.Equal(float.PositiveInfinity, Math.Max(float.NegativeInfinity, float.PositiveInfinity));
+        Assert.Equal(float.NaN, Math.Max(float.PositiveInfinity, float.NaN));
+        Assert.Equal(float.NaN, Math.Max(float.NaN, float.NaN));
+    }
+
+    [Fact]
+    public static void Max_UShort()
+    {
+        Assert.Equal((ushort)3, Math.Max((ushort)2, (ushort)3));
+        Assert.Equal(ushort.MaxValue, Math.Max(ushort.MinValue, ushort.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_UInt()
+    {
+        Assert.Equal((uint)3, Math.Max((uint)2, (uint)3));
+        Assert.Equal(uint.MaxValue, Math.Max(uint.MinValue, uint.MaxValue));
+    }
+
+    [Fact]
+    public static void Max_ULong()
+    {
+        Assert.Equal((ulong)3, Math.Max((ulong)2, (ulong)3));
+        Assert.Equal(ulong.MaxValue, Math.Max(ulong.MinValue, ulong.MaxValue));
+    }
+
+    [Fact]
+    public static void Sign_Decimal()
+    {
+        Assert.Equal(0, Math.Sign(0.0m));
+        Assert.Equal(0, Math.Sign(-0.0m));
+        Assert.Equal(-1, Math.Sign(-3.14m));
+        Assert.Equal(1, Math.Sign(3.14m));
+    }
+
+    [Fact]
+    public static void Sign_Double()
+    {
+        Assert.Equal(0, Math.Sign(0.0));
+        Assert.Equal(0, Math.Sign(-0.0));
+        Assert.Equal(-1, Math.Sign(-3.14));
+        Assert.Equal(1, Math.Sign(3.14));
+        Assert.Equal(-1, Math.Sign(double.NegativeInfinity));
+        Assert.Equal(1, Math.Sign(double.PositiveInfinity));
+        Assert.Throws<ArithmeticException>(() => Math.Sign(double.NaN));
+    }
+
+    [Fact]
+    public static void Sign_Short()
+    {
+        Assert.Equal(0, Math.Sign((short)0));
+        Assert.Equal(-1, Math.Sign((short)(-3)));
+        Assert.Equal(1, Math.Sign((short)3));
+    }
+
+    [Fact]
+    public static void Sign_Int()
+    {
+        Assert.Equal(0, Math.Sign(0));
+        Assert.Equal(-1, Math.Sign(-3));
+        Assert.Equal(1, Math.Sign(3));
+    }
+
+    [Fact]
+    public static void Sign_Long()
+    {
+        Assert.Equal(0, Math.Sign(0));
+        Assert.Equal(-1, Math.Sign(-3));
+        Assert.Equal(1, Math.Sign(3));
+    }
+
+    [Fact]
+    public static void Sign_SByte()
+    {
+        Assert.Equal(0, Math.Sign((sbyte)0));
+        Assert.Equal(-1, Math.Sign((sbyte)(-3)));
+        Assert.Equal(1, Math.Sign((sbyte)3));
+    }
+
+    [Fact]
+    public static void Sign_Float()
+    {
+        Assert.Equal(0, Math.Sign(0.0f));
+        Assert.Equal(0, Math.Sign(-0.0f));
+        Assert.Equal(-1, Math.Sign(-3.14f));
+        Assert.Equal(1, Math.Sign(3.14f));
+        Assert.Equal(-1, Math.Sign(float.NegativeInfinity));
+        Assert.Equal(1, Math.Sign(float.PositiveInfinity));
+        Assert.Throws<ArithmeticException>(() => Math.Sign(float.NaN));
+    }
+
+    [Fact]
+    public static void Truncate_Decimal()
+    {
+        Assert.Equal(0.0m, Math.Truncate(0.12345m));
+        Assert.Equal(3.0m, Math.Truncate(3.14159m));
+        Assert.Equal(-3.0m, Math.Truncate(-3.14159m));
+    }
+
+    [Fact]
+    public static void Truncate_Double()
+    {
+        Assert.Equal(0.0, Math.Truncate(0.12345));
+        Assert.Equal(3.0, Math.Truncate(3.14159));
+        Assert.Equal(-3.0, Math.Truncate(-3.14159));
+    }
+
+    private static void AssertSimilar(double expected, double actual)
+    {
+        if (expected == actual)
             return;
-        if (Double.IsNaN(d1) && Double.IsNaN(d2))
+
+        if (double.IsNaN(expected) && double.IsNaN(actual))
             return;
-        double delta = d2 - d1;
+
+        double delta = actual - expected;
         if (delta < 0.0)
             delta = -delta;
 
-        if (d1 == 0.0 && delta < 0.00000001)
+        if (expected == 0.0 && delta < 0.00000001)
             return;
-        double dividend = d1;
+
+        // Assert that actual is within 0.01% of expected
+        double dividend = expected;
         if (dividend < 0)
             dividend = -dividend;
-        if ((delta / dividend) < 0.0001)
+        if (delta / dividend < 0.0001)
             return;
 
-        throw new Exception("Doubles not equal: " + d1 + " != " + d2);
+        Assert.True(false, string.Format("Doubles not equal: Expected [{0}] != Actual [{1}]", expected, actual));
     }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -1,0 +1,514 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public static unsafe class MathTests
+{
+    [Fact]
+    public static void TestCos()
+    {
+        double d;
+
+        d = Math.Cos(1.0);
+        IsEqual(d, 0.54030230586814);
+        d = Math.Cos(0.0);
+        IsEqual(d, 1.0);
+        d = Math.Cos(-1.0);
+        IsEqual(d, 0.54030230586814);
+        d = Math.Cos(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Cos(Double.PositiveInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Cos(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestSin()
+    {
+        double d;
+
+        d = Math.Sin(1.0);
+        IsEqual(d, 0.841470984807897);
+        d = Math.Sin(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Sin(-1.0);
+        IsEqual(d, -0.841470984807897);
+        d = Math.Sin(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Sin(Double.PositiveInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Sin(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestTan()
+    {
+        double d;
+
+        d = Math.Tan(1.0);
+        IsEqual(d, 1.5574077246549);
+        d = Math.Tan(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Tan(-1.0);
+        IsEqual(d, -1.5574077246549);
+        d = Math.Tan(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Tan(Double.PositiveInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Tan(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestCosh()
+    {
+        double d;
+
+        d = Math.Cosh(1.0);
+        IsEqual(d, 1.54308063481524);
+        d = Math.Cosh(0.0);
+        IsEqual(d, 1.0);
+        d = Math.Cosh(-1.0);
+        IsEqual(d, 1.54308063481524);
+        d = Math.Cosh(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Cosh(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Cosh(Double.NegativeInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+    }
+
+    [Fact]
+    public static void TestSinh()
+    {
+        double d;
+
+        d = Math.Sinh(1.0);
+        IsEqual(d, 1.1752011936438);
+        d = Math.Sinh(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Sinh(-1.0);
+        IsEqual(d, -1.1752011936438);
+        d = Math.Sinh(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Sinh(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Sinh(Double.NegativeInfinity);
+        IsEqual(d, Double.NegativeInfinity);
+    }
+
+    [Fact]
+    public static void TestTanh()
+    {
+        double d;
+
+        d = Math.Tanh(1.0);
+        IsEqual(d, 0.761594155955765);
+        d = Math.Tanh(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Tanh(-1.0);
+        IsEqual(d, -0.761594155955765);
+        d = Math.Tanh(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Tanh(Double.PositiveInfinity);
+        IsEqual(d, 1.0);
+        d = Math.Tanh(Double.NegativeInfinity);
+        IsEqual(d, -1.0);
+    }
+
+    [Fact]
+    public static void TestACos()
+    {
+        double d;
+
+        d = Math.Acos(1.0);
+        IsEqual(d, 0.0);
+        d = Math.Acos(0.0);
+        IsEqual(d, 1.5707963267949);
+        d = Math.Acos(-1.0);
+        IsEqual(d, 3.14159265358979);
+        d = Math.Acos(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Acos(Double.PositiveInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Acos(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestASin()
+    {
+        double d;
+
+        d = Math.Asin(1.0);
+        IsEqual(d, 1.5707963267949);
+        d = Math.Asin(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Asin(-1.0);
+        IsEqual(d, -1.5707963267949);
+        d = Math.Asin(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Asin(Double.PositiveInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Asin(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestATan()
+    {
+        double d;
+
+        d = Math.Atan(1.0);
+        IsEqual(d, 0.785398163397448);
+        d = Math.Atan(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Atan(-1.0);
+        IsEqual(d, -0.785398163397448);
+        d = Math.Atan(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Atan(Double.PositiveInfinity);
+        IsEqual(d, 1.5707963267949);
+        d = Math.Atan(Double.NegativeInfinity);
+        IsEqual(d, -1.5707963267949);
+    }
+
+    [Fact]
+    public static void TestATan2()
+    {
+        double d;
+
+        d = Math.Atan2(0.0, 0.0);
+        IsEqual(d, 0.0);
+        d = Math.Atan2(1.0, 0.0);
+        IsEqual(d, 1.5707963267949);
+        d = Math.Atan2(2.0, 3.0);
+        IsEqual(d, 0.588002603547568);
+        d = Math.Atan2(0.0, 3.0);
+        IsEqual(d, 0.0);
+        d = Math.Atan2(-2.0, 3.0);
+        IsEqual(d, -0.588002603547568);
+        d = Math.Atan2(Double.NaN, 1.0);
+        IsEqual(d, Double.NaN);
+        d = Math.Atan2(1.0, Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Atan2(Double.PositiveInfinity, 1.0);
+        IsEqual(d, 1.5707963267949);
+        d = Math.Atan2(Double.NegativeInfinity, 1.0);
+        IsEqual(d, -1.5707963267949);
+        d = Math.Atan2(1.0, Double.PositiveInfinity);
+        IsEqual(d, 0.0);
+        d = Math.Atan2(1.0, Double.NegativeInfinity);
+        IsEqual(d, 3.14159265358979);
+    }
+
+    [Fact]
+    public static void TestCeiling()
+    {
+        double d;
+
+        d = Math.Ceiling(1.1);
+        IsEqual(d, 2.0);
+        d = Math.Ceiling(1.9);
+        IsEqual(d, 2.0);
+        d = Math.Ceiling(-1.1);
+        IsEqual(d, -1.0);
+        d = Math.Ceiling(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Ceiling(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Ceiling(Double.NaN);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestFloor()
+    {
+        double d;
+
+        d = Math.Floor(1.1);
+        IsEqual(d, 1.0);
+        d = Math.Floor(1.9);
+        IsEqual(d, 1.0);
+        d = Math.Floor(-1.1);
+        IsEqual(d, -2.0);
+        d = Math.Floor(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Floor(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Floor(Double.NaN);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestRound()
+    {
+        double d;
+
+        d = Math.Round(0.0);
+        IsEqual(d, 0.0);
+
+        d = Math.Round(1.4);
+        IsEqual(d, 1.0);
+
+        d = Math.Round(1.5);
+        IsEqual(d, 2.0);
+
+        d = Math.Round(2e16);
+        IsEqual(d, 2e16);
+
+        d = Math.Round(-0.0);
+        IsEqual(d, 0.0);
+
+        d = Math.Round(-1.4);
+        IsEqual(d, -1.0);
+
+        d = Math.Round(-1.5);
+        IsEqual(d, -2.0);
+
+        d = Math.Round(-2e16);
+        IsEqual(d, -2e16);
+    }
+
+    [Fact]
+    public static void TestRoundDigits()
+    {
+        double d;
+
+        d = Math.Round(3.42156, 3, MidpointRounding.AwayFromZero);
+        IsEqual(d, 3.422);
+
+        d = Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero);
+        IsEqual(d, -3.422);
+
+        d = Math.Round(0.0, 3, MidpointRounding.AwayFromZero);
+        IsEqual(d, 0.0);
+
+        d = Math.Round(Double.NaN, 3, MidpointRounding.AwayFromZero);
+        IsEqual(d, Double.NaN);
+
+        d = Math.Round(Double.PositiveInfinity, 3, MidpointRounding.AwayFromZero);
+        IsEqual(d, Double.PositiveInfinity);
+
+        d = Math.Round(Double.NegativeInfinity, 3, MidpointRounding.AwayFromZero);
+        IsEqual(d, Double.NegativeInfinity);
+
+        Decimal dec;
+        dec = Math.Round((Decimal)3.42156, 3, MidpointRounding.AwayFromZero);
+        Assert.Equal(dec, (Decimal)3.422);
+
+        dec = Math.Round((Decimal)(-3.42156), 3, MidpointRounding.AwayFromZero);
+        Assert.Equal(dec, (Decimal)(-3.422));
+
+        dec = Math.Round(Decimal.Zero, 3, MidpointRounding.AwayFromZero);
+        Assert.Equal(dec, Decimal.Zero);
+    }
+
+    [Fact]
+    public static void TestSqrt()
+    {
+        double d;
+
+        d = Math.Sqrt(3.0);
+        IsEqual(d, 1.73205080756888);
+        d = Math.Sqrt(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Sqrt(-3.0);
+        IsEqual(d, Double.NaN);
+        d = Math.Sqrt(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Sqrt(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Sqrt(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestLog()
+    {
+        double d;
+
+        d = Math.Log(3.0);
+        IsEqual(d, 1.09861228866811);
+        d = Math.Log(0.0);
+        IsEqual(d, Double.NegativeInfinity);
+        d = Math.Log(-3.0);
+        IsEqual(d, Double.NaN);
+        d = Math.Log(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Log(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Log(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestLog10()
+    {
+        double d;
+
+        d = Math.Log10(3.0);
+        IsEqual(d, 0.477121254719662);
+        d = Math.Log10(0.0);
+        IsEqual(d, Double.NegativeInfinity);
+        d = Math.Log10(-3.0);
+        IsEqual(d, Double.NaN);
+        d = Math.Log10(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Log10(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Log10(Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+    }
+
+    [Fact]
+    public static void TestPow()
+    {
+        double d;
+
+        d = Math.Pow(0.0, 0.0);
+        IsEqual(d, 1.0);
+        d = Math.Pow(1.0, 0.0);
+        IsEqual(d, 1.0);
+        d = Math.Pow(2.0, 3.0);
+        IsEqual(d, 8.0);
+        d = Math.Pow(0.0, 3.0);
+        IsEqual(d, 0.0);
+        d = Math.Pow(-2.0, 3.0);
+        IsEqual(d, -8.0);
+        d = Math.Pow(Double.NaN, 1.0);
+        IsEqual(d, Double.NaN);
+        d = Math.Pow(1.0, Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Pow(Double.PositiveInfinity, 1.0);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Pow(Double.NegativeInfinity, 1.0);
+        IsEqual(d, Double.NegativeInfinity);
+        d = Math.Pow(1.0, Double.PositiveInfinity);
+        IsEqual(d, 1.0);
+        d = Math.Pow(1.0, Double.NegativeInfinity);
+        IsEqual(d, 1.0);
+        d = Math.Pow(-1.0, Double.PositiveInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Pow(-1.0, Double.NegativeInfinity);
+        IsEqual(d, Double.NaN);
+        d = Math.Pow(1.1, Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Pow(1.1, Double.NegativeInfinity);
+        IsEqual(d, 0.0);
+    }
+
+    [Fact]
+    public static void TestFAbs()
+    {
+        float d;
+
+        d = Math.Abs(3.0f);
+        IsEqual(d, 3.0);
+        d = Math.Abs(0.0f);
+        IsEqual(d, 0.0);
+        d = Math.Abs(-3.0f);
+        IsEqual(d, 3.0);
+        d = Math.Abs(Single.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Abs(Single.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Abs(Single.NegativeInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+    }
+
+    [Fact]
+    public static void TestAbs()
+    {
+        double d;
+
+        d = Math.Abs(3.0);
+        IsEqual(d, 3.0);
+        d = Math.Abs(0.0);
+        IsEqual(d, 0.0);
+        d = Math.Abs(-3.0);
+        IsEqual(d, 3.0);
+        d = Math.Abs(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Abs(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Abs(Double.NegativeInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+    }
+
+    [Fact]
+    public static void TestExp()
+    {
+        double d;
+
+        d = Math.Exp(3.0);
+        IsEqual(d, 20.0855369231877);
+        d = Math.Exp(0.0);
+        IsEqual(d, 1.0);
+        d = Math.Exp(-3.0);
+        IsEqual(d, 0.0497870683678639);
+        d = Math.Exp(Double.NaN);
+        IsEqual(d, Double.NaN);
+        d = Math.Exp(Double.PositiveInfinity);
+        IsEqual(d, Double.PositiveInfinity);
+        d = Math.Exp(Double.NegativeInfinity);
+        IsEqual(d, 0.0);
+    }
+
+    [Fact]
+    public static void TestDecimalAbs()
+    {
+        Decimal d;
+
+        d = Math.Abs(new Decimal(3.0));
+        IsEqual(Decimal.ToDouble(d), 3.0);
+        d = Math.Abs(new Decimal(-3.0));
+        IsEqual(Decimal.ToDouble(d), 3.0);
+    }
+
+    [Fact]
+    public static void TestDecimalMin()
+    {
+        Decimal d;
+
+        d = Math.Min(new Decimal(3.0), new Decimal(-2.0));
+        Assert.Equal(d, new Decimal(-2.0));
+    }
+
+    [Fact]
+    public static void TestDecimalMax()
+    {
+        Decimal d;
+
+        d = Math.Max(new Decimal(3.0), new Decimal(-2.0));
+        Assert.Equal(d, new Decimal(3.0));
+    }
+
+    private static void IsEqual(double d1, double d2)
+    {
+        if (d1 == d2)
+            return;
+        if (Double.IsNaN(d1) && Double.IsNaN(d2))
+            return;
+        double delta = d2 - d1;
+        if (delta < 0.0)
+            delta = -delta;
+
+        if (d1 == 0.0 && delta < 0.00000001)
+            return;
+        double dividend = d1;
+        if (dividend < 0)
+            dividend = -dividend;
+        if ((delta / dividend) < 0.0001)
+            return;
+
+        throw new Exception("Doubles not equal: " + d1 + " != " + d2);
+    }
+}
+

--- a/src/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/System.Runtime.Extensions/tests/System/Random.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
-public static unsafe class RandomTests
+public static class RandomTests
 {
     [Fact]
-    public static void TestUnseeded()
+    public static void Unseeded()
     {
         Random r = new Random();
         for (int i = 0; i < 1000; i++)
@@ -30,7 +28,7 @@ public static unsafe class RandomTests
     }
 
     [Fact]
-    public static void TestSeeded()
+    public static void Seeded()
     {
         int seed = Environment.TickCount;
 
@@ -54,7 +52,7 @@ public static unsafe class RandomTests
     }
 
     [Fact]
-    public static void TestSample()
+    public static void Sample()
     {
         SubRandom r = new SubRandom();
 
@@ -73,4 +71,3 @@ public static unsafe class RandomTests
         }
     }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/System.Runtime.Extensions/tests/System/Random.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public static unsafe class RandomTests
+{
+    [Fact]
+    public static void TestUnseeded()
+    {
+        Random r = new Random();
+        for (int i = 0; i < 1000; i++)
+        {
+            int x = r.Next(20);
+            Assert.True(x >= 0 && x < 20);
+        }
+        for (int i = 0; i < 1000; i++)
+        {
+            int x = r.Next(20, 30);
+            Assert.True(x >= 20 && x < 30);
+        }
+        for (int i = 0; i < 1000; i++)
+        {
+            double x = r.NextDouble();
+            Assert.True(x >= 0.0 && x < 1.0);
+        }
+    }
+
+    [Fact]
+    public static void TestSeeded()
+    {
+        int seed = Environment.TickCount;
+
+        Random r1 = new Random(seed);
+        Random r2 = new Random(seed);
+
+        byte[] b1 = new byte[1000];
+        r1.NextBytes(b1);
+        byte[] b2 = new byte[1000];
+        r2.NextBytes(b2);
+        for (int i = 0; i < b1.Length; i++)
+        {
+            Assert.Equal(b1[i], b2[i]);
+        }
+        for (int i = 0; i < b1.Length; i++)
+        {
+            int x1 = r1.Next();
+            int x2 = r2.Next();
+            Assert.Equal(x1, x2);
+        }
+    }
+
+    [Fact]
+    public static void TestSample()
+    {
+        SubRandom r = new SubRandom();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            double d = r.ExposeSample();
+            Assert.True(d >= 0.0 && d < 1.0);
+        }
+    }
+
+    private class SubRandom : Random
+    {
+        public double ExposeSample()
+        {
+            return Sample();
+        }
+    }
+}
+

--- a/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/FrameworkName.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Versioning;
+using Xunit;
+
+public static class FrameworkNameTests
+{
+    private const string TestIdentifier = "TestFramework";
+    private const string TestProfile = "TestProfile";
+
+    private static readonly Version s_testVersion = new Version(1, 2, 3, 4);
+    private static readonly string s_testNameString = string.Format("{0},Version=v{1},Profile={2}", TestIdentifier, s_testVersion, TestProfile);
+    private static readonly string s_testNameNoProfileString = string.Format("{0},Version=v{1}", TestIdentifier, s_testVersion);
+    private static readonly FrameworkName s_testName = new FrameworkName(s_testNameString);
+    private static readonly FrameworkName s_testNameNoProfile = new FrameworkName(s_testNameNoProfileString);
+
+    [Fact]
+    public static void ConstructFromString()
+    {
+        VerifyConstructor(s_testName, s_testNameString, TestIdentifier, s_testVersion, TestProfile);
+    }
+
+    [Fact]
+    public static void ConstructFromStringWithWhitespace()
+    {
+        var nameString = string.Format("   \r{0}\r\n, Version = {1}\t,  Profile =  {2} \r\n", TestIdentifier, s_testVersion, TestProfile);
+        VerifyConstructor(new FrameworkName(nameString), s_testNameString, TestIdentifier, s_testVersion, TestProfile);
+    }
+
+    [Fact]
+    public static void ConstructFromStringOmitProfile()
+    {
+        VerifyConstructor(s_testNameNoProfile, s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
+    }
+
+    [Fact]
+    public static void ConstructFromInvalidString()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FrameworkName(null));
+        Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("A"));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("A,B"));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("A,B,C"));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("A,Version=1.0.0.0,C"));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("A,1.0.0.0,Profile=C"));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("A,Profile=C"));
+    }
+
+    [Fact]
+    public static void ConstructFromIdentifierVersion()
+    {
+        VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion),
+            s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
+    }
+
+    [Fact]
+    public static void ConstructFromInvalidIdentifierVersion()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FrameworkName(null, s_testVersion));
+        Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty, s_testVersion));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("   \r\n\t", s_testVersion));
+
+        Assert.Throws<ArgumentNullException>(() => new FrameworkName(TestIdentifier, null));
+    }
+
+    [Fact]
+    public static void ConstructFromIdentifierVersionProfile()
+    {
+        VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion, TestProfile),
+            s_testNameString, TestIdentifier, s_testVersion, TestProfile);
+
+        VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion, null),
+            s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
+    }
+
+    [Fact]
+    public static void ConstructFromInvalidIdentifierVersionProfile()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FrameworkName(null, s_testVersion, TestProfile));
+        Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty, s_testVersion, TestProfile));
+        Assert.Throws<ArgumentException>(() => new FrameworkName("   \r\n\t", s_testVersion, TestProfile));
+
+        Assert.Throws<ArgumentNullException>(() => new FrameworkName(TestIdentifier, null, TestProfile));
+    }
+
+    [Fact]
+    public static void Equality()
+    {
+        VerifyEquality(s_testName, s_testName);
+        VerifyEquality(s_testName, new FrameworkName(s_testNameString));
+        VerifyEquality(s_testName, new FrameworkName(TestIdentifier, s_testVersion, TestProfile));
+    }
+
+    [Fact]
+    public static void Inequality()
+    {
+        VerifyInequality(s_testName, null);
+        VerifyInequality(s_testName, new FrameworkName("NotTheTestIdentifier", s_testVersion, TestProfile));
+        VerifyInequality(s_testName, new FrameworkName(TestIdentifier, s_testVersion));
+        VerifyInequality(s_testName, new FrameworkName(TestIdentifier, new Version(9, 8, 7, 6), TestProfile));
+    }
+
+    private static void VerifyConstructor(FrameworkName name, string expectedName, string expectedIdentifier, Version expectedVersion, string expectedProfile)
+    {
+        Assert.Equal(expectedName, name.FullName);
+        Assert.Equal(expectedName, name.ToString());
+        Assert.Equal(expectedIdentifier, name.Identifier);
+        Assert.Equal(expectedProfile, name.Profile);
+        Assert.Equal(expectedVersion, name.Version);
+    }
+
+    private static void VerifyInequality(FrameworkName x, FrameworkName y)
+    {
+        Assert.NotNull(x);
+
+        Assert.True(x != y);
+        Assert.False(x == y);
+        Assert.False(x.Equals(y));
+        Assert.False(((IEquatable<FrameworkName>)x).Equals(y));
+    }
+
+    private static void VerifyEquality(FrameworkName x, FrameworkName y)
+    {
+        Assert.NotNull(x);
+
+        Assert.True(x == y);
+        Assert.False(x != y);
+        Assert.True(x.Equals(y));
+        Assert.True(((IEquatable<FrameworkName>)x).Equals(y));
+        Assert.Equal(x.GetHashCode(), y.GetHashCode());
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
-public static unsafe class StringComparerTests
+public static class StringComparerTests
 {
     [Fact]
     public static void TestCurrent()
@@ -26,63 +25,38 @@ public static unsafe class StringComparerTests
     {
         String s1 = "Hello";
         String s1a = "Hello";
-        String s1A = "HELLO";
+        String s1b = "HELLO";
         String s2 = "There";
 
-        bool b;
-        int i;
+        Assert.True(sc.Equals(s1, s1a));
+        Assert.True(sc.Equals(s1, s1a));
 
-        b = sc.Equals(s1, s1a);
-        Assert.True(b);
-        b = ((IEqualityComparer)sc).Equals(s1, s1a);
-        Assert.True(b);
+        Assert.Equal(0, sc.Compare(s1, s1a));
+        Assert.Equal(0, ((IComparer)sc).Compare(s1, s1a));
 
-        i = sc.Compare(s1, s1a);
-        Assert.True(i == 0);
-        i = ((IComparer)sc).Compare(s1, s1a);
-        Assert.True(i == 0);
+        Assert.True(sc.Equals(s1, s1));
+        Assert.True(((IEqualityComparer)sc).Equals(s1, s1));
+        Assert.Equal(0, sc.Compare(s1, s1));
+        Assert.Equal(0, ((IComparer)sc).Compare(s1, s1));
 
-        b = sc.Equals(s1, s1);
-        Assert.True(b);
-        b = ((IEqualityComparer)sc).Equals(s1, s1);
-        Assert.True(b);
-        i = sc.Compare(s1, s1);
-        Assert.True(i == 0);
-        i = ((IComparer)sc).Compare(s1, s1);
-        Assert.True(i == 0);
+        Assert.False(sc.Equals(s1, s2));
+        Assert.False(((IEqualityComparer)sc).Equals(s1, s2));
+        Assert.True(sc.Compare(s1, s2) < 0);
+        Assert.True(((IComparer)sc).Compare(s1, s2) < 0);
 
-        b = sc.Equals(s1, s2);
-        Assert.False(b);
-        b = ((IEqualityComparer)sc).Equals(s1, s2);
-        Assert.False(b);
-        i = sc.Compare(s1, s2);
-        Assert.True(i < 0);
-        i = ((IComparer)sc).Compare(s1, s2);
-        Assert.True(i < 0);
+        Assert.Equal(ignoreCase, sc.Equals(s1, s1b));
+        Assert.Equal(ignoreCase, ((IEqualityComparer)sc).Equals(s1, s1b));
 
-        b = sc.Equals(s1, s1A);
+        int result = sc.Compare(s1, s1b);
         if (ignoreCase)
-            Assert.True(b);
+            Assert.Equal(0, result);
         else
-            Assert.False(b);
+            Assert.NotEqual(0, result);
 
-        b = ((IEqualityComparer)sc).Equals(s1, s1A);
+        result = ((IComparer)sc).Compare(s1, s1b);
         if (ignoreCase)
-            Assert.True(b);
+            Assert.Equal(0, result);
         else
-            Assert.False(b);
-
-        i = sc.Compare(s1, s1A);
-        if (ignoreCase)
-            Assert.True(i == 0);
-        else
-            Assert.True(i != 0);
-
-        i = ((IComparer)sc).Compare(s1, s1A);
-        if (ignoreCase)
-            Assert.True(i == 0);
-        else
-            Assert.True(i != 0);
+            Assert.NotEqual(0, result);
     }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public static unsafe class StringComparerTests
+{
+    [Fact]
+    public static void TestCurrent()
+    {
+        VerifyComparer(StringComparer.CurrentCulture, false);
+        VerifyComparer(StringComparer.CurrentCultureIgnoreCase, true);
+    }
+
+    [Fact]
+    public static void TestOrdinal()
+    {
+        VerifyComparer(StringComparer.Ordinal, false);
+        VerifyComparer(StringComparer.OrdinalIgnoreCase, true);
+    }
+
+    private static void VerifyComparer(StringComparer sc, bool ignoreCase)
+    {
+        String s1 = "Hello";
+        String s1a = "Hello";
+        String s1A = "HELLO";
+        String s2 = "There";
+
+        bool b;
+        int i;
+
+        b = sc.Equals(s1, s1a);
+        Assert.True(b);
+        b = ((IEqualityComparer)sc).Equals(s1, s1a);
+        Assert.True(b);
+
+        i = sc.Compare(s1, s1a);
+        Assert.True(i == 0);
+        i = ((IComparer)sc).Compare(s1, s1a);
+        Assert.True(i == 0);
+
+        b = sc.Equals(s1, s1);
+        Assert.True(b);
+        b = ((IEqualityComparer)sc).Equals(s1, s1);
+        Assert.True(b);
+        i = sc.Compare(s1, s1);
+        Assert.True(i == 0);
+        i = ((IComparer)sc).Compare(s1, s1);
+        Assert.True(i == 0);
+
+        b = sc.Equals(s1, s2);
+        Assert.False(b);
+        b = ((IEqualityComparer)sc).Equals(s1, s2);
+        Assert.False(b);
+        i = sc.Compare(s1, s2);
+        Assert.True(i < 0);
+        i = ((IComparer)sc).Compare(s1, s2);
+        Assert.True(i < 0);
+
+        b = sc.Equals(s1, s1A);
+        if (ignoreCase)
+            Assert.True(b);
+        else
+            Assert.False(b);
+
+        b = ((IEqualityComparer)sc).Equals(s1, s1A);
+        if (ignoreCase)
+            Assert.True(b);
+        else
+            Assert.False(b);
+
+        i = sc.Compare(s1, s1A);
+        if (ignoreCase)
+            Assert.True(i == 0);
+        else
+            Assert.True(i != 0);
+
+        i = ((IComparer)sc).Compare(s1, s1A);
+        if (ignoreCase)
+            Assert.True(i == 0);
+        else
+            Assert.True(i != 0);
+    }
+}
+


### PR DESCRIPTION
Adds additional tests for System.Runtime.Extensions to cover more of the contract surface area.

Fixes #975.