### PR TITLE
New test cases for IsPointer & GetArrayRank methods

### DIFF
--- a/src/System.Runtime/tests/System/Type.cs
+++ b/src/System.Runtime/tests/System/Type.cs
@@ -327,6 +327,10 @@ public class TypeTests
         i = t.GetArrayRank();
         Assert.Equal(i, 1);
 
+        t = typeof(int[,,]);
+        i = t.GetArrayRank();
+        Assert.Equal(i, 3);
+
         t = typeof(IList<int>);
         Assert.Throws<ArgumentException>(() => i = t.GetArrayRank());
 

--- a/src/System.Runtime/tests/System/Type.cs
+++ b/src/System.Runtime/tests/System/Type.cs
@@ -190,6 +190,10 @@ public class TypeTests
         t = typeof(IList<int>);
         b = t.IsPointer;
         Assert.False(b);
+
+        t = typeof (int *);
+        b = t.IsPointer;
+        Assert.True(b);
     }
 
     [Fact]


### PR DESCRIPTION
IsPointer method had no test cases returning true.

I also noticed this test library has mixed up the parameters(expected & actual) in Assert.Equal method calls. It trips up the messages when the tests fail. I can send another pull request to fix them all.