### PR TITLE
Replace Thread with Task and drop dependency on System.Threading.Thread

### DIFF
--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Windows.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Diagnostics
 {
@@ -100,8 +100,6 @@ namespace System.Diagnostics
                 private readonly string _body;
                 private readonly string _title;
                 private readonly int _flags;
-                private int _returnValue;
-
 
                 [SecurityCritical]
                 public MessageBoxPopup(string body, string title, int flags)
@@ -113,16 +111,13 @@ namespace System.Diagnostics
 
                 public int ShowMessageBox()
                 {
-                    Thread t = new Thread(DoPopup);
-                    t.Start();
-                    t.Join();
-                    return _returnValue;
+                    return Task.Run(new Func<int>(DoPopup)).Result;
                 }
 
                 [SecuritySafeCritical]
-                public void DoPopup()
+                private int DoPopup()
                 {
-                    _returnValue = Interop.User32.MessageBox(IntPtr.Zero, _body, _title, _flags);
+                    return Interop.User32.MessageBox(IntPtr.Zero, _body, _title, _flags);
                 }
             }
         }

--- a/src/System.Diagnostics.Debug/src/packages.config
+++ b/src/System.Diagnostics.Debug/src/packages.config
@@ -14,5 +14,4 @@
   <package id="System.Text.Encoding" version="4.0.10-beta-22512" targetFramework="portable-net45+win" />
   <package id="System.Threading" version="4.0.10-beta-22605" targetFramework="portable-net45+win" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22412" targetFramework="portable-net45+win" />
-  <package id="System.Threading.Thread" version="4.0.0-beta-22605" targetFramework="portable-net45+win" />
 </packages>


### PR DESCRIPTION
Windows implementation of assert dialog creates new thread for showing dialog.
For creating new thread `Thread` class was used.

This commit replaces using `Thread` class with `Task`. It allows to drop dependency on System.Threading.Thread.