### PR TITLE
Fix a couple of DebuggerDisplayAttributes

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/AllocFreeConcurrentStack.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/AllocFreeConcurrentStack.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace System.Collections.Immutable
 {
-    [DebuggerDisplay("Count = {stack != null ? stack.Count : 0}")]
     internal static class AllocFreeConcurrentStack<T>
     {
         private const int MaxSize = 35;

--- a/src/System.Collections.NonGeneric/src/System/Collections/KeyValuePairs.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/KeyValuePairs.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace System.Collections
 {
-    [DebuggerDisplay("{_value}", Name = "[{_key}]", Type = "")]
+    [DebuggerDisplay("{_value}", Name = "[{_key}]")]
     internal class KeyValuePairs
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]


### PR DESCRIPTION
AllocFreeConcurrentStack has a DebuggerDisplay attribute that a) uses a non-trivial expression (which is ill-advised) and b) uses field names that don't exist.  Further, as far as I can tell, there's no way in VS2015 to get the debugger to display a DebuggerDisplay for a static type like this; any attempts I've made yield an error "error CS0119: 'AllocFreeConcurrentStack<int>' is a type, which is not valid in the given context".  I've simply deleted the attribute.

KeyValuePairs in System.Collections.NonGeneric has included in its DDA the string 'Type = ""'.  I've just removed that portion of the DDA.