### PR TITLE
Fix edge cases with Complex.Acos and Complex.Asin

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -332,6 +332,10 @@ namespace System.Numerics
         }
         public static Complex Asin(Complex value) /* Arcsin */
         {
+            if ((value._imaginary == 0 && value._real < 0) || value._imaginary > 0)
+            {
+                return -Asin(-value);
+            }
             return (-ImaginaryOne) * Log(ImaginaryOne * value + Sqrt(One - value * value));
         }
 
@@ -351,6 +355,10 @@ namespace System.Numerics
         }
         public static Complex Acos(Complex value) /* Arccos */
         {
+            if ((value._imaginary == 0 && value._real > 0) || value._imaginary < 0)
+            {
+                return System.Math.PI - Acos(-value);
+            }
             return (-ImaginaryOne) * Log(value + ImaginaryOne * Sqrt(One - (value * value)));
         }
         public static Complex Tan(Complex value)

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
@@ -133,5 +133,14 @@ namespace System.Numerics.Tests
                 }
             }
         }
+
+        [Fact]
+        public static void RunTests_EdgeCases()
+        {
+            // Verify edge cases where imaginary part is zero and real part is positive.
+            VerifyACos(1234000000, 0, 0, 21.62667394298955);
+
+            // Verify edge cases where imaginary part is negative.
+        }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
@@ -141,6 +141,7 @@ namespace System.Numerics.Tests
             VerifyACos(1234000000, 0, 0, 21.62667394298955);
 
             // Verify edge cases where imaginary part is negative.
+            VerifyACos(0, -1234000000, 1.5707963267948966, 21.62667394298955);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
@@ -128,5 +128,14 @@ namespace System.Numerics.Tests
                 }
             }
         }
+
+        [Fact]
+        public static void RunTests_EdgeCases()
+        {
+            // Verify edge cases where imaginary part is zero and real part is negative.
+            VerifyASin(-1234000000, 0, -1.5707963267948966, 21.62667394298955);
+
+            // Verify edge cases where imaginary part is positive.
+        }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
@@ -136,6 +136,7 @@ namespace System.Numerics.Tests
             VerifyASin(-1234000000, 0, -1.5707963267948966, 21.62667394298955);
 
             // Verify edge cases where imaginary part is positive.
+            VerifyASin(0, 1234000000, 0, 21.62667394298955);
         }
     }
 }


### PR DESCRIPTION
Acos where imaginary part is zero and real part is positive.
Acos where imaginary part is negative.

Asin where imaginary part is zero and real part is negative.
Asin where imaginary part is positive.

Previously reported @ https://connect.microsoft.com/VisualStudio/feedback/details/790328