### PR TITLE
Add syslog writing to Debug.Assert

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.syslog.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.syslog.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [DllImport(Libraries.Libc)]
+        internal static extern void syslog(int priority, string format, string arg1);
+
+        internal const int LOG_DEBUG = 7;
+        internal const int LOG_USER = (1 << 3);
+    }
+}

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -74,6 +74,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
       <Link>Common\Interop\Unix\libc\Interop.strerror.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.syslog.cs">
+      <Link>Common\Interop\Unix\libc\Interop.syslog.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.write.cs">
       <Link>Common\Interop\Unix\libc\Interop.write.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
@@ -26,7 +26,18 @@ namespace System.Diagnostics
 
             public void WriteCore(string message)
             {
-                // We don't want to write UTF-16 to standard error.  Ideally we would transcode this
+                WriteToSyslog(message);
+                WriteToFile(Interop.Devices.stderr, message);
+            }
+
+            private static void WriteToSyslog(string message)
+            {
+                Interop.libc.syslog(Interop.libc.LOG_USER | Interop.libc.LOG_DEBUG, "%s", message);
+            }
+
+            private static void WriteToFile(string filePath, string message)
+            {
+                // We don't want to write UTF-16 to a file like standard error.  Ideally we would transcode this
                 // to UTF8, but the downside of that is it pulls in a bunch of stuff into what is ideally
                 // a path with minimal dependencies (as to prevent re-entrency), so we'll take the strategy
                 // of just throwing away any non ASCII characters from the message and writing the rest
@@ -39,7 +50,7 @@ namespace System.Diagnostics
                     int bufCount;
                     int i = 0;
 
-                    using (SafeFileHandle stderr = SafeFileHandle.Open(Interop.Devices.stderr, Interop.libc.OpenFlags.O_WRONLY, 0))
+                    using (SafeFileHandle fileHandle = SafeFileHandle.Open(filePath, Interop.libc.OpenFlags.O_WRONLY, 0))
                     {
                         while (i < message.Length)
                         {
@@ -54,7 +65,7 @@ namespace System.Diagnostics
 
                             if (bufCount != 0)
                             {
-                                while (Interop.CheckIo((long)Interop.libc.write((int)stderr.DangerousGetHandle(), buf, new IntPtr(bufCount)))) ;
+                                while (Interop.CheckIo((long)Interop.libc.write((int)fileHandle.DangerousGetHandle(), buf, new IntPtr(bufCount)))) ;
                             }
                         }
                     }


### PR DESCRIPTION
Currently on Unix, failed Debug.Asserts get written to stderr.  Logging with syslog is also an accepted means of such debug output, and allows you to monitor debug output with a command like ```tail -f /var/log/syslog``` separate from the output streams.  This commit just adds writing with syslog as well. (In the future, we could choose to make these configurable via an environment variable.)