### PR TITLE
Replace Contract.Assert with Debug.Assert/Fail

### DIFF
--- a/src/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Security;
-using System.Diagnostics.Contracts;
 
 namespace System.Globalization
 {
@@ -312,7 +312,7 @@ namespace System.Globalization
             [System.Security.SecurityCritical]  // auto-generated
             private unsafe static char* MatchChars(char* p, char* str)
             {
-                Contract.Assert(p != null && str != null, "");
+                Debug.Assert(p != null && str != null);
 
                 if (*str == '\0')
                 {
@@ -587,7 +587,7 @@ namespace System.Globalization
                 {
                     return false;
                 }
-                Contract.Assert(numfmt != null, "");
+                Debug.Assert(numfmt != null);
 
                 fixed (char* stringPointer = str)
                 {

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -10,12 +10,12 @@
 =============================================================================*/
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using System.Text;
-using Conditional = System.Diagnostics.ConditionalAttribute;
 
 namespace System.Numerics
 {
@@ -48,13 +48,13 @@ namespace System.Numerics
         {
             if (_bits != null)
             {
-                Contract.Assert(_sign == 1 || _sign == -1 /*, "_sign must be +1 or -1 when _bits is non-null"*/);
-                Contract.Assert(Length(_bits) > 0 /*, "_bits must contain at least 1 element or be null"*/);
+                Debug.Assert(_sign == 1 || _sign == -1 /*, "_sign must be +1 or -1 when _bits is non-null"*/);
+                Debug.Assert(Length(_bits) > 0 /*, "_bits must contain at least 1 element or be null"*/);
                 if (Length(_bits) == 1)
-                    Contract.Assert(_bits[0] >= kuMaskHighBit /*, "Wasted space _bits[0] could have been packed into _sign"*/);
+                    Debug.Assert(_bits[0] >= kuMaskHighBit /*, "Wasted space _bits[0] could have been packed into _sign"*/);
             }
             else
-                Contract.Assert(_sign > int.MinValue /*, "Int32.MinValue should not be stored in the _sign field"*/);
+                Debug.Assert(_sign > int.MinValue /*, "Int32.MinValue should not be stored in the _sign field"*/);
         }
         #endregion members supporting exposed properties
 
@@ -443,7 +443,7 @@ namespace System.Numerics
             }
             else
             {
-                Contract.Assert(value != 0);
+                Debug.Assert(value != 0);
                 x = (ulong)value;
                 _sign = +1;
             }
@@ -505,7 +505,7 @@ namespace System.Numerics
             // First truncate to get scale to 0 and extract bits
             int[] bits = Decimal.GetBits(Decimal.Truncate(value));
 
-            Contract.Assert(bits.Length == 4 && (bits[3] & DecimalScaleFactorMask) == 0);
+            Debug.Assert(bits.Length == 4 && (bits[3] & DecimalScaleFactorMask) == 0);
 
             int size = 3;
             while (size > 0 && bits[size - 1] == 0)
@@ -1802,7 +1802,7 @@ namespace System.Numerics
             ulong man;
             bool fFinite;
             NumericsHelpers.GetDoubleParts(value, out sign, out exp, out man, out fFinite);
-            Contract.Assert(sign == +1 || sign == -1);
+            Debug.Assert(sign == +1 || sign == -1);
 
             if (man == 0)
             {
@@ -1810,8 +1810,8 @@ namespace System.Numerics
                 return;
             }
 
-            Contract.Assert(man < (1UL << 53));
-            Contract.Assert(exp <= 0 || man >= (1UL << 52));
+            Debug.Assert(man < (1UL << 53));
+            Debug.Assert(exp <= 0 || man >= (1UL << 52));
 
             if (exp <= 0)
             {
@@ -1840,8 +1840,8 @@ namespace System.Numerics
                 // Compute cu and cbit so that exp == 32 * cu - cbit and 0 <= cbit < 32.
                 int cu = (exp - 1) / kcbitUint + 1;
                 int cbit = cu * kcbitUint - exp;
-                Contract.Assert(0 <= cbit && cbit < kcbitUint);
-                Contract.Assert(cu >= 1);
+                Debug.Assert(0 <= cbit && cbit < kcbitUint);
+                Debug.Assert(cu >= 1);
 
                 // Populate the uints.
                 _bits = new uint[cu + 2];
@@ -1863,7 +1863,7 @@ namespace System.Numerics
             int cu = rgu.Length;
             if (rgu[cu - 1] != 0)
                 return cu;
-            Contract.Assert(cu >= 2 && rgu[cu - 2] != 0);
+            Debug.Assert(cu >= 2 && rgu[cu - 2] != 0);
             return cu - 1;
         }
 

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerBuilder.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerBuilder.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
-using Conditional = System.Diagnostics.ConditionalAttribute;
 
 namespace System.Numerics
 {
@@ -39,13 +39,13 @@ namespace System.Numerics
         {
             if (_iuLast <= 0)
             {
-                Contract.Assert(_iuLast == 0);
-                Contract.Assert(!_fWritable || _rgu != null);
+                Debug.Assert(_iuLast == 0);
+                Debug.Assert(!_fWritable || _rgu != null);
             }
             else
             {
-                Contract.Assert(_rgu != null && _rgu.Length > _iuLast);
-                Contract.Assert(!fTrimmed || _rgu[_iuLast] != 0);
+                Debug.Assert(_rgu != null && _rgu.Length > _iuLast);
+                Debug.Assert(!fTrimmed || _rgu[_iuLast] != 0);
             }
         }
 
@@ -159,7 +159,7 @@ namespace System.Numerics
             sign = signSrc;
 
             int cuExtra = _rgu.Length - _iuLast - 1;
-            Contract.Assert(cuExtra >= 0);
+            Debug.Assert(cuExtra >= 0);
             if (cuExtra <= 1)
             {
                 if (cuExtra == 0 || _rgu[_iuLast + 1] == 0)
@@ -233,7 +233,7 @@ namespace System.Numerics
             if (cuLeft > 0 && (cbit = NumericsHelpers.CbitHighZero(_rgu[cuLeft + 1])) > 0)
             {
                 // Get 64 bits.
-                Contract.Assert(cbit < kcbitUint);
+                Debug.Assert(cbit < kcbitUint);
                 man = (man << cbit) | (_rgu[cuLeft - 1] >> (kcbitUint - cbit));
                 exp -= cbit;
             }
@@ -255,7 +255,7 @@ namespace System.Numerics
         {
             get
             {
-                Contract.Assert(_iuLast > 0);
+                Debug.Assert(_iuLast > 0);
                 int cu = 0;
                 for (int iu = _iuLast; iu >= 0; --iu)
                 {
@@ -373,7 +373,7 @@ namespace System.Numerics
         {
             Contract.Requires(cuExtra >= 0);
             AssertValid(false);
-            Contract.Assert(_iuLast > 0);
+            Debug.Assert(_iuLast > 0);
 
             if (_fWritable)
                 return;
@@ -481,7 +481,7 @@ namespace System.Numerics
             {
                 cuAdd = _iuLast + 1;
                 Array.Copy(reg._rgu, _iuLast + 1, _rgu, _iuLast + 1, reg._iuLast - _iuLast);
-                Contract.Assert(_iuLast > 0);
+                Debug.Assert(_iuLast > 0);
                 _iuLast = reg._iuLast;
             }
 
@@ -490,7 +490,7 @@ namespace System.Numerics
             for (int iu = 0; iu < cuAdd; iu++)
             {
                 uCarry = AddCarry(ref _rgu[iu], reg._rgu[iu], uCarry);
-                Contract.Assert(uCarry <= 1);
+                Debug.Assert(uCarry <= 1);
             }
 
             // Deal with extra carry.
@@ -592,11 +592,11 @@ namespace System.Numerics
 
                 if (u1 < u2)
                 {
-                    Contract.Assert(_iuLast > 0);
+                    Debug.Assert(_iuLast > 0);
                     reg._iuLast = _iuLast;
                     SubRev(ref reg);
                     reg._iuLast = cuSub - 1;
-                    Contract.Assert(reg._iuLast > 0);
+                    Debug.Assert(reg._iuLast > 0);
                     sign = -sign;
                     return;
                 }
@@ -610,11 +610,11 @@ namespace System.Numerics
             for (int iu = 0; iu < cuSub; iu++)
             {
                 uBorrow = SubBorrow(ref _rgu[iu], reg._rgu[iu], uBorrow);
-                Contract.Assert(uBorrow <= 1);
+                Debug.Assert(uBorrow <= 1);
             }
             if (uBorrow != 0)
             {
-                Contract.Assert(uBorrow == 1 && cuSub <= _iuLast);
+                Debug.Assert(uBorrow == 1 && cuSub <= _iuLast);
                 ApplyBorrow(cuSub);
             }
             Trim();
@@ -624,8 +624,8 @@ namespace System.Numerics
         // Asserts that reg is larger in the most significant uint.
         private void SubRev(ref BigIntegerBuilder reg)
         {
-            Contract.Assert(0 < _iuLast && _iuLast <= reg._iuLast);
-            Contract.Assert(_iuLast < reg._iuLast || _rgu[_iuLast] < reg._rgu[_iuLast]);
+            Debug.Assert(0 < _iuLast && _iuLast <= reg._iuLast);
+            Debug.Assert(_iuLast < reg._iuLast || _rgu[_iuLast] < reg._rgu[_iuLast]);
 
             EnsureWritable(reg._iuLast + 1, 0);
 
@@ -633,7 +633,7 @@ namespace System.Numerics
             if (_iuLast < reg._iuLast)
             {
                 Array.Copy(reg._rgu, _iuLast + 1, _rgu, _iuLast + 1, reg._iuLast - _iuLast);
-                Contract.Assert(_iuLast > 0);
+                Debug.Assert(_iuLast > 0);
                 _iuLast = reg._iuLast;
             }
 
@@ -641,11 +641,11 @@ namespace System.Numerics
             for (int iu = 0; iu < cuSub; iu++)
             {
                 uBorrow = SubRevBorrow(ref _rgu[iu], reg._rgu[iu], uBorrow);
-                Contract.Assert(uBorrow <= 1);
+                Debug.Assert(uBorrow <= 1);
             }
             if (uBorrow != 0)
             {
-                Contract.Assert(uBorrow == 1);
+                Debug.Assert(uBorrow == 1);
                 ApplyBorrow(cuSub);
             }
             Trim();
@@ -752,7 +752,7 @@ namespace System.Numerics
             }
             else
             {
-                Contract.Assert(reg1._iuLast > 0 && reg2._iuLast > 0);
+                Debug.Assert(reg1._iuLast > 0 && reg2._iuLast > 0);
                 SetSizeClear(reg1._iuLast + reg2._iuLast + 2);
 
                 uint[] rgu1, rgu2;
@@ -890,13 +890,13 @@ namespace System.Numerics
 
         private static void ModDivCore(ref BigIntegerBuilder regNum, ref BigIntegerBuilder regDen, bool fQuo, ref BigIntegerBuilder regQuo)
         {
-            Contract.Assert(regNum._iuLast > 0 && regDen._iuLast > 0);
+            Debug.Assert(regNum._iuLast > 0 && regDen._iuLast > 0);
 
             regQuo.Set(0);
             if (regNum._iuLast < regDen._iuLast)
                 return;
 
-            Contract.Assert(0 < regDen._iuLast && regDen._iuLast <= regNum._iuLast);
+            Debug.Assert(0 < regDen._iuLast && regDen._iuLast <= regNum._iuLast);
             int cuDen = regDen._iuLast + 1;
             int cuDiff = regNum._iuLast - regDen._iuLast;
 
@@ -935,17 +935,17 @@ namespace System.Numerics
                 if (cuDen > 2)
                     uDenNext |= regDen._rgu[cuDen - 3] >> cbitShiftRight;
             }
-            Contract.Assert((uDen & 0x80000000) != 0);
+            Debug.Assert((uDen & 0x80000000) != 0);
 
             // Allocate and initialize working space.
-            Contract.Assert(cuQuo + cuDen == regNum._iuLast + 1 || cuQuo + cuDen == regNum._iuLast + 2);
+            Debug.Assert(cuQuo + cuDen == regNum._iuLast + 1 || cuQuo + cuDen == regNum._iuLast + 2);
             regNum.EnsureWritable();
 
             for (int iu = cuQuo; --iu >= 0;)
             {
                 // Get the high (normalized) bits of regNum.
                 uint uNumHi = (iu + cuDen <= regNum._iuLast) ? regNum._rgu[iu + cuDen] : 0;
-                Contract.Assert(uNumHi <= regDen._rgu[cuDen - 1]);
+                Debug.Assert(uNumHi <= regDen._rgu[cuDen - 1]);
 
                 ulong uuNum = NumericsHelpers.MakeUlong(uNumHi, regNum._rgu[iu + cuDen - 1]);
                 uint uNumNext = regNum._rgu[iu + cuDen - 2];
@@ -960,7 +960,7 @@ namespace System.Numerics
                 // Divide to get the quotient digit.
                 ulong uuQuo = uuNum / uDen;
                 ulong uuRem = (uint)(uuNum % uDen);
-                Contract.Assert(uuQuo <= (ulong)uint.MaxValue + 2);
+                Debug.Assert(uuQuo <= (ulong)uint.MaxValue + 2);
                 if (uuQuo > uint.MaxValue)
                 {
                     uuRem += uDen * (uuQuo - uint.MaxValue);
@@ -987,7 +987,7 @@ namespace System.Numerics
                         regNum._rgu[iu + iu2] -= uSub;
                     }
 
-                    Contract.Assert(uNumHi == uuBorrow || uNumHi == uuBorrow - 1);
+                    Debug.Assert(uNumHi == uuBorrow || uNumHi == uuBorrow - 1);
                     if (uNumHi < uuBorrow)
                     {
                         // Add, tracking carry.
@@ -995,9 +995,9 @@ namespace System.Numerics
                         for (int iu2 = 0; iu2 < cuDen; iu2++)
                         {
                             uCarry = AddCarry(ref regNum._rgu[iu + iu2], regDen._rgu[iu2], uCarry);
-                            Contract.Assert(uCarry <= 1);
+                            Debug.Assert(uCarry <= 1);
                         }
-                        Contract.Assert(uCarry == 1);
+                        Debug.Assert(uCarry == 1);
                         uuQuo--;
                     }
                     regNum._iuLast = iu + cuDen - 1;
@@ -1012,7 +1012,7 @@ namespace System.Numerics
                 }
             }
 
-            Contract.Assert(cuDen > 1 && regNum._iuLast > 0);
+            Debug.Assert(cuDen > 1 && regNum._iuLast > 0);
             regNum._iuLast = cuDen - 1;
             regNum.Trim();
         }
@@ -1035,7 +1035,7 @@ namespace System.Numerics
         {
             Contract.Requires(cuShift >= 0);
             Contract.Requires(0 <= cbitShift);
-            Contract.Assert(cbitShift < kcbitUint);
+            Debug.Assert(cbitShift < kcbitUint);
             AssertValid(true);
 
             if ((cuShift | cbitShift) == 0)
@@ -1059,7 +1059,7 @@ namespace System.Numerics
                 _uSmall = rguSrc[cuShift] >> cbitShift;
             else
             {
-                Contract.Assert(_rgu.Length > _iuLast);
+                Debug.Assert(_rgu.Length > _iuLast);
                 if (!_fWritable)
                 {
                     _rgu = new uint[_iuLast + 1];
@@ -1094,7 +1094,7 @@ namespace System.Numerics
         {
             Contract.Requires(cuShift >= 0);
             Contract.Requires(0 <= cbitShift);
-            Contract.Assert(cbitShift < kcbitUint);
+            Debug.Assert(cbitShift < kcbitUint);
             AssertValid(true);
 
             int iuLastNew = _iuLast + cuShift;
@@ -1147,8 +1147,8 @@ namespace System.Numerics
         private ulong GetHigh2(int cu)
         {
             Contract.Requires(cu >= 2);
-            Contract.Assert(_iuLast > 0);
-            Contract.Assert(cu > _iuLast);
+            Debug.Assert(_iuLast > 0);
+            Debug.Assert(cu > _iuLast);
 
             if (cu - 1 <= _iuLast)
                 return NumericsHelpers.MakeUlong(_rgu[cu - 1], _rgu[cu - 2]);
@@ -1162,8 +1162,8 @@ namespace System.Numerics
         private void ApplyCarry(int iu)
         {
             Contract.Requires(0 <= iu);
-            Contract.Assert(_fWritable && _iuLast > 0);
-            Contract.Assert(iu <= _iuLast + 1);
+            Debug.Assert(_fWritable && _iuLast > 0);
+            Debug.Assert(iu <= _iuLast + 1);
 
             for (; ; iu++)
             {
@@ -1183,8 +1183,8 @@ namespace System.Numerics
         private void ApplyBorrow(int iuMin)
         {
             Contract.Requires(0 < iuMin);
-            Contract.Assert(_fWritable && _iuLast > 0);
-            Contract.Assert(iuMin <= _iuLast);
+            Debug.Assert(_fWritable && _iuLast > 0);
+            Debug.Assert(iuMin <= _iuLast);
 
             for (int iu = iuMin; iu <= _iuLast; iu++)
             {
@@ -1193,7 +1193,7 @@ namespace System.Numerics
                     return;
             }
             // Borrowed off the end!
-            Contract.Assert(false, "Invalid call to ApplyBorrow");
+            Debug.Fail("Invalid call to ApplyBorrow");
         }
 
         private static uint AddCarry(ref uint u1, uint u2, uint uCarry)
@@ -1273,8 +1273,8 @@ namespace System.Numerics
                     NumericsHelpers.Swap(ref reg1, ref reg2);
                     NumericsHelpers.Swap(ref cuMax, ref cuMin);
                 }
-                Contract.Assert(cuMax == reg1._iuLast + 1);
-                Contract.Assert(cuMin == reg2._iuLast + 1);
+                Debug.Assert(cuMax == reg1._iuLast + 1);
+                Debug.Assert(cuMin == reg2._iuLast + 1);
 
                 if (cuMin == 1)
                 {
@@ -1300,7 +1300,7 @@ namespace System.Numerics
 
                 ulong uu1 = reg1.GetHigh2(cuMax);
                 ulong uu2 = reg2.GetHigh2(cuMax);
-                Contract.Assert(uu1 != 0 && uu2 != 0);
+                Debug.Assert(uu1 != 0 && uu2 != 0);
 
                 int cbit = NumericsHelpers.CbitHighZero(uu1 | uu2);
                 if (cbit > 0)
@@ -1321,15 +1321,15 @@ namespace System.Numerics
                     uu1 >>= 1;
                     uu2 >>= 1;
                 }
-                Contract.Assert(uu1 >= uu2); // We ensured this above.
+                Debug.Assert(uu1 >= uu2); // We ensured this above.
                 if (uu1 == uu2)
                 {
                     // The high bits are the same, so we don't know which
                     // is larger. No matter, just subtract one from the other
                     // and keep the absolute value of the result.
-                    Contract.Assert(cuMax == cuMin);
+                    Debug.Assert(cuMax == cuMin);
                     reg1.Sub(ref signTmp, ref reg2);
-                    Contract.Assert(reg1._iuLast < cuMin - 1);
+                    Debug.Assert(reg1._iuLast < cuMin - 1);
                     continue;
                 }
                 if (NumericsHelpers.GetHi(uu2) == 0)
@@ -1346,11 +1346,11 @@ namespace System.Numerics
 
                 for (; ;)
                 {
-                    Contract.Assert(uu1 + a > a); // no overflow
-                    Contract.Assert(uu2 + d > d);
-                    Contract.Assert(uu1 > b);
-                    Contract.Assert(uu2 > c);
-                    Contract.Assert(uu2 + d <= uu1 - b);
+                    Debug.Assert(uu1 + a > a); // no overflow
+                    Debug.Assert(uu2 + d > d);
+                    Debug.Assert(uu1 > b);
+                    Debug.Assert(uu2 > c);
+                    Debug.Assert(uu2 + d <= uu1 - b);
 
                     uint uQuo = 1;
                     ulong uuNew = uu1 - uu2;
@@ -1375,8 +1375,8 @@ namespace System.Numerics
                     if (uuNew < uuBcNew || uuNew + uuAdNew > uu2 - c)
                         break;
 
-                    Contract.Assert(uQuo == (uu1 + a - 1) / (uu2 - c));
-                    Contract.Assert(uQuo == (uu1 - b) / (uu2 + d));
+                    Debug.Assert(uQuo == (uu1 + a - 1) / (uu2 - c));
+                    Debug.Assert(uQuo == (uu1 - b) / (uu2 + d));
 
                     a = (uint)uuAdNew;
                     b = (uint)uuBcNew;
@@ -1384,15 +1384,15 @@ namespace System.Numerics
 
                     if (uu1 <= b)
                     {
-                        Contract.Assert(uu1 == b);
+                        Debug.Assert(uu1 == b);
                         break;
                     }
 
-                    Contract.Assert(uu1 + a > a); // no overflow
-                    Contract.Assert(uu2 + d > d);
-                    Contract.Assert(uu2 > c);
-                    Contract.Assert(uu1 > b);
-                    Contract.Assert(uu1 + a <= uu2 - c);
+                    Debug.Assert(uu1 + a > a); // no overflow
+                    Debug.Assert(uu2 + d > d);
+                    Debug.Assert(uu2 > c);
+                    Debug.Assert(uu1 > b);
+                    Debug.Assert(uu1 + a <= uu2 - c);
 
                     uQuo = 1;
                     uuNew = uu2 - uu1;
@@ -1417,8 +1417,8 @@ namespace System.Numerics
                     if (uuNew < uuBcNew || uuNew + uuAdNew > uu1 - b)
                         break;
 
-                    Contract.Assert(uQuo == (uu2 + d - 1) / (uu1 - b));
-                    Contract.Assert(uQuo == (uu2 - c) / (uu1 + a));
+                    Debug.Assert(uQuo == (uu2 + d - 1) / (uu1 - b));
+                    Debug.Assert(uQuo == (uu2 - c) / (uu1 + a));
 
                     d = (uint)uuAdNew;
                     c = (uint)uuBcNew;
@@ -1426,15 +1426,15 @@ namespace System.Numerics
 
                     if (uu2 <= c)
                     {
-                        Contract.Assert(uu2 == c);
+                        Debug.Assert(uu2 == c);
                         break;
                     }
                 }
 
                 if (b == 0)
                 {
-                    Contract.Assert(a == 1 && c == 0 && d == 1);
-                    Contract.Assert(uu1 > uu2); // We ensured this above.
+                    Debug.Assert(a == 1 && c == 0 && d == 1);
+                    Debug.Assert(uu1 > uu2); // We ensured this above.
                     if (uu1 / 2 >= uu2)
                         reg1.Mod(ref reg2);
                     else

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -271,7 +271,7 @@
 //
 
 using System;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Security;
@@ -405,7 +405,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Contract.Assert(c >= 'a' && c <= 'f');
+                    Debug.Assert(c >= 'a' && c <= 'f');
                     b = (byte)((c - 'a') + 10);
                 }
                 if (i == 0 && (b & 0x08) == 0x08)
@@ -573,7 +573,7 @@ namespace System.Numerics
                 uint uCarry = value._bits[iuSrc];
                 for (int iuDst = 0; iuDst < cuDst; iuDst++)
                 {
-                    Contract.Assert(rguDst[iuDst] < kuBase);
+                    Debug.Assert(rguDst[iuDst] < kuBase);
                     ulong uuRes = NumericsHelpers.MakeUlong(rguDst[iuDst], uCarry);
                     rguDst[iuDst] = (uint)(uuRes % kuBase);
                     uCarry = (uint)(uuRes / kuBase);
@@ -627,7 +627,7 @@ namespace System.Numerics
             for (int iuDst = 0; iuDst < cuDst - 1; iuDst++)
             {
                 uint uDig = rguDst[iuDst];
-                Contract.Assert(uDig < kuBase);
+                Debug.Assert(uDig < kuBase);
                 for (int cch = kcchBase; --cch >= 0;)
                 {
                     rgch[--ichDst] = (char)('0' + uDig % 10);

--- a/src/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
@@ -72,7 +72,7 @@ namespace System.Numerics
                 else
                     man <<= cbitShift;
                 exp -= cbitShift;
-                Contract.Assert((man & 0xFFF0000000000000) == 0x0010000000000000);
+                Debug.Assert((man & 0xFFF0000000000000) == 0x0010000000000000);
 
                 // Move the point to just behind the leading 1: 0x001.0 0000 0000 0000
                 // (52 bits) and skew the exponent (by 0x3FF == 1023).
@@ -95,7 +95,7 @@ namespace System.Numerics
                     else
                     {
                         du.uu = man >> -exp;
-                        Contract.Assert(du.uu != 0);
+                        Debug.Assert(du.uu != 0);
                     }
                 }
                 else
@@ -169,7 +169,7 @@ namespace System.Numerics
             if (u1 < u2)
                 goto LOther;
             LTop:
-            Contract.Assert(u2 <= u1);
+            Debug.Assert(u2 <= u1);
             if (u2 == 0)
                 return u1;
             for (int cv = cvMax; ;)
@@ -184,7 +184,7 @@ namespace System.Numerics
                 }
             }
         LOther:
-            Contract.Assert(u1 < u2);
+            Debug.Assert(u1 < u2);
             if (u1 == 0)
                 return u2;
             for (int cv = cvMax; ;)
@@ -207,7 +207,7 @@ namespace System.Numerics
             if (uu1 < uu2)
                 goto LOther;
             LTop:
-            Contract.Assert(uu2 <= uu1);
+            Debug.Assert(uu2 <= uu1);
             if (uu1 <= uint.MaxValue)
                 goto LSmall;
             if (uu2 == 0)
@@ -224,7 +224,7 @@ namespace System.Numerics
                 }
             }
         LOther:
-            Contract.Assert(uu1 < uu2);
+            Debug.Assert(uu1 < uu2);
             if (uu2 <= uint.MaxValue)
                 goto LSmall;
             if (uu1 == 0)
@@ -248,7 +248,7 @@ namespace System.Numerics
             if (u1 < u2)
                 goto LOtherSmall;
             LTopSmall:
-            Contract.Assert(u2 <= u1);
+            Debug.Assert(u2 <= u1);
             if (u2 == 0)
                 return u1;
             for (int cv = cvMax; ;)
@@ -263,7 +263,7 @@ namespace System.Numerics
                 }
             }
         LOtherSmall:
-            Contract.Assert(u1 < u2);
+            Debug.Assert(u1 < u2);
             if (u1 == 0)
                 return u2;
             for (int cv = cvMax; ;)


### PR DESCRIPTION
We previously agreed to unify on Debug.Assert rather than Contract.Assert, and @ellismg did a sweep through the code in the repo at the time to make the change.  Since then, some more Contract.Assert calls have snuck in.

This commit replaces another ~90 Contract.Assert usages, which is currently all of those left in the repo.