### PR TITLE
Propose to fix a bug that the events can only be used by casting

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyObservableCollection.cs
@@ -63,7 +63,7 @@ namespace System.Collections.ObjectModel
         /// <remarks>
         /// see <seealso cref="INotifyCollectionChanged"/>
         /// </remarks>
-        protected virtual event NotifyCollectionChangedEventHandler CollectionChanged;
+        public virtual event NotifyCollectionChangedEventHandler CollectionChanged;
 
         /// <summary>
         /// raise CollectionChanged event to any listeners
@@ -95,7 +95,7 @@ namespace System.Collections.ObjectModel
         /// <remarks>
         /// see <seealso cref="INotifyPropertyChanged"/>
         /// </remarks>
-        protected virtual event PropertyChangedEventHandler PropertyChanged;
+        public virtual event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
         /// raise PropertyChanged event to any listeners


### PR DESCRIPTION
A detailed bug description can be found here: https://connect.microsoft.com/VisualStudio/feedback/details/641395/readonlyobservablecollection-t-collectionchanged-event-should-be-public