### PR TITLE
Fix copy pasted comment for method return value

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -598,7 +598,8 @@ namespace System.Collections.Concurrent
         /// When this method returns, if the pop succeeded, contains the removed object. If no object was
         /// available to be removed, the value is unspecified. This parameter is passed uninitialized.
         /// </param>
-        /// <returns>True if an element was removed and returned; otherwise, false.</returns>
+        /// <returns>The number of objects successfully popped from the top of
+        /// the <see cref="ConcurrentStack{T}"/>.</returns>
         private int TryPopCore(int count, out Node poppedHead)
         {
             SpinWait spin = new SpinWait();


### PR DESCRIPTION
TryPopCore private method seems to have copy-pasted comment for return value, I checked other places and didn't find other errors. I used comment for public method to fix it.