### PR TITLE
Remove WriteLineCore from IDebugLogger

### DIFF
--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
@@ -24,12 +24,6 @@ namespace System.Diagnostics
                 throw new NotImplementedException();
             }
 
-            public void WriteLineCore(string message)
-            {
-                message += Environment.NewLine;
-                Write(message);
-            }
-
             public void WriteCore(string message)
             {
                 // We don't want to write UTF-16 to standard error.  Ideally we would transcode this

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Windows.cs
@@ -49,12 +49,6 @@ namespace System.Diagnostics
                 }
             }
 
-            public void WriteLineCore(string message)
-            {
-                message += Environment.NewLine;
-                Write(message);
-            }
-
             public void WriteCore(string message)
             {
                 // really huge messages mess up both VS and dbmon, so we chop it up into 

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.cs
@@ -77,7 +77,7 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(string message)
         {
-            s_logger.WriteLineCore(message);
+            Write(message + Environment.NewLine);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
@@ -217,7 +217,6 @@ namespace System.Diagnostics
         internal interface IDebugLogger
         {
             void ShowAssertDialog(string stackTrace, string message, string detailMessage);
-            void WriteLineCore(string message);
             void WriteCore(string message);
         }
     }

--- a/src/System.Diagnostics.Debug/tests/DebugTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTests.cs
@@ -166,11 +166,6 @@ namespace System.Diagnostics.Tests
                 AssertUIOutput += stackTrace + message + detailMessage;
             }
 
-            public void WriteLineCore(string message)
-            {
-                LoggedOutput += message + Environment.NewLine;
-            }
-
             public void WriteCore(string message)
             {
                 LoggedOutput += message;


### PR DESCRIPTION
WriteLineCore was previously part of the internal IDebugLogger abstraction due to having different newline representations on different platforms.  Since the change was made to just use Environment.NewLine, all of the platforms share the same implementation, and we can remove the method from the interface.