### PR TITLE
Fix System.ObjectModel.Tests to use P2P reference

### DIFF
--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -23,6 +23,12 @@
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollectionTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\src\System.ObjectModel.csproj">
+      <Project>{F24D3391-2928-4E83-AADE-A4461E5CAE50}</Project>
+      <Name>System.ObjectModel</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ObjectModel/tests/packages.config
+++ b/src/System.ObjectModel/tests/packages.config
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22605" />
-  <package id="System.ObjectModel" version="4.0.10-beta-22605" />
-  <package id="System.Runtime" version="4.0.20-beta-22605" />
-  <package id="System.Threading" version="4.0.0-beta-22512" />
-  <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
+  <package id="System.Runtime" version="4.0.20-beta-22512" />
+  <package id="System.Threading" version="4.0.10-beta-22605" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22605" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
The ObjectModel tests were pulling in System.ObjectModel from NuGet, not via a P2P reference.  This not only meant that the tests were testing an older version of the library, it also broke code coverage due to the System.ObjectModel.pdb not being copied to the tests directory.

This commit fixes the tests project file to use a project-to-project reference for System.ObjectModel.  It also updates the test project's packages.config to use the same versions of assemblies as System.ObjectModel is defined to use, as failures otherwise result.

Fixes #980 