### PR TITLE
Add individual project coverage report generation

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -172,4 +172,23 @@
 
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
   </Target>
+
+  <!-- Generate coverage for individual projects. -->
+  <Target Name="GenerateIndividualCoverageReport"
+    AfterTargets="BuildAndTest"
+    Inputs="$(CoverageReportDir)\*.coverage.xml"
+    Outputs="$(CoverageReportDir)*.*"
+    Condition="$(_CoverageEnabled) and $(MSBuildProjectFile.Contains('Tests.csproj'))">
+
+    <PropertyGroup>
+      <ReportGeneratorVersion>2.0.4.0</ReportGeneratorVersion>
+      <ReportGeneratorCommandLine>$(PackagesDir)ReportGenerator.$(ReportGeneratorVersion)\ReportGenerator.exe</ReportGeneratorCommandLine>
+      <ReportGeneratorOptions>-reports:$(CoverageReportDir)\$(MSBuildProjectFile.Replace(".csproj","")).dll.coverage.xml -targetdir:$(CoverageReportDir) -reporttypes:Html</ReportGeneratorOptions>
+    </PropertyGroup>
+
+    <Exec
+      Command="$(ReportGeneratorCommandLine) $(ReportGeneratorOptions)"
+      ContinueOnError="ErrorAndContinue" />
+
+  </Target>
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -174,16 +174,20 @@
   </Target>
 
   <!-- Generate coverage for individual projects. -->
+  <PropertyGroup>
+    <ProjectInput>$(MSBuildProjectName).dll.coverage.xml</ProjectInput>
+  </PropertyGroup>
+  
   <Target Name="GenerateIndividualCoverageReport"
-    AfterTargets="BuildAndTest"
-    Inputs="$(CoverageReportDir)\*.coverage.xml"
-    Outputs="$(CoverageReportDir)*.*"
-    Condition="$(_CoverageEnabled) and $(MSBuildProjectFile.Contains('Tests.csproj'))">
+    AfterTargets="RunTestsForProject"
+    Inputs="$(CoverageReportDir)\$(ProjectInput)"
+    Outputs="$(CoverageReportDir)$(MSBuildProjectName)_*.*"
+    Condition="$(_CoverageEnabled) and $(IsTestProject)">
 
     <PropertyGroup>
       <ReportGeneratorVersion>2.0.4.0</ReportGeneratorVersion>
       <ReportGeneratorCommandLine>$(PackagesDir)ReportGenerator.$(ReportGeneratorVersion)\ReportGenerator.exe</ReportGeneratorCommandLine>
-      <ReportGeneratorOptions>-reports:$(CoverageReportDir)\$(MSBuildProjectFile.Replace(".csproj","")).dll.coverage.xml -targetdir:$(CoverageReportDir) -reporttypes:Html</ReportGeneratorOptions>
+      <ReportGeneratorOptions>-reports:$(CoverageReportDir)$(ProjectInput) -targetdir:$(CoverageReportDir) -reporttypes:Html</ReportGeneratorOptions>
     </PropertyGroup>
 
     <Exec


### PR DESCRIPTION
When building within an individual project's tests folder, coverage reports for that project are generated in the bin\tests\coverage folder.

Improvement per #991