### PR TITLE
ProcessTest_ConsoleApp.csproj: set TargetFrameworkVersion to v4.5

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.csproj
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>ProcessTest_ConsoleApp</RootNamespace>
     <AssemblyName>ProcessTest_ConsoleApp</AssemblyName>
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
On Mono/xbuild simply using '4.5' doesn't work, but 'v4.5' does.