### PR TITLE
Fix warning when building with Dev12

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -223,12 +223,12 @@ namespace System.Diagnostics
                     throw new Win32Exception(); // match Windows exception
                 }
 
-                long bits = 0;
+                ulong bits = 0;
                 int maxCpu = IntPtr.Size == 4 ? 32 : 64;
                 for (int cpu = 0; cpu < maxCpu; cpu++)
                 {
                     if (Interop.libc.CPU_ISSET(cpu, &set))
-                        bits |= (1 << cpu);
+                        bits |= (1u << cpu);
                 }
                 return (IntPtr)bits;
             }


### PR DESCRIPTION
When building the Unix version of Syetem.Diagnostics.Process with
Dev12, there was an instance of warning CS0675 around some of our
bit-shifting.  This doesn't fire with Dev14, either due to a deliberate
change or a bug in Roslyn.  However, it's easy enough for us to fix
the code to not trigger the warning.