### PR TITLE
Delimiter list in the type name grammer was incorrect

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/AssemblyNameParsing/AssemblyNameParser.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/AssemblyNameParsing/AssemblyNameParser.cs
@@ -74,6 +74,7 @@ namespace System.Reflection.Metadata.Decoding
     //      ","
     //      "="
     //      """
+    //      "\"
     //
     internal partial class AssemblyNameParser
     {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/TypeNameParsing/TypeNameParserOfT.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/TypeNameParsing/TypeNameParserOfT.cs
@@ -109,7 +109,7 @@ namespace System.Reflection.Metadata.Decoding
     //      "["
     //      "]"
     //      "," 
-    //      "*"
+    //      "\"
     //      "&"
     //      "+"
     //


### PR DESCRIPTION
Duplicated "*" in the delimiter list, it should be "\".

See Tokenizer.HandleEscapeSequence for more information.