### PR TITLE
Fix failing tests in Turkish locale

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/ValidatorTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/ValidatorTests.cs
@@ -750,7 +750,7 @@ namespace System.ComponentModel.DataAnnotations
             protected override ValidationResult IsValid(object value, ValidationContext _)
             {
                 if (value == null) { return ValidationResult.Success; }
-                if (value.GetType().Name.ToLower().Contains("invalid"))
+                if (value.GetType().Name.ToLowerInvariant().Contains("invalid"))
                 {
                     return new ValidationResult("ValidClassAttribute.IsValid failed for class of type " + value.GetType().FullName);
                 }


### PR DESCRIPTION
'Invalid' becomes 'ınvalid' in Turkish culture, which makes the
following tests fail:

TryValidateObject_returns_false_if_all_properties_are_valid_but_class_is_invalid

TryValidateObject_returns_true_if_validateAllProperties_is_true_and_all_attributes_are_valid