### PR TITLE
Fix datetime issues

### DIFF
--- a/src/System.Collections.NonGeneric/tests/Hashtable/PropertyItemThreadSafety.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/PropertyItemThreadSafety.cs
@@ -4,6 +4,7 @@
 using Xunit;
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,7 +29,7 @@ public class ItemThreadSafetyTests
     private bool _errorOccured = false;
     private bool _timeExpired = false;
 
-    private const long MAX_TEST_TIME_TICKS = 10L * 10000000L; // 10 seconds
+    private const int MAX_TEST_TIME_MS = 10000; // 10 seconds
 
     [Fact]
     [OuterLoop]
@@ -51,7 +52,8 @@ public class ItemThreadSafetyTests
         Task[] readers1 = new Task[taskCount];
         Task[] readers2 = new Task[taskCount];
         Task writer;
-        DateTime startTime = DateTime.Now;
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
 
         for (int i = 0; i < readers1.Length; i++)
         {
@@ -68,7 +70,7 @@ public class ItemThreadSafetyTests
         SpinWait spin = new SpinWait();
         while (!_errorOccured && !_timeExpired)
         {
-            if (MAX_TEST_TIME_TICKS < DateTime.Now.Ticks - startTime.Ticks)
+            if (MAX_TEST_TIME_MS < stopwatch.ElapsedMilliseconds)
             {
                 _timeExpired = true;
             }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -559,10 +559,14 @@ namespace System.Diagnostics
             }
 
             // Use the uptime and the current time to determine the absolute boot time
-            DateTime bootTime = DateTime.Now - TimeSpan.FromSeconds(uptime);
+            DateTime bootTime = DateTime.UtcNow - TimeSpan.FromSeconds(uptime);
 
             // And use that to determine the absolute time for ticksStartedAfterBoot
-            return bootTime + TicksToTimeSpan(ticksAfterBoot);
+            DateTime dt = bootTime + TicksToTimeSpan(ticksAfterBoot);
+
+            // The return value is expected to be in the local time zone.
+            // It is converted here (rather than starting with DateTime.Now) to avoid DST issues.
+            return dt.ToLocalTime();
         }
 
         /// <summary>Convert a number of "jiffies", or ticks, to a TimeSpan.</summary>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -149,8 +149,8 @@ namespace System.Diagnostics.ProcessTests
             p.Start();
             p.Kill();
             p.WaitForExit();
-            DateTime exitTime = p.ExitTime;
-            DateTime dt2 = DateTime.Now;
+            DateTime exitTime = p.ExitTime.ToUniversalTime();
+            DateTime dt2 = DateTime.UtcNow;
             TimeSpan elapsedTime = new TimeSpan(dt2.Ticks - exitTime.Ticks);
             Assert.True(elapsedTime.TotalSeconds <= 1, "Process_ExitTime is incorrect.");
         }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -152,7 +152,7 @@ namespace System.Diagnostics.ProcessTests
             DateTime exitTime = p.ExitTime;
             DateTime dt2 = DateTime.Now;
             TimeSpan elapsedTime = new TimeSpan(dt2.Ticks - exitTime.Ticks);
-            Assert.True(elapsedTime.Seconds <= 1, "Process_ExitTime is incorrect.");
+            Assert.True(elapsedTime.TotalSeconds <= 1, "Process_ExitTime is incorrect.");
         }
 
 


### PR DESCRIPTION
Fixing some date/time related issues I found.
- DateTime.Now should not be used when any kind of math is involved.  If the value is near a daylight saving time transition, the calculation could yield an incorrect result.
- Measurement of elapsed time should use `System.Diagnostics.Stopwatch` whenever possible.  Comparing values obtained by `DateTime.UtcNow` is less accurate.
- `TimeSpan.Seconds` only returns seconds _within the minute_.  So if a function wants the elapsed time in seconds, it needs to use `TimeSpan.TotalSeconds` instead.
