### PR TITLE
Update Metadata package to depend on latest Immutable package.

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -179,8 +179,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.34-rc-00001\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Reflection.Metadata/src/packages.config
+++ b/src/System.Reflection.Metadata/src/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net45+win" />
+  <package id="System.Collections.Immutable" version="1.1.34-rc-00001" targetFramework="portable-net45+win" />
 </packages>

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -97,8 +97,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.34-rc-00001\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>true</Private>
     </Reference>
   </ItemGroup>

--- a/src/nuget/System.Reflection.Metadata.nuspec
+++ b/src/nuget/System.Reflection.Metadata.nuspec
@@ -21,7 +21,7 @@ Supported Platforms:
     <tags>BCL Microsoft System ECMA ECMA335 Metadata Reflection</tags>
     <dependencies>
       <group>
-        <dependency id="System.Collections.Immutable" version="1.1.33-beta" />
+        <dependency id="System.Collections.Immutable" version="1.1.34-rc-00001" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Update the System.Reflection.Metadata package to depend on the RC build of
System.Collections.Immutable.

Update packages.config with the S.C.Immutable package.

Update src and test projects for S.R.Metadata to reference the RC build.
The RC builds are real signed so update assembly reference to specify the
full assembly identity.