### PR TITLE
Reference NativeTestService.vcxproj for ServiceController tests only on Windows

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -27,6 +27,8 @@
       <Project>{f4821cb6-91a3-4546-bc4f-e00dbfbdaa05}</Project>
       <Name>System.ServiceProcess.ServiceController</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup  Condition="'$(OS)'=='Windows_NT'">
     <ProjectReference Include="..\NativeTestService\NativeTestService.vcxproj"> 
        <Project>{ceb0775c-4273-4ac4-b50e-4492718051ae}</Project> 
        <Name>NativeTestService</Name> 


### PR DESCRIPTION
Mono's xbuild can't build the native project.