### PR TITLE
Update immutable and metadata assembly versions and .nuspecs

### DIFF
--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -19,6 +19,7 @@
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
+    <AssemblyVersion>1.1.34</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -20,6 +20,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoWarn>1591</NoWarn>
     <CLSCompliant>false</CLSCompliant>
+    <AssemblyVersion>1.0.19.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/nuget/System.Collections.Immutable.nuspec
+++ b/src/nuget/System.Collections.Immutable.nuspec
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata minClientVersion="2.8.1">
-    <id>Microsoft.Bcl.Immutable</id>
-    <version>1.1.34-beta</version>
+    <id>System.Collections.Immutable</id>
+    <version>1.1.34-rc</version>
     <title>Microsoft Immutable Collections</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/System.Reflection.Metadata.nuspec
+++ b/src/nuget/System.Reflection.Metadata.nuspec
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata minClientVersion="2.8.1">
-    <id>Microsoft.Bcl.Metadata</id>
-    <version>1.0.19-beta</version>
+    <id>System.Reflection.Metadata</id>
+    <version>1.0.19-rc</version>
     <title>Microsoft ECMA-335 Metadata Reader</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -19,6 +19,11 @@ Supported Platforms:
     <summary>Provides a low-level .NET metadata reader.</summary>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags>BCL Microsoft System ECMA ECMA335 Metadata Reflection</tags>
+    <dependencies>
+      <group>
+        <dependency id="System.Collections.Immutable" version="1.1.33-beta" />
+      </group>
+    </dependencies>
   </metadata>
   <files>
 


### PR DESCRIPTION
System.Collections.Immutable and System.Reflection.Metadata will
ship RC packages soon.

Adjust things so that the assemblies and packages produced in the
open-source build process match what we're shipping.

* Use correct, up-to-date package IDs:
 * Microsoft.Bcl.Immutable -> System.Collections.Imutable
 * Microsoft.Bcl.Metadata -> System.Reflection.Metadata

* Add missing S.R.Metadata -> S.C.Immutable nuget dependency

* Move package versions from -beta to -rc

* Set assembly versions to match package versions