### PR TITLE
Huge allocation reduction in XmlReader/Writer's async implementation

### DIFF
--- a/src/Common/src/System/Threading/Tasks/TaskValue.cs
+++ b/src/Common/src/System/Threading/Tasks/TaskValue.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>Value type discriminated union for a TResult and a <see cref="Task{TResult}"/>.</summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    internal struct TaskValue<TResult>
+    {
+        /// <summary>The task. this will be non-null iff the operation didn't complete successfully synchronously.</summary>
+        private readonly Task<TResult> _task;
+        /// <summary>The result to be used if the operation completed successfully synchronously.</summary>
+        private readonly TResult _result;
+
+        /// <summary>Initialize the TaskValue with the result of the successful operation.</summary>
+        /// <param name="result">The result.</param>
+        public TaskValue(TResult result)
+        {
+            _result = result;
+            _task = null;
+        }
+
+        /// <summary>
+        /// Initialize the TaskValue with a <see cref="Task{TResult}"/> that represents 
+        /// the non-successful or incomplete operation.
+        /// </summary>
+        /// <param name="task"></param>
+        public TaskValue(Task<TResult> task)
+        {
+            Debug.Assert(task != null);
+            _result = default(TResult);
+            _task = task;
+        }
+
+        /// <summary>Implicit operator to wrap a TaskValue around a task.</summary>
+        public static implicit operator TaskValue<TResult>(Task<TResult> task)
+        {
+            return new TaskValue<TResult>(task);
+        }
+
+        /// <summary>Implicit operator to wrap a TaskValue around a result.</summary>
+        public static implicit operator TaskValue<TResult>(TResult result)
+        {
+            return new TaskValue<TResult>(result);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Task{TResult}"/> object to represent this TaskValue.  It will
+        /// either return the wrapped task object if one exists, or it'll manufacture a new
+        /// task object to represent the result.
+        /// </summary>
+        public Task<TResult> AsTask()
+        {
+            return _task ?? Task.FromResult(_result);
+        }
+
+        /// <summary>Gets whether the TaskValue represents a successfully completed operation.</summary>
+        public bool IsRanToCompletion
+        {
+            get { return _task == null || _task.Status == TaskStatus.RanToCompletion; }
+        }
+
+        /// <summary>Gets the result.</summary>
+        public TResult Result
+        {
+            get { return _task == null ? _result : _task.GetAwaiter().GetResult(); }
+        }
+
+        /// <summary>Gets an awaiter for this value.</summary>
+        public TaskValueAwaiter GetAwaiter()
+        {
+            return new TaskValueAwaiter(this);
+        }
+
+        /// <summary>Provides an awaiter for a TaskValue.</summary>
+        public struct TaskValueAwaiter : ICriticalNotifyCompletion
+        {
+            /// <summary>The value being awaited.</summary>
+            private readonly TaskValue<TResult> _value;
+
+            /// <summary>Initializes the awaiter.</summary>
+            /// <param name="value">The value to be awaited.</param>
+            public TaskValueAwaiter(TaskValue<TResult> value)
+            {
+                _value = value;
+            }
+
+            /// <summary>Gets whether the TaskValue has completed.</summary>
+            public bool IsCompleted
+            {
+                get { return _value._task == null || _value._task.IsCompleted; }
+            }
+
+            /// <summary>Gets the result of the TaskValue.</summary>
+            public TResult GetResult()
+            {
+                return _value._task == null ?
+                    _value._result :
+                    _value._task.GetAwaiter().GetResult();
+            }
+
+            /// <summary>Schedules the continuation action for this TaskValue.</summary>
+            public void OnCompleted(Action continuation)
+            {
+                _value.AsTask().ConfigureAwait(false).GetAwaiter().OnCompleted(continuation);
+            }
+
+            /// <summary>Schedules the continuation action for this TaskValue.</summary>
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                _value.AsTask().ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(continuation);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/ValueTuple.cs
+++ b/src/Common/src/System/ValueTuple.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System
+{
+    internal struct ValueTuple<T1, T2>
+    {
+        public readonly T1 Item1;
+        public readonly T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            Item1 = item1;
+            Item2 = item2;
+        }
+    }
+
+    internal struct ValueTuple<T1, T2, T3>
+    {
+        public readonly T1 Item1;
+        public readonly T2 Item2;
+        public readonly T3 Item3;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+        }
+    }
+
+    internal struct ValueTuple<T1, T2, T3, T4>
+    {
+        public readonly T1 Item1;
+        public readonly T2 Item2;
+        public readonly T3 Item3;
+        public readonly T4 Item4;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+        }
+    }
+}

--- a/src/System.Xml.ReaderWriter/src/System.Xml.ReaderWriter.csproj
+++ b/src/System.Xml.ReaderWriter/src/System.Xml.ReaderWriter.csproj
@@ -21,6 +21,12 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\ValueTuple.cs">
+      <Link>Common\System\ValueTuple.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskValue.cs">
+      <Link>Common\System\Threading\Tasks\TaskValue.cs</Link>
+    </Compile>
     <Compile Include="System\Xml\AsyncHelper.cs" />
     <Compile Include="System\Xml\Base64Decoder.cs" />
     <Compile Include="System\Xml\Base64Encoder.cs" />

--- a/src/System.Xml.ReaderWriter/src/System/Xml/AsyncHelper.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/AsyncHelper.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace System.Xml
 {
     internal static class AsyncHelper
     {
-        public static readonly Task DoneTask = Task.FromResult(true);
-
         public static readonly Task<bool> DoneTaskTrue = Task.FromResult(true);
 
         public static readonly Task<bool> DoneTaskFalse = Task.FromResult(false);
@@ -21,106 +15,85 @@ namespace System.Xml
 
         public static bool IsSuccess(this Task task)
         {
-            return task.IsCompleted && task.Exception == null;
+            return task.Status == TaskStatus.RanToCompletion;
         }
 
-        public static Task CallVoidFuncWhenFinish(this Task task, Action func)
+        public static Task CallVoidFuncWhenFinishAsync<TArg>(this Task task, Action<TArg> func, TArg arg)
         {
             if (task.IsSuccess())
             {
-                func();
-                return DoneTask;
+                func(arg);
+                return Task.CompletedTask;
             }
             else
             {
-                return _CallVoidFuncWhenFinish(task, func);
+                return CallVoidFuncWhenFinishCoreAsync(task, func, arg);
             }
         }
 
-        private static async Task _CallVoidFuncWhenFinish(this Task task, Action func)
+        private static async Task CallVoidFuncWhenFinishCoreAsync<TArg>(this Task task, Action<TArg> func, TArg arg)
         {
             await task.ConfigureAwait(false);
-            func();
+            func(arg);
         }
 
-        public static Task<bool> ReturnTaskBoolWhenFinish(this Task task, bool ret)
+        public static Task<bool> ReturnTrueTaskWhenFinishAsync(this Task task)
         {
-            if (task.IsSuccess())
-            {
-                if (ret)
-                    return DoneTaskTrue;
-                else
-                    return DoneTaskFalse;
-            }
-            else
-            {
-                return _ReturnTaskBoolWhenFinish(task, ret);
-            }
+            return task.IsSuccess() ?
+                DoneTaskTrue :
+                ReturnTrueTaskWhenFinishCoreAsync(task);
         }
 
-        public static async Task<bool> _ReturnTaskBoolWhenFinish(this Task task, bool ret)
+        private static async Task<bool> ReturnTrueTaskWhenFinishCoreAsync(this Task task)
         {
             await task.ConfigureAwait(false);
-            return ret;
+            return true;
         }
 
-        public static Task CallTaskFuncWhenFinish(this Task task, Func<Task> func)
+        public static Task CallTaskFuncWhenFinishAsync<TArg>(this Task task, Func<TArg, Task> func, TArg arg)
         {
-            if (task.IsSuccess())
-            {
-                return func();
-            }
-            else
-            {
-                return _CallTaskFuncWhenFinish(task, func);
-            }
+            return task.IsSuccess() ?
+                func(arg) :
+                CallTaskFuncWhenFinishCoreAsync(task, func, arg);
         }
 
-        private static async Task _CallTaskFuncWhenFinish(Task task, Func<Task> func)
+        private static async Task CallTaskFuncWhenFinishCoreAsync<TArg>(Task task, Func<TArg, Task> func, TArg arg)
         {
             await task.ConfigureAwait(false);
-            await func().ConfigureAwait(false);
+            await func(arg).ConfigureAwait(false);
         }
 
-        public static Task<bool> CallBoolTaskFuncWhenFinish(this Task task, Func<Task<bool>> func)
+        public static Task<bool> CallBoolTaskFuncWhenFinishAsync<TArg>(this Task task, Func<TArg, Task<bool>> func, TArg arg)
         {
-            if (task.IsSuccess())
-            {
-                return func();
-            }
-            else
-            {
-                return _CallBoolTaskFuncWhenFinish(task, func);
-            }
+            return task.IsSuccess() ?
+                func(arg) :
+                CallBoolTaskFuncWhenFinishCoreAsync(task, func, arg);
         }
 
-        private static async Task<bool> _CallBoolTaskFuncWhenFinish(this Task task, Func<Task<bool>> func)
+        private static async Task<bool> CallBoolTaskFuncWhenFinishCoreAsync<TArg>(this Task task, Func<TArg, Task<bool>> func, TArg arg)
         {
             await task.ConfigureAwait(false);
-            return await func().ConfigureAwait(false);
+            return await func(arg).ConfigureAwait(false);
         }
 
-        public static Task<bool> ContinueBoolTaskFuncWhenFalse(this Task<bool> task, Func<Task<bool>> func)
+        public static Task<bool> ContinueBoolTaskFuncWhenFalseAsync<TArg>(this Task<bool> task, Func<TArg, Task<bool>> func, TArg arg)
         {
             if (task.IsSuccess())
             {
-                if (task.Result)
-                    return DoneTaskTrue;
-                else
-                    return func();
+                return task.Result ? DoneTaskTrue : func(arg);
             }
             else
             {
-                return _ContinueBoolTaskFuncWhenFalse(task, func);
+                return ContinueBoolTaskFuncWhenFalseCoreAsync(task, func, arg);
             }
         }
 
-        private static async Task<bool> _ContinueBoolTaskFuncWhenFalse(Task<bool> task, Func<Task<bool>> func)
+        private static async Task<bool> ContinueBoolTaskFuncWhenFalseCoreAsync<TArg>(Task<bool> task, Func<TArg, Task<bool>> func, TArg arg)
         {
             if (await task.ConfigureAwait(false))
                 return true;
             else
-                return await func().ConfigureAwait(false);
+                return await func(arg).ConfigureAwait(false);
         }
     }
 }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlAsyncCheckReader.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlAsyncCheckReader.cs
@@ -11,7 +11,7 @@ namespace System.Xml
     internal class XmlAsyncCheckReader : XmlReader
     {
         private readonly XmlReader _coreReader = null;
-        private Task _lastTask = AsyncHelper.DoneTask;
+        private Task _lastTask = Task.CompletedTask;
 
         internal XmlReader CoreReader
         {

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlAsyncCheckWriter.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlAsyncCheckWriter.cs
@@ -8,7 +8,7 @@ namespace System.Xml
     internal class XmlAsyncCheckWriter : XmlWriter
     {
         private readonly XmlWriter _coreWriter = null;
-        private Task _lastTask = AsyncHelper.DoneTask;
+        private Task _lastTask = Task.CompletedTask;
 
         internal XmlWriter CoreWriter
         {

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlRawWriterAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlRawWriterAsync.cs
@@ -60,7 +60,7 @@ namespace System.Xml
 
         public override Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
         {
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Raw writers do not have to keep a stack of element names.
@@ -165,11 +165,11 @@ namespace System.Xml
         // Write the xml declaration.  This must be the first call.
         internal virtual Task WriteXmlDeclarationAsync(XmlStandalone standalone)
         {
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
         internal virtual Task WriteXmlDeclarationAsync(string xmldecl)
         {
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Called after an element's attributes have been enumerated, but before any children have been

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlReaderAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlReaderAsync.cs
@@ -126,7 +126,7 @@ namespace System.Xml
         {
             if (ReadState != ReadState.Interactive)
             {
-                return AsyncHelper.DoneTask;
+                return Task.CompletedTask;
             }
             return SkipSubtreeAsync();
         }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
@@ -508,7 +508,7 @@ namespace System.Xml
                 case State.EndOfFile:
                 case State.Closed:
                 case State.Error:
-                    return Task.FromResult(0);
+                    return AsyncHelper.DoneTaskZero;
 
                 case State.ClearNsAttributes:
                 case State.PopNamespaceScope:
@@ -547,7 +547,7 @@ namespace System.Xml
 
                 default:
                     Debug.Assert(false);
-                    return Task.FromResult(0);
+                    return AsyncHelper.DoneTaskZero;
             }
         }
 

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -70,7 +70,7 @@ namespace System.Xml
                 default:
                     //should never hit here
                     Debug.Assert(false, "Invalid InitInputType");
-                    return AsyncHelper.DoneTask;
+                    return Task.CompletedTask;
             }
         }
 
@@ -121,7 +121,7 @@ namespace System.Xml
 
             if (_laterInitParam != null)
             {
-                return FinishInitAsync().CallBoolTaskFuncWhenFinish(ReadAsync);
+                return FinishInitAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
             }
 
             for (; ;)
@@ -179,13 +179,13 @@ namespace System.Xml
                         ThrowWithoutLineInfo(SR.Xml_MissingRoot);
                         return AsyncHelper.DoneTaskFalse;
                     case ParsingFunction.PartialTextValue:
-                        return SkipPartialTextValueAsync().CallBoolTaskFuncWhenFinish(ReadAsync);
+                        return SkipPartialTextValueAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
                     case ParsingFunction.InReadValueChunk:
-                        return FinishReadValueChunkAsync().CallBoolTaskFuncWhenFinish(ReadAsync);
+                        return FinishReadValueChunkAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
                     case ParsingFunction.InReadContentAsBinary:
-                        return FinishReadContentAsBinaryAsync().CallBoolTaskFuncWhenFinish(ReadAsync);
+                        return FinishReadContentAsBinaryAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
                     case ParsingFunction.InReadElementContentAsBinary:
-                        return FinishReadElementContentAsBinaryAsync().CallBoolTaskFuncWhenFinish(ReadAsync);
+                        return FinishReadElementContentAsBinaryAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
                     default:
                         Debug.Assert(false);
                         break;
@@ -669,7 +669,7 @@ namespace System.Xml
                 {
                     int orChars = 0;
 
-                    var tuple_0 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                    var tuple_0 = await ParseTextAsync(orChars);
                     startPos = tuple_0.Item1;
                     endPos = tuple_0.Item2;
                     orChars = tuple_0.Item3;
@@ -918,7 +918,7 @@ namespace System.Xml
                     break;
             }
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Switches the reader's encoding
@@ -933,7 +933,7 @@ namespace System.Xml
                 return ReadDataAsync();
             }
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         private Task SwitchEncodingToUTF8Async()
@@ -1401,7 +1401,7 @@ namespace System.Xml
                         // processing instruction
                         case '?':
                             _ps.charPos = pos + 1;
-                            return ParsePIAsync().ContinueBoolTaskFuncWhenFalse(ParseDocumentContentAsync);
+                            return ParsePIAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
                         case '!':
                             pos++;
                             if (_ps.charsUsed - pos < 2) // minimum characters expected "--"
@@ -1412,7 +1412,7 @@ namespace System.Xml
                                 if (chars[pos + 1] == '-')
                                 {
                                     _ps.charPos = pos + 2;
-                                    return ParseCommentAsync().ContinueBoolTaskFuncWhenFalse(ParseDocumentContentAsync);
+                                    return ParseCommentAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
                                 }
                                 else
                                 {
@@ -1432,7 +1432,7 @@ namespace System.Xml
                                     if (XmlConvert.StrEqual(chars, pos, 6, "CDATA["))
                                     {
                                         _ps.charPos = pos + 6;
-                                        return ParseCDataAsync().CallBoolTaskFuncWhenFinish(ParseDocumentContentAsync_CData);
+                                        return ParseCDataAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ParseDocumentContentAsync_CData(), this);
                                     }
                                     else
                                     {
@@ -1451,7 +1451,7 @@ namespace System.Xml
                                 {
                                     _fragmentType = XmlNodeType.Document;
                                     _ps.charPos = pos;
-                                    return ParseDoctypeDeclAsync().ContinueBoolTaskFuncWhenFalse(ParseDocumentContentAsync);
+                                    return ParseDoctypeDeclAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
                                 }
                                 else
                                 {
@@ -1484,7 +1484,7 @@ namespace System.Xml
                             }
                             _ps.charPos = pos;
                             _rootElementParsed = true;
-                            return ParseElementAsync().ReturnTaskBoolWhenFinish(true);
+                            return ParseElementAsync().ReturnTrueTaskWhenFinishAsync();
                     }
                 }
                 else if (chars[pos] == '&')
@@ -1501,7 +1501,7 @@ namespace System.Xml
                 {
                     if (_fragmentType == XmlNodeType.Document)
                     {
-                        return ParseRootLevelWhitespaceAsync().ContinueBoolTaskFuncWhenFalse(ParseDocumentContentAsync);
+                        return ParseRootLevelWhitespaceAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
                     }
                     else
                     {
@@ -1645,7 +1645,7 @@ namespace System.Xml
                             // processing instruction
                             case '?':
                                 _ps.charPos = pos + 2;
-                                return ParsePIAsync().ContinueBoolTaskFuncWhenFalse(ParseElementContentAsync);
+                                return ParsePIAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
                             case '!':
                                 pos += 2;
                                 if (_ps.charsUsed - pos < 2)
@@ -1656,7 +1656,7 @@ namespace System.Xml
                                     if (chars[pos + 1] == '-')
                                     {
                                         _ps.charPos = pos + 2;
-                                        return ParseCommentAsync().ContinueBoolTaskFuncWhenFalse(ParseElementContentAsync);
+                                        return ParseCommentAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
                                     }
                                     else
                                     {
@@ -1674,7 +1674,7 @@ namespace System.Xml
                                     if (XmlConvert.StrEqual(chars, pos, 6, "CDATA["))
                                     {
                                         _ps.charPos = pos + 6;
-                                        return ParseCDataAsync().ReturnTaskBoolWhenFinish(true);
+                                        return ParseCDataAsync().ReturnTrueTaskWhenFinishAsync();
                                     }
                                     else
                                     {
@@ -1696,7 +1696,7 @@ namespace System.Xml
                             // element end tag
                             case '/':
                                 _ps.charPos = pos + 2;
-                                return ParseEndElementAsync().ReturnTaskBoolWhenFinish(true);
+                                return ParseEndElementAsync().ReturnTrueTaskWhenFinishAsync();
                             default:
                                 // end of buffer
                                 if (pos + 1 == _ps.charsUsed)
@@ -1707,12 +1707,12 @@ namespace System.Xml
                                 {
                                     // element start tag
                                     _ps.charPos = pos + 1;
-                                    return ParseElementAsync().ReturnTaskBoolWhenFinish(true);
+                                    return ParseElementAsync().ReturnTrueTaskWhenFinishAsync();
                                 }
                         }
                         break;
                     case '&':
-                        return ParseTextAsync().ContinueBoolTaskFuncWhenFalse(ParseElementContentAsync);
+                        return ParseTextAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
                     default:
                         // end of buffer
                         if (pos == _ps.charsUsed)
@@ -1722,7 +1722,7 @@ namespace System.Xml
                         else
                         {
                             // text node, whitespace or entity reference
-                            return ParseTextAsync().ContinueBoolTaskFuncWhenFalse(ParseElementContentAsync);
+                            return ParseTextAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
                         }
                 }
             }
@@ -1835,14 +1835,14 @@ namespace System.Xml
             }
 
         ParseQNameSlow:
-            Task<Tuple<int, int>> parseQNameTask = ParseQNameAsync();
+            Task<ValueTuple<int, int>> parseQNameTask = ParseQNameAsync();
             return ParseElementAsync_ContinueWithSetElement(parseQNameTask);
 
         SetElement:
             return ParseElementAsync_SetElement(colonPos, pos);
         }
 
-        private Task ParseElementAsync_ContinueWithSetElement(Task<Tuple<int, int>> task)
+        private Task ParseElementAsync_ContinueWithSetElement(Task<ValueTuple<int, int>> task)
         {
             if (task.IsSuccess())
             {
@@ -1857,7 +1857,7 @@ namespace System.Xml
             }
         }
 
-        private async Task _ParseElementAsync_ContinueWithSetElement(Task<Tuple<int, int>> task)
+        private async Task _ParseElementAsync_ContinueWithSetElement(Task<ValueTuple<int, int>> task)
         {
             var tuple_4 = await task.ConfigureAwait(false);
             int colonPos = tuple_4.Item1;
@@ -1958,7 +1958,7 @@ namespace System.Xml
             // lookup element namespace
             ElementNamespaceLookup();
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         private async Task ParseElementAsync_ReadData(int pos)
@@ -2104,7 +2104,7 @@ namespace System.Xml
                 if (pos == _ps.charsUsed)
                 {
                     _parseEndElement_NextFunc = ParseEndElementParseFunction.ReadData;
-                    return AsyncHelper.DoneTask;
+                    return Task.CompletedTask;
                 }
 
                 bool tagMismatch = false;
@@ -2160,7 +2160,7 @@ namespace System.Xml
                 else if (pos == _ps.charsUsed)
                 {
                     _parseEndElement_NextFunc = ParseEndElementParseFunction.ReadData;
-                    return AsyncHelper.DoneTask;
+                    return Task.CompletedTask;
                 }
                 else
                 {
@@ -2185,7 +2185,7 @@ namespace System.Xml
             _parsingFunction = ParsingFunction.PopElementContext;
 
             _parseEndElement_NextFunc = ParseEndElementParseFunction.Done;
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         private async Task ParseEndElementAsync_ReadData()
@@ -2736,11 +2736,11 @@ namespace System.Xml
 
             // the whole value is in buffer
 
-            Task<Tuple<int, int, int, bool>> parseTextTask = ParseTextAsync(orChars);
+            TaskValue<ValueTuple<int, int, int, bool>> parseTextTask = ParseTextAsync(orChars);
             bool fullValue = false;
-            if (!parseTextTask.IsSuccess())
+            if (!parseTextTask.IsRanToCompletion)
             {
-                return _ParseTextAsync(parseTextTask);
+                return _ParseTextAsync(parseTextTask.AsTask());
             }
             else
             {
@@ -2769,7 +2769,7 @@ namespace System.Xml
             // only piece of the value was returned
             else
             {
-                return _ParseTextAsync(parseTextTask);
+                return _ParseTextAsync(parseTextTask.AsTask());
             }
         }
 
@@ -2777,7 +2777,7 @@ namespace System.Xml
         // Returns true if a node has been parsed and its data set to curNode. 
         // Returns false when a white space has been parsed and ignored (according to current whitespace handling) or when parsing mode is not Full.
         // Also returns false if there is no text to be parsed.
-        private async Task<bool> _ParseTextAsync(Task<Tuple<int, int, int, bool>> parseTask)
+        private async Task<bool> _ParseTextAsync(Task<ValueTuple<int, int, int, bool>> parseTask)
         {
             int startPos;
             int endPos;
@@ -2789,10 +2789,10 @@ namespace System.Xml
             // skip over the text if not in full parsing mode
             if (_parsingMode != ParsingMode.Full)
             {
-                Tuple<int, int, int, bool> tuple_9;
+                ValueTuple<int, int, int, bool> tuple_9;
                 do
                 {
-                    tuple_9 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                    tuple_9 = await ParseTextAsync(orChars);
                     startPos = tuple_9.Item1;
                     endPos = tuple_9.Item2;
                     orChars = tuple_9.Item3;
@@ -2804,7 +2804,7 @@ namespace System.Xml
             _curNode.SetLineInfo(_ps.LineNo, _ps.LinePos);
             Debug.Assert(_stringBuilder.Length == 0);
 
-            parseTask = ParseTextAsync(orChars);
+            parseTask = ParseTextAsync(orChars).AsTask();
 
         Parse:
             var tuple_10 = await parseTask.ConfigureAwait(false);
@@ -2833,7 +2833,7 @@ namespace System.Xml
                 // V1 compatibility mode -> cache the whole value
                 if (_v1Compat)
                 {
-                    Tuple<int, int, int, bool> tuple_11;
+                    ValueTuple<int, int, int, bool> tuple_11;
 
                     do
                     {
@@ -2842,7 +2842,7 @@ namespace System.Xml
                             _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
                         }
 
-                        tuple_11 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                        tuple_11 = await ParseTextAsync(orChars);
                         startPos = tuple_11.Item1;
                         endPos = tuple_11.Item2;
                         orChars = tuple_11.Item3;
@@ -2888,7 +2888,7 @@ namespace System.Xml
                     }
                     do
                     {
-                        var tuple_12 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                        var tuple_12 = await ParseTextAsync(orChars);
                         startPos = tuple_12.Item1;
                         endPos = tuple_12.Item2;
                         orChars = tuple_12.Item3;
@@ -2909,10 +2909,10 @@ namespace System.Xml
                         _stringBuilder.Length = 0;
                         if (!fullValue)
                         {
-                            Tuple<int, int, int, bool> tuple_13;
+                            ValueTuple<int, int, int, bool> tuple_13;
                             do
                             {
-                                tuple_13 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                                tuple_13 = await ParseTextAsync(orChars);
                                 startPos = tuple_13.Item1;
                                 endPos = tuple_13.Item2;
                                 orChars = tuple_13.Item3;
@@ -2951,15 +2951,15 @@ namespace System.Xml
         // Returns true when the whole value has been parsed. Return false when it needs to be called again to get a next chunk of value.
 
 
-        private class ParseTextState
+        private struct ParseTextState
         {
-            public int outOrChars;
-            public char[] chars;
-            public int pos;
-            public int rcount;
-            public int rpos;
-            public int orChars;
-            public char c;
+            public readonly int outOrChars;
+            public readonly char[] chars;
+            public readonly int pos;
+            public readonly int rcount;
+            public readonly int rpos;
+            public readonly int orChars;
+            public readonly char c;
 
             public ParseTextState(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
             {
@@ -2987,12 +2987,12 @@ namespace System.Xml
 
         private ParseTextState _lastParseTextState;
 
-        private Task<Tuple<int, int, int, bool>> _parseText_dummyTask = Task.FromResult(new Tuple<int, int, int, bool>(0, 0, 0, false));
+        private Task<ValueTuple<int, int, int, bool>> _parseText_dummyTask = Task.FromResult(new ValueTuple<int, int, int, bool>(0, 0, 0, false));
 
         //To avoid stackoverflow like ParseText->ParseEntity->ParText->..., use a loop and parsing function to implement such call.
-        private Task<Tuple<int, int, int, bool>> ParseTextAsync(int outOrChars)
+        private TaskValue<ValueTuple<int, int, int, bool>> ParseTextAsync(int outOrChars)
         {
-            Task<Tuple<int, int, int, bool>> task = ParseTextAsync(outOrChars, _ps.chars, _ps.charPos, 0, -1, outOrChars, (char)0);
+            Task<ValueTuple<int, int, int, bool>> task = ParseTextAsync(outOrChars, _ps.chars, _ps.charPos, 0, -1, outOrChars, (char)0);
             while (true)
             {
                 if (!task.IsSuccess())
@@ -3030,7 +3030,7 @@ namespace System.Xml
             }
         }
 
-        private async Task<Tuple<int, int, int, bool>> ParseTextAsync_AsyncFunc(Task<Tuple<int, int, int, bool>> task)
+        private async Task<ValueTuple<int, int, int, bool>> ParseTextAsync_AsyncFunc(Task<ValueTuple<int, int, int, bool>> task)
         {
             while (true)
             {
@@ -3061,12 +3061,12 @@ namespace System.Xml
                     case ParseTextFunction.NoValue:
                         return await ParseTextAsync_NoValue(outOrChars, pos).ConfigureAwait(false);
                     case ParseTextFunction.PartialValue:
-                        return await ParseTextAsync_PartialValue(pos, rcount, rpos, orChars, c).ConfigureAwait(false);
+                        return await ParseTextAsync_PartialValue(pos, rcount, rpos, orChars, c);
                 }
             }
         }
 
-        private Task<Tuple<int, int, int, bool>> ParseTextAsync(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
+        private Task<ValueTuple<int, int, int, bool>> ParseTextAsync(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
         {
             for (; ;)
             {
@@ -3171,7 +3171,7 @@ namespace System.Xml
             }
         }
 
-        private async Task<Tuple<int, int, int, bool>> ParseTextAsync_ParseEntity(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
+        private async Task<ValueTuple<int, int, int, bool>> ParseTextAsync_ParseEntity(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
         {
             // try to parse char entity inline
             int charRefEndPos, charCount;
@@ -3232,7 +3232,7 @@ namespace System.Xml
             return _parseText_dummyTask.Result;
         }
 
-        private async Task<Tuple<int, int, int, bool>> ParseTextAsync_Surrogate(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
+        private async Task<ValueTuple<int, int, int, bool>> ParseTextAsync_Surrogate(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
         {
             char ch = chars[pos];
             if (XmlCharType.IsHighSurrogate(ch))
@@ -3270,7 +3270,7 @@ namespace System.Xml
             throw new Exception();
         }
 
-        private async Task<Tuple<int, int, int, bool>> ParseTextAsync_ReadData(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
+        private async Task<ValueTuple<int, int, int, bool>> ParseTextAsync_ReadData(int outOrChars, char[] chars, int pos, int rcount, int rpos, int orChars, char c)
         {
             if (pos > _ps.charPos)
             {
@@ -3308,12 +3308,12 @@ namespace System.Xml
             return _parseText_dummyTask.Result;
         }
 
-        private Task<Tuple<int, int, int, bool>> ParseTextAsync_NoValue(int outOrChars, int pos)
+        private Task<ValueTuple<int, int, int, bool>> ParseTextAsync_NoValue(int outOrChars, int pos)
         {
-            return Task.FromResult(new Tuple<int, int, int, bool>(pos, pos, outOrChars, true));
+            return Task.FromResult(new ValueTuple<int, int, int, bool>(pos, pos, outOrChars, true));
         }
 
-        private Task<Tuple<int, int, int, bool>> ParseTextAsync_PartialValue(int pos, int rcount, int rpos, int orChars, char c)
+        private TaskValue<ValueTuple<int, int, int, bool>> ParseTextAsync_PartialValue(int pos, int rcount, int rpos, int orChars, char c)
         {
             if (_parsingMode == ParsingMode.Full && rcount > 0)
             {
@@ -3324,7 +3324,7 @@ namespace System.Xml
             _ps.charPos = pos;
             int outOrChars = orChars;
 
-            return Task.FromResult(new Tuple<int, int, int, bool>(startPos, endPos, outOrChars, c == '<'));
+            return new ValueTuple<int, int, int, bool>(startPos, endPos, outOrChars, c == '<');
         }
 
 
@@ -3341,7 +3341,7 @@ namespace System.Xml
             int endPos;
             int orChars = 0;
 
-            var tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(false);
+            var tuple_15 = await ParseTextAsync(orChars);
             startPos = tuple_15.Item1;
             endPos = tuple_15.Item2;
             orChars = tuple_15.Item3;
@@ -3350,7 +3350,7 @@ namespace System.Xml
             {
                 _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
 
-                tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                tuple_15 = await ParseTextAsync(orChars);
                 startPos = tuple_15.Item1;
                 endPos = tuple_15.Item2;
                 orChars = tuple_15.Item3;
@@ -3418,10 +3418,10 @@ namespace System.Xml
 
             _parsingFunction = _nextParsingFunction;
 
-            Tuple<int, int, int, bool> tuple_16;
+            ValueTuple<int, int, int, bool> tuple_16;
             do
             {
-                tuple_16 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                tuple_16 = await ParseTextAsync(orChars);
                 startPos = tuple_16.Item1;
                 endPos = tuple_16.Item2;
                 orChars = tuple_16.Item3;
@@ -3443,7 +3443,7 @@ namespace System.Xml
                 _parsingFunction = _nextParsingFunction;
                 _nextParsingFunction = _nextNextParsingFunction;
 
-                return AsyncHelper.DoneTask;
+                return Task.CompletedTask;
             }
         }
 
@@ -3522,7 +3522,7 @@ namespace System.Xml
         }
 
 
-        private async Task<Tuple<int, EntityType>> HandleEntityReferenceAsync(bool isInAttributeValue, EntityExpandType expandType)
+        private async Task<ValueTuple<int, EntityType>> HandleEntityReferenceAsync(bool isInAttributeValue, EntityExpandType expandType)
         {
             int charRefEndPos;
 
@@ -3548,7 +3548,7 @@ namespace System.Xml
 
                 Debug.Assert(entityType == EntityType.CharacterDec || entityType == EntityType.CharacterHex);
 
-                return new Tuple<int, EntityType>(charRefEndPos, entityType);
+                return new ValueTuple<int, EntityType>(charRefEndPos, entityType);
             }
             // named reference
             else
@@ -3557,7 +3557,7 @@ namespace System.Xml
                 charRefEndPos = await ParseNamedCharRefAsync(expandType != EntityExpandType.OnlyGeneral, null).ConfigureAwait(false);
                 if (charRefEndPos >= 0)
                 {
-                    return new Tuple<int, EntityType>(charRefEndPos, EntityType.CharacterNamed);
+                    return new ValueTuple<int, EntityType>(charRefEndPos, EntityType.CharacterNamed);
                 }
 
                 // general entity reference
@@ -3573,7 +3573,7 @@ namespace System.Xml
                 {
                     Throw(SR.Xml_ErrorParsingEntityName, _ps.LineNo, savedLinePos);
 
-                    return new Tuple<int, EntityType>(charRefEndPos, EntityType.Skipped);
+                    return new ValueTuple<int, EntityType>(charRefEndPos, EntityType.Skipped);
                 }
 
                 // check ';'
@@ -3588,7 +3588,7 @@ namespace System.Xml
                 charRefEndPos = -1;
 
                 Throw(SR.Xml_UndeclaredEntity, entityName, _ps.LineNo, entityLinePos);
-                return null;//unreachable
+                return default(ValueTuple<int, EntityType>);//unreachable
             }
         }
 
@@ -3678,7 +3678,7 @@ namespace System.Xml
                 {
                     if (_ignorePIs || _parsingMode != ParsingMode.Full)
                     {
-                        Tuple<int, int, bool> tuple_19;
+                        ValueTuple<int, int, bool> tuple_19;
                         do
                         {
                             tuple_19 = await ParsePIValueAsync().ConfigureAwait(false);
@@ -3696,7 +3696,7 @@ namespace System.Xml
                     sb = piInDtdStringBuilder;
                 }
 
-                Tuple<int, int, bool> tuple_20;
+                ValueTuple<int, int, bool> tuple_20;
 
                 do
                 {
@@ -3718,7 +3718,7 @@ namespace System.Xml
             return true;
         }
 
-        private async Task<Tuple<int, int, bool>> ParsePIValueAsync()
+        private async Task<ValueTuple<int, int, bool>> ParsePIValueAsync()
         {
             int outStartPos;
             int outEndPos;
@@ -3766,7 +3766,7 @@ namespace System.Xml
                             outStartPos = _ps.charPos;
                             _ps.charPos = pos + 2;
 
-                            return new Tuple<int, int, bool>(outStartPos, outEndPos, true);
+                            return new ValueTuple<int, int, bool>(outStartPos, outEndPos, true);
                         }
                         else if (pos + 1 == _ps.charsUsed)
                         {
@@ -3871,7 +3871,7 @@ namespace System.Xml
             outStartPos = _ps.charPos;
             _ps.charPos = pos;
 
-            return new Tuple<int, int, bool>(outStartPos, outEndPos, false);
+            return new ValueTuple<int, int, bool>(outStartPos, outEndPos, false);
         }
 
         private async Task<bool> ParseCommentAsync()
@@ -3916,7 +3916,7 @@ namespace System.Xml
                 }
                 else
                 {
-                    Tuple<int, int, bool> tuple_22;
+                    ValueTuple<int, int, bool> tuple_22;
 
                     do
                     {
@@ -3934,7 +3934,7 @@ namespace System.Xml
             }
             else
             {
-                Tuple<int, int, bool> tuple_23;
+                ValueTuple<int, int, bool> tuple_23;
                 do
                 {
                     tuple_23 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(false);
@@ -3946,7 +3946,7 @@ namespace System.Xml
 
         // Parses a chunk of CDATA section or comment. Returns true when the end of CDATA or comment was reached.
 
-        private async Task<Tuple<int, int, bool>> ParseCDataOrCommentTupleAsync(XmlNodeType type)
+        private async Task<ValueTuple<int, int, bool>> ParseCDataOrCommentTupleAsync(XmlNodeType type)
         {
             int outStartPos;
             int outEndPos;
@@ -3995,7 +3995,7 @@ namespace System.Xml
                             outStartPos = _ps.charPos;
                             _ps.charPos = pos + 3;
 
-                            return new Tuple<int, int, bool>(outStartPos, outEndPos, true);
+                            return new ValueTuple<int, int, bool>(outStartPos, outEndPos, true);
                         }
                         else if (pos + 2 == _ps.charsUsed)
                         {
@@ -4109,7 +4109,7 @@ namespace System.Xml
 
                 _ps.charPos = pos;
 
-                return new Tuple<int, int, bool>(outStartPos, outEndPos, false);
+                return new ValueTuple<int, int, bool>(outStartPos, outEndPos, false);
             }
         }
 
@@ -4587,7 +4587,7 @@ namespace System.Xml
         //      - returns position of the end of the character reference, that is of the character next to the original ';'
         //      - if (expand == true) then ps.charPos is changed to point to the replaced character
 
-        private async Task<Tuple<EntityType, int>> ParseNumericCharRefAsync(bool expand, BufferBuilder internalSubsetBuilder)
+        private async Task<ValueTuple<EntityType, int>> ParseNumericCharRefAsync(bool expand, BufferBuilder internalSubsetBuilder)
         {
             EntityType entityType;
 
@@ -4611,7 +4611,7 @@ namespace System.Xml
                             _ps.charPos = newPos - charCount;
                         }
 
-                        return new Tuple<EntityType, int>(entityType, newPos);
+                        return new ValueTuple<EntityType, int>(entityType, newPos);
                 }
             }
         }
@@ -4655,12 +4655,12 @@ namespace System.Xml
             return tuple_25.Item2;
         }
 
-        private Task<Tuple<int, int>> ParseQNameAsync()
+        private Task<ValueTuple<int, int>> ParseQNameAsync()
         {
             return ParseQNameAsync(true, 0);
         }
 
-        private async Task<Tuple<int, int>> ParseQNameAsync(bool isQName, int startOffset)
+        private async Task<ValueTuple<int, int>> ParseQNameAsync(bool isQName, int startOffset)
         {
             int colonPos;
 
@@ -4775,16 +4775,16 @@ namespace System.Xml
             // end of name
             colonPos = (colonOffset == -1) ? -1 : _ps.charPos + colonOffset;
 
-            return new Tuple<int, int>(colonPos, pos);
+            return new ValueTuple<int, int>(colonPos, pos);
         }
 
-        private async Task<Tuple<int, bool>> ReadDataInNameAsync(int pos)
+        private async Task<ValueTuple<int, bool>> ReadDataInNameAsync(int pos)
         {
             int offset = pos - _ps.charPos;
             bool newDataRead = (await ReadDataAsync().ConfigureAwait(false) != 0);
             pos = _ps.charPos + offset;
 
-            return new Tuple<int, bool>(pos, newDataRead);
+            return new ValueTuple<int, bool>(pos, newDataRead);
         }
 
 
@@ -4941,7 +4941,7 @@ namespace System.Xml
                         // store current line info and parse more text
                         _incReadLineInfo.Set(_ps.LineNo, _ps.LinePos);
 
-                        var tuple_36 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                        var tuple_36 = await ParseTextAsync(orChars);
                         startPos = tuple_36.Item1;
                         endPos = tuple_36.Item2;
                         orChars = tuple_36.Item3;
@@ -5018,4 +5018,3 @@ namespace System.Xml
         }
     }
 }
-

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -65,7 +65,7 @@ namespace System.Xml
                 return WriteProcessingInstructionAsync("xml", xmldecl);
             }
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Serialize the document type declaration.
@@ -119,14 +119,14 @@ namespace System.Xml
             Task task;
             if (prefix != null && prefix.Length != 0)
             {
-                task = RawTextAsync(string.Concat(prefix, ":", localName));
+                task = RawTextAsync(prefix, ":", localName);
             }
             else
             {
                 task = RawTextAsync(localName);
             }
 
-            return task.CallVoidFuncWhenFinish(WriteStartElementAsync_SetAttEndPos);
+            return task.CallVoidFuncWhenFinishAsync(thisRef => thisRef.WriteStartElementAsync_SetAttEndPos(), this);
         }
 
         private void WriteStartElementAsync_SetAttEndPos()
@@ -150,11 +150,11 @@ namespace System.Xml
 
                 if (prefix != null && prefix.Length != 0)
                 {
-                    return RawTextAsync(string.Concat(prefix, ":", localName, ">"));
+                    return RawTextAsync(prefix, ":", localName, ">");
                 }
                 else
                 {
-                    return RawTextAsync(string.Concat(localName, ">"));
+                    return RawTextAsync(localName, ">");
                 }
             }
             else
@@ -165,7 +165,7 @@ namespace System.Xml
                 bufBytes[bufPos++] = (byte)'/';
                 bufBytes[bufPos++] = (byte)'>';
             }
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Serialize a full element end tag: "</prefix:localName>"
@@ -180,11 +180,11 @@ namespace System.Xml
 
             if (prefix != null && prefix.Length != 0)
             {
-                return RawTextAsync(string.Concat(prefix, ":", localName, ">"));
+                return RawTextAsync(prefix, ":", localName, ">");
             }
             else
             {
-                return RawTextAsync(string.Concat(localName, ">"));
+                return RawTextAsync(localName, ">");
             }
         }
 
@@ -202,13 +202,13 @@ namespace System.Xml
             Task task;
             if (prefix != null && prefix.Length > 0)
             {
-                task = RawTextAsync(string.Concat(prefix, ":", localName, "=\""));
+                task = RawTextAsync(prefix, ":", localName, "=\"");
             }
             else
             {
-                task = RawTextAsync(string.Concat(localName, "=\""));
+                task = RawTextAsync(localName, "=\"");
             }
-            return task.CallVoidFuncWhenFinish(WriteStartAttribute_SetInAttribute);
+            return task.CallVoidFuncWhenFinishAsync(thisRef => thisRef.WriteStartAttribute_SetInAttribute(), this);
         }
 
         private void WriteStartAttribute_SetInAttribute()
@@ -225,7 +225,7 @@ namespace System.Xml
             inAttributeValue = false;
             attrEndPos = bufPos;
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         internal override async Task WriteNamespaceDeclarationAsync(string prefix, string namespaceName)
@@ -268,7 +268,7 @@ namespace System.Xml
             bufBytes[bufPos++] = (byte)'"';
             attrEndPos = bufPos;
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Serialize a CData section.  If the "]]>" pattern is found within
@@ -549,7 +549,7 @@ namespace System.Xml
         {
             // intentionally empty
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         // Serialize text that is part of an attribute value.  The '&', '<', '>', and '"' characters
@@ -721,7 +721,7 @@ namespace System.Xml
                 return _WriteAttributeTextBlockAsync(text, curIndex, leftCount);
             }
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         private async Task _WriteAttributeTextBlockAsync(string text, int curIndex, int leftCount)
@@ -929,7 +929,7 @@ namespace System.Xml
                 return _WriteElementTextBlockAsync(false, text, curIndex, leftCount);
             }
 
-            return AsyncHelper.DoneTask;
+            return Task.CompletedTask;
         }
 
         private async Task _WriteElementTextBlockAsync(bool newLine, string text, int curIndex, int leftCount)
@@ -1031,25 +1031,80 @@ namespace System.Xml
             }
         }
 
+        // special-case the one string overload, as it's so common
         protected Task RawTextAsync(string text)
         {
-            int writeLen = 0;
-            int curIndex = 0;
-            int leftCount = text.Length;
-
-            writeLen = RawTextNoFlush(text, curIndex, leftCount);
-            curIndex += writeLen;
-            leftCount -= writeLen;
-            if (writeLen >= 0)
-            {
-                return _RawTextAsync(text, curIndex, leftCount);
-            }
-
-            return AsyncHelper.DoneTask;
+            int writeLen = RawTextNoFlush(text, 0, text.Length);
+            return writeLen >= 0 ?
+                _RawTextAsync(text, writeLen, text.Length - writeLen) :
+                Task.CompletedTask;
         }
 
-        private async Task _RawTextAsync(string text, int curIndex, int leftCount)
+        protected Task RawTextAsync(string text1, string text2 = null, string text3 = null, string text4 = null)
         {
+            Debug.Assert(text1 != null);
+            Debug.Assert(text2 != null || (text3 == null && text4 == null));
+            Debug.Assert(text3 != null || (text4 == null));
+
+            int writeLen;
+
+            // Write out the first string
+            writeLen = RawTextNoFlush(text1, 0, text1.Length);
+            if (writeLen >= 0)
+            {
+                // If we were only able to partially write it, write out the remainder
+                // and then write out the other strings.
+                return _RawTextAsync(text1, writeLen, text1.Length - writeLen, text2, text3, text4);
+            }
+
+            // We wrote out the first string.  Try to write out the second, if it exists.
+            if (text2 != null)
+            {
+                writeLen = RawTextNoFlush(text2, 0, text2.Length);
+                if (writeLen >= 0)
+                {
+                    // If we were only able to write out some of the second string,
+                    // write out the remainder and then the other strings, 
+                    return _RawTextAsync(text2, writeLen, text2.Length - writeLen, text3, text4);
+                }
+            }
+
+            // We wrote out the first and second strings.  Try to write out the third
+            // if it exists.
+            if (text3 != null)
+            {
+                writeLen = RawTextNoFlush(text3, 0, text3.Length);
+                if (writeLen >= 0)
+                {
+                    // If we were only able to write out some of the third string,
+                    // write out the remainder and then the last string.
+                    return _RawTextAsync(text3, writeLen, text3.Length - writeLen, text4);
+                }
+            }
+
+            // Finally, try to write out the fourth string, if it exists.
+            if (text4 != null)
+            {
+                writeLen = RawTextNoFlush(text4, 0, text4.Length);
+                if (writeLen >= 0)
+                {
+                    return _RawTextAsync(text4, writeLen, text4.Length - writeLen);
+                }
+            }
+
+            // All strings written successfully.
+            return Task.CompletedTask;
+        }
+
+        private async Task _RawTextAsync(
+            string text, int curIndex, int leftCount, 
+            string text2 = null, string text3 = null, string text4 = null)
+        {
+            Debug.Assert(text != null);
+            Debug.Assert(text2 != null || (text3 == null && text4 == null));
+            Debug.Assert(text3 != null || (text4 == null));
+
+            // Write out the remainder of the first string
             await FlushBufferAsync().ConfigureAwait(false);
             int writeLen = 0;
             do
@@ -1062,6 +1117,12 @@ namespace System.Xml
                     await FlushBufferAsync().ConfigureAwait(false);
                 }
             } while (writeLen >= 0);
+
+            // If there are additional strings, write them out as well
+            if (text2 != null)
+            {
+                await RawTextAsync(text2, text3, text4).ConfigureAwait(false);
+            }
         }
 
         [SecuritySafeCritical]

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWriterAsync.cs
@@ -75,7 +75,7 @@ namespace System.Xml
             Task task = WriteStartAttributeAsync(prefix, localName, ns);
             if (task.IsSuccess())
             {
-                return WriteStringAsync(value).CallTaskFuncWhenFinish(WriteEndAttributeAsync);
+                return WriteStringAsync(value).CallTaskFuncWhenFinishAsync(thisRef => thisRef.WriteEndAttributeAsync(), this);
             }
             else
             {


### PR DESCRIPTION
This PR significantly reduces the allocations involved in the async implementation of XmlReader and XmlWriter.

As an example, consider the following code snippet that reads all of the nodes from a reader and writes them all to a writer:
```
using (XmlReader reader = XmlReader.Create(input, new XmlReaderSettings { Async = true }))
using (XmlWriter writer = XmlWriter.Create(output, new XmlWriterSettings { Async = true }))
{
    await writer.WriteNodeAsync(reader, true);
}
```
With this PR, the number of allocations / gen0 GCs dropped on my machine by almost _80%_.  And in this example that just iterates through the nodes of a reader:
```
while (await reader.ReadAsync());
```
almost all allocations were removed.

Primary changes:
- Several of the AsyncHelpers methods took delegates, and the call sites were passing in method groups for instance methods.  I changed these helpers to accept an argument that’s passed into the delegate and the call sites to pass the this reference into a lambda, letting the compiler cache the delegate allocation so that it’s not allocated on each call.  This reduced the allocations in the previous read loop example by ~25%.
- The synchronous reader implementation used out parameters to pass back multiple values, while the async implementation used a ```Tuple<>```.  I added several ```ValueTuple<>``` struct types to use instead.  This reduced the allocations in the read loop example by ~10%.
- Similarly, the async implementation used a ParseTextState class to pass back data.  I changed this to be a struct.  This reduced the allocations of the read loop example by ~25%.
- Profiling showed that the vast majority of remaining allocations while doing the read loop were coming from a Task.FromResult call inside a very hot method ParseTextAsync_PartialValue.  Rather than return a ```Task<T>``` from this method, I added a ```struct TaskValue<T>``` type that’s a discriminated union of either a ```T``` or a ```Task<T>```, and I added to it an awaiter implementation.  Most of the rest of the code just consumed this result using await, and thus required few additional changes.  This removed almost all of the rest of the allocations involved in the read loop.
- For writing, one of the biggest allocation hot spots was in calls to RawTextAsync(string.Concat(…)), for the string allocations.  I changed the RawTextAsync implementation to support 1-4 strings instead of just 1, avoiding the need for the concatenation.
- Several places were doing Task.FromResult(0), when AsyncHelpers was already caching a 0-task.  I just switched to using the already cached task.
- Just as cleanup, I replaced the custom AsyncHelpers.DoneTask with the now built-in Task.CompletedTask.

With no other concurrent work happening, these changes also improved throughput of the aforementioned examples by ~20%.  As is usually the case with GC, I'd expect the benefits to increase the more work is being done concurrently, on the server, etc.