### PR TITLE
Initial commit of System.IO.FileSystem tests (File, Directory, FI, DI)

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Ansichars.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Ansichars.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Security;
+using Xunit;
+
+public class Directory_AnsiChars
+{
+    [Fact]
+    public static void runTest()
+    {
+        bool bTestPassed = false;
+        try
+        {
+            String strPath = Directory.GetCurrentDirectory();
+            String s = "..\u2044*";
+            String[] d = Directory.GetFiles(".", s);
+            if (d.Length != 0)
+            {
+                //print out all the files.
+                for (int i = 0; i < d.Length; i++)
+                    Console.WriteLine(d[i]);
+                bTestPassed = false;
+            }
+            else
+            {
+                Console.WriteLine(@"Skipped test. Make sure you have a parent directory (not root) with somes files before running this test");
+                bTestPassed = true;
+            }
+        }
+        catch (Exception e)
+        {
+            bTestPassed = false;
+            Console.WriteLine("unexpected exception occured... Exception message:" + e.ToString());
+        }
+
+        if (bTestPassed)
+        {
+            Console.WriteLine("Test PASSED");
+        }
+        else
+        {
+            Console.WriteLine("Test FAILED");
+        }
+
+        Assert.True(bTestPassed);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -1,0 +1,449 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Linq;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_CreateDirectory
+{
+    [Fact]
+    public static void CreateDirectory_NullAsPath_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            Directory.CreateDirectory((string)null);
+        });
+    }
+
+    [Fact]
+    public static void CreateDirectory_EmptyAsPath_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>              // BUG 995784: Not setting the parameter name
+        {
+            Directory.CreateDirectory(string.Empty);
+        });
+    }
+
+    [Fact]
+    public static void CreateDirectory_NonSignificantWhiteSpaceAsPath_ThrowsArgumentException()
+    {
+        var paths = IOInputs.GetNonSignificantTrailingWhiteSpace();
+        foreach (var path in paths)
+        {
+            Assert.Throws<ArgumentException>(() =>          // BUG 995784: Not setting the parameter name
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_PathWithInvalidCharactersAsPath_ThrowsArgumentException()
+    {
+        var paths = IOInputs.GetPathsWithInvalidCharacters();
+        foreach (var path in paths)
+        {
+            Assert.Throws<ArgumentException>(() =>          // BUG 995784: Not setting the parameter name
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_PathWithAlternativeDataStreams_ThrowsNotSupportedException()
+    {
+        var paths = IOInputs.GetPathsWithAlternativeDataStreams();
+        foreach (var path in paths)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void CreateDirectory_PathWithReservedDeviceNameAsPath_ThrowsDirectoryNotFoundException()
+    {   // Throws DirectoryNotFoundException, when the behavior really should be an invalid path
+        var paths = IOInputs.GetPathsWithReservedDeviceNames();
+        foreach (var path in paths)
+        {
+            Assert.Throws<DirectoryNotFoundException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_UncPathWithoutShareNameAsPath_ThrowsArgumentException()
+    {
+        var paths = IOInputs.GetUncPathsWithoutShareName();
+        foreach (var path in paths)
+        {
+            Assert.Throws<ArgumentException>(() =>      // BUG 995784: Not setting the parameter name
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsPathTooLongException()
+    {
+        // While paths themselves can be up to 260 characters including trailing null, file systems
+        // limit each components of the path to a total of 255 characters.
+
+        var paths = IOInputs.GetPathsWithComponentLongerThanMaxComponent();
+
+        foreach (string path in paths)
+        {
+            Assert.Throws<PathTooLongException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_DirectoryLongerThanMaxDirectoryAsPath_ThrowsPathTooLongException()
+    {
+        var paths = IOInputs.GetPathsLongerThanMaxDirectory();
+        foreach (var path in paths)
+        {
+            Assert.Throws<PathTooLongException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_DirectoryLongerThanMaxPathAsPath_ThrowsPathTooLongException()
+    {
+        var paths = IOInputs.GetPathsLongerThanMaxPath();
+        foreach (var path in paths)
+        {
+            Assert.Throws<PathTooLongException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_NotReadyDriveAsPath_ThrowsDirectoryNotFoundException()
+    {   // Behavior is suspect, should really have thrown IOException similar to the SubDirectory case
+        var drive = IOServices.GetNotReadyDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a not-ready drive, such as CD-Rom with no disc inserted.");
+            return;
+        }
+
+        Assert.Throws<DirectoryNotFoundException>(() =>
+        {
+            Directory.CreateDirectory(drive);
+        });
+    }
+
+    [Fact]
+    public static void CreateDirectory_SubdirectoryOnNotReadyDriveAsPath_ThrowsIOException()
+    {
+        var drive = IOServices.GetNotReadyDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a not-ready drive, such as CD-Rom with no disc inserted.");
+            return;
+        }
+
+        // 'Device is not ready'
+        Assert.Throws<IOException>(() =>
+        {
+            Directory.CreateDirectory(Path.Combine(drive, "Subdirectory"));
+        });
+    }
+
+    [Fact]
+    public static void CreateDirectory_NonExistentDriveAsPath_ThrowsDirectoryNotFoundException()
+    {
+        var drive = IOServices.GetNonExistentDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a non-existent drive.");
+            return;
+        }
+
+
+        Assert.Throws<DirectoryNotFoundException>(() =>
+        {
+            Directory.CreateDirectory(drive);
+        });
+    }
+
+    [Fact]
+    public static void CreateDirectory_SubdirectoryOnNonExistentDriveAsPath_ThrowsDirectoryNotFoundException()
+    {
+        var drive = IOServices.GetNonExistentDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a non-existent drive.");
+            return;
+        }
+
+        Assert.Throws<DirectoryNotFoundException>(() =>
+        {
+            Directory.CreateDirectory(Path.Combine(drive, "Subdirectory"));
+        });
+    }
+
+    [Fact]
+    public static void CreateDirectory_FileWithoutTrailingSlashAsPath_ThrowsIOException()
+    {   // VSWhidbey #104049
+        using (TemporaryFile file = new TemporaryFile())
+        {
+            string path = IOServices.RemoveTrailingSlash(file.Path);
+
+            Assert.Throws<IOException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+
+    [Fact]
+    public static void CreateDirectory_FileWithTrailingSlashAsPath_ThrowsIOException()
+    {
+        using (TemporaryFile file = new TemporaryFile())
+        {
+            string path = IOServices.AddTrailingSlashIfNeeded(file.Path);
+
+            Assert.Throws<IOException>(() =>
+            {
+                Directory.CreateDirectory(path);
+            });
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_ExistingDirectoryWithoutTrailingSlashAsPath_DoesNotThrow()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            string path = IOServices.RemoveTrailingSlash(directory.Path);
+
+            DirectoryInfo result = Directory.CreateDirectory(path);
+
+            Assert.Equal(path, result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_ExistingDirectoryWithTrailingSlashAsPath_DoesNotThrow()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            string path = IOServices.AddTrailingSlashIfNeeded(directory.Path);
+
+            DirectoryInfo result = Directory.CreateDirectory(path);
+
+            Assert.Equal(path, result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_DotWithoutTrailingSlashAsPath_DoesNotThrow()
+    {
+        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\."); // "Current" directory
+
+        Assert.True(Directory.Exists(result.FullName));
+    }
+
+    [Fact]
+    public static void CreateDirectory_DotWithTrailingSlashAsPath_DoesNotThrow()
+    {
+        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\.\"); // "Current" directory
+
+        Assert.True(Directory.Exists(result.FullName));
+    }
+
+    [Fact]
+    public static void CreateDirectory_DotDotWithoutTrailingSlashAsPath_DoesNotThrow()
+    {
+        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\..");    // "Parent" of current directory
+
+        Assert.True(Directory.Exists(result.FullName));
+    }
+
+    [Fact]
+    public static void CreateDirectory_DotDotWithTrailingSlashAsPath_DoesNotThrow()
+    {
+        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\..\");    // "Parent" of current directory
+
+        Assert.True(Directory.Exists(result.FullName));
+    }
+
+#if !TEST_WINRT // Cannot set current directory to root from appcontainer with it's default ACL
+    /*
+    [Fact]
+    [ActiveIssue(1220)] // SetCurrentDirectory
+    public static void CreateDirectory_DotDotAsPath_WhenCurrentDirectoryIsRoot_DoesNotThrow()
+    {
+        string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+
+        using (CurrentDirectoryContext context = new CurrentDirectoryContext(root))
+        {
+            DirectoryInfo result = Directory.CreateDirectory("..");
+
+            Assert.True(Directory.Exists(result.FullName));
+            Assert.Equal(root, result.FullName);
+        }
+    }
+    */
+#endif
+
+    [Fact]
+    public static void CreateDirectory_NonSignificantTrailingWhiteSpace_TreatsAsNonSignificant()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            var components = IOInputs.GetNonSignificantTrailingWhiteSpace();
+
+            foreach (string component in components)
+            {
+                string path = directory.Path + component;
+
+                DirectoryInfo result = Directory.CreateDirectory(path);
+
+                Assert.True(Directory.Exists(result.FullName));
+                Assert.Equal(directory.Path, result.FullName);
+            }
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_ReadOnlyFileAsPath_ThrowsIOException()
+    {
+        using (TemporaryFile file = new TemporaryFile())
+        {
+            file.IsReadOnly = true;
+
+            Assert.Throws<IOException>(() =>
+            {
+                Directory.CreateDirectory(file.Path);
+            });
+        }
+    }
+
+#if !TEST_WINRT // TODO: Enable once we implement WinRT file attributes
+    [Fact]
+    public static void CreateDirectory_ReadOnlyExistingDirectoryAsPath_DoesNotThrow()
+    {   // DevDivBugs #33833 
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            directory.IsReadOnly = true;
+
+            DirectoryInfo result = Directory.CreateDirectory(directory.Path);
+
+            Assert.Equal(directory.Path, result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+        }
+    }
+
+
+    [Fact]
+    public static void CreateDirectory_HiddenExistingDirectoryAsPath_DoesNotThrow()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            directory.IsHidden = true;
+
+            DirectoryInfo result = Directory.CreateDirectory(directory.Path);
+
+            Assert.Equal(directory.Path, result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+        }
+    }
+#endif
+
+    [Fact]
+    public static void CreateDirectory_DirectoryEqualToMaxDirectory_CanBeCreated()
+    {   // Recursively creates directories right up to the maximum directory length ("247 chars not including null")
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            PathInfo path = IOServices.GetPath(directory.Path, IOInputs.MaxDirectory);
+
+            // First create 'C:\AAA...AA', followed by 'C:\AAA...AAA\AAA...AAA', etc
+            foreach (string subpath in path.SubPaths)
+            {
+                DirectoryInfo result = Directory.CreateDirectory(subpath);
+
+                Assert.Equal(subpath, result.FullName);
+                Assert.True(Directory.Exists(result.FullName));
+            }
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_DirectoryEqualToMaxDirectory_CanBeCreatedAllAtOnce()
+    {   // Creates directories up to the maximum directory length all at once
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            PathInfo path = IOServices.GetPath(directory.Path, IOInputs.MaxDirectory, maxComponent: 10);
+
+            DirectoryInfo result = Directory.CreateDirectory(path.FullPath);
+
+            Assert.Equal(path.FullPath, result.FullName);
+            Assert.True(Directory.Exists(result.FullName));
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_ValidPathWithTrailingSlash_CanBeCreated()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            var components = IOInputs.GetValidPathComponentNames();
+
+            foreach (var component in components)
+            {
+                string path = IOServices.AddTrailingSlashIfNeeded(directory.Path + "\\" + component);
+
+                DirectoryInfo result = Directory.CreateDirectory(path);
+
+                Assert.Equal(path, result.FullName);
+                Assert.True(Directory.Exists(result.FullName));
+            }
+        }
+    }
+
+    [Fact]
+    public static void CreateDirectory_ValidPathWithoutTrailingSlashAsPath_CanBeCreated()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            var components = IOInputs.GetValidPathComponentNames();
+
+            foreach (var component in components)
+            {
+                string path = directory.Path + @"\" + component;
+
+                DirectoryInfo result = Directory.CreateDirectory(path);
+
+                Assert.Equal(path, result.FullName);
+                Assert.True(Directory.Exists(result.FullName));
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
@@ -1,0 +1,461 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+This testcase attempts to delete some directories in a mounted volume
+ - Different drive is mounted on the current drive
+ - Current drive is mounted on a different drive
+ - Current drive is mounted on current directory
+ 	 - refer to the directory in a recursive manner in addition to the normal one
+**/
+using System;
+using System.IO;
+using System.Text;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+public class Directory_Delete_MountVolume
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    [ActiveIssue(1221)]
+    public static void RunTest()
+    {
+        try
+        {
+            const String MountPrefixName = "LaksMount";
+
+            String mountedDirName;
+            String dirName;
+            String dirNameWithoutRoot;
+            String dirNameReferedFromMountedDrive;
+
+            //Adding debug info since this test hangs sometime in RTS runs
+            String debugFileName = "Co7604Delete_MountVolume_Debug.txt";
+            DeleteFile(debugFileName);
+            String scenarioDescription;
+
+            scenarioDescription = "Scenario 1: Vanilla - Different drive is mounted on the current drive";
+            try
+            {
+                File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+
+                string otherDriveInMachine = IOServices.GetNtfsDriveOtherThanCurrent();
+                //out labs use UIP tools in one drive and dont expect this drive to be used by others. We avoid this problem by not testing if the other drive is not NTFS
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS() && otherDriveInMachine != null)
+                {
+                    Console.WriteLine(scenarioDescription);
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+
+                        File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", otherDriveInMachine.Substring(0, 2), mountedDirName, Environment.NewLine));
+                        MountHelper.Mount(otherDriveInMachine.Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(otherDriveInMachine, ManageFileSystem.DirPrefixName);
+                        File.AppendAllText(debugFileName, String.Format("Creating a sub tree at: {0}{1}", dirName, Environment.NewLine));
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            Eval(Directory.Exists(dirName), "Err_3974g! Directory {0} doesn't exist: {1}", dirName, Directory.Exists(dirName));
+                            //Lets refer to these via mounted drive and check
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            Directory.Delete(dirNameReferedFromMountedDrive, true);
+                            Task.Delay(300).Wait();
+                            Eval(!Directory.Exists(dirName), "Err_20387g! Directory {0} still exist: {1}", dirName, Directory.Exists(dirName));
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+                else
+                    File.AppendAllText(debugFileName, String.Format("Scenario 1 - Vanilla - NOT RUN: Different drive is mounted on the current drive {0}", Environment.NewLine));
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_768lme! Exception caught in scenario: {0}", ex);
+            }
+
+            scenarioDescription = "Scenario 2: Current drive is mounted on a different drive";
+            Console.WriteLine(scenarioDescription);
+            File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+            try
+            {
+                string otherDriveInMachine = IOServices.GetNtfsDriveOtherThanCurrent();
+                if (otherDriveInMachine != null)
+                {
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(otherDriveInMachine.Substring(0, 3), MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+
+                        File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName, Environment.NewLine));
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        File.AppendAllText(debugFileName, String.Format("Creating a sub tree at: {0}{1}", dirName, Environment.NewLine));
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            Eval(Directory.Exists(dirName), "Err_239ufz! Directory {0} doesn't exist: {1}", dirName, Directory.Exists(dirName));
+                            //Lets refer to these via mounted drive and check
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            Directory.Delete(dirNameReferedFromMountedDrive, true);
+                            Task.Delay(300).Wait();
+                            Eval(!Directory.Exists(dirName), "Err_794aiu! Directory {0} still exist: {1}", dirName, Directory.Exists(dirName));
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_231vwf! Exception caught in scenario: {0}", ex);
+            }
+
+            //scenario 3.1: Current drive is mounted on current drive
+            scenarioDescription = "Scenario 3.1 - Current drive is mounted on current drive";
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+
+                        File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName, Environment.NewLine));
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        File.AppendAllText(debugFileName, String.Format("Creating a sub tree at: {0}{1}", dirName, Environment.NewLine));
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            Eval(Directory.Exists(dirName), "Err_324eez! Directory {0} doesn't exist: {1}", dirName, Directory.Exists(dirName));
+                            //Lets refer to these via mounted drive and check
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            Directory.Delete(dirNameReferedFromMountedDrive, true);
+                            Task.Delay(300).Wait();
+                            Eval(!Directory.Exists(dirName), "Err_195whv! Directory {0} still exist: {1}", dirName, Directory.Exists(dirName));
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_493ojg! Exception caught in scenario: {0}", ex);
+            }
+
+            //scenario 3.2: Current drive is mounted on current directory
+            scenarioDescription = "Scenario 3.2 - Current drive is mounted on current directory";
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+
+                        File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName, Environment.NewLine));
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        File.AppendAllText(debugFileName, String.Format("Creating a sub tree at: {0}{1}", dirName, Environment.NewLine));
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            Eval(Directory.Exists(dirName), "Err_951ipb! Directory {0} doesn't exist: {1}", dirName, Directory.Exists(dirName));
+                            //Lets refer to these via mounted drive and check
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            Directory.Delete(dirNameReferedFromMountedDrive, true);
+                            Task.Delay(300).Wait();
+                            Eval(!Directory.Exists(dirName), "Err_493yin! Directory {0} still exist: {1}", dirName, Directory.Exists(dirName));
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_432qcp! Exception caught in scenario: {0}", ex);
+            }
+
+            //@WATCH - potentially dangerous code - can delete the whole drive!!
+            //scenario 3.3: we call delete on the mounted volume - this should only delete the mounted drive?
+            //Current drive is mounted on current directory
+            scenarioDescription = "Scenario 3.3 - we call delete on the mounted volume";
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+
+                        File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName, Environment.NewLine));
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        Directory.Delete(mountedDirName, true);
+                        Task.Delay(300).Wait();
+                    }
+                    finally
+                    {
+                        if (!Eval(!Directory.Exists(mountedDirName), "Err_001yph! Directory {0} still exist: {1}", mountedDirName, Directory.Exists(mountedDirName)))
+                        {
+                            MountHelper.Unmount(mountedDirName);
+                            DeleteDir(mountedDirName, true);
+                        }
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_386rpj! Exception caught in scenario: {0}", ex);
+            }
+
+            //@WATCH - potentially dangerous code - can delete the whole drive!!
+            //scenario 3.4: we call delete on parent directory of the mounted volume, the parent directoriy will have some other directories and files
+            //Current drive is mounted on current directory
+            scenarioDescription = "Scenario 3.4 - we call delete on parent directory of the mounted volume, the parent directoriy will have some other directories and files";
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+                    mountedDirName = null;
+                    try
+                    {
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        File.AppendAllText(debugFileName, String.Format("Creating a sub tree at: {0}{1}", dirName, Environment.NewLine));
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 2, 20))
+                        {
+                            Eval(Directory.Exists(dirName), "Err_469yvh! Directory {0} doesn't exist: {1}", dirName, Directory.Exists(dirName));
+                            String[] dirs = fileManager.GetDirectories(1);
+                            mountedDirName = Path.GetFullPath(dirs[0]);
+                            if (Eval(Directory.GetDirectories(mountedDirName).Length == 0, "Err_974tsg! the sub directory has directories: {0}", mountedDirName))
+                            {
+                                foreach (String file in Directory.GetFiles(mountedDirName))
+                                    File.Delete(file);
+                                if (Eval(Directory.GetFiles(mountedDirName).Length == 0, "Err_13ref! the mounted directory has files: {0}", mountedDirName))
+                                {
+                                    File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName, Environment.NewLine));
+                                    MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+                                    //now lets call delete on the parent directory
+                                    Directory.Delete(dirName, true);
+                                    Task.Delay(300).Wait();
+                                    Eval(!Directory.Exists(dirName), "Err_006jsf! Directory {0} still exist: {1}", dirName, Directory.Exists(dirName));
+                                    Console.WriteLine("Completed Scenario 3.4");
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (!Eval(!Directory.Exists(mountedDirName), "Err_625ckx! Directory {0} still exist: {1}", mountedDirName, Directory.Exists(mountedDirName)))
+                        {
+                            MountHelper.Unmount(mountedDirName);
+                            DeleteDir(mountedDirName, true);
+                        }
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_578tni! Exception caught in scenario: {0}", ex);
+            }
+
+            //@WATCH - potentially dangerous code - can delete the whole drive!!
+            //scenario 3.5: we call delete on parent directory of the mounted volume, the parent directoriy will have some other directories and files
+            //we call a different directory than the first
+            //Current drive is mounted on current directory
+            scenarioDescription = "Scenario 3.5 - we call delete on parent directory of the mounted volume, the parent directoriy will have some other directories and files";
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
+                    mountedDirName = null;
+                    try
+                    {
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        File.AppendAllText(debugFileName, String.Format("Creating a sub tree at: {0}{1}", dirName, Environment.NewLine));
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 2, 30))
+                        {
+                            Eval(Directory.Exists(dirName), "Err_715tdq! Directory {0} doesn't exist: {1}", dirName, Directory.Exists(dirName));
+                            String[] dirs = fileManager.GetDirectories(1);
+                            mountedDirName = Path.GetFullPath(dirs[0]);
+                            if (dirs.Length > 1)
+                                mountedDirName = Path.GetFullPath(dirs[1]);
+                            if (Eval(Directory.GetDirectories(mountedDirName).Length == 0, "Err_492qwl! the sub directory has directories: {0}", mountedDirName))
+                            {
+                                foreach (String file in Directory.GetFiles(mountedDirName))
+                                    File.Delete(file);
+                                if (Eval(Directory.GetFiles(mountedDirName).Length == 0, "Err_904kij! the mounted directory has files: {0}", mountedDirName))
+                                {
+                                    File.AppendAllText(debugFileName, String.Format("Mounting on {0}{1}{2}", Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName, Environment.NewLine));
+                                    MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+                                    //now lets call delete on the parent directory
+                                    Directory.Delete(dirName, true);
+                                    Task.Delay(300).Wait();
+                                    Eval(!Directory.Exists(dirName), "Err_900edl! Directory {0} still exist: {1}", dirName, Directory.Exists(dirName));
+                                    Console.WriteLine("Completed Scenario 3.5: {0}", mountedDirName);
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (!Eval(!Directory.Exists(mountedDirName), "Err_462xtc! Directory {0} still exist: {1}", mountedDirName, Directory.Exists(mountedDirName)))
+                        {
+                            MountHelper.Unmount(mountedDirName);
+                            DeleteDir(mountedDirName, true);
+                        }
+                    }
+                    File.AppendAllText(debugFileName, String.Format("Completed scenario {0}", Environment.NewLine));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_471jli! Exception caught in scenario: {0}", ex);
+            }
+        }
+        catch (Exception ex)
+        {
+            s_pass = false;
+            Console.WriteLine("Err_234rsgf! Uncaught exception in RunTest: {0}", ex);
+        }
+        finally
+        {
+            Assert.True(s_pass);
+        }
+    }
+
+    private static void DeleteFile(String debugFileName)
+    {
+        if (File.Exists(debugFileName))
+            File.Delete(debugFileName);
+    }
+
+    private static void DeleteDir(String debugFileName, bool sub)
+    {
+        bool deleted = false; int maxAttempts = 5;
+        while (!deleted && maxAttempts > 0)
+        {
+            if (Directory.Exists(debugFileName))
+            {
+                try
+                {
+                    Directory.Delete(debugFileName, sub);
+                    deleted = true;
+                }
+                catch (Exception)
+                {
+                    if (--maxAttempts == 0)
+                        throw;
+                    else
+                        Task.Delay(300).Wait();
+                }
+            }
+        }
+    }
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/Delete_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_str.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Delete_str
+{
+    public static String s_strDtTmVer = "2000/04/26 20:33";
+    public static String s_strClassMethod = "Directory.Delete(String)";
+    public static String s_strTFName = "Delete_str.cs";
+    public static String s_strTFPath = TestInfo.CurrentDirectory;
+    public static String s_dirName = "Delete_str_test_TestDir";
+
+#if !TEST_WINRT // TODO: renable once attributes are implemented.
+    [Fact]
+    public static void ShouldBeAbleToDeleteHiddenDirectory()
+    {
+        string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
+        // [] Hidden Property set
+        //-----------------------------------------------------------------
+
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirPath);
+        dir2.Attributes = FileAttributes.Hidden;
+
+        Directory.Delete(dir2.FullName);
+
+        if (Directory.Exists(dirPath))
+        {
+            printerr("Error_948ug Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void ShouldThrowIOExceptionDeletingReadOnlyDirectory()
+    {
+        string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
+        // [] Readonly property set
+        //-----------------------------------------------------------------
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirPath);
+        dir2.Attributes = FileAttributes.ReadOnly;
+
+        try
+        {
+            Directory.Delete(dir2.FullName);
+            printerr("Error_t01uv! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_198yv! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        dir2.Attributes = new FileAttributes();
+        dir2.Delete(true);
+    }
+#endif
+
+    [Fact]
+    public static void ShouldThrowIOExceptionIfContainedFileInUse()
+    {
+        string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
+        // [] Delete directory with a file that is in use
+        //-----------------------------------------------------------------
+        Directory.CreateDirectory(dirPath);
+        FileStream fs = new FileStream(Path.Combine(dirPath, Path.GetRandomFileName()), FileMode.Create);
+        DirectoryInfo dir2 = new DirectoryInfo(dirPath);
+
+        try
+        {
+            Directory.Delete(dir2.FullName);
+            printerr("Error_ty7b7! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_4919o! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+        fs.Dispose();
+        Directory.Delete(dir2.FullName, true);
+    }
+
+    [Fact]
+    public static void ShouldThrowIOExceptionForDirectoryWithFiles()
+    {
+        string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
+        // [] Delete directory with subdirectories containing files
+        // [] String should be case insensitive
+        //-----------------------------------------------------------------
+        DirectoryInfo di1 = Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
+        Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
+        new FileStream(Path.Combine(di1.FullName, Path.GetRandomFileName()), FileMode.Create).Dispose();
+
+        DirectoryInfo dir2 = new DirectoryInfo(dirPath);
+        try
+        {
+            Directory.Delete(dir2.FullName);
+            printerr("Error_241y7! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_07509! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        Directory.Delete(dir2.FullName.ToLower(), true);
+        if (Directory.Exists(dirPath))
+        {
+            printerr("Error_26y7b! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void ShouldThrowIOExceptionForDirectoryWithSubdirectories()
+    {
+        string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
+        // [] Directory with subdirectories should fail
+        //-----------------------------------------------------------------
+        Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
+        DirectoryInfo dir2 = Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
+        Directory.Delete(dir2.FullName.ToUpper());
+
+        if (Directory.Exists(dir2.FullName))
+        {
+            printerr("Error_49928! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+
+        // Trying to delete one with subdirs
+        Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
+        dir2 = new DirectoryInfo(dirPath);
+        try
+        {
+            Directory.Delete(dir2.FullName);
+            printerr("Error_5y78b! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_98yg7! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        // Now delete it
+        Directory.Delete(dir2.FullName, true);
+        if (Directory.Exists(dirPath))
+        {
+            printerr("Error_917ct! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void PositiveTest()
+    {
+        string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
+        // [] Delete a directory without subdirectories or files
+        //-----------------------------------------------------------------
+
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirPath);
+        Directory.Delete(dir2.FullName);
+        if (Directory.Exists(dirPath))
+        {
+            printerr("Error_987g7! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void ShouldThrowDirectoryNotFoundExceptionForNonexistentDirectory()
+    {
+        // [] Exception when trying to delete a directory that does not exist
+        //-----------------------------------------------------------------
+        DirectoryInfo dir2 = new DirectoryInfo("ThisDoesNotExist");
+        try
+        {
+            Directory.Delete("ThisDoesNotExist");
+            printerr("Error_9138v! Expected exception not thrown");
+            Assert.True(false, "Expected DirectoryNotFoundException not thrown");
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_799tb! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+    }
+
+    [Fact]
+    public static void ShouldThrowIOExceptionDeletingCurrentDirectory()
+    {
+        // [] Exception when trying to delete current directory
+        //-----------------------------------------------------------------
+
+        DirectoryInfo dir2 = new DirectoryInfo(".");
+        try
+        {
+            Directory.Delete(".");
+            printerr("Error_48y7b! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_2019c! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/Delete_str_bool.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_str_bool.cs
@@ -1,0 +1,289 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Co5663Delete_str_bool
+{
+    public static String s_strDtTmVer = "2000/04/26 20:33";
+    public static String s_strClassMethod = "Directory.Delete(String,Boolean)";
+    public static String s_strTFName = "Delete_str_bool.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    public static string s_dirName = Path.GetRandomFileName();
+
+#if !TEST_WINRT // TODO: renable once attributes are implemented.
+    [Fact]
+    public static void DirectoryWithHiddenAttribute()
+    {
+        // [] Deleting directory with Hidden property set should pass
+        //-----------------------------------------------------------------
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_hidden");
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirName);
+        dir2.Attributes = FileAttributes.Hidden;
+
+        Directory.Delete(dir2.FullName, true);
+
+        if (Directory.Exists(dirName))
+        {
+            printerr("Error_948ug Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+
+        if (Directory.Exists(dirName))
+        {
+            new DirectoryInfo(dirName).Attributes = new FileAttributes();
+            Directory.Delete(dirName, true);
+        }
+    }
+
+    [Fact]
+    public static void DirectoryWithReadOnlyAttribute()
+    {
+        // [] Deleting directory with Readonly property set should always fail 
+        //-----------------------------------------------------------------
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_readOnly");
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirName);
+        dir2.Attributes = FileAttributes.ReadOnly;
+
+        try
+        {
+            Directory.Delete(dir2.FullName, false);
+
+            printerr("Error_t01uv! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_198yv! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        try
+        {
+            Directory.Delete(dir2.FullName, true);
+
+            printerr("Error_948ug Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_y7853! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+        dir2.Attributes = new FileAttributes();
+        dir2.Delete(true);
+    }
+#endif
+
+    [Fact]
+    public static void DirectoryWithFileInUse()
+    {
+        // [] Delete directory with a file that is in use
+        //-----------------------------------------------------------------
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_inUse");
+        Directory.CreateDirectory(dirName);
+        FileStream fs = new FileStream(Path.Combine(dirName, Path.GetRandomFileName()), FileMode.Create);
+        DirectoryInfo dir2 = new DirectoryInfo(dirName);
+
+        try
+        {
+            Directory.Delete(dir2.FullName, true);
+
+            printerr("Error_ty7b7! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_4919o! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+        fs.Dispose();
+        Directory.Delete(dir2.FullName, true);
+    }
+
+    [Fact]
+    public static void DirectoryContainingFiles()
+    {
+        // [] Delete directory with subdirectories containing files should fail when false and pass when true
+        // [] String should be case insensitive
+        //-----------------------------------------------------------------
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_withFiles");
+        Directory.CreateDirectory(dirName + "\\Test1");
+        Directory.CreateDirectory(dirName + "\\Test2");
+        new FileStream(dirName + "\\Test1\\Hello.tmp", FileMode.Create).Dispose();
+
+        DirectoryInfo dir2 = new DirectoryInfo(dirName);
+        try
+        {
+            Directory.Delete(dir2.FullName, false);
+
+            printerr("Error_241y7! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_07509! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        Directory.Delete(dir2.FullName.ToLower(), true);
+        if (Directory.Exists(dirName))
+        {
+            printerr("Error_26y7b! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void DirectoryWithSubdirectories()
+    {
+        // [] Directory with subdirectories should fail when passed false and pass when true
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_withSubDirs");
+        Directory.CreateDirectory(dirName + "\\Test1");
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirName + "\\Test2");
+        Directory.Delete(dir2.FullName.ToUpper(), false);
+        if (Directory.Exists(dirName + "\\Test2"))
+        {
+            printerr("Error_49928! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+
+        // Trying to delete one with subdirs
+        Directory.CreateDirectory(dirName + "\\Test2");
+        dir2 = new DirectoryInfo(dirName);
+        try
+        {
+            Directory.Delete(dir2.FullName, false);
+
+            printerr("Error_5y78b! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_98yg7! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        // Now delete it
+        Directory.Delete(dir2.FullName, true);
+        if (Directory.Exists(dirName))
+        {
+            printerr("Error_917ct! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void PositiveTest()
+    {
+        // [] Delete a directory without subdirectories or files should work for recursive and non-recursive
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_empty");
+        DirectoryInfo dir2 = Directory.CreateDirectory(dirName);
+        Directory.Delete(dir2.FullName, false);
+        if (Directory.Exists(dirName))
+        {
+            printerr("Error_987g7! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+
+        dir2 = Directory.CreateDirectory(dirName);
+        Directory.Delete(dir2.FullName, true);
+        if (Directory.Exists(dirName))
+        {
+            printerr("Error_0919c! Directory not deleted");
+            Assert.True(false, "Directory not deleted");
+        }
+    }
+
+    [Fact]
+    public static void ShouldGetDirectoryNotFoundExceptionDeletingNonexistantDirectory()
+    {
+        // [] Exception when trying to delete a directory that does not exist
+        DirectoryInfo dir2 = new DirectoryInfo("ThisDoesNotExist");
+        try
+        {
+            Directory.Delete("ThisDoesNotExist", false);
+
+            printerr("Error_9138v! Expected exception not thrown");
+            Assert.True(false, "Expected DirectoryNotFoundException not thrown");
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_799tb! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+
+        try
+        {
+            Directory.Delete("ThisDoesNotExist", true);
+
+            printerr("Error_7958x! Expected exception not thrown");
+            Assert.True(false, "Expected DirectoryNotFoundException not thrown");
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_1t859! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+    }
+
+    [Fact]
+    public static void ShouldGetIOExceptionDeletingCurrentDirectory()
+    {
+        // [] Exception when trying to delete a Directory in use and 
+        //-----------------------------------------------------------------
+        DirectoryInfo dir2 = new DirectoryInfo(".");
+        try
+        {
+            Directory.Delete(".", false);
+
+            printerr("Error_48y7b! Expected exception not thrown");
+            Assert.True(false, "Expected IOException not thrown");
+        }
+        catch (IOException)
+        {
+        }
+        catch (Exception exc)
+        {
+            printerr("Error_2019c! Incorrect exception thrown, exc==" + exc.ToString());
+            throw;
+        }
+    }
+
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/Directory_EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Directory_EnumerableAPIs.cs
@@ -1,0 +1,738 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Security;
+using Xunit;
+
+namespace EnumerableTests
+{
+    public class Directory_EnumerableTests
+    {
+        private static EnumerableUtils s_utils;
+
+        [Fact]
+        public static void runTest()
+        {
+            s_utils = new EnumerableUtils();
+
+            s_utils.CreateTestDirs();
+
+            TestDirectoryAPIs();
+
+            TestExceptions();
+
+            TestWhileEnumerating();
+
+            s_utils.DeleteTestDirs();
+
+            Assert.True(s_utils.Passed);
+        }
+
+        // Directory tests
+        private static void TestDirectoryAPIs()
+        {
+            DoDirectoryGetXTests(s_utils.testDir);
+        }
+
+        private static void DoDirectoryGetXTests(String name)
+        {
+            DoDirectoryGetDirectoriesTest(name, "*", SearchOption.AllDirectories, s_utils.expected_Dirs_Deep);
+            DoDirectoryGetDirectoriesTest(name, "*", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Shallow);
+            DoDirectoryGetDirectoriesTest(name, ".", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Shallow);
+            DoDirectoryGetDirectoriesTest(name, "", SearchOption.AllDirectories, new HashSet<String>());
+
+            DoDirectoryGetDirectoriesTest(name, "lev2_*", SearchOption.AllDirectories, s_utils.expected_Dirs_Lev2SearchPattern);
+            DoDirectoryGetDirectoriesTest(name, "lev2_*", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryGetDirectoriesTest(name, "lev2_f", SearchOption.AllDirectories, s_utils.expected_Dirs_ExactSearchPattern);
+            DoDirectoryGetDirectoriesTest(name, "lev2_f", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryGetDirectoriesTest(name, @"lev1_a\*", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Subdir);
+
+            DoDirectoryGetFilesTest(name, "*", SearchOption.AllDirectories, s_utils.expected_Files_Deep);
+            DoDirectoryGetFilesTest(name, "*", SearchOption.TopDirectoryOnly, s_utils.expected_Files_Shallow);
+            DoDirectoryGetFilesTest(name, ".", SearchOption.TopDirectoryOnly, s_utils.expected_Files_Shallow);
+            DoDirectoryGetFilesTest(name, "", SearchOption.AllDirectories, new HashSet<String>());
+            DoDirectoryGetFilesTest(name, "lev2_f", SearchOption.AllDirectories, new HashSet<String>());
+            DoDirectoryGetFilesTest(name, "lev2_f", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryGetFileSystemEntriesTest(name, "*", SearchOption.AllDirectories, new HashSet<String>(s_utils.expected_Files_Deep.Union(s_utils.expected_Dirs_Deep)));
+            DoDirectoryGetFileSystemEntriesTest(name, "*", SearchOption.TopDirectoryOnly, new HashSet<String>(s_utils.expected_Files_Shallow.Union(s_utils.expected_Dirs_Shallow)));
+            DoDirectoryGetFileSystemEntriesTest(name, ".", SearchOption.TopDirectoryOnly, new HashSet<String>(s_utils.expected_Files_Shallow.Union(s_utils.expected_Dirs_Shallow)));
+            DoDirectoryGetFileSystemEntriesTest(name, "", SearchOption.AllDirectories, new HashSet<String>());
+            DoDirectoryGetFileSystemEntriesTest(name, "lev2_f", SearchOption.AllDirectories, s_utils.expected_Dirs_ExactSearchPattern);
+            DoDirectoryGetFileSystemEntriesTest(name, "lev2_f", SearchOption.TopDirectoryOnly, new HashSet<String>());
+            DoDirectoryGetFileSystemEntriesTest(name, "file1", SearchOption.AllDirectories, s_utils.expected_Files_Shallow);
+        }
+
+        private static void DoDirectoryGetDirectoriesTest(String path, String searchPattern, SearchOption searchOption, HashSet<String> expected)
+        {
+            String chkptFlag = "chkpt_dgd1_";
+
+            IEnumerable<String> dirs = Directory.EnumerateDirectories(path, searchPattern, searchOption);
+            HashSet<String> dirsAsHS = new HashSet<string>(dirs);
+            int failCount = 0;
+            if (!dirsAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                foreach (String d in dirs)
+                {
+                    Console.WriteLine(d);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateDirectories", failCount);
+        }
+
+        private static void DoDirectoryGetFilesTest(String path, String searchPattern, SearchOption searchOption, HashSet<String> expected)
+        {
+            String chkptFlag = "chkpt_dgf1_";
+
+            IEnumerable<String> dirs = Directory.EnumerateFiles(path, searchPattern, searchOption);
+            HashSet<String> dirsAsHS = new HashSet<string>(dirs);
+            int failCount = 0;
+            if (!dirsAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                foreach (String d in dirs)
+                {
+                    Console.WriteLine(d);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateFiles", failCount);
+        }
+
+        private static void DoDirectoryGetFileSystemEntriesTest(String path, String searchPattern, SearchOption searchOption, HashSet<String> expected)
+        {
+            String chkptFlag = "chkpt_dgi1_";
+
+            IEnumerable<String> dirs = Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+            HashSet<String> dirsAsHS = new HashSet<string>(dirs);
+            int failCount = 0;
+            if (!dirsAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected filesysteminfos....");
+                foreach (String d in dirs)
+                {
+                    Console.WriteLine(d);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateFileSystemEntries", failCount);
+        }
+
+        // Exception tests
+        private static void TestExceptions()
+        {
+            TestSearchPatterns();
+            TestSearchOptionOutOfRange();
+            TestWeirdPaths();
+        }
+
+
+        private static void TestSearchPatterns()
+        {
+            TestSearchPatternIter(s_utils.testDir, null, "null SP", new ArgumentNullException());
+            TestSearchPatternIter(s_utils.testDir, "..", "invalid SP", new ArgumentException());
+        }
+
+        private static void TestSearchOptionOutOfRange()
+        {
+            TestSearchOptionOutOfRange(Directory.GetDirectories, "Directory.GetDirectories");
+            TestSearchOptionOutOfRange(Directory.GetFiles, "Directory.GetFiles");
+            TestSearchOptionOutOfRangeFast(Directory.EnumerateDirectories, "Directory.EnumerateDirectories");
+            TestSearchOptionOutOfRangeFast(Directory.EnumerateFiles, "Directory.EnumerateFiles");
+        }
+
+        private static void TestWeirdPaths()
+        {
+            // null path
+            String nullPath = null;
+            TestWeirdPathIter(nullPath, "nullPath", new ArgumentNullException());
+
+            // empty path
+            String emptyPath = "";
+            TestWeirdPathIter(emptyPath, "emptyPath", new ArgumentException());
+
+            // whitespace-only path
+            char[] whitespacePathChars = { (char)0x9, (char)0xA };
+            String whitespacePath = new String(whitespacePathChars);
+            TestWeirdPathIter(whitespacePath, "whitespacePath", new ArgumentException());
+
+            // try to test a path that doesn't exist. Skip if can't find an unused drive
+            String pathNotExists = null;
+            String unusedDrive = EnumerableUtils.GetUnusedDrive();
+            if (unusedDrive != null)
+            {
+                pathNotExists = Path.Combine(unusedDrive, @"temp\dir");
+            }
+            if (pathNotExists != null)
+            {
+                TestWeirdPathIter(pathNotExists, "pathNotExists", new DirectoryNotFoundException());
+            }
+
+            // file (not dir) name. If we try to do GetFiles, GetDirs, etc in a file (not dir) we get IOException
+            String filePath = null;
+            foreach (String s in s_utils.expected_Files_Deep)
+            {
+                if (s != null)
+                {
+                    filePath = s;
+                    break;
+                }
+            }
+            TestWeirdPathIter(filePath, "pathIsFile", new IOException());
+
+            // PathTooLong
+            String longPath = new String('a', 240) + @"\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+            TestWeirdPathIter(longPath, "pathTooLong", new PathTooLongException());
+
+            // path invalid chars
+            String invalidCharPath = @"temp\fsd<sdsds";
+            TestWeirdPathIter(invalidCharPath, "invalidCharPath", new ArgumentException());
+        }
+
+        private static void TestWeirdPathIter(String path, String pathDescription, Exception expectedException)
+        {
+            TestWeirdPath(path, pathDescription, expectedException, Directory.GetDirectories, Directory.GetDirectories, Directory.GetDirectories, "Directory.GetDirectories");
+            TestWeirdPath(path, pathDescription, expectedException, Directory.GetFiles, Directory.GetFiles, Directory.GetFiles, "Directory.GetFiles");
+            TestWeirdPath(path, pathDescription, expectedException, Directory.GetFileSystemEntries, Directory.GetFileSystemEntries, Directory.GetFileSystemEntries, "Directory.GetFileSystemEntries");
+            TestWeirdPathFast(path, pathDescription, expectedException, Directory.EnumerateDirectories, Directory.EnumerateDirectories, Directory.EnumerateDirectories, "Directory.EnumerateDirectories");
+            TestWeirdPathFast(path, pathDescription, expectedException, Directory.EnumerateFiles, Directory.EnumerateFiles, Directory.EnumerateFiles, "Directory.EnumerateFiles");
+            TestWeirdPathFast(path, pathDescription, expectedException, Directory.EnumerateFileSystemEntries, Directory.EnumerateFileSystemEntries, Directory.EnumerateFileSystemEntries, "Directory.EnumerateFileSystemEntries");
+        }
+
+        private static void TestSearchPatternIter(String path, String pattern, String patternDescription, Exception expectedException)
+        {
+            TestSearchPattern(path, pattern, patternDescription, expectedException, Directory.GetDirectories, Directory.GetDirectories, "Directory.GetDirectories");
+            TestSearchPattern(path, pattern, patternDescription, expectedException, Directory.GetFiles, Directory.GetFiles, "Directory.GetFiles");
+            TestSearchPattern(path, pattern, patternDescription, expectedException, Directory.GetFileSystemEntries, Directory.GetFileSystemEntries, "Directory.GetFileSystemEntries");
+            TestSearchPatternFast(path, pattern, patternDescription, expectedException, Directory.EnumerateDirectories, Directory.EnumerateDirectories, "Directory.EnumerateDirectories");
+            TestSearchPatternFast(path, pattern, patternDescription, expectedException, Directory.EnumerateFiles, Directory.EnumerateFiles, "Directory.EnumerateFiles");
+            TestSearchPatternFast(path, pattern, patternDescription, expectedException, Directory.EnumerateFileSystemEntries, Directory.EnumerateFileSystemEntries, "Directory.EnumerateFileSystemEntries");
+        }
+
+        private static void TestSearchPattern(String path, String pattern, String patternDescription, Exception expectedException,
+                                                EnumerableUtils.GetFSEs1 fseMethod1, EnumerableUtils.GetFSEs2 fseMethod2, String methodName)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_nspat_";
+            try
+            {
+                String[] dirs1 = fseMethod1(path, pattern);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            if (fseMethod2 != null)
+            {
+                try
+                {
+                    String[] dirs2 = fseMethod2(path, pattern, SearchOption.AllDirectories);
+                    Console.WriteLine(chkptFlag + "3: didn't throw");
+                    failCount++;
+                }
+                catch (Exception e)
+                {
+                    if (e.GetType() != expectedException.GetType())
+                    {
+                        failCount++;
+                        Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                        Console.WriteLine(e);
+                    }
+                }
+            }
+
+            String testName = String.Format("TestSearchPattern({0})", patternDescription);
+            s_utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+        private static void TestSearchPatternFast(String path, String pattern, String patternDescription, Exception expectedException, EnumerableUtils.GetFSEsFast1 fseMethod1, EnumerableUtils.GetFSEsFast2 fseMethod2, String methodName)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_nspatf_";
+            try
+            {
+                IEnumerable<String> dirs1 = fseMethod1(path, pattern);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            if (fseMethod2 != null)
+            {
+                try
+                {
+                    IEnumerable<String> dirs2 = fseMethod2(path, pattern, SearchOption.AllDirectories);
+                    Console.WriteLine(chkptFlag + "3: didn't throw");
+                    failCount++;
+                }
+                catch (Exception e)
+                {
+                    if (e.GetType() != expectedException.GetType())
+                    {
+                        failCount++;
+                        Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                        Console.WriteLine(e);
+                    }
+                }
+            }
+            String testName = String.Format("TestSearchPatternFast({0})", patternDescription);
+            s_utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+        private static void TestSearchOptionOutOfRange(EnumerableUtils.GetFSEs2 fseMethod, String methodName)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_soor_";
+            try
+            {
+                String[] dirs1 = fseMethod(s_utils.testDir, "*", (SearchOption)5);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (ArgumentOutOfRangeException) { } // expected
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                Console.WriteLine(e);
+            }
+
+            s_utils.PrintTestStatus("TestSearchOptionOutOfRange", methodName, failCount);
+        }
+
+        private static void TestSearchOptionOutOfRangeFast(EnumerableUtils.GetFSEsFast2 fseMethod, String methodName)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_soorf_";
+            try
+            {
+                IEnumerable<String> dirs1 = fseMethod(s_utils.testDir, "*", (SearchOption)5);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (ArgumentOutOfRangeException) { } // expected
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                Console.WriteLine(e);
+            }
+
+            s_utils.PrintTestStatus("TestSearchOptionOutOfRangeFast", methodName, failCount);
+        }
+
+        private static void TestWeirdPath(String path, String pathDescription, Exception expectedException, EnumerableUtils.GetFSEs0 fseMethod0, EnumerableUtils.GetFSEs1 fseMethod1, EnumerableUtils.GetFSEs2 fseMethod2, String methodName)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_wp_";
+
+            try
+            {
+                String[] dirs1 = fseMethod0(path);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            try
+            {
+                String[] dirs1 = fseMethod1(path, "*");
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            if (fseMethod2 != null)
+            {
+                try
+                {
+                    String[] dirs2 = fseMethod2(path, "*", SearchOption.AllDirectories);
+                    Console.WriteLine(chkptFlag + "5: didn't throw");
+                    failCount++;
+                }
+                catch (Exception e)
+                {
+                    if (e.GetType() != expectedException.GetType())
+                    {
+                        Console.WriteLine("e.GetType = " + e.GetType());
+                        Console.WriteLine("expectedException.GetType = " + expectedException.GetType());
+                        failCount++;
+                        Console.WriteLine(chkptFlag + "6: threw wrong exception");
+                        Console.WriteLine(e);
+                    }
+                }
+            }
+            String testName = String.Format("TestWeirdPath({0})", pathDescription);
+            s_utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+        private static void TestWeirdPathFast(String path, String pathDescription, Exception expectedException, EnumerableUtils.GetFSEsFast0 fseMethod0, EnumerableUtils.GetFSEsFast1 fseMethod1, EnumerableUtils.GetFSEsFast2 fseMethod2, String methodName)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_wpf_";
+            try
+            {
+                IEnumerable<String> dirs1 = fseMethod0(path);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+
+            try
+            {
+                IEnumerable<String> dirs1 = fseMethod1(path, "*");
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            if (fseMethod2 != null)
+            {
+                try
+                {
+                    IEnumerable<String> dirs2 = fseMethod2(path, "*", SearchOption.AllDirectories);
+                    Console.WriteLine(chkptFlag + "5: didn't throw");
+                    failCount++;
+                }
+                catch (Exception e)
+                {
+                    if (e.GetType() != expectedException.GetType())
+                    {
+                        failCount++;
+                        Console.WriteLine(chkptFlag + "6: threw wrong exception");
+                        Console.WriteLine(e);
+                    }
+                }
+            }
+
+            String testName = String.Format("TestWeirdPathFast({0})", pathDescription);
+            s_utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+        private static void TestWhileEnumerating()
+        {
+            TestChangeWhileEnumerating();
+        }
+
+
+        private static void TestChangeWhileEnumerating()
+        {
+            DoGetDirectories_Add();
+            DoGetFiles_Add();
+            DoGetFileSystemInfos_Add();
+            DoGetDirectories_Delete();
+            DoGetFiles_Delete();
+            DoGetFileSystemInfos_Delete();
+        }
+
+        private static void DoGetDirectories_Add()
+        {
+            String chkptFlag = "chkpt_dgdm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            IEnumerable<String> dis = Directory.EnumerateDirectories(s_utils.testDir, "*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (String d in dis)
+                {
+                    disAsHS.Add(d);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSAdd();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Dirs_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                    foreach (String d in dis)
+                    {
+                        Console.WriteLine(d);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "addFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateDirectories", failCount);
+        }
+
+        private static void DoGetDirectories_Delete()
+        {
+            String chkptFlag = "chkpt_dgdm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            IEnumerable<String> dis = Directory.EnumerateDirectories(s_utils.testDir, "*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (String d in dis)
+                {
+                    disAsHS.Add(d);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSDelete();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Dirs_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                    foreach (String d in dis)
+                    {
+                        Console.WriteLine(d);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "deleteFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateDirectories", failCount);
+        }
+
+        private static void DoGetFiles_Add()
+        {
+            String chkptFlag = "chkpt_dgfm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            IEnumerable<String> fis = Directory.EnumerateFiles(s_utils.testDir, "*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (String d in fis)
+                {
+                    disAsHS.Add(d);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSAdd();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Files_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (String f in fis)
+                    {
+                        Console.WriteLine(f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "addFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateFiles", failCount);
+        }
+
+        private static void DoGetFiles_Delete()
+        {
+            String chkptFlag = "chkpt_dgfm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            IEnumerable<String> fis = Directory.EnumerateFiles(s_utils.testDir, "*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (String d in fis)
+                {
+                    disAsHS.Add(d);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSDelete();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Files_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (String f in fis)
+                    {
+                        Console.WriteLine(f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "deleteFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateFiles", failCount);
+        }
+
+        private static void DoGetFileSystemInfos_Add()
+        {
+            String chkptFlag = "chkpt_dgim_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            IEnumerable<String> fis = Directory.EnumerateFileSystemEntries(s_utils.testDir, "*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (String d in fis)
+                {
+                    disAsHS.Add(d);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSAdd();
+                }
+                if (!disAsHS.SetEquals(new HashSet<String>(s_utils.expected_Dirs_Changed.Union(s_utils.expected_Files_Changed))))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (String f in fis)
+                    {
+                        Console.WriteLine(f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "addFilesWhileEnumerating";
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateFileSystemEntries", failCount);
+        }
+
+        private static void DoGetFileSystemInfos_Delete()
+        {
+            String chkptFlag = "chkpt_dgim_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            IEnumerable<String> fis = Directory.EnumerateFileSystemEntries(s_utils.testDir, "*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (String d in fis)
+                {
+                    disAsHS.Add(d);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSDelete();
+                }
+                if (!disAsHS.SetEquals(new HashSet<String>(s_utils.expected_Dirs_Changed.Union(s_utils.expected_Files_Changed))))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (String f in fis)
+                    {
+                        Console.WriteLine(f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "deleteFilesWhileEnumerating";
+            s_utils.PrintTestStatus(testName, "Directory.EnumerateFileSystemEntries", failCount);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -1,0 +1,372 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Exists
+{
+    [Fact]
+    public static void Exists_NullAsPath_ReturnsFalse()
+    {
+        bool result = Directory.Exists((string)null);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void Exists_EmptyAsPath_ReturnsFalse()
+    {
+        bool result = Directory.Exists(string.Empty);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void Exists_DoesCaseInsensitiveInvariantComparions()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            var paths = new string[] { directory.Path,
+                                       directory.Path.ToUpperInvariant(),
+                                       directory.Path.ToLowerInvariant() };
+
+
+            foreach (string path in paths)
+            {
+                bool result = Directory.Exists(path);
+
+                Assert.True(result, path);
+            }
+        }
+    }
+
+    [Fact]
+    public static void Exists_NonExistentValidPathAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetValidPathComponentNames();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_ExistentValidPathAsPath_ReturnsTrue()
+    {
+        var components = IOInputs.GetValidPathComponentNames();
+
+        foreach (string component in components)
+        {
+            using (TemporaryDirectory directory = new TemporaryDirectory())
+            {
+                string path = Path.Combine(directory.Path, component);
+                Directory.CreateDirectory(path);
+
+                bool result = Directory.Exists(path);
+
+                Assert.True(result, path);
+            }
+        }
+    }
+
+
+    [Fact]
+    public static void Exists_NonSignificantWhiteSpaceAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetNonSignificantTrailingWhiteSpace();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+
+    [Fact]
+    public static void Exists_ExistingDirectoryWithNonSignificantTrailingWhiteSpaceAsPath_ReturnsTrue()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            var components = IOInputs.GetNonSignificantTrailingWhiteSpace();
+
+            foreach (string component in components)
+            {
+                string path = directory.Path + component;
+
+                bool result = Directory.Exists(path);
+
+                Assert.True(result, path);
+            }
+        }
+    }
+
+    [Fact]
+    public static void Exists_PathWithInvalidCharactersAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetPathsWithInvalidCharacters();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_PathWithAlternativeDataStreams_ReturnsFalse()
+    {
+        var paths = IOInputs.GetPathsWithAlternativeDataStreams();
+        foreach (var path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void Exists_PathWithReservedDeviceNameAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetPathsWithReservedDeviceNames();
+        foreach (var path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_UncPathWithoutShareNameAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetUncPathsWithoutShareName();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_DirectoryEqualToMaxDirectory_ReturnsTrue()
+    {   // Creates directories up to the maximum directory length all at once
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            PathInfo path = IOServices.GetPath(directory.Path, IOInputs.MaxDirectory, maxComponent: 10);
+
+            Directory.CreateDirectory(path.FullPath);
+
+            bool result = Directory.Exists(path.FullPath);
+
+            Assert.True(result, path.FullPath);
+        }
+    }
+
+    [Fact]
+    public static void Exists_DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetPathsWithComponentLongerThanMaxComponent();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_DirectoryLongerThanMaxDirectoryAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetPathsLongerThanMaxDirectory();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_DirectoryLongerThanMaxPathAsPath_ReturnsFalse()
+    {
+        var paths = IOInputs.GetPathsLongerThanMaxPath();
+
+        foreach (string path in paths)
+        {
+            bool result = Directory.Exists(path);
+
+            Assert.False(result, path);
+        }
+    }
+
+    [Fact]
+    public static void Exists_NotReadyDriveAsPath_ReturnsFalse()
+    {
+        var drive = IOServices.GetNotReadyDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a not-ready drive, such as CD-Rom with no disc inserted.");
+            return;
+        }
+
+        bool result = Directory.Exists(drive);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void Exists_SubdirectoryOnNotReadyDriveAsPath_ReturnsFalse()
+    {
+        var drive = IOServices.GetNotReadyDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a not-ready drive, such as CD-Rom with no disc inserted.");
+            return;
+        }
+
+        bool result = Directory.Exists(Path.Combine(drive, "Subdirectory"));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void Exists_NonExistentDriveAsPath_ReturnsFalse()
+    {
+        var drive = IOServices.GetNonExistentDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a non-existent drive.");
+            return;
+        }
+
+        bool result = Directory.Exists(drive);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void Exists_SubdirectoryOnNonExistentDriveAsPath_ReturnsFalse()
+    {
+        var drive = IOServices.GetNonExistentDrive();
+        if (drive == null)
+        {
+            Console.WriteLine("Skipping test. Unable to find a non-existent drive.");
+            return;
+        }
+
+        bool result = Directory.Exists(Path.Combine(drive, "Subdirectory"));
+
+        Assert.False(result);
+    }
+
+
+    [Fact]
+    public static void Exists_FileWithoutTrailingSlashAsPath_ReturnsFalse()
+    {
+        using (TemporaryFile file = new TemporaryFile())
+        {
+            string path = IOServices.RemoveTrailingSlash(file.Path);
+
+            bool result = Directory.Exists(path);
+
+            Assert.False(result);
+        }
+    }
+
+    [Fact]
+    public static void Exists_FileWithTrailingSlashAsPath_ReturnsFalse()
+    {
+        using (TemporaryFile file = new TemporaryFile())
+        {
+            string path = IOServices.AddTrailingSlashIfNeeded(file.Path);
+
+            bool result = Directory.Exists(path);
+
+            Assert.False(result);
+        }
+    }
+
+    [Fact]
+    public static void Exists_ExistingDirectoryWithoutTrailingSlashAsPath_ReturnsTrue()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            string path = IOServices.RemoveTrailingSlash(directory.Path);
+
+            bool result = Directory.Exists(path);
+
+            Assert.True(result);
+        }
+    }
+
+    [Fact]
+    public static void Exists_ExistingDirectoryWithTrailingSlashAsPath_ReturnsTrue()
+    {
+        using (TemporaryDirectory directory = new TemporaryDirectory())
+        {
+            string path = IOServices.AddTrailingSlashIfNeeded(directory.Path);
+
+            bool result = Directory.Exists(path);
+
+            Assert.True(result);
+        }
+    }
+
+    [Fact]
+    public static void Exists_DotAsPath_ReturnsTrue()
+    {
+        bool result = Directory.Exists(TestInfo.CurrentDirectory + @"\.");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void Exists_DotDotAsPath_ReturnsTrue()
+    {
+        bool result = Directory.Exists(TestInfo.CurrentDirectory + @"\..");
+
+        Assert.True(result);
+    }
+
+#if !TEST_WINRT // WinRT cannot access root
+    /*
+    [Fact]
+    [ActiveIssue(1220)] // SetCurrentDirectory
+    public static void Exists_DotDotAsPath_WhenCurrentDirectoryIsRoot_ReturnsTrue()
+    {
+        string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+
+        using (CurrentDirectoryContext context = new CurrentDirectoryContext(root))
+        {
+            bool result = Directory.Exists("..");
+
+            Assert.True(result);
+        }
+    }
+    */
+#endif
+
+    [Fact]
+    public static void Exists_DirectoryGetCurrentDirectoryAsPath_ReturnsTrue()
+    {
+        bool result = Directory.Exists(Directory.GetCurrentDirectory());
+
+        Assert.True(result);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetCreationTime_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetCreationTime_str.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Xunit;
+
+public class Directory_GetCreationTime
+{
+    public static String s_strDtTmVer = "2009/02/18";
+    public static String s_strClassMethod = "Directory.GetCreationTime()";
+    public static String s_strTFName = "GetCreationTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        try
+        {
+            DirectoryInfo dir = null;
+            String strDirName = "";
+
+            // [] Create a directory and check the creation time
+            strLoc = "Loc_r8r7j";
+
+            strDirName = Path.Combine(TestInfo.CurrentDirectory, "TestDir");
+            dir = Directory.CreateDirectory(strDirName);
+            iCountTestcases++;
+            try
+            {
+                if (Math.Abs((Directory.GetCreationTime(strDirName) - DateTime.Now).TotalSeconds) > 3)
+                {
+                    iCountErrors++;
+                    printerr("Error_20hjx! Creation time should be within 3 seconds of now");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            dir.Delete(true);
+
+            // remote directory test moved to RemoteIOTests.cs
+
+            // [] Check the creation time for an existing file.
+
+            strLoc = "Loc_20er";
+
+            strDirName = Path.Combine(TestInfo.CurrentDirectory, "blah");
+            dir = Directory.CreateDirectory(strDirName);
+            Task.Delay(2000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - Directory.GetCreationTime(strDirName)).Seconds > 3)
+                {
+                    iCountErrors++;
+                    printerr("Eror_3123! Creation time is off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_3543! Unexpected exception thrown: " + exc.ToString());
+            }
+            dir.Delete(true);
+
+#if !TEST_WINRT
+            //#469226 - DirectoryInfo.CreationTime throws System.ArgumentOutOfRangeException for directories on CDs
+            //postponed but we will add the scenario
+            try
+            {
+                IEnumerable<string> drives = IOServices.GetReadyDrives();
+                foreach (string drive in drives)
+                {
+                    String[] dirs = Directory.GetDirectories(drive);
+                    int count = 10;
+                    if (dirs.Length < count)
+                        count = dirs.Length;
+                    for (int i = 0; i < count; i++)
+                    {
+                        try
+                        {
+                            DateTime time = Directory.GetCreationTime(dirs[i]);
+                        }
+                        catch (ArgumentOutOfRangeException)
+                        {
+                            Console.WriteLine("Info_9237tgfasd: #469226? drive: {0}, directory: {1}", drive, dirs[i]);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ++iCountErrors;
+                Console.WriteLine("Err_734g@! exception thrown: {0}", ex);
+            }
+#endif
+
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private bool CompareDates(DateTime dt1, DateTime dt2)
+    {
+        Console.WriteLine(dt1);
+        Console.WriteLine(dt2);
+        if ((dt1.Year == dt2.Year) && (dt1.Month == dt2.Month) && (dt1.Day == dt2.Day))
+            return true;
+        else
+            return false;
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetCurrentDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetCurrentDirectory.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetCurrentDirectory
+{
+    public static String s_strDtTmVer = "2000/07/07 19:00";
+    public static String s_strClassMethod = "Directory.GetCurrentDirectory()";
+    public static String s_strTFName = "GetCurrentDirectory.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo currentdir = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+            // [] ArgumentNullException for null argument
+
+            strLoc = "Loc_23849";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCurrentDirectory(null);
+                iCountErrors++;
+                printerr("Error_388rf! Expected exception not thrown, dir==" + Directory.GetCurrentDirectory());
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28t7b! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] Vanilla case
+            /* Scenario disabled when porting because it modifies global process state and can not be run in parallel with other tests
+            DirectoryInfo dir = null;
+            strLoc = "Loc_2g77b";
+
+            dir = new DirectoryInfo("..");
+            Directory.SetCurrentDirectory(dir.FullName);
+
+            iCountTestcases++;
+            if (!Directory.GetCurrentDirectory().Equals(dir.FullName))
+            {
+                Console.WriteLine(Directory.GetCurrentDirectory());
+                iCountErrors++;
+                printerr("Error_38g8b! Directory Not set correctly");
+            }
+            */
+
+            // [] Another vanilla case
+            /* Scenario disabled when porting because it modifies global process state and can not be run in parallel with other tests
+            strLoc = "Loc_9t8gt";
+
+            dir = new DirectoryInfo("C:\\");
+            Directory.SetCurrentDirectory(dir.FullName);
+            iCountTestcases++;
+            if (!Directory.GetCurrentDirectory().Equals(dir.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_238g7! Directory not set correctly, dir==" + Directory.GetCurrentDirectory());
+            }
+            */
+
+            // [] Set back to original
+            /* Scenario disabled when porting because it modifies global process state and can not be run in parallel with other tests
+            strLoc = "Loc_87ygv";
+            
+            Directory.SetCurrentDirectory(currentdir.FullName);
+            iCountTestcases++;
+            if (!Directory.GetCurrentDirectory().Equals(currentdir.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_2g7b7! Directory not set correctly, dir==" + Directory.GetCurrentDirectory());
+            }
+            */
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str.cs
@@ -1,0 +1,348 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetDirectories_str
+{
+    public static String s_strDtTmVer = "2000/04/27 17:00";
+    public static String s_strClassMethod = "Directory.GetDirectories()";
+    public static String s_strTFName = "GetDirectories_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = "GetDirectories_str_TestDir";
+            DirectoryInfo[] dirArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories(null);
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] ArgumentException for String.Empty
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories(String.Empty);
+                iCountErrors++;
+                printerr("Error_8ytbm! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for all whitespace
+            //-----------------------------------------------------------------
+            strLoc = "Loc_1190x";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories("*");
+                iCountErrors++;
+                printerr("Error_2198y! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dirArr = dir2.GetDirectories();
+            iCountTestcases++;
+            if (dirArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and check it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+            new FileInfo(dir2.ToString() + "TestFile1");
+            new FileInfo(dir2.ToString() + "TestFile2");
+
+            // [] Searchstring ending with '*'
+
+            iCountTestcases++;
+            dirArr = dir2.GetDirectories("TestDir*");
+            iCountTestcases++;
+            if (dirArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned");
+            }
+
+
+            String[] names = new String[3];
+            int i = 0;
+            foreach (DirectoryInfo d in dirArr)
+                names[i++] = d.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + dirArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + dirArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + dirArr[2].Name);
+            }
+
+
+            // [] Searchstring is '*'
+
+            dirArr = dir2.GetDirectories("*");
+            iCountTestcases++;
+            if (dirArr.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of directories==" + dirArr.Length);
+            }
+            names = new String[5];
+            i = 0;
+            foreach (DirectoryInfo d in dirArr)
+                names[i++] = d.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + dirArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + dirArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + dirArr[2].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + dirArr[3].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + dirArr[4].Name);
+            }
+
+            // [] Searchstring starting with '*'
+
+            dirArr = dir2.GetDirectories("*Dir2");
+            iCountTestcases++;
+            if (dirArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_8019x! Incorrect number of directories==" + dirArr.Length);
+            }
+
+            names = new String[2];
+            i = 0;
+            foreach (DirectoryInfo d in dirArr)
+                names[i++] = d.Name;
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_167yb! Incorrect name==" + dirArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_49yb7! Incorrect name==" + dirArr[1].Name);
+            }
+
+            // [] Exact match
+
+            strLoc = "Loc_fy87e";
+
+            dirArr = dir2.GetDirectories("Test1Dir2");
+            iCountTestcases++;
+            if (dirArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_2398v! Incorrect number of directories returned, expected==1, got==" + dirArr.Length);
+            }
+            iCountTestcases++;
+            if (!dirArr[0].Name.Equals("Test1Dir2"))
+            {
+                iCountErrors++;
+                printerr("Error_88gbb! Incorrect directory returned==" + dirArr[0]);
+            }
+
+            // [] Multiple wildcards
+
+            strLoc = "Loc_48yg7";
+
+            dirArr = dir2.GetDirectories("T*st*d*2");
+            iCountTestcases++;
+            if (dirArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_39g8b! Incorrect number of directories returned, expected==2, got==" + dirArr.Length);
+            }
+
+
+            // [] Searchstring starting and ending with '*'
+            // [] Search is case insensitive
+            dir2.CreateSubdirectory("AAABB");
+            dir2.CreateSubdirectory("aaabbcc");
+
+            dirArr = dir2.GetDirectories("*BB*");
+            iCountTestcases++;
+            if (dirArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y190! Incorrect number of directories==" + dirArr.Length);
+            }
+            names = new String[2];
+            i = 0;
+            foreach (DirectoryInfo d in dirArr)
+                names[i++] = d.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "AAABB") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_956yb! Incorrect name==" + dirArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "aaabbcc") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_48yg7! Incorrect name==" + dirArr[1]);
+            }
+
+            // [] Should not search on fullpath
+            // [] No match should return zero length array
+
+            dirArr = dir2.GetDirectories("Directory");
+            iCountTestcases++;
+            if (dirArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_209v7! Incorrect number of directories==" + dirArr.Length);
+            }
+
+
+            //-----------------------------------------------------------------
+
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine(s_strTFName + " : Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(iCountErrors, 0);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str.cs
@@ -1,0 +1,407 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Co5674GetDirectories_Str_Str
+{
+    public static String s_strDtTmVer = "2000/04/27 17:00";
+    public static String s_strClassMethod = "Directory.GetDirectories()";
+    public static String s_strTFName = "GetDirectories_Str_Str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = "GetDirectories_Str_Str_test_TestDir";
+            String[] strArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories(null, "*");
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories(".", null);
+                iCountErrors++;
+                printerr("Error_y767b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2y67b! Incorrect exception thrown, aexc==" + exc.ToString());
+            }
+
+
+            //-----------------------------------------------------------------
+
+
+            // [] ArgumentException for String.Empty
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories(String.Empty, "*");
+                iCountErrors++;
+                printerr("Error_8ytbm! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            iCountTestcases++;
+            try
+            {
+                String[] sDirs = Directory.GetDirectories(".", String.Empty);
+                // To avoid OS differences we have decided not to throw an argument exception when empty
+                // string passed. But we should return 0 items.
+                if (sDirs.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_543543! Invalid number of directories returned");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21t0b! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for all whitespace in directory name or search string
+            //-----------------------------------------------------------------
+            strLoc = "Loc_1190x";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                Directory.GetDirectories("\n", "*");
+                iCountErrors++;
+                printerr("Error_2198y! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            iCountTestcases++;
+            try
+            {
+                String[] strDirs = Directory.GetDirectories(".", "\n");
+                if (strDirs.Length > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_27109! Incorrect number of directories are return.. " + strDirs.Length);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_107gy! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            strArr = Directory.GetDirectories(dirName, "*");
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and check it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+            new FileInfo(dir2.ToString() + "TestFile1");
+            new FileInfo(dir2.ToString() + "TestFile2");
+
+            // [] SearchString ending with '*'
+
+            iCountTestcases++;
+            strArr = Directory.GetDirectories(".\\" + dirName, "TestDir*");
+            iCountTestcases++;
+            if (strArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned");
+            }
+
+            String[] names = new String[strArr.Length];
+            int i = 0;
+            foreach (String d in strArr)
+                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + strArr[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + strArr[2].ToString());
+            }
+
+
+            // [] SearchString is '*'
+            strLoc = "Loc_249yv";
+
+            strArr = Directory.GetDirectories(Directory.GetCurrentDirectory() + "\\" + dirName, "*");
+            iCountTestcases++;
+            if (strArr.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of directories==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String d in strArr)
+                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + strArr[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + strArr[2].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + strArr[3].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + strArr[4].ToString());
+            }
+
+            // [] SearchString starting with '*'
+            strLoc = "Loc_20v99";
+
+            strArr = Directory.GetDirectories(Directory.GetCurrentDirectory() + "\\" + dirName, "*Dir2");
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_8019x! Incorrect number of directories==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String d in strArr)
+                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_167yb! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_49yb7! Incorrect name==" + strArr[1].ToString());
+            }
+
+
+            // SearchString beginning and ending with '*'
+            strLoc = "Loc_2498g";
+            dir2.CreateSubdirectory("AAABB");
+            dir2.CreateSubdirectory("aaabbcc");
+
+            strArr = Directory.GetDirectories(".\\" + dirName, "*BB*");
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y190! Incorrect number of directories==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String d in strArr)
+                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "AAABB") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_956yb! Incorrect name==" + strArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "aaabbcc") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_48yg7! Incorrect name==" + strArr[1]);
+            }
+
+            // [] Should not search on fullpath
+            // [] No matches should return empty array
+
+            strArr = Directory.GetDirectories(".\\" + dirName, "Directory");
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_209v7! Incorrect number of directories==" + strArr.Length);
+            }
+
+            //Code coverage
+            //Search pattern could have subdirectories
+            strArr = Directory.GetDirectories(".", String.Format("{0}\\TestDir*", dirName));
+            if (strArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned");
+            }
+
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String d in strArr)
+                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + strArr[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + strArr[2].ToString());
+            }
+
+
+
+
+            //-----------------------------------------------------------------
+
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str_so.cs
@@ -1,0 +1,714 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Security;
+using System.Globalization;
+using Xunit;
+
+public class Directory_GetDirectories_str_str_so
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            String dirName;
+            String[] expectedDirs;
+            String[] dirs;
+            List<String> list;
+            // part I - SearchOption.TopDirectoryOnly
+            //Scenario 1:Vanilla - Create a directory, add a few dirs and call with searchPattern * and verify 
+            //that all directories are returned.
+            //Scenario 1.1: Ensure that the path contains deep subdirectories and call this API and ensure that only the top directories are returned
+            //Scenario 1.2: no subdirectories exist in the directory
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedDirs = fileManager.GetDirectories(1);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_3947g! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_582bmw! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_891vut! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
+                {
+                    expectedDirs = fileManager.GetDirectories(1);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_412viu! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_004jzv! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_041qti! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+
+
+            //Scenario 2: Path is not in the current directory (same drive)
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedDirs = fileManager.GetDirectories(1);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_386gef! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        //This will return as \<dirName>\<fileName> whereas our utility will return as <drive>:\<dirName>\<fileName>
+                        String fileFullName = Path.GetFullPath(dirs[i]);
+                        if (Eval(list.Contains(fileFullName), "Err_932izm! No file found: {0}", fileFullName))
+                            list.Remove(fileFullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_915sae! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+                //only 1 level
+                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = Path.GetFullPath(dirName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
+                {
+                    expectedDirs = fileManager.GetDirectories(1);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_792ifb! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_281tff! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_792qdn! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_992hic! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+
+            //Scenario 5: searchPattern variations - valid search characters, file match exactly the searchPattern, searchPattern is a subset of existing dirs, superset, no match, 
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                String searchPattern;
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedDirs = fileManager.GetDirectories(1);
+                    //?
+                    int maxLen = 0;
+                    foreach (String dir in expectedDirs)
+                    {
+                        //we want the simple name of the directory and 
+                        String realDir = new DirectoryInfo(dir).Name;
+                        if (realDir.Length > maxLen)
+                            maxLen = realDir.Length;
+                    }
+                    searchPattern = new String('?', maxLen);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_488sjb! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_750dop! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_629dvi! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine("list - {0}", fileName);
+
+                        foreach (String fileName in dirs)
+                            Console.WriteLine("dirs - {0}", fileName);
+
+                        Console.WriteLine("dirName: {0} searchPattern: {1}", dirName, searchPattern);
+                    }
+
+                    //*.*
+                    searchPattern = "*.*";
+                    expectedDirs = fileManager.GetDirectories(1);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_403phi! wrong count: {0} - {1}", dirs.Length, list.Count);
+
+
+                    //directory match exactly 			
+
+                    searchPattern = expectedDirs[0].Substring(expectedDirs[0].LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                    list = new List<String>(new String[] { expectedDirs[0] });
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_841dnz! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_796xxd! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_552puh! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine("SearchPattern: [{0}]", searchPattern);
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //subset
+                    String tempSearchPattern = expectedDirs[0].Substring(expectedDirs[0].LastIndexOf(Path.DirectorySeparatorChar) + 1).Substring(2);
+                    List<String> newFiles = new List<String>();
+                    foreach (String dir in expectedDirs)
+                    {
+                        String realFile = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                        if (realFile.Substring(2).Equals(tempSearchPattern))
+                            newFiles.Add(dir);
+                    }
+                    searchPattern = String.Format("??{0}", tempSearchPattern);
+
+                    list = newFiles;
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_847vxz! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_736kfh! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_576atr! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //there shouldn't be any with just the suffix
+                    searchPattern = tempSearchPattern;
+                    list = new List<String>();
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_624jmn! wrong count: {0} - {1}", dirs.Length, list.Count);
+
+
+                    //superset
+                    searchPattern = String.Format("blah{0}", expectedDirs[0].Substring(expectedDirs[0].LastIndexOf(Path.DirectorySeparatorChar) + 1));
+                    newFiles = new List<String>();
+                    foreach (String dir in expectedDirs)
+                    {
+                        String realFile = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                        if (realFile.Equals(searchPattern))
+                            newFiles.Add(dir);
+                    }
+
+                    list = newFiles;
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_026zqz! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_832yyg! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_605dke! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //pattern match an existing file name
+                    String[] files = fileManager.GetFiles(dirName, 0);
+                    searchPattern = Path.GetFileName(files[0]);
+                    list = new List<String>();
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(dirs.Length == list.Count, "Err_786uyo! wrong count: {0} - {1}", dirs.Length, list.Count);
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_728ono! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 6: Different local drives, Network drives (UNC and drive letters)
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                string otherDriveInMachine = IOServices.GetNonNtfsDriveOtherThanCurrent();
+                if (otherDriveInMachine != null)
+                {
+                    dirName = ManageFileSystem.GetNonExistingDir(otherDriveInMachine, ManageFileSystem.DirPrefixName);
+                    using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                    {
+                        Console.WriteLine("otherDriveInMachine: {0}", dirName);
+                        expectedDirs = fileManager.GetDirectories(1);
+                        list = new List<String>(expectedDirs);
+                        dirs = Directory.GetDirectories(dirName, "*", SearchOption.TopDirectoryOnly);
+                        Eval(dirs.Length == list.Count, "Err_337kkf! wrong count");
+                        for (int i = 0; i < expectedDirs.Length; i++)
+                        {
+                            if (Eval(list.Contains(dirs[i]), "Err_448nzn! No file found: {0}", dirs[i]))
+                                list.Remove(dirs[i]);
+                        }
+                        if (!Eval(list.Count == 0, "Err_849fvp! wrong count: {0}", list.Count))
+                        {
+                            Console.WriteLine();
+                            foreach (String fileName in list)
+                                Console.WriteLine(fileName);
+                        }
+                    }
+                }
+
+                // network path scenario moved to RemoteIOTests.cs
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_768lme! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+
+
+            //Scenario 7: Arguments validation: nulls for the first 2, outside range for the enum value. Path contains empty, space and invalid filename 
+            //characters. The same for searchPattern parm as well
+            try
+            {
+                String[] invalidValuesForPath = { "", " ", ">" };
+                String[] invalidValuesForSearch = { "..", @"..\" };
+                CheckException<ArgumentNullException>(delegate { dirs = Directory.GetDirectories(null, "*", SearchOption.TopDirectoryOnly); }, "Err_347g! worng exception thrown");
+                CheckException<ArgumentNullException>(delegate { dirs = Directory.GetDirectories(Directory.GetCurrentDirectory(), null, SearchOption.TopDirectoryOnly); }, "Err_326pgt! worng exception thrown");
+                CheckException<ArgumentOutOfRangeException>(delegate { dirs = Directory.GetDirectories(Directory.GetCurrentDirectory(), "*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
+                CheckException<ArgumentOutOfRangeException>(delegate { dirs = Directory.GetDirectories(Directory.GetCurrentDirectory(), "*", (SearchOption)(-1)); }, "Err_359vcj! worng exception thrown - see bug #386545");
+                for (int i = 0; i < invalidValuesForPath.Length; i++)
+                {
+                    CheckException<ArgumentException>(delegate { dirs = Directory.GetDirectories(invalidValuesForPath[i], "*", SearchOption.TopDirectoryOnly); }, String.Format("Err_347sd_{0}! worng exception thrown: {1}", i, invalidValuesForPath[i]));
+                }
+                for (int i = 0; i < invalidValuesForSearch.Length; i++)
+                {
+                    CheckException<ArgumentException>(delegate { dirs = Directory.GetDirectories(Directory.GetCurrentDirectory(), invalidValuesForSearch[i], SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy! worng exception thrown: {1}", i, invalidValuesForSearch[i]));
+                }
+                Char[] invalidPaths = Path.GetInvalidPathChars();
+                for (int i = 0; i < invalidPaths.Length; i++)
+                {
+                    CheckException<ArgumentException>(delegate { dirs = Directory.GetDirectories(invalidPaths[i].ToString(), "*", SearchOption.TopDirectoryOnly); }, String.Format("Err_538wyc! worng exception thrown: {1}", i, invalidPaths[i]));
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_995bae! Exception caught in scenario: {0}", ex);
+            }
+
+
+
+            // part II - SearchOption.AllDirectories
+            //Scenario 1: Vanilla - create a directory with some dirs and then add a couple of directories with some dirs and check with searchPattern *
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedDirs = fileManager.GetAllDirectories();
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_415mbz! wrong count {0} {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_287kkm! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_921mhs! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_415nwr! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 2: create a directory only top level dirs and directories and check
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
+                {
+                    expectedDirs = fileManager.GetAllDirectories();
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_202wur! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_611lgv! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_648ibm! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_391mwx! Exception caught in scenario: {0}", ex);
+            }
+
+            // Path is not in the current directory (same drive)
+            //Scenario 3: Ensure that the path contains subdirectories and call this API and ensure that only the top directory dirs are returned
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedDirs = fileManager.GetAllDirectories();
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, "*", SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_123rcm! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        //This will return as \<dirName>\<fileName> whereas our utility will return as <drive>:\<dirName>\<fileName>
+                        String fileFullName = Path.GetFullPath(dirs[i]);
+                        if (Eval(list.Contains(fileFullName), "Err_242yur! No file found: {0}", fileFullName))
+                            list.Remove(fileFullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_477xiv! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_401dkm! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+            //Scenario 4: searchPattern variations - valid search characters, file match exactly the searchPattern, searchPattern is a subset of existing dirs, superset, no match, 
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                String searchPattern;
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedDirs = fileManager.GetAllDirectories();
+                    //?
+                    int maxLen = 0;
+                    foreach (String dir in expectedDirs)
+                    {
+                        //we want the simple name of the directory and 
+                        String realDir = new DirectoryInfo(dir).Name;
+                        if (realDir.Length > maxLen)
+                            maxLen = realDir.Length;
+                    }
+                    searchPattern = new String('?', maxLen);
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_261jae! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_631xmw! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_790fuv! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //*.*
+                    searchPattern = "*.*";
+                    expectedDirs = fileManager.GetAllDirectories();
+                    list = new List<String>(expectedDirs);
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_304qte! wrong count: {0} - {1}", dirs.Length, list.Count);
+
+
+                    //directory match exactly - @TODO!!!
+
+                    searchPattern = expectedDirs[0].Substring(expectedDirs[0].LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                    list = new List<String>();
+                    foreach (String dir in expectedDirs)
+                    {
+                        String dirLastName = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                        if (searchPattern.Equals(dirLastName, StringComparison.CurrentCultureIgnoreCase))
+                            list.Add(dir);
+                    }
+                    Console.WriteLine("<{0}>", searchPattern);
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_188xbk! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_120xcj! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_664zyk! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+
+                    //subset
+                    String tempSearchPattern = expectedDirs[0].Substring(expectedDirs[0].LastIndexOf(Path.DirectorySeparatorChar) + 1).Substring(2);
+                    List<String> newFiles = new List<String>();
+                    foreach (String dir in expectedDirs)
+                    {
+                        String realFile = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                        if (realFile.Substring(2).Equals(tempSearchPattern))
+                            newFiles.Add(dir);
+                    }
+                    searchPattern = String.Format("??{0}", tempSearchPattern);
+
+                    list = newFiles;
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_245luj! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_251vky! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_168yge! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //there shouldn't be any with just the suffix
+                    searchPattern = tempSearchPattern;
+                    list = new List<String>();
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_272suf! wrong count: {0} - {1}", dirs.Length, list.Count);
+
+
+                    //superset
+                    searchPattern = String.Format("blah{0}", expectedDirs[0].Substring(expectedDirs[0].LastIndexOf(Path.DirectorySeparatorChar) + 1));
+                    newFiles = new List<String>();
+                    foreach (String dir in expectedDirs)
+                    {
+                        String realFile = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                        if (realFile.Equals(searchPattern))
+                            newFiles.Add(dir);
+                    }
+
+                    list = newFiles;
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_888snc! wrong count: {0} - {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < dirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i]), "Err_330akg! No file found: {0}", dirs[i]))
+                            list.Remove(dirs[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_660npm! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //pattern match an existing file name
+                    String[] files = fileManager.GetFiles(dirName, 0);
+                    searchPattern = Path.GetFileName(files[0]);
+                    list = new List<String>();
+                    dirs = Directory.GetDirectories(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_238cul! wrong count: {0} - {1}", dirs.Length, list.Count);
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_474hse! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 6: Different local drives, Network drives (UNC and drive letters)
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                string otherDriveInMachine = IOServices.GetNonNtfsDriveOtherThanCurrent();
+                if (otherDriveInMachine != null)
+                {
+                    dirName = ManageFileSystem.GetNonExistingDir(otherDriveInMachine, ManageFileSystem.DirPrefixName);
+                    using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                    {
+                        expectedDirs = fileManager.GetAllDirectories();
+                        list = new List<String>(expectedDirs);
+                        dirs = Directory.GetDirectories(dirName, "*", SearchOption.AllDirectories);
+                        Eval(dirs.Length == list.Count, "Err_573sdo! wrong count");
+                        for (int i = 0; i < expectedDirs.Length; i++)
+                        {
+                            if (Eval(list.Contains(dirs[i]), "Err_778kdo! No file found: {0}", dirs[i]))
+                                list.Remove(dirs[i]);
+                        }
+                        if (!Eval(list.Count == 0, "Err_954xcx! wrong count: {0}", list.Count))
+                        {
+                            Console.WriteLine();
+                            foreach (String fileName in list)
+                                Console.WriteLine(fileName);
+                        }
+                    }
+                }
+
+                // network path scenario moved to RemoteIOTests.cs
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_064vel! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+            // Regression Test (DevDiv Bug927807): throw NotSupportException when there are whitespace before drive letter
+            try
+            {
+                string pathStr = @" C:\";
+                var fullPath = Path.GetFullPath(pathStr);
+                Eval(fullPath, "C:\\", "Wrong Full Path");
+
+                pathStr = "  D:\\";
+                fullPath = Path.GetFullPath(pathStr);
+                Eval(fullPath, "D:\\", "Wrong Full Path");
+
+                pathStr = "   E:\\Test\\Test.cs  ";
+                fullPath = Path.GetFullPath(pathStr);
+                Eval(fullPath, @"E:\Test\Test.cs", "Wrong Full Path");
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Bug927807! Exception caught in scenario: {0}", ex);
+            }
+        }
+        catch (Exception ex)
+        {
+            s_pass = false;
+            Console.WriteLine("Err_234rsgf! Uncaught exception in RunTest: {0}", ex);
+        }
+
+        Assert.True(s_pass);
+    }
+
+    private void DeleteFile(String fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}, {2}", error, e.GetType().ToString(), e.ToString());
+        }
+        Eval(exception, error);
+    }
+}
+
+
+
+
+
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot_str.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetDirectoryRoot_str
+{
+    public static String s_strActiveBugNums = "28196";
+    public static String s_strDtTmVer = "2000/04/27 16:55";
+    public static String s_strClassMethod = "Directory.Root";
+    public static String s_strTFName = "GetDirectoryRoot_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String str2;
+
+            // [] COMMENT: Simple string parsing of existing fullpath
+            iCountTestcases++; // To make maddog happy
+
+            //Code coverage
+            try
+            {
+                str2 = Directory.GetDirectoryRoot(null);
+                iCountErrors++;
+                Console.WriteLine("Err_34tgs! No exception thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34tgs! No exception thrown: {0}", ex);
+            }
+
+
+            // [] Get root of root
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_49b78";
+
+            str2 = Directory.GetDirectoryRoot("C:\\");
+            iCountTestcases++;
+            if (!str2.Equals("C:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_69y7b! Unexpected parent==" + str2);
+            }
+
+            // [] Get root of \Directory
+
+            strLoc = "Loc_98ygg";
+
+            str2 = Directory.GetDirectoryRoot("\\Machine\\Test");
+            iCountTestcases++;
+            String root = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().IndexOf('\\') + 1);
+            if (!str2.Equals(root))
+            {
+                iCountErrors++;
+                printerr("Error_91y7b! Unexpected parent==" + str2);
+            }
+
+            // [] Get root of \\Machine\Directory
+
+            strLoc = "Loc_yg7bk";
+
+            str2 = Directory.GetDirectoryRoot("\\\\Machine\\Test");
+            iCountTestcases++;
+            if (!str2.Equals("\\\\Machine\\Test"))
+            {
+                iCountErrors++;
+                printerr("Error_4y7gb! Unexpected parent==" + str2);
+            }
+
+
+            // [] Get root of many nested directories ending with \
+
+            strLoc = "Loc_9876b";
+
+            str2 = Directory.GetDirectoryRoot("X:\\a\\b\\c\\d\\");
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_298yg! Unexpected parent==" + str2);
+            }
+
+            // [] Get root of many nested directories
+
+            strLoc = "Loc_75y7b";
+
+            str2 = Directory.GetDirectoryRoot("X:\\a\\b\\c");
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_9887b! Unexpected parent==" + str2);
+            }
+
+            // [] Get root of many subdirs on UNC share
+
+            strLoc = "Loc_y7t98";
+
+            str2 = Directory.GetDirectoryRoot("\\\\Machine\\Test1\\Test2\\Test3");
+            iCountTestcases++;
+            if (!str2.Equals("\\\\Machine\\Test1"))
+            {
+                iCountErrors++;
+                printerr("Error_69929! Unexpected parent==" + str2);
+            }
+
+            // [] Play with "." and ".." in the middle of the directory string
+
+            strLoc = "Loc_2984y";
+
+            str2 = Directory.GetDirectoryRoot("C:\\Test\\..\\.\\Test\\Test");
+            iCountTestcases++;
+            if (!str2.Equals("C:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_20928! Unexpected parent==" + str2);
+            }
+
+
+            // [] Use directory names that include spaces
+
+            strLoc = "Loc_8y76y";
+
+            str2 = Directory.GetDirectoryRoot("X:\\My Samples\\Hello To The World\\Test");
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_9019c! Unexpected parent==" + str2);
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine(s_strTFName + " : Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString() + " , BugNums?: " + s_strActiveBugNums);
+        }
+
+        Assert.Equal(iCountErrors, 0);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -1,0 +1,272 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetFileSystemEntries_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2001/02/12 21:00";
+    public static String s_strClassMethod = "Directory.GetFileSystemEntries()";
+    public static String s_strTFName = "GetFileSystemEntries_str.cs";
+
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+        try
+        {
+            DirectoryInfo dir2;
+            String dirName = "GetFileSystemEntries_str_TestDir";
+            String[] strArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            strLoc = "Loc_4y982";
+
+            // [] With null string
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries(null);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] With an empty string.
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries("");
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] With white spaces....
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries("            ");
+                iCountErrors++;
+                printerr("Error_0008! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0009! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //Directory that doesn't exist
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries(dirName);
+                iCountErrors++;
+                printerr("Error_1001! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1002! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //TODO:: Add UNC path testcase.
+
+            //With wild character's
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "c:\\dls;d\\442349-0\\v443094(*)(+*$#$*\\\\\\";
+                Directory.GetFileSystemEntries(strTempDir);
+                iCountErrors++;
+                printerr("Error_1003! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1004! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With lot's of \'s at the end
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "c:\\\\\\\\\\";
+                strArr = Directory.GetFileSystemEntries(strTempDir);
+                if (strArr == null || strArr.Length == 0)
+                {
+                    printerr("Error_1234!!! INvalid number of file system entries count :: " + strArr.Length);
+                    iCountErrors++;
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1006! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With the current directory
+            iCountTestcases++;
+            try
+            {
+                strArr = Directory.GetFileSystemEntries(s_strTFPath);
+                if (strArr == null || strArr.Length == 0)
+                {
+                    printerr("Error_2434!!! INvalid number of file system entries count :: " + strArr.Length);
+                    iCountErrors++;
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_12321!!! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With valid directory
+            dir2 = new DirectoryInfo(dirName);
+            dir2.Create();
+
+            strArr = Directory.GetFileSystemEntries(dirName);
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+
+            // [] Create a directorystructure get all the filesystementries
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            FileStream fs1 = new FileInfo(dir2.ToString() + "\\" + "TestFile1").Create();
+            FileStream fs2 = new FileInfo(dir2.ToString() + "\\" + "TestFile2").Create();
+            FileStream fs3 = new FileInfo(dir2.ToString() + "\\" + "Test.bat").Create();
+            FileStream fs4 = new FileInfo(dir2.ToString() + "\\" + "Test.exe").Create();
+
+            iCountTestcases++;
+            strArr = Directory.GetFileSystemEntries(dir2.Name);
+            iCountTestcases++;
+            if (strArr.Length != 7)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned" + strArr.Length);
+            }
+
+            for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
+                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4yg76! Incorrect name==" + strArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_1987y! Incorrect name==" + strArr[1]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4yt76! Incorrect name==" + strArr[2]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test.bat") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + strArr[3]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test.exe") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + strArr[4]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + strArr[5]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_29894! Incorrect name==" + strArr[6]);
+            }
+
+            fs1.Dispose();
+            fs2.Dispose();
+            fs3.Dispose();
+            fs4.Dispose();
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -1,0 +1,497 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetFileSystemEntries_str_str
+{
+    public static String s_strDtTmVer = "2001/02/12 22:00";
+    public static String s_strClassMethod = "Directory.GetFileSystemEntries()";
+    public static String s_strTFName = "GetFileSystemEntries_str_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+        try
+        {
+            DirectoryInfo dir2;
+            String dirName = "GetFileSystemEntries_str_str_TestDir";
+            String[] strArr;
+
+            FailSafeDirectoryOperations.DeleteDirectory(dirName, true);
+
+            strLoc = "Loc_4y982";
+
+            // [] With null file name
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries(null, "*");
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] With empty file name
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries("", "*");
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //Directory that doesn't exist
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries(dirName, "*");
+                iCountErrors++;
+                printerr("Error_1001! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1002! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With wild character's as file name
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "c:\\dls;d\\442349-0\\v443094(*)(+*$#$*\\\\\\";
+                Directory.GetFileSystemEntries(strTempDir, "*");
+                iCountErrors++;
+                printerr("Error_1003! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1004! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With spaces as file name
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "             ";
+                Directory.GetFileSystemEntries(strTempDir, "*");
+                iCountErrors++;
+                printerr("Error_1044! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            dir2 = new DirectoryInfo(dirName);
+            dir2.Create();
+
+            // [] With null search pattern 
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFileSystemEntries(dirName, null);
+                iCountErrors++;
+                printerr("Error_02002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] With empty search pattern
+            iCountTestcases++;
+            try
+            {
+                String[] strInfos = Directory.GetFileSystemEntries(dirName, "");
+                // To avoid OS differences we have decided not to throw an argument exception when empty
+                // string passed. But we should return 0 items.
+                if (strInfos.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_9004! Invalid number of directories returned");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With wild character's as search pattern
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "c:\\dls;d\\442349-0\\v443094(*)(+*$#$*\\\\\\";
+                Directory.GetFileSystemEntries(dirName, strTempDir);
+                iCountErrors++;
+                printerr("Error_3003! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_3004! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //Valid characters for search pattern
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "a..b abc..d";
+                Directory.GetFileSystemEntries(dirName, strTempDir);
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_4004! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //Invalid characters for search pattern
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "..ab ab.. .. abc..d\abc..";
+                Directory.GetFileSystemEntries(dirName, strTempDir);
+                iCountErrors++;
+                printerr("Error_144003! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_10404! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            strLoc = "Loc_0001";
+            //Path that doesn't exist 
+            iCountTestcases++;
+            try
+            {
+                strArr = Directory.GetFileSystemEntries("ThisDirectoryShouldNotExist", "*");
+                iCountErrors++;
+                printerr("Error_14443! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_10433! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With lot's of \'s at the end of file name
+            iCountTestcases++;
+            try
+            {
+                String strTempDir = "c:\\\\\\\\\\";
+                strArr = Directory.GetFileSystemEntries(strTempDir, "*");
+                if (strArr == null || strArr.Length == 0)
+                {
+                    printerr("Error_1234!!! INvalid number of file system entries count :: " + strArr.Length);
+                    iCountErrors++;
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_10406! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With the current directory
+            iCountTestcases++;
+            try
+            {
+                strArr = Directory.GetFileSystemEntries(s_strTFPath, "*");
+                if (strArr == null || strArr.Length == 0)
+                {
+                    printerr("Error_2434!!! INvalid number of file system entries count :: " + strArr.Length);
+                    iCountErrors++;
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_12321!!! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            //With valid directory
+
+            strArr = Directory.GetFileSystemEntries(dirName, "*");
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure get all the filesystementries
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            FileStream fs1 = new FileInfo(dir2.ToString() + "\\" + "TestFile1").Create();
+            FileStream fs2 = new FileInfo(dir2.ToString() + "\\" + "TestFile2").Create();
+            FileStream fs3 = new FileInfo(dir2.ToString() + "\\" + "Test1File2").Create();
+            FileStream fs4 = new FileInfo(dir2.ToString() + "\\" + "Test1Dir2").Create();
+
+            //white spaces for search pattern
+            strArr = Directory.GetFileSystemEntries(dirName, "           ");
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                Console.WriteLine(dir2.ToString());
+                iCountErrors++;
+                printerr("Error_24324! Incorrect number of directories returned" + strArr.Length);
+            }
+
+            //Search pattern with '?'.
+            strArr = Directory.GetFileSystemEntries(dirName, "Test1*");
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_24343! Incorrect number of directories returned" + strArr.Length);
+            }
+
+            strArr = Directory.GetFileSystemEntries(dir2.Name, "*");
+            iCountTestcases++;
+            if (strArr.Length != 7)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned" + strArr.Length);
+            }
+
+            for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
+                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4yg76! Incorrect name==" + strArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_1987y! Incorrect name==" + strArr[1]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4yt76! Incorrect name==" + strArr[2]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + strArr[3]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + strArr[4]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + strArr[5]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_29894! Incorrect name==" + strArr[6]);
+            }
+
+            fs1.Dispose();
+            fs2.Dispose();
+            fs3.Dispose();
+            fs4.Dispose();
+
+            // [] Search criteria beginning with '*'
+
+            strArr = Directory.GetFileSystemEntries(dir2.Name, "*2");
+            iCountTestcases++;
+            if (strArr.Length != 4)
+            {
+                iCountErrors++;
+                printerr("Error_8019x! Incorrect number of files==" + strArr.Length);
+            }
+
+            for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
+                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_247yg! Incorrect name==" + strArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_24gy7! Incorrect name==" + strArr[1]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_167yb! Incorrect name==" + strArr[2]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_49yb7! Incorrect name==" + strArr[3]);
+            }
+
+            strArr = Directory.GetFileSystemEntries(dir2.Name, "*Dir2");
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_948yv! Incorrect number of files==" + strArr.Length);
+            }
+            for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
+                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_247yg! Incorrect name==" + strArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_24gy7! Incorrect name==" + strArr[1]);
+            }
+
+            // [] Search criteria Beginning and ending with '*'
+
+            new FileInfo(dir2.FullName + "\\" + "AAABB").Create();
+            Directory.CreateDirectory(dir2.FullName + "\\" + "aaabbcc");
+
+            strArr = Directory.GetFileSystemEntries(dir2.Name, "*BB*");
+
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y190! Incorrect number of files==" + strArr.Length);
+            }
+            for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
+                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "aaabbcc") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_956yb! Incorrect name==" + strArr[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(strArr, "AAABB") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_48yg7! Incorrect name==" + strArr[1]);
+            }
+
+            // [] Should not search on fullpath
+            // [] Search Criteria without match should return empty array
+
+            strLoc = "Loc_2301";
+            FileInfo f = new FileInfo(dir2.Name + "\\" + "TestDir1\\Test.tmp");
+            FileStream fs6 = f.Create();
+            strArr = Directory.GetFileSystemEntries(dir2.Name, "TestDir1\\*");
+            iCountTestcases++;
+            if (strArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_28gyb! Incorrect number of files");
+            }
+            fs6.Dispose();
+
+            //if(Directory.Exists(dirName))
+            //	Directory.Delete(dirName, true);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
@@ -1,0 +1,379 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetFiles_str
+{
+    public static String s_strDtTmVer = "2000/04/28 14:00";
+    public static String s_strClassMethod = "Directory.GetFiles()";
+    public static String s_strTFName = "GetFiles_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = Path.GetRandomFileName();
+            FileInfo[] filArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                dir2.GetFiles(null);
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Pass String.Empty as the search pattern
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                FileInfo[] fInfos = dir2.GetFiles(String.Empty);
+                // To avoid OS differences we have decided not to throw an argument exception when empty
+                // string passed. But we should return 0 FileInfo objects.
+                if (fInfos.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_8ytbm! Invalid number of file infos are returned");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for all whitespace
+            //-----------------------------------------------------------------
+            strLoc = "Loc_1190x";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                FileInfo[] strFiles = dir2.GetFiles("\n");
+                if (strFiles.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_2198y!Unexpected files retrieved..");
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            filArr = dir2.GetFiles();
+            iCountTestcases++;
+            if (filArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of files returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and check it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+
+            new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
+            new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
+            new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+
+            // [] Searchstring ending with '*'
+
+            iCountTestcases++;
+            filArr = dir2.GetFiles("TestFile*");
+            iCountTestcases++;
+            if (filArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of files returned" + filArr.Length);
+            }
+
+            String[] names = new String[3];
+            int i = 0;
+            foreach (FileInfo f in filArr)
+                names[i++] = f.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + filArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + filArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + filArr[2].Name);
+            }
+
+
+            // [] SearchString is '*'
+
+            filArr = dir2.GetFiles("*");
+            iCountTestcases++;
+            if (filArr.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of files==" + filArr.Length);
+            }
+
+            names = new String[5];
+            i = 0;
+            foreach (FileInfo f in filArr)
+                names[i++] = f.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + filArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + filArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + filArr[2].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + filArr[3].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + filArr[4].Name);
+            }
+
+            // [] Searchstring starting with '*'
+
+            filArr = dir2.GetFiles("*File2");
+            iCountTestcases++;
+            if (filArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_8019x! Incorrect number of files==" + filArr.Length);
+            }
+
+            names = new String[2];
+            i = 0;
+            foreach (FileInfo f in filArr)
+                names[i++] = f.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_167yb! Incorrect name==" + filArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_49yb7! Incorrect name==" + filArr[1].Name);
+            }
+
+            // [] Multiple wildcards in searchstring
+
+            strLoc = "Loc_9438y";
+            filArr = dir2.GetFiles("*es*f*l*");
+            iCountTestcases++;
+            if (filArr.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_38fy3! Incorrect number of files returned, expected==5, got==" + filArr.Length);
+            }
+
+
+            // [] Searchstring beginning and ending with '*'
+            // [] Search should be case insensitive
+            dirName = Path.GetRandomFileName();
+            Directory.CreateDirectory(dirName);
+            dir2 = new DirectoryInfo(dirName);
+            FileInfo fi1 = new FileInfo(Path.Combine(dirName, "AAABB"));
+            FileInfo fi2 = new FileInfo(Path.Combine(dirName, "aaabbcc"));
+            FileStream fs1 = fi1.Create();
+            FileStream fs2 = fi2.Create();
+            fs1.Dispose();
+            fs2.Dispose();
+
+            filArr = dir2.GetFiles("*BB*");
+            iCountTestcases++;
+            if (filArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y190! Incorrect number of files==" + filArr.Length);
+            }
+            names = new String[2];
+            i = 0;
+            foreach (FileInfo f in filArr)
+            {
+                names[i++] = f.Name;
+            }
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "AAABB") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_956yb! Incorrect name==" + filArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "aaabbcc") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_48yg7! Incorrect name==" + filArr[1].Name);
+            }
+
+            // [] Exact match
+
+            strLoc = "Loc_3y8cc";
+
+            filArr = dir2.GetFiles("AAABB");
+            iCountTestcases++;
+            if (filArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_398s1! Incorrect number of files==" + filArr.Length);
+            }
+            iCountTestcases++;
+            if (!filArr[0].Name.Equals("AAABB"))
+            {
+                iCountErrors++;
+                printerr("Error_3298y! Incorrect file name==" + filArr[0].Name);
+            }
+
+            // [] Should not search on fullpath
+            // [] Should return zero length array when no match
+            strLoc = "Loc_5435";
+
+            filArr = dir2.GetFiles("Directory");
+            iCountTestcases++;
+            if (filArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_209v7! Incorrect number of files==" + filArr.Length);
+            }
+
+            dirName = Path.GetRandomFileName();
+            dir2 = new DirectoryInfo(dirName);
+            dir2.Create();
+            FileStream fs = new FileInfo(Path.Combine(dirName, Path.GetRandomFileName())).Create();
+            fs.Dispose();
+            filArr = dir2.GetFiles("*");
+            iCountTestcases++;
+            if (filArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_28gyb! Incorrect number of files");
+            }
+
+            //-----------------------------------------------------------------
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str_Str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str_Str.cs
@@ -1,0 +1,516 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetFiles_str_str
+{
+    public static String s_strDtTmVer = "2000/04/28 14:00";
+    public static String s_strClassMethod = "Directory.GetFiles()";
+    public static String s_strTFName = "GetFiles_str_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = "GetFiles_str_str_test_TestDir";
+            String[] strArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(null, "*");
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(".", null);
+                iCountErrors++;
+                printerr("Error_2y867! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_39yb7! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            //-----------------------------------------------------------------
+
+
+
+
+
+            // [] ArgumentException for String.Empty
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(String.Empty, "*");
+                iCountErrors++;
+                printerr("Error_8ytbm! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            iCountTestcases++;
+            try
+            {
+                String[] strFiles = Directory.GetFiles(".", String.Empty);
+                if (strFiles.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_478b8! Incorrect number of files");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21999! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for all whitespace for filename and searchstring
+            //-----------------------------------------------------------------
+            strLoc = "Loc_1190x";
+
+            iCountTestcases++;
+            try
+            {
+                String[] str = Directory.GetFiles(".", "       ");
+                if (str.Length != 0)
+                {
+                    Console.WriteLine("Number of files :: " + str.Length);
+                    iCountErrors++;
+                    printerr("Error_43432! Incorrect number of files");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles("     ", ".");
+                iCountErrors++;
+                printerr("Error_29019! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9678g! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "*");
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of files returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and check it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+            new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
+            new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
+            new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+
+            // [] SearchString ending with '*'
+
+            iCountTestcases++;
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "TestFile*");
+            iCountTestcases++;
+            if (strArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75 Incorrect number of files returned==" + strArr.Length);
+            }
+
+            String[] names = new String[strArr.Length];
+            int i = 0;
+            foreach (String f in strArr)
+                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + strArr[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + strArr[2].ToString());
+            }
+
+
+            // Search string is '*'
+            strLoc = "Loc_4y7gb";
+
+            strArr = Directory.GetFiles(".\\" + dirName, "*");
+            iCountTestcases++;
+            if (strArr.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of files==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String f in strArr)
+                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + strArr[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + strArr[2].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + strArr[3].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + strArr[4].ToString());
+            }
+
+            strLoc = "Loc_4yg7b";
+
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "*File2");
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_8019x! Incorrect number of files==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String f in strArr)
+                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_167yb! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_49yb7! Incorrect name==" + strArr[1].ToString());
+            }
+
+
+            // [] Searchstring beginning and ending with '*'
+            // [] Search should be case insensitive.
+            strLoc = "Loc_767b7";
+
+            new FileInfo(dir2.FullName + "\\" + "AAABB").Create();
+            new FileInfo(dir2.FullName + "\\" + "aaabbcc").Create();
+
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "*BB*");
+            iCountTestcases++;
+            if (strArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y190! Incorrect number of files==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String f in strArr)
+                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "AAABB") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_956yb! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "aaabbcc") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_48yg7! Incorrect name==" + strArr[1].ToString());
+            }
+
+            // [] Exact match on searchstring
+
+            strLoc = "Loc_38yf8";
+
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "AAABB");
+            iCountTestcases++;
+            if (strArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_20989! Incorrect number of files==" + strArr.Length);
+            }
+            if ((strArr[0].ToString().IndexOf("AAABB")) == -1)
+            {
+                iCountErrors++;
+                printerr("Error_4y8v8! Incorrect name==" + strArr[0].ToString());
+            }
+
+
+            // [] Should not search on fullpath
+            // [] No match returns zero length array
+            strLoc = "Loc_yg78b";
+
+            strArr = Directory.GetFiles(".\\" + dirName, "Directory");
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_209v7! Incorrect number of files==" + strArr.Length);
+            }
+
+            new FileInfo(dir2.FullName + "\\" + "TestDir1\\Test.tmp").Create();
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "TestDir1\\*");
+            iCountTestcases++;
+            if (strArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_28gyb! Incorrect number of files");
+            }
+
+            //-----------------------------------------------------------------
+
+
+            // [] Some invalid directory testing
+            //-----------------------------------------------------------------
+            strLoc = "Loc_98yg5";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(",", "*");
+                iCountErrors++;
+                printerr("Error_2y675! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_249y6! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            strLoc = "Loc_98001";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles("DoesNotExist", "*");
+                iCountErrors++;
+                printerr("Error_2y76b! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Err_24y7g! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //bug #417100 - not sure if this hard coded approach is safe in all 9x platforms!!!
+            //But RunAnotherScenario is probably more accurate
+            try
+            {
+                int[] validGreaterThan128ButLessThans160 = { 129, 133, 141, 143, 144, 157 };
+                for (i = 0; i < validGreaterThan128ButLessThans160.Length; i++)
+                {
+                    Directory.GetFiles(".", ((Char)validGreaterThan128ButLessThans160[i]).ToString());
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Err_247gdo! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            try
+            {
+                for (i = 160; i < 256; i++)
+                {
+                    Directory.GetFiles(".", ((Char)i).ToString());
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Err_960tli! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+#if DESKTOP
+            try {
+                if(!RunAnotherScenario())
+                {
+                    iCountErrors++;
+                    printerr( "Error_2937efg! RunAnotherScenario failed");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Err_960tli! Incorrect exception thrown, exc=="+exc.ToString());
+            }
+#endif
+            //bug VSWhdibey #580357 - A customer ran into an issue with Directory.GetFiles and short file name
+            //We search for files with "2006" and get some even though the directory doesn't contain any files with 2006
+            try
+            {
+                String[] files = { "20050512_1600_ImpressionPart106_ClickSummary.DAT", "20050512_1600_ImpressionPart126_ClickSummary.DAT", "20050512_1600_ImpressionPart40_ClickSummary.DAT", "20050512_1600_ImpressionPart42_ClickSummary.DAT", "20050512_1600_ImpressionPart44_ClickSummary.DAT", "20050512_1600_ImpressionPart46_ClickSummary.DAT", "20050512_1600_ImpressionPart48_ClickSummary.DAT", "20050512_1600_ImpressionPart50_ClickSummary.DAT", "20050512_1600_ImpressionPart52_ClickSummary.DAT", "20050512_1600_ImpressionPart54_ClickSummary.DAT", "20050512_1600_ImpressionPart56_ClickSummary.DAT", "20050512_1600_ImpressionPart58_ClickSummary.DAT", "20050513_1400_ImpressionPart116_ClickSummary.DAT", "20050513_1400_ImpressionPart41_ClickSummary.DAT", "20050513_1400_ImpressionPart43_ClickSummary.DAT", "20050513_1400_ImpressionPart45_ClickSummary.DAT", "20050513_1400_ImpressionPart47_ClickSummary.DAT", "20050513_1400_ImpressionPart49_ClickSummary.DAT", "20050513_1400_ImpressionPart51_ClickSummary.DAT", "20050513_1400_ImpressionPart53_ClickSummary.DAT", "20050513_1400_ImpressionPart55_ClickSummary.DAT", "20050513_1400_ImpressionPart57_ClickSummary.DAT", "20050513_1400_ImpressionPart59_ClickSummary.DAT" };
+                i = 0;
+                String basePath = "laks";
+                String path;
+                do
+                {
+                    path = String.Format("{0}_{1}", basePath, i++);
+                } while (Directory.Exists(path) || File.Exists(path));
+                Directory.CreateDirectory(path);
+                foreach (String file in files)
+                {
+                    File.CreateText(Path.Combine(path, file)).Dispose();
+                }
+
+                String[] filterList = Directory.GetFiles(path, "2006*");
+                int expected = 0;
+                if (filterList.Length != expected)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Error_32497sdg! Wrong file count: returned: {0}, expeced: {1}", filterList.Length, expected);
+                }
+
+                Directory.Delete(path, true);
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Err_247gdo! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str_str_so.cs
@@ -1,0 +1,702 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Security;
+using System.Globalization;
+using Xunit;
+
+public class Directory_GetFiles_str_str_so
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            String dirName;
+            String[] expectedFiles;
+            String[] files;
+            List<String> list;
+            // part I - SearchOption.TopDirectoryOnly
+            //Scenario 1:Vanilla - Create a directory, add a few files and call with searchPattern *.* and verify 
+            //that all files are returned.
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
+                {
+                    expectedFiles = fileManager.GetFiles(dirName, 0);
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_3947g! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_582bmw! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_891vut! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 2: Add some directories to the vanilla scenario and ensure that these are not returned
+            //Scenario 3: Ensure that the path contains subdirectories and call this API and ensure that only the top directory files are returned
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedFiles = fileManager.GetFiles(dirName, 0);
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_763pjg! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_512kvk! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_839rbd! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_997pvx! Exception caught in scenario: {0}", ex);
+            }
+
+            // Path is not in the current directory (same drive)
+            //Scenario 4: Ensure that the path contains subdirectories and call this API and ensure that only the top directory files are returned
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedFiles = fileManager.GetFiles(dirName, 0);
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_386gef! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        //This will return as \<dirName>\<fileName> whereas our utility will return as <drive>:\<dirName>\<fileName>
+                        String fileFullName = Path.GetFullPath(files[i]);
+                        if (Eval(list.Contains(fileFullName), "Err_932izm! unexpected file found: {0}", fileFullName))
+                            list.Remove(fileFullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_915sae! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+                //only 1 level
+                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = Path.GetFullPath(dirName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
+                {
+                    expectedFiles = fileManager.GetFiles(dirName, 0);
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_792ifb! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_281tff! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_792qdn! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_992hic! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+            //Scenario 5: searchPattern variations - valid search characters, file match exactly the searchPattern, searchPattern is a subset of existing files, superset, no match, 
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                String searchPattern;
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedFiles = fileManager.GetFiles(dirName, 0);
+                    //?
+                    int maxLen = 0;
+                    foreach (String file in expectedFiles)
+                    {
+                        String realFile = Path.GetFileNameWithoutExtension(file);
+                        if (realFile.Length > maxLen)
+                            maxLen = realFile.Length;
+                    }
+                    searchPattern = String.Format("{0}.???", new String('?', maxLen));
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_488sjb! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_750dop! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_629dvi! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //file match exactly 
+                    searchPattern = Path.GetFileName(expectedFiles[0]);
+                    list = new List<String>(new String[] { expectedFiles[0] });
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_841dnz! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_796xxd! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_552puh! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //subset
+                    String tempSearchPattern = Path.GetFileName(expectedFiles[0]).Substring(2);
+                    List<String> newFiles = new List<String>();
+                    foreach (String file in expectedFiles)
+                    {
+                        String realFile = Path.GetFileName(file);
+                        if (realFile.Substring(2).Equals(tempSearchPattern))
+                            newFiles.Add(file);
+                    }
+                    searchPattern = String.Format("??{0}", tempSearchPattern);
+
+                    list = newFiles;
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_847vxz! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_736kfh! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_576atr! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //there shouldn't be any with just the suffix
+                    searchPattern = tempSearchPattern;
+                    list = new List<String>();
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_624jmn! wrong file count.");
+
+                    //superset
+                    searchPattern = String.Format("blah{0}", Path.GetFileName(expectedFiles[0]));
+                    newFiles = new List<String>();
+                    foreach (String file in expectedFiles)
+                    {
+                        String realFile = Path.GetFileName(file);
+                        if (realFile.Equals(searchPattern))
+                            newFiles.Add(file);
+                    }
+
+                    list = newFiles;
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.TopDirectoryOnly);
+                    Eval(files.Length, list.Count, "Err_026zqz! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_832yyg! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_605dke! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_728ono! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 6: Different local drives, Network drives (UNC and drive letters)
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                string otherDriveInMachine = IOServices.GetNonNtfsDriveOtherThanCurrent();
+                if (otherDriveInMachine != null)
+                {
+                    dirName = ManageFileSystem.GetNonExistingDir(otherDriveInMachine, ManageFileSystem.DirPrefixName);
+                    using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                    {
+                        Console.WriteLine("otherDriveInMachine: {0}", dirName);
+                        expectedFiles = fileManager.GetFiles(dirName, 0);
+                        list = new List<String>(expectedFiles);
+                        files = Directory.GetFiles(dirName, "*.*", SearchOption.TopDirectoryOnly);
+                        Eval(files.Length, list.Count, "Err_337kkf! wrong file count.");
+                        for (int i = 0; i < files.Length; i++)
+                        {
+                            if (Eval(list.Contains(files[i]), "Err_448nzn! unexpected file found: {0}", files[i]))
+                                list.Remove(files[i]);
+                        }
+                        if (!Eval(list.Count == 0, "Err_849fvp! {0} expected files not found.", list.Count))
+                        {
+                            foreach (String fileName in list)
+                                Console.WriteLine(fileName);
+                        }
+                    }
+                }
+
+                // network path scenario moved to RemoteIOTests.cs
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_768lme! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+
+            //Scenario 7: Arguments validation: 
+            // - nulls for the first 2, 
+            // - outside range for the enum value. 
+            // - Path contains empty, space and invalid filename, long, readonly invalid characters. The same for searchPattern parm as well
+            try
+            {
+                String[] invalidValuesForPath = { "", " ", ">" };
+                String[] invalidValuesForSearch = { "..", @"..\" };
+                CheckException<ArgumentNullException>(delegate { files = Directory.GetFiles(null, "*.*", SearchOption.TopDirectoryOnly); }, "Err_347g! worng exception thrown");
+                CheckException<ArgumentNullException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), null, SearchOption.TopDirectoryOnly); }, "Err_326pgt! worng exception thrown");
+                CheckException<ArgumentOutOfRangeException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
+                CheckException<ArgumentOutOfRangeException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.*", (SearchOption)(-1)); }, "Err_359vcj! worng exception thrown - see bug #386545");
+                for (int i = 0; i < invalidValuesForPath.Length; i++)
+                {
+                    CheckException<ArgumentException>(delegate { files = Directory.GetFiles(invalidValuesForPath[i], "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_347sd_{0}! worng exception thrown: {1}", i, invalidValuesForPath[i]));
+                }
+                for (int i = 0; i < invalidValuesForSearch.Length; i++)
+                {
+                    CheckException<ArgumentException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), invalidValuesForSearch[i], SearchOption.TopDirectoryOnly); }, String.Format("Err_074ts! worng exception thrown: {1}", i, invalidValuesForSearch[i]));
+                }
+                Char[] invalidPaths = Path.GetInvalidPathChars();
+                for (int i = 0; i < invalidPaths.Length; i++)
+                {
+                    CheckException<ArgumentException>(delegate { files = Directory.GetFiles(invalidPaths[i].ToString(), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_538wyc! worng exception thrown: {1}", i, invalidPaths[i]));
+                }
+                Char[] invalidFileNames = Path.GetInvalidFileNameChars();
+                for (int i = 0; i < invalidFileNames.Length; i++)
+                {
+                    switch (invalidFileNames[i])
+                    {
+                        case '\\':
+                        case '/':
+                            CheckException<DirectoryNotFoundException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy_{0}! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
+                            break;
+                        //We dont throw in V1 too
+                        case ':':
+                            //History:
+                            // 1) we assumed that this will work in all non-9x machine
+                            // 2) Then only in XP
+                            // 3) NTFS?
+                            if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                            {
+                                CheckException<IOException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_997gqs_{0}! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    files = Directory.GetFiles(Directory.GetCurrentDirectory(), String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly);
+                                }
+                                catch (IOException)
+                                {
+                                    Console.WriteLine(FileSystemDebugInfo.MachineInfo());
+                                    Eval(false, "Err_961lcx! Another OS throwing for DI.GetFiles(). modify the above check after confirming the v1.x behavior in that machine");
+                                }
+                            }
+
+                            break;
+                        case '*':
+                        case '?':
+                            files = Directory.GetFiles(Directory.GetCurrentDirectory(), String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly);
+                            break;
+                        default:
+                            CheckException<ArgumentException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_036gza! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
+                            break;
+                    }
+                }
+                //path too long
+                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(String.Format("{0}\\{1}", new String('a', 100), new String('b', 200)), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_927gs! wrong exception thrown"));
+                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(new String('a', 100), new String('b', 200), SearchOption.TopDirectoryOnly); }, String.Format("Err_213aka! wrong exception thrown"));
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_995bae! Exception caught in scenario: {0}", ex);
+            }
+
+            // part II - SearchOption.AllDirectories
+            //Scenario 1: Vanilla - create a directory with some files and then add a couple of directories with some files and check with searchPattern *.*
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedFiles = fileManager.GetAllFiles();
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_415mbz! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_287kkm! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_921mhs! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_415nwr! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 2: create a directory only top level files and directories and check
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
+                {
+                    expectedFiles = fileManager.GetAllFiles();
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_202wur! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_611lgv! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_648ibm! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_391mwx! Exception caught in scenario: {0}", ex);
+            }
+
+            // Path is not in the current directory (same drive)
+            //Scenario 3: Ensure that the path contains subdirectories and call this API and ensure that only the top directory files are returned
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedFiles = fileManager.GetAllFiles();
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_123rcm! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        //This will return as \<dirName>\<fileName> whereas our utility will return as <drive>:\<dirName>\<fileName>
+                        String fileFullName = Path.GetFullPath(files[i]);
+                        if (Eval(list.Contains(fileFullName), "Err_242yur! unexpected file found: {0}", fileFullName))
+                            list.Remove(fileFullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_477xiv! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_401dkm! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+            //Scenario 4: searchPattern variations - valid search characters, file match exactly the searchPattern, searchPattern is a subset of existing files, superset, no match, 
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                String searchPattern;
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    expectedFiles = fileManager.GetAllFiles();
+                    //?
+                    int maxLen = 0;
+                    foreach (String file in expectedFiles)
+                    {
+                        String realFile = Path.GetFileNameWithoutExtension(file);
+                        if (realFile.Length > maxLen)
+                            maxLen = realFile.Length;
+                    }
+                    searchPattern = String.Format("{0}.???", new String('?', maxLen));
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_654wlf! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_792olh! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_434gew! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //file match exactly 
+                    searchPattern = Path.GetFileName(expectedFiles[0]);
+                    list = new List<String>(new String[] { expectedFiles[0] });
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_427fug! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_382bzl! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_008xan! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //subset
+                    String tempSearchPattern = Path.GetFileName(expectedFiles[0]).Substring(2);
+                    List<String> newFiles = new List<String>();
+                    foreach (String file in expectedFiles)
+                    {
+                        String realFile = Path.GetFileName(file);
+                        if (realFile.Substring(2).Equals(tempSearchPattern))
+                            newFiles.Add(file);
+                    }
+                    searchPattern = String.Format("??{0}", tempSearchPattern);
+
+                    list = newFiles;
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_030bfw! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_393mly! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_328gse! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+
+                    //there shouldn't be any with just the suffix
+                    searchPattern = tempSearchPattern;
+                    list = new List<String>();
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_747fnq! wrong file count.");
+
+                    //superset
+                    searchPattern = String.Format("blah{0}", Path.GetFileName(expectedFiles[0]));
+                    newFiles = new List<String>();
+                    foreach (String file in expectedFiles)
+                    {
+                        String realFile = Path.GetFileName(file);
+                        if (realFile.Equals(searchPattern))
+                            newFiles.Add(file);
+                    }
+
+                    list = newFiles;
+                    files = Directory.GetFiles(dirName, searchPattern, SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_969vnk! wrong file count.");
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_353ygu! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_830vvw! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_983ist! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 6: Different local drives, Network drives (UNC and drive letters)
+            /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
+            try
+            {
+                string otherDriveInMachine = IOServices.GetNonNtfsDriveOtherThanCurrent();
+                if (otherDriveInMachine != null)
+                {
+                    dirName = ManageFileSystem.GetNonExistingDir(otherDriveInMachine, ManageFileSystem.DirPrefixName);
+                    using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                    {
+                        expectedFiles = fileManager.GetAllFiles();
+                        list = new List<String>(expectedFiles);
+                        files = Directory.GetFiles(dirName, "*.*", SearchOption.AllDirectories);
+                        Eval(files.Length, list.Count, "Err_573sdo! wrong file count.");
+                        for (int i = 0; i < files.Length; i++)
+                        {
+                            if (Eval(list.Contains(files[i]), "Err_778kdo! unexpected file found: {0}", files[i]))
+                                list.Remove(files[i]);
+                        }
+                        if (!Eval(list.Count == 0, "Err_954xcx! {0} expected files not found.", list.Count))
+                        {
+                            foreach (String fileName in list)
+                                Console.WriteLine(fileName);
+                        }
+                    }
+                }
+
+                // network path scenario moved to RemoteIOTests.cs
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_064vel! Exception caught in scenario: {0}", ex);
+            }
+            */
+
+            //Scenario 7: dir is readonly
+            try
+            {
+                //Readonly
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    //now lets make this directory readonly?
+                    new DirectoryInfo(dirName).Attributes = new DirectoryInfo(dirName).Attributes | FileAttributes.ReadOnly;
+
+                    expectedFiles = fileManager.GetAllFiles();
+                    list = new List<String>(expectedFiles);
+                    files = Directory.GetFiles(dirName, "*.*", SearchOption.AllDirectories);
+                    Eval(files.Length, list.Count, "Err_862vhr! wrong file count.");
+
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i]), "Err_556ioj! unexpected file found: {0}", files[i]))
+                            list.Remove(files[i]);
+                    }
+                    if (!Eval(list.Count == 0, "Err_562xwh! {0} expected files not found.", list.Count))
+                    {
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                    if (Directory.Exists(dirName) && (new DirectoryInfo(dirName).Attributes & FileAttributes.ReadOnly) != 0)
+                        new DirectoryInfo(dirName).Attributes = new DirectoryInfo(dirName).Attributes ^ FileAttributes.ReadOnly;
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_418qfv! Exception caught in scenario: {0}", ex);
+            }
+        }
+        catch (Exception ex)
+        {
+            s_pass = false;
+            Console.WriteLine("Err_234rsgf! Uncaught exception in RunTest: {0}", ex);
+        }
+
+        Assert.True(s_pass);
+    }
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}, expected {2}", error, e.GetType().ToString(), typeof(E).ToString());
+        }
+        Eval(exception, error);
+    }
+}
+
+
+

--- a/src/System.IO.FileSystem/tests/Directory/GetLastAccessTime_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetLastAccessTime_str.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Co9027GetLastAccessTime_str
+{
+    public static String s_strDtTmVer = "2001/02/12 13:19";
+    public static String s_strClassMethod = "Directory.GetLastAccessTime()";
+    public static String s_strTFName = "GetLastAccessTime_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String dirName = Path.Combine(TestInfo.CurrentDirectory, "GetLastAccessTime_str_TestDir");
+            DirectoryInfo dir2;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            // [] Create a directory and check the last access time 
+
+            strLoc = "Loc_r8r7j";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dir2.Refresh();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - Directory.GetLastAccessTime(dirName)).Days != 0)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(Directory.GetLastAccessTime(dirName));
+                    Console.WriteLine((DateTime.Now - dir2.LastAccessTime).Days);
+                    printerr("Error_20hjx! Access time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14952: Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] access the directory and check the time
+
+            strLoc = "Loc_20yxc";
+
+            //dir2.GetFiles();
+            dir2.Refresh();
+            Task.Delay(1000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - Directory.GetLastAccessTime(dirName)).Days != 0)
+                {
+                    iCountErrors++;
+                    Console.WriteLine((DateTime.Now - Directory.GetLastAccessTime(dirName)).Days);
+                    printerr("Eror_209x9! LastAccessTime is way off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            dir2.Delete();
+
+            //-----------------------------------------------------------
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetLastWriteTime_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetLastWriteTime_str.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_GetLastWriteTime_str
+{
+    public static String s_strDtTmVer = "2001/02/12 17:29";
+    public static String s_strClassMethod = "Directory.GetLastWriteTime()";
+    public static String s_strTFName = "GetLastWriteTime_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String dirName = Path.Combine(TestInfo.CurrentDirectory, "GetLastWriteTime_str_TestDir");
+            DirectoryInfo dir2;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            // [] Create a directory and check the last access time 
+
+            strLoc = "Loc_r8r7j";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            //dir2.GetFileSystemInfos (dirName);
+            dir2.Refresh();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - Directory.GetLastWriteTime(dirName)).Minutes > 6)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(Directory.GetLastWriteTime(dirName));
+                    Console.WriteLine("Now:" + DateTime.Now);
+                    Console.WriteLine((DateTime.Now - Directory.GetLastWriteTime(dirName)).TotalMilliseconds);
+                    printerr("Error_20hjx! GetLastWriteTime( dirName ) time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] access the directory and check the time
+
+            strLoc = "Loc_20yxc";
+
+            //dir2.GetFiles();
+            dir2.CreateSubdirectory("Sub");
+            dir2.Refresh();
+            Task.Delay(1000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - Directory.GetLastWriteTime(dirName)).Minutes > 6)
+                {
+                    iCountErrors++;
+                    Console.WriteLine((DateTime.Now - Directory.GetLastWriteTime(dirName)).TotalMilliseconds);
+                    printerr("Eror_209x9! GetLastWriteTime( dirName ) is way off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            dir2.Delete(true);
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class Directory_GetSetTimes
+{
+    private enum TimeProperty
+    {
+        CreationTime,
+        LastAccessTime,
+        LastWriteTime
+    }
+
+    [Fact]
+    public static void ConsistencyTest()
+    {
+        String dirName = Path.Combine(TestInfo.CurrentDirectory, "Directory_GetSetTimes");
+
+        Directory.CreateDirectory(dirName);
+
+        foreach (TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
+        {
+            foreach (DateTimeKind kind in Enum.GetValues(typeof(DateTimeKind)))
+            {
+                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);
+                foreach (bool setUtc in new[] { false, true })
+                {
+                    if (setUtc)
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                Directory.SetCreationTimeUtc(dirName, dt);
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                Directory.SetLastAccessTimeUtc(dirName, dt);
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                Directory.SetLastWriteTimeUtc(dirName, dt);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                Directory.SetCreationTime(dirName, dt);
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                Directory.SetLastAccessTime(dirName, dt);
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                Directory.SetLastWriteTime(dirName, dt);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    DateTime actual, actualUtc;
+                    switch (timeProperty)
+                    {
+                        case TimeProperty.CreationTime:
+                            actual = Directory.GetCreationTime(dirName);
+                            actualUtc = Directory.GetCreationTimeUtc(dirName);
+                            break;
+                        case TimeProperty.LastAccessTime:
+                            actual = Directory.GetLastAccessTime(dirName);
+                            actualUtc = Directory.GetLastAccessTimeUtc(dirName);
+                            break;
+                        case TimeProperty.LastWriteTime:
+                            actual = Directory.GetLastWriteTime(dirName);
+                            actualUtc = Directory.GetLastWriteTimeUtc(dirName);
+                            break;
+                        default:
+                            throw new ArgumentException("Invalid time property type");
+                    }
+
+                    DateTime expected = dt.ToLocalTime();
+                    DateTime expectedUtc = dt.ToUniversalTime();
+
+                    if (dt.Kind == DateTimeKind.Unspecified)
+                    {
+                        if (setUtc)
+                        {
+                            expectedUtc = dt;
+                        }
+                        else
+                        {
+                            expected = dt;
+                        }
+                    }
+
+                    Assert.Equal(expected, actual); //, "Local {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                    Assert.Equal(expectedUtc, actualUtc); //, "Universal {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                }
+            }
+        }
+
+        Directory.Delete(dirName);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/IEnumerator_IO_EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/Directory/IEnumerator_IO_EnumerableAPIs.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace EnumerableTests
+{
+    public class Directory_IEnumeratorTests
+    {
+        private static EnumerableUtils s_utils;
+
+        [Fact]
+        public static void runTest()
+        {
+            s_utils = new EnumerableUtils();
+
+            s_utils.CreateTestDirs();
+
+            TestIEnumerator();
+            TestClone();
+
+            s_utils.DeleteTestDirs();
+
+            Assert.True(s_utils.Passed);
+        }
+
+        private static void TestIEnumerator()
+        {
+            String chkptFlag = "chkpt_ienum_";
+            int failCount = 0;
+
+            IEnumerable<String> dirs_temp = Directory.EnumerateDirectories(s_utils.testDir, "*", SearchOption.AllDirectories);
+            IEnumerator dirs = dirs_temp.GetEnumerator();
+
+            try
+            {
+                if (!dirs.MoveNext())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: MoveNext returned false. Expected some contents");
+                }
+                if (dirs.Current == null)
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: Current returned null. Expected some contents");
+                }
+
+                // Reset should throw
+                dirs.Reset();
+                failCount++;
+                Console.WriteLine(chkptFlag + "3: Reset didn't throw exception. It should have thrown NotSupportedException");
+            }
+            catch (NotSupportedException)
+            {
+            }
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "4: Unexpected exception...");
+                Console.WriteLine(e);
+            }
+            finally
+            {
+                ((IEnumerator<String>)dirs).Dispose();  // if we jump out while enumerating, the enumerator still holds the file handle
+            }
+
+
+            string testname = "IEnumerator";
+            s_utils.PrintTestStatus(testname, "EnumerateDirectories", failCount);
+        }
+
+        // This testcase hits the FSEIterator's Clone method. Ensures that 2 different enumerators are returned and quick
+        // functionality test.
+        private static void TestClone()
+        {
+            String chkptFlag = "chkpt_clone_";
+            int failCount = 0;
+
+            IEnumerable<String> dirs_temp = Directory.EnumerateDirectories(s_utils.testDir, "*", SearchOption.AllDirectories);
+            IEnumerator<String> dirs_enum_a = dirs_temp.GetEnumerator();
+
+            dirs_enum_a.MoveNext();
+            String da1 = dirs_enum_a.Current;
+            dirs_enum_a.MoveNext();
+            String da2 = dirs_enum_a.Current;
+
+            IEnumerator<String> dirs_enum_b = dirs_temp.GetEnumerator();
+            dirs_enum_b.MoveNext();
+            String db1 = dirs_enum_b.Current;
+            dirs_enum_b.MoveNext();
+            String db2 = dirs_enum_b.Current;
+
+            if (da1 != db1)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: Enumerator A's 1st element ({0}) not equal to Enumerator B's 1st element ({1})", da1, db1);
+            }
+            if (da2 != db2)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: Enumerator A's 2nd element ({0}) not equal to Enumerator B's 2nd element ({1})", da1, db1);
+            }
+            if (da1 == da2)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "3: Enumerator A's 1st and 2nd elements are the same: {0}", da1);
+            }
+
+            // if we jump out while enumerating, the enumerator still holds the file handle
+            ((IEnumerator<String>)dirs_enum_a).Dispose();
+            ((IEnumerator<String>)dirs_enum_b).Dispose();
+
+            string testname = "Clone";
+            s_utils.PrintTestStatus(testname, "EnumerateDirectories", failCount);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/Modify_FailSafe.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Modify_FailSafe.cs
@@ -1,0 +1,581 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+public class Directory_Modify_FailSafe
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    // Don't change the files array - it's used both by the 
+    // FileManipulationTest and the FileEnumeratorTest (in two different
+    // directories, of course).
+    private static String[] s_files = new String[5];
+
+    static Directory_Modify_FailSafe()
+    {
+        s_files[0] = "a.1";
+        s_files[1] = "b.1";
+        s_files[2] = "c.txt";
+        s_files[3] = "d.blah";
+        s_files[4] = "e.blah";
+    }
+
+    [Fact]
+    public static void DirectoryInfoTest()
+    {
+        const String dirName = "DirectoryInfoTestDir";
+        const String altDirName = "DirectoryInfoTestDir2";
+
+        // Clean up from any failed test run
+        if (Directory.Exists(dirName))
+            Directory.Delete(dirName, true);
+        if (Directory.Exists(altDirName))
+            Directory.Delete(altDirName, true);
+
+        DirectoryInfo di = new DirectoryInfo(dirName);
+        if (di.Exists)
+            throw new Exception("Directory exists at beginning of test!");
+        di.Create();
+        Stream s = File.Create(Path.Combine(di.Name, "foo"));
+        s.Dispose();
+        di.CreateSubdirectory("bar");
+
+        // Attributes test
+        di.Refresh();  // Reload attributes information!
+        FileAttributes attr = di.Attributes;
+        if ((attr & FileAttributes.Directory) != FileAttributes.Directory)
+            throw new Exception("Unexpected attributes on the directory - the directory bit wasn't set!  Got: " + attr);
+        // BLORF TODO: blorf write set the system attribute?
+
+        // Rename directory via the MoveTo method, the move it back.
+        di = FailSafeDirectoryOperations.MoveDirectoryInfo(di, altDirName);
+        if (Directory.Exists(dirName))
+            throw new Exception("Old directory still exists after MoveTo!");
+        if (!Directory.Exists(altDirName))
+            throw new Exception("New directory doesn't exists after MoveTo!");
+        if (!di.Exists)
+            throw new Exception("DirectoryInfo says the directory doesn't exist after first MoveTo!");
+        di = FailSafeDirectoryOperations.MoveDirectoryInfo(di, dirName);
+        if (!di.Exists)
+            throw new Exception("DirectoryInfo says the directory doesn't exist after second MoveTo!");
+
+        // Get files and directories now.
+        FileInfo[] files = di.GetFiles();
+        if (files.Length != 1)
+            throw new Exception("GetFiles should have returned just one file!  got: " + files.Length);
+        if (!"foo".Equals(files[0].Name))
+            throw new Exception("FileInfo's Name should have been foo, but was: " + files[0].Name);
+
+        DirectoryInfo[] dirs = di.GetDirectories();
+        if (dirs.Length != 1)
+            throw new Exception("GetDirectories should have returned just one dir!  got: " + dirs.Length);
+        if (!"bar".Equals(dirs[0].Name))
+            throw new Exception("DirectoryInfo's Name should have been bar, but was: " + dirs[0].Name);
+
+        FileSystemInfo[] infos = di.GetFileSystemInfos();
+        if (infos.Length != 2)
+            throw new Exception("GetFileSystemInfos should have returned 2!  got: " + infos.Length);
+        FileInfo tempFi = infos[0] as FileInfo;
+        DirectoryInfo tempDi = null;
+        if (tempFi == null)
+        {
+            tempFi = infos[1] as FileInfo;
+            tempDi = infos[0] as DirectoryInfo;
+        }
+        else
+        {
+            tempDi = infos[1] as DirectoryInfo;
+        }
+        if (!tempFi.Name.Equals("foo"))
+            throw new Exception("GetFileSystemInfo returned FileInfo with wrong name!  got: " + tempFi.Name);
+        if (!tempDi.Name.Equals("bar"))
+            throw new Exception("GetFileSystemInfo returned DirectoryInfo with wrong name!  got: " + tempDi.Name);
+
+
+        // Test DirectoryInfo.Name on something like "c:\bar\"
+        DirectoryInfo subDir = new DirectoryInfo(Path.Combine(di.Name, "bar\\"));
+        if (!subDir.Name.Equals("bar"))
+            throw new Exception("Subdirectory name was wrong.  Expected bar, Got: " + subDir.Name);
+
+        DirectoryInfo parent = subDir.Parent;
+        if (!DirNameEquals(parent.FullName, di.FullName))
+            throw new Exception("DI.FullName != SubDir.Parent.FullName!  subdir full name: " + parent.FullName);
+
+        // Check more info about the DirectoryInfo
+        String rootName = Path.GetPathRoot(Directory.GetCurrentDirectory());
+        DirectoryInfo root = di.Root;
+        if (!rootName.Equals(root.Name))
+            throw new Exception(String.Format("Root directory name was wrong!  rootName: {0}  DI.Root.Name: {1}", rootName, root.Name));
+
+        // Test DirectoryInfo behavior for "c:\"
+        DirectoryInfo c = new DirectoryInfo("c:\\");
+        if (!"c:\\".Equals(c.Name))
+            throw new Exception("DirectoryInfo name for c:\\ was wrong!  got: " + c.Name);
+        if (!"c:\\".Equals(c.FullName))
+            throw new Exception("DirectoryInfo FullName for c:\\ was wrong!  got: " + c.FullName);
+        if (null != c.Parent)
+            throw new Exception("DirectoryInfo::Parent for c:\\ is not null!");
+
+        FailSafeDirectoryOperations.DeleteDirectoryInfo(di, true);
+        di.Refresh();
+        if (di.Exists)
+            throw new Exception("Directory still exists at end of test!");
+
+        Assert.True(s_pass);
+    }
+
+    private static bool DirNameEquals(String a, String b)
+    {
+        if (a.Length > 3 && a[a.Length - 1] == Path.DirectorySeparatorChar)
+            a = a.Substring(0, a.Length - 1);
+        if (b.Length > 3 && b[b.Length - 1] == Path.DirectorySeparatorChar)
+            b = b.Substring(0, b.Length - 1);
+        return a.Equals(b);
+    }
+
+    [Fact]
+    [ActiveIssue(1220)] // SetCurrentDirectory
+    public static void FileManipulationTest()
+    {
+        String dirName = "FileManipulationTest";
+        try
+        {
+            Directory.CreateDirectory(dirName);
+        }
+        catch (IOException)
+        {
+            /*
+            if (io.ErrorCode != 183) { // Path exists
+                Console.WriteLine("Error when creating directory "+dir);
+                Console.WriteLine(io.ErrorCode);
+                throw io;
+            }
+            */
+            // assume the path exists.
+            // Clean out the directory
+            /*
+            FileEnumerator cleaner = new FileEnumerator(dir+"\\*");
+            while(cleaner.MoveNext())
+                if (!cleaner.Name.Equals(".") && !cleaner.Name.Equals(".."))
+                    cleaner.Remove();
+            cleaner.Close();
+            */
+            Directory.Delete(dirName, true);
+            Directory.CreateDirectory(dirName);
+        }
+
+        String origDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(dirName);
+        CreateTestFiles();
+        Directory.SetCurrentDirectory(origDir);
+        DirectoryInfo dir = new DirectoryInfo(dirName);
+
+        // Try getting all files.
+        FileInfo[] found = dir.GetFiles("*");
+        if (found.Length != s_files.Length)
+            throw new Exception("After creating files, num found != num created. expected: " + s_files.Length + "  got: " + found.Length);
+        for (int i = 0; i < s_files.Length; i++)
+        {
+            if (!s_files[i].Equals(found[i].Name))
+                throw new Exception("Couldn't find a file in the directory!  thought I'd get: " + s_files[i] + "  got: " + found[i]);
+        }
+
+        // Try getting a file that isn't there.
+        found = dir.GetFiles("this_file_doesnt_exist.nope");
+        if (found.Length != 0)
+            throw new Exception("Ack!  Tried to do GetFiles(non-existant file) and got something!");
+
+        // Try getting a wildcard pattern that isn't there.
+        found = dir.GetFiles("*.nope");
+        if (found.Length != 0)
+            throw new Exception("Ack!  Tried to do GetFiles(*.nope) and got something!");
+
+        // Try listing all .blah files.
+        found = dir.GetFiles("*.blah");
+        if (found.Length != 2)
+            throw new Exception("When looking for *.blah, found wrong number!  expected: 2  got: " + found.Length);
+        if (!found[0].Name.Equals(s_files[3]))
+            throw new Exception("Found[0] wasn't files[3] when listing *.blah!  got: " + found[0] + "  expected: " + s_files[3]);
+        if (!found[1].Name.Equals(s_files[4]))
+            throw new Exception("Found[1] wasn't files[4] when listing *.blah!  got: " + found[1]);
+
+        // Try listing all .txt files.
+        found = dir.GetFiles("*.txt");
+        if (found.Length != 1)
+            throw new Exception("When looking for *.txt, found wrong number!  expected: 1  got: " + found.Length);
+        if (!found[0].Name.Equals(s_files[2]))
+            throw new Exception("Found[0] wasn't files[2] when listing *.txt!  got: " + found[0]);
+
+        // Try listing all .1 files.
+        found = dir.GetFiles("*.1");
+        if (found.Length != 2)
+            throw new Exception("When looking for *.1, found wrong number!  expected: 2  got: " + found.Length);
+        if (!found[0].Name.Equals(s_files[0]))
+            throw new Exception("Found[0] wasn't files[0] when listing *.1!  got: " + found[0]);
+        if (!found[1].Name.Equals(s_files[1]))
+            throw new Exception("Found[1] wasn't files[1] when listing *.1!  got: " + found[1]);
+
+        // Try listing all c* files.
+        found = dir.GetFiles("c*");
+        if (found.Length != 1)
+            throw new Exception("When looking for c*, found wrong number!  expected: 1  got: " + found.Length);
+        if (!found[0].Name.Equals(s_files[2]))
+            throw new Exception("Found[0] wasn't files[2] when listing c*!  got: " + found[0]);
+
+        // Copy then delete a file to make sure it's gone.
+        File.Copy(dir + "\\" + s_files[0], dir.FullName + "\\newfile.new");
+        found = dir.GetFiles("new*.new");
+        if (found.Length != 1)
+            throw new Exception("Didn't find copied file!");
+        if (!found[0].Name.Equals("newfile.new"))
+            throw new Exception("Didn't find newfile.new after copy! got: " + found[0]);
+        File.Delete(Path.Combine(dirName, "newfile.new"));
+        found = dir.GetFiles("new*.new");
+        if (found.Length != 0)
+            throw new Exception("new file wasn't deleted!  " + found[0]);
+
+        String curDir = Directory.GetCurrentDirectory();
+        if (curDir == null)
+            throw new Exception("Ack! got null string from get current directory");
+        String newDir = Path.Combine(curDir, dirName); //curDir+'\\'+dirName;
+        Directory.SetCurrentDirectory(newDir);
+        if (!newDir.Equals(Directory.GetCurrentDirectory()))
+            throw new Exception("Ack!  new directory didn't equal getcwd!  " + Directory.GetCurrentDirectory());
+        if (!File.Exists(s_files[s_files.Length - 1]))
+            throw new Exception("Not in the new directory!  Couldn't find last file!");
+        Directory.SetCurrentDirectory(curDir);
+        if (!curDir.Equals(Directory.GetCurrentDirectory()))
+            throw new Exception("Ack!  old directory didn't equal getcwd!  " + Directory.GetCurrentDirectory());
+
+        Directory.SetCurrentDirectory(newDir);
+        // Test CreateDirectories on a directory tree
+        Directory.CreateDirectory("a/b/c");
+        if (!Directory.Exists("a"))
+            throw new Exception("Directory a didn't exist!");
+        if (!Directory.Exists("a/b"))
+            throw new Exception("Directory a\\b didn't exist!");
+        if (!Directory.Exists("a/b/c"))
+            throw new Exception("Directory a\\b\\c didn't exist!");
+
+        Directory.Delete("a/b/c");
+        // Test creating one directory nested under existing ones
+        Directory.CreateDirectory("a/b/c");
+        if (!Directory.Exists("a/b/c"))
+            throw new Exception("Directory a\\b\\c didn't exist!");
+
+        // Delete "a\b\c\" recursively
+        Directory.Delete("a", true);
+        if (Directory.Exists("a"))
+            throw new Exception("Directory \"a\" still exists!");
+
+        try
+        {
+            Directory.CreateDirectory(s_files[0]);
+        }
+        catch (IOException)
+        {
+            /*
+            if (e.ErrorCode != 183) { // File Exists
+                Console.WriteLine("CreateDirectories threw: "+e);
+                Console.WriteLine(e.ErrorCode);
+                throw e;
+            }
+            */
+            // Assume the path exists.
+        }
+
+        try
+        {
+            // SetCurrentDirectory on one that doesn't exist
+            Directory.SetCurrentDirectory("a/b");  // doesn't exist
+            throw new Exception("Ack!  Set Current Directory to one that doesn't exist!  should have thrown");
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+
+        // Try FileEnumerator on files[] in the test directory
+        /*
+        FileEnumerator fe = new FileEnumerator("*");
+        // Skip over . and ..
+        fe.MoveNext();
+        if (fe.Name.Equals(".") && ((fe.Attributes & FileAttributes.Directory) != 0))
+            fe.MoveNext();
+        if (!fe.Name.Equals(".."))
+            throw new Exception("Trying to skip . and .. in FileEnumerator test - not what I expected  "+fe.Name);
+        int num = 0;
+        Console.WriteLine("\tFileEnumerator Creation, Last Write, and Last Access Times and Size:");
+        while(fe.MoveNext()) {
+            if (!fe.Name.Equals(files[num]))
+                throw new Exception("FileEnumerator name wasn't what was expected!  got: "+fe.Name);
+            Console.WriteLine("\t"+fe.CreationTime+"\t"+fe.LastWriteTime+"\t"+fe.LastAccessTime+"  "+fe.Size);
+            num++;
+        }
+        if (num != files.Length)
+            throw new Exception("Files.Length wasn't equal number of files enumerated!  got: "+num+"  expected: "+files.Length);
+        if (fe.MoveNext())
+            throw new Exception("FileEnumerator GetNext returned true after enumeration finished!");
+        fe.Close();
+        */
+        Directory.SetCurrentDirectory(curDir);
+
+        // Delete files.
+        for (int i = 0; i < s_files.Length; i++)
+        {
+            File.Delete(dirName + "/" + s_files[i]);
+        }
+
+        dir.Delete();
+
+        Assert.True(s_pass);
+    }
+
+    public static void CreateTestFiles()
+    {
+        for (int i = 0; i < s_files.Length; i++)
+        {
+            Stream fs = File.Create(s_files[i]);
+            BinaryWriter bw = new BinaryWriter(fs);
+            bw.Write(s_files[i]);
+            bw.Dispose();
+        }
+    }
+
+    [Fact]
+    public static void CreateDirTest()
+    {
+        String dir = "CreateDirTest";
+
+        try
+        {
+            Directory.Delete(dir);
+        }
+        catch (IOException) { }
+
+        Directory.CreateDirectory(dir);
+
+
+        Directory.Delete(dir);
+
+        Assert.True(s_pass);
+    }
+
+    [Fact]
+    public static void DeleteDirTest()
+    {
+        String dir = "DeleteDirTest";
+
+        try
+        {
+            Directory.CreateDirectory(dir);
+        }
+        catch (IOException)
+        {
+        }
+
+
+        try
+        {
+            Directory.Delete(dir);
+            Stream f = File.Create(dir);
+            f.Dispose();
+            File.Delete(dir);
+        }
+        catch (IOException io)
+        {
+            Console.WriteLine("File name: \"" + dir + '\"');
+            Console.WriteLine("caught IOException when trying to delete the dir then open file");
+            Console.WriteLine(io);
+            Console.WriteLine(io.StackTrace);
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine("Got unexpected exception from Delete or surrounding code: " + e);
+            Console.WriteLine(e.StackTrace);
+            throw;
+        }
+
+        Assert.True(s_pass);
+    }
+
+    [Fact]
+    [ActiveIssue(1220)] // SetCurrentDirectory
+    public static void GetSubdirectoriesTest()
+    {
+        String testDir = "GetSubdirectoriesTempDir";
+        if (Directory.Exists("." + Path.DirectorySeparatorChar + testDir))
+        {
+            Console.WriteLine("Test didn't clean up right, trying to delete directory \"" + testDir + "\"");
+            try
+            {
+                Directory.Delete(testDir);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Ack!  Test couldn't clean up after itself.  Delete .\\\"" + testDir + "\"");
+                throw;
+            }
+        }
+
+        String oldDirectory = Directory.GetCurrentDirectory();
+        Directory.CreateDirectory(testDir);
+        Directory.SetCurrentDirectory(testDir);
+
+        DirectoryInfo current = new DirectoryInfo(".");
+        Directory.CreateDirectory("a1");
+        Directory.CreateDirectory("a2");
+        current.CreateSubdirectory("b1");
+        Directory.CreateDirectory("b2");
+        Stream junk = File.Create("c1");
+        junk.Dispose();
+
+        try
+        {
+            DirectoryInfo[] dirs = current.GetDirectories("*");
+            if (dirs == null)
+                throw new Exception("Directory Names array was NULL!");
+            /*
+            Console.WriteLine("Directory names: ");
+            for(int i=0; i<dirs.Length; i++)
+                Console.WriteLine(dirs[i]);
+            */
+
+            if (dirs.Length != 4)  // 4 directories + "." & ".." ( looks like . and .. are not returned )
+                throw new Exception("Directory names array should have been length 4!  was: " + dirs.Length);
+
+            // Now try wildcards, such as "*1" and "a*"
+            dirs = current.GetDirectories("*1");
+            if (dirs.Length != 2)
+                throw new Exception("Directory names array should have been length 2 when asking for \"*1\", but was: " + dirs.Length);
+
+            dirs = current.GetDirectories("a*");
+            if (dirs.Length != 2)
+                throw new Exception("Directory names array should have been length 2 after looking for \"a*\", but was: " + dirs.Length);
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("Error in GetDirectoryNamesTest - throwing an exception");
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                Console.Out.Flush();
+                Directory.Delete("a1");
+                Directory.Delete("a2");
+                Directory.Delete("b1");
+                Directory.Delete("b2");
+                File.Delete("c1");
+                Directory.SetCurrentDirectory(oldDirectory);
+                //Directory.Delete(testDir);
+                current.Delete(false);  // We've deleted everything else, it should clean up fine.
+            }
+            catch (Exception ex)
+            {
+                Console.Write("Ran into error cleaning up GetDirectoriesTest... {0}", ex.ToString());
+                throw;
+            }
+        }
+
+        Assert.True(s_pass);
+    }
+
+    private void DeleteFile(String fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //A short cut API that doesn't need to repeat the error 
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+        {
+            String value = String.Format("{0} Expected: {1}, Actual: {2}", errorMsg, (null == expected ? "<null>" : expected.ToString()), (null == actual ? "<null>" : actual.ToString()));
+            Eval(retValue, value);
+        }
+
+        return retValue;
+    }
+
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error, params Object[] values)
+    {
+        CheckException<E>(test, error, null, values);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected, params Object[] values)
+    {
+        bool exception = false;
+        String exErrMsg = String.Format(error, values);
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", exErrMsg);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", exErrMsg, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", exErrMsg, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+
+
+    //Checks for a 2 types of exceptions
+    private static void CheckException<E, V>(ExceptionCode test, string error)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E) || e.GetType() == typeof(V))
+            {
+                exception = true;
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
@@ -1,0 +1,420 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Move_str_str
+{
+    public static String s_strDtTmVer = "2000/07/12 10:42";
+    public static String s_strClassMethod = "Directory.Move(String,String)";
+    public static String s_strTFName = "Move_str_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String tempDirName = Path.Combine(TestInfo.CurrentDirectory, "TempDirectory");
+            String dirName = Path.Combine(TestInfo.CurrentDirectory, "Move_str_str_test_Dir");
+            DirectoryInfo dir2 = null;
+
+            if (Directory.Exists(tempDirName))
+                Directory.Delete(tempDirName, true);
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Argumentnull exception for null arguments
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00001";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(null, dirName);
+                iCountErrors++;
+                printerr("Error_00002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00004! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(dirName, null);
+                iCountErrors++;
+                printerr("Error_00005! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00007! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for zero length arguments
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00008";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(String.Empty, dirName);
+                iCountErrors++;
+                printerr("Error_00008! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00010! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(dirName, String.Empty);
+                iCountErrors++;
+                printerr("Error_00011! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00013! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] Try to move a directory that does not exist
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00014";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(Path.Combine(TestInfo.CurrentDirectory, "NonExistentDirectory"), dirName);
+                iCountErrors++;
+                printerr("Error_00015! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00017! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] AccessException when moving onto existing directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00018";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(TestInfo.CurrentDirectory, TestInfo.CurrentDirectory);
+                iCountErrors++;
+                printerr("Error_00019! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00021! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] Move a directory and check that it is moved
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00022";
+
+            Directory.CreateDirectory(dirName);
+            Directory.Move(dirName, tempDirName);
+            iCountTestcases++;
+            if (Directory.Exists(dirName))
+            {
+                iCountErrors++;
+                printerr("Error_00023! Source directory still there");
+            }
+            if (!Directory.Exists(tempDirName))
+            {
+                iCountErrors++;
+                printerr("Error_00024! destination directory missing");
+            }
+            Directory.Delete(tempDirName);
+
+            //[]Move directories that end with directory separator
+            //-----------------------------------------------------------------
+
+            Directory.CreateDirectory(dirName);
+            Directory.Move(dirName + "\\", tempDirName + "\\");
+            iCountTestcases++;
+            if (Directory.Exists(dirName))
+            {
+                iCountErrors++;
+                printerr("Error_00023! Source directory still there");
+            }
+            if (!Directory.Exists(tempDirName))
+            {
+                iCountErrors++;
+                printerr("Error_00024! destination directory missing");
+            }
+            Directory.Delete(tempDirName);
+
+#if !TEST_WINRT
+            // [] Move to different drive will throw AccessException
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00025";
+            string fullDirName = Path.GetFullPath(dirName);
+            Directory.CreateDirectory(dirName);
+            iCountTestcases++;
+            try
+            {
+                if (fullDirName.Substring(0, 3) == @"d:\" || fullDirName.Substring(0, 3) == @"D:\")
+                    Directory.Move(fullDirName, "C:\\TempDirectory");
+                else
+                    Directory.Move(fullDirName, "D:\\TempDirectory");
+                Console.WriteLine("Root directory..." + fullDirName.Substring(0, 3));
+                iCountErrors++;
+                printerr("Error_00026! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00000! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            if (Directory.Exists(fullDirName))
+                Directory.Delete(fullDirName, true);
+            //-----------------------------------------------------------------
+#endif
+
+            // [] Moving Directory with subdirectories
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00028";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dir2.CreateSubdirectory("SubDir\\SubSubDir");
+            FailSafeDirectoryOperations.MoveDirectory(dirName, tempDirName);
+            //			Directory.Move(dirName, tempDirName);
+            iCountTestcases++;
+            if (Directory.Exists(dirName))
+            {
+                iCountErrors++;
+                printerr("Error_00029! Source directory still there");
+            }
+            dir2 = new DirectoryInfo(tempDirName);
+            iCountTestcases++;
+            if (!Directory.Exists(dir2.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_00030! Destination directory missing");
+            }
+            iCountTestcases++;
+            if (!Directory.Exists(dir2.FullName + "\\SubDir\\SubSubDir"))
+            {
+                iCountErrors++;
+                printerr("Error_00031! Subdirectories not moved");
+            }
+            dir2.Delete(true);
+
+            //-----------------------------------------------------------------
+
+            // [] wildchars in src directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00032";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move("*", tempDirName);
+                iCountErrors++;
+                printerr("Error_00033! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00035! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] wildchars in dest directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00036";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(TestInfo.CurrentDirectory, "Temp*");
+                iCountErrors++;
+                printerr("Error_00037! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00039! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] InvalidPathChars
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00040";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(TestInfo.CurrentDirectory, "<MyDirectory>");
+                iCountErrors++;
+                printerr("Error_00041! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00043 Incorret exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] PathTooLongException if destination name is too long
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00044";
+
+            String str = "";
+            for (int i = 0; i < 250; i++)
+                str += "a";
+            iCountTestcases++;
+            try
+            {
+                Directory.Move(TestInfo.CurrentDirectory, str);
+                iCountErrors++;
+                printerr("Error_00045! Expected exception not thrown");
+            }
+            catch (PathTooLongException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00047! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] Non-existent drive specified for destination
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00048";
+
+            iCountTestcases++;
+            Directory.CreateDirectory(dirName);
+            try
+            {
+                Directory.Move(dirName, "X:\\Temp");
+                iCountErrors++;
+                printerr("Error_00049! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00051! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            Directory.Delete(dirName);
+            //-----------------------------------------------------------------
+
+            // [] Use directory names with spaces
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00052";
+            string destDirName = Path.Combine(TestInfo.CurrentDirectory, "This is my directory");
+
+            Directory.CreateDirectory(dirName);
+            Directory.Move(dirName, destDirName);
+            iCountTestcases++;
+            if (!Directory.Exists(destDirName))
+            {
+                iCountErrors++;
+                printerr("Error_00053! Destination directory missing");
+            }
+            Directory.Delete(destDirName);
+            //-----------------------------------------------------------------
+
+
+            // ][ Directory names in different cultures
+            //-----------------------------------------------------------------
+            //-----------------------------------------------------------------
+
+            if (Directory.Exists(tempDirName))
+                Directory.Delete(tempDirName, true);
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
@@ -1,0 +1,435 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+This testcase attempts to checks GetDirectories/GetFiles with the following ReparsePoint implementations
+ - Mount Volumes
+**/
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
+
+public class Directory_ReparsePoints_MountVolume
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    [ActiveIssue(1221)]
+    public static void runTest()
+    {
+        try
+        {
+            Stopwatch watch;
+
+            const String MountPrefixName = "LaksMount";
+
+            String mountedDirName;
+            String dirNameWithoutRoot;
+            String dirNameReferedFromMountedDrive;
+            String dirName;
+            String[] expectedFiles;
+            String[] files;
+            String[] expectedDirs;
+            String[] dirs;
+            List<String> list;
+
+            watch = new Stopwatch();
+            watch.Start();
+            try
+            {
+                //Scenario 1: Vanilla - Different drive is mounted on the current drive
+                Console.WriteLine("Scenario 1 - Vanilla: Different drive is mounted on the current drive: {0}", watch.Elapsed);
+
+                string otherDriveInMachine = IOServices.GetNtfsDriveOtherThanCurrent();
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS() && otherDriveInMachine != null)
+                {
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    try
+                    {
+                        Console.WriteLine("Creating directory " + mountedDirName);
+                        Directory.CreateDirectory(mountedDirName);
+                        MountHelper.Mount(otherDriveInMachine.Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(otherDriveInMachine, ManageFileSystem.DirPrefixName);
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+
+                            //Files
+                            expectedFiles = fileManager.GetAllFiles();
+                            list = new List<String>();
+                            //We will only test the filenames since they are unique
+                            foreach (String file in expectedFiles)
+                                list.Add(Path.GetFileName(file));
+                            files = Directory.GetFiles(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(files.Length == list.Count, "Err_3947g! wrong count");
+                            for (int i = 0; i < expectedFiles.Length; i++)
+                            {
+                                if (Eval(list.Contains(Path.GetFileName(files[i])), "Err_582bmw! No file found: {0}", files[i]))
+                                    list.Remove(Path.GetFileName(files[i]));
+                            }
+                            if (!Eval(list.Count == 0, "Err_891vut! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String fileName in list)
+                                    Console.WriteLine(fileName);
+                            }
+
+                            //Directories
+                            expectedDirs = fileManager.GetAllDirectories();
+                            list = new List<String>();
+                            foreach (String dir in expectedDirs)
+                                list.Add(dir.Substring(dirName.Length));
+                            dirs = Directory.GetDirectories(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(dirs.Length == list.Count, "Err_813weq! wrong count");
+                            for (int i = 0; i < dirs.Length; i++)
+                            {
+                                string exDir = dirs[i].Substring(dirNameReferedFromMountedDrive.Length);
+                                if (Eval(list.Contains(exDir), "Err_287kkm! No file found: {0}", exDir))
+                                    list.Remove(exDir);
+                            }
+                            if (!Eval(list.Count == 0, "Err_921mhs! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String value in list)
+                                    Console.WriteLine(value);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Skipping since drive is not NTFS and there is no other drive on the machine");
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_768lme! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 2: Current drive is mounted on a different drive
+            Console.WriteLine(Environment.NewLine + "Scenario 2 - Current drive is mounted on a different drive: {0}", watch.Elapsed);
+            try
+            {
+                string otherDriveInMachine = IOServices.GetNtfsDriveOtherThanCurrent();
+                if (otherDriveInMachine != null)
+                {
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(otherDriveInMachine.Substring(0, 3), MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            //Files
+                            expectedFiles = fileManager.GetAllFiles();
+                            list = new List<String>();
+                            //We will only test the filenames since they are unique
+                            foreach (String file in expectedFiles)
+                                list.Add(Path.GetFileName(file));
+                            files = Directory.GetFiles(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(files.Length == list.Count, "Err_689myg! wrong count");
+                            for (int i = 0; i < expectedFiles.Length; i++)
+                            {
+                                if (Eval(list.Contains(Path.GetFileName(files[i])), "Err_894vhm! No file found: {0}", files[i]))
+                                    list.Remove(Path.GetFileName(files[i]));
+                            }
+                            if (!Eval(list.Count == 0, "Err_952qkj! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String fileName in list)
+                                    Console.WriteLine(fileName);
+                            }
+
+                            //Directories
+                            expectedDirs = fileManager.GetAllDirectories();
+                            list = new List<String>();
+                            foreach (String dir in expectedDirs)
+                                list.Add(dir.Substring(dirName.Length));
+                            dirs = Directory.GetDirectories(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(dirs.Length == list.Count, "Err_154vrz! wrong count");
+                            for (int i = 0; i < dirs.Length; i++)
+                            {
+                                string exDir = dirs[i].Substring(dirNameReferedFromMountedDrive.Length);
+                                if (Eval(list.Contains(exDir), "Err_301sao! No file found: {0}", exDir))
+                                    list.Remove(exDir);
+                            }
+                            if (!Eval(list.Count == 0, "Err_630gjj! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String value in list)
+                                    Console.WriteLine(value);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Skipping since drive is not NTFS and there is no other drive on the machine");
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_231vwf! Exception caught in scenario: {0}", ex);
+            }
+
+            //scenario 3.1: Current drive is mounted on current drive
+            Console.WriteLine(Environment.NewLine + "Scenario 3.1 - Current drive is mounted on current drive: {0}", watch.Elapsed);
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            //Files
+                            expectedFiles = fileManager.GetAllFiles();
+                            list = new List<String>();
+                            //We will only test the filenames since they are unique
+                            foreach (String file in expectedFiles)
+                                list.Add(Path.GetFileName(file));
+                            files = Directory.GetFiles(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(files.Length == list.Count, "Err_213fuo! wrong count");
+                            for (int i = 0; i < expectedFiles.Length; i++)
+                            {
+                                if (Eval(list.Contains(Path.GetFileName(files[i])), "Err_499oxz! No file found: {0}", files[i]))
+                                    list.Remove(Path.GetFileName(files[i]));
+                            }
+                            if (!Eval(list.Count == 0, "Err_301gtz! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String fileName in list)
+                                    Console.WriteLine(fileName);
+                            }
+
+                            //Directories
+                            expectedDirs = fileManager.GetAllDirectories();
+                            list = new List<String>();
+                            foreach (String dir in expectedDirs)
+                                list.Add(dir.Substring(dirName.Length));
+                            dirs = Directory.GetDirectories(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(dirs.Length == list.Count, "Err_771dxv! wrong count");
+                            for (int i = 0; i < dirs.Length; i++)
+                            {
+                                string exDir = dirs[i].Substring(dirNameReferedFromMountedDrive.Length);
+                                if (Eval(list.Contains(exDir), "Err_315jey! No file found: {0}", exDir))
+                                    list.Remove(exDir);
+                            }
+                            if (!Eval(list.Count == 0, "Err_424opm! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String value in list)
+                                    Console.WriteLine(value);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Drive is not NTFS. Skipping scenario");
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_493ojg! Exception caught in scenario: {0}", ex);
+            }
+
+            //scenario 3.2: Current drive is mounted on current directory
+            Console.WriteLine(Environment.NewLine + "Scenario 3.2 - Current drive is mounted on current directory: {0}", watch.Elapsed);
+            try
+            {
+                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                {
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), MountPrefixName));
+                    try
+                    {
+                        Directory.CreateDirectory(mountedDirName);
+                        MountHelper.Mount(Directory.GetCurrentDirectory().Substring(0, 2), mountedDirName);
+
+                        dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                        using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                        {
+                            dirNameWithoutRoot = dirName.Substring(3);
+                            dirNameReferedFromMountedDrive = Path.Combine(mountedDirName, dirNameWithoutRoot);
+                            //Files
+                            expectedFiles = fileManager.GetAllFiles();
+                            list = new List<String>();
+                            //We will only test the filenames since they are unique
+                            foreach (String file in expectedFiles)
+                                list.Add(Path.GetFileName(file));
+                            files = Directory.GetFiles(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(files.Length == list.Count, "Err_253yit! wrong count");
+                            for (int i = 0; i < expectedFiles.Length; i++)
+                            {
+                                if (Eval(list.Contains(Path.GetFileName(files[i])), "Err_798mjs! No file found: {0}", files[i]))
+                                    list.Remove(Path.GetFileName(files[i]));
+                            }
+                            if (!Eval(list.Count == 0, "Err_141lgl! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String fileName in list)
+                                    Console.WriteLine(fileName);
+                            }
+
+                            //Directories
+                            expectedDirs = fileManager.GetAllDirectories();
+                            list = new List<String>();
+                            foreach (String dir in expectedDirs)
+                                list.Add(dir.Substring(dirName.Length));
+                            dirs = Directory.GetDirectories(dirNameReferedFromMountedDrive, "*.*", SearchOption.AllDirectories);
+                            Eval(dirs.Length == list.Count, "Err_512oxq! wrong count");
+                            for (int i = 0; i < dirs.Length; i++)
+                            {
+                                string exDir = dirs[i].Substring(dirNameReferedFromMountedDrive.Length);
+                                if (Eval(list.Contains(exDir), "Err_907zbr! No file found: {0}", exDir))
+                                    list.Remove(exDir);
+                            }
+                            if (!Eval(list.Count == 0, "Err_574raf! wrong count: {0}", list.Count))
+                            {
+                                Console.WriteLine();
+                                foreach (String value in list)
+                                    Console.WriteLine(value);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        MountHelper.Unmount(mountedDirName);
+                        DeleteDir(mountedDirName, true);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Drive is not NTFS. Skipping scenario");
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_432qcp! Exception caught in scenario: {0}", ex);
+            }
+
+            Console.WriteLine("Completed {0}", watch.Elapsed);
+        }
+        catch (Exception ex)
+        {
+            s_pass = false;
+            Console.WriteLine("Err_234rsgf! Uncaught exception in RunTest: {0}", ex);
+        }
+
+        Assert.True(s_pass);
+    }
+
+    private static void DeleteFile(String fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+    private static void DeleteDir(String fileName, bool sub)
+    {
+        if (Directory.Exists(fileName))
+            Directory.Delete(fileName, sub);
+    }
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+}
+
+
+
+
+

--- a/src/System.IO.FileSystem/tests/Directory/SetCreationTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetCreationTime_str_dt.cs
@@ -1,0 +1,301 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_SetCreationTime_str_dt
+{
+    public static String s_strDtTmVer = "2001/02/12 17.04";
+    public static String s_strClassMethod = "Directory.GetCreationTime()";
+    public static String s_strTFName = "SetCreationTime_str_dt.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    public static void EnsureDirectoryDeletion(string directoryPath)
+    {
+        if (Directory.Exists(directoryPath))
+            Directory.Delete(directoryPath, true);
+        int i = 5000;
+        while (Directory.Exists(directoryPath) && i > 0)
+        {
+            Task.Delay(500).Wait(); // Allow some time for file system to settle down
+            i -= 500;
+        }
+        if (Directory.Exists(directoryPath))
+            throw new Exception("Directory still exists");
+    }
+    public static void EnsureDirectoryCreation(string directoryPath)
+    {
+        if (!Directory.Exists(directoryPath))
+            Directory.CreateDirectory(directoryPath);
+        int i = 5000;
+        while (!Directory.Exists(directoryPath) && i > 0)
+        {
+            Task.Delay(500).Wait(); // Allow some time for file system to settle down
+            i -= 500;
+        }
+        if (!Directory.Exists(directoryPath))
+            throw new Exception("Directory does not exists");
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String directoryName = "SetCreationTime_str_dt_TestDirectory";
+
+            // [] With null string
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(null, DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exception thrown: " + exc.ToString());
+            }
+
+            // [] With an empty string.
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime("", DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exception thrown: " + exc.ToString());
+            }
+
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Today);
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Now.AddYears(1));
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now.AddYears(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Now.AddYears(-1));
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now.AddYears(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Now.AddMonths(1));
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now.AddMonths(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Now.AddMonths(-1));
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now.AddMonths(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Now.AddDays(1));
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now.AddDays(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, DateTime.Now.AddDays(-1));
+                if ((Directory.GetCreationTime(directoryName) - DateTime.Now.AddDays(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCreationTime(directoryName, new DateTime(2001, 332, 20, 50, 50, 50));
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+
+            EnsureDirectoryCreation(directoryName);
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                Directory.SetCreationTime(directoryName, dt);
+                if ((Directory.GetCreationTime(directoryName) - dt).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exception thrown: " + exc.ToString());
+            }
+            EnsureDirectoryDeletion(directoryName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_0100!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_Co5736SetCurrentDirectory_dir
+{
+    public static String s_strDtTmVer = "2000/07/07 19:00";
+    public static String s_strClassMethod = "Directory.SetCurrentDirectory(Directory)";
+    public static String s_strTFName = "set_SetCurrentDirectory_dir.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [ActiveIssue(1220)] // SetCurrentDirectory
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir = null;
+            DirectoryInfo currentdir = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+            //Code coverage
+            try
+            {
+                Directory.SetCurrentDirectory(new String('a', 1000));
+                iCountErrors++;
+                Console.WriteLine("Err_34tgs! No exception thrown");
+            }
+            catch (PathTooLongException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34tgs! No exception thrown: {0}", ex);
+            }
+
+
+            // [] ArgumentNullException for null argument
+
+            strLoc = "Loc_23849";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.SetCurrentDirectory(null);
+                iCountErrors++;
+                printerr("Error_388rf! Expected exception not thrown, dir==" + Directory.GetCurrentDirectory());
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28t7b! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] Vanilla case
+
+            strLoc = "Loc_2g77b";
+
+            Directory.SetCurrentDirectory("..");
+            dir = new DirectoryInfo(".");
+            iCountTestcases++;
+            if (!Directory.GetCurrentDirectory().Equals(dir.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_38g8b! Directory Not set correctly");
+            }
+
+
+            // [] Another vanilla case
+
+            strLoc = "Loc_9t8gt";
+
+            dir = new DirectoryInfo("c:\\");
+            Directory.SetCurrentDirectory("c:\\");
+            iCountTestcases++;
+            if (!Directory.GetCurrentDirectory().Equals(dir.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_238g7! Directory not set correctly, dir==" + Directory.GetCurrentDirectory());
+            }
+
+
+            // [] Set back to original
+
+            strLoc = "Loc_87ygv";
+
+            Directory.SetCurrentDirectory(currentdir.FullName);
+            iCountTestcases++;
+            if (!Directory.GetCurrentDirectory().Equals(currentdir.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_2g7b7! Directory not set correctly, dir==" + Directory.GetCurrentDirectory());
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/Directory/SetLastAccessTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetLastAccessTime_str_dt.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_SetLastAccessTime_str_dt
+{
+    public static String s_strDtTmVer = "2001/02/12 17.04";
+    public static String s_strClassMethod = "Directory.SetLastAccessTime()";
+    public static String s_strTFName = "SetLastAccessTime_str_dt.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = "SetLastAccessTime_str_dt_test_TestDirectory";
+
+            // [] With null string
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(null, DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] With an empty string.
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime("", DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            DirectoryInfo dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Today);
+                if ((Directory.GetLastAccessTime(fileName) - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Now.AddYears(1));
+                if ((Directory.GetLastAccessTime(fileName) - DateTime.Now.AddYears(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Now.AddYears(-1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddYears(-1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Now.AddMonths(1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Now.AddMonths(-1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Now.AddDays(1));
+                if ((Directory.GetLastAccessTime(fileName) - DateTime.Now.AddDays(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, DateTime.Now.AddDays(-1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastAccessTime(fileName, new DateTime(2001, 332, 20, 50, 50, 50));
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                Directory.SetLastAccessTime(fileName, dt);
+                if ((Directory.GetLastAccessTime(fileName) - dt).Seconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_0100!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+

--- a/src/System.IO.FileSystem/tests/Directory/SetLastWriteTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetLastWriteTime_str_dt.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Directory_SetLastWriteTime_str_dt
+{
+    public static String s_strDtTmVer = "2001/02/12 17.04";
+    public static String s_strClassMethod = "Directory.SetLastWriteTime()";
+    public static String s_strTFName = "SetLastWriteTime_str_dt.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = "SetLastWriteTime_str_dt_test_TestDirectory";
+
+            // [] With null string
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(null, DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] With an empty string.
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime("", DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            DirectoryInfo dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Today);
+                if ((Directory.GetLastWriteTime(fileName) - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Now.AddYears(1));
+                int iSeconds = (Directory.GetLastWriteTime(fileName) - DateTime.Now.AddYears(1)).Seconds;
+                if (iSeconds > 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Error_0010! Creation time cannot be correct, Expected....(<2), Actual....{0}", iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Now.AddYears(-1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Now.AddMonths(1));
+                int iSeconds = (Directory.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(1)).Seconds;
+                if (iSeconds > 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Error_0016! Creation time cannot be correct, Expected....(<2), Actual....{0}", iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Now.AddMonths(-1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Now.AddDays(1));
+                int iSeconds = (Directory.GetLastWriteTime(fileName) - DateTime.Now.AddDays(1)).Seconds;
+                if (iSeconds > 2)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Error_0022! Creation time cannot be correct, Expected....(<2), Actual....{0}", iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, DateTime.Now.AddDays(-1));
+                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds;
+                if (iSeconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct" + iSeconds);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                Directory.SetLastWriteTime(fileName, new DateTime(2001, 332, 20, 50, 50, 50));
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                Directory.SetLastWriteTime(fileName, dt);
+                if ((Directory.GetLastWriteTime(fileName) - dt).Seconds > 60)
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            printerr("Error Err_0100!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    public partial class DirectoryInfo_Create : FileSystemTest
+    {
+        [Fact]
+        public void CreateCurrentDirectory()
+        {
+            DirectoryInfo dir = new DirectoryInfo(Path.Combine(TestDirectory, "."));
+            dir.Create();
+            Assert.Equal(dir.FullName, TestDirectory);
+        }
+
+        [Fact]
+        public void CreateCurrentDirectoryWithRelativeTraversal()
+        {
+            DirectoryInfo dir = new DirectoryInfo(Path.Combine(TestDirectory, "abc\\xyz\\..\\.."));
+            dir.Create();
+            Assert.Equal(dir.FullName, TestDirectory);
+        }
+
+        [Fact]
+        public void MultipleTabCharacters()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo("\t\t\t\t"));
+        }
+
+        [Fact]
+        public void ValidDirectoryName()
+        {
+            string dirName = Path.Combine(TestDirectory, Path.GetRandomFileName());
+            DirectoryInfo dir = new DirectoryInfo(dirName);
+            dir.Create();
+            Assert.Equal(dir.Name, Path.GetFileName(dirName));
+        }
+
+        [Fact]
+        public void DirectoryAlreadyExists()
+        {
+            DirectoryInfo dir = new DirectoryInfo(TestDirectory);
+            dir.Create();
+            Assert.Equal(dir.FullName, TestDirectory);
+        }
+
+        [Fact]
+        public void PathTooLong()
+        {
+            StringBuilder sb = new StringBuilder(TestDirectory);
+            while (sb.Length < 259)
+            {
+                sb.Append("a");
+            }
+
+            DirectoryInfo dir = new DirectoryInfo(sb.ToString());
+
+            Assert.Throws<PathTooLongException>(() => dir.Create());
+        }
+
+        [Fact]
+        public void PathJustTooLong()
+        {
+            StringBuilder sb = new StringBuilder(TestDirectory + "\\");
+            while (sb.Length < 248)
+            {
+                sb.Append("a");
+            }
+
+            DirectoryInfo dir = new DirectoryInfo(sb.ToString());
+
+            Assert.Throws<PathTooLongException>(() => dir.Create());
+        }
+
+        [Fact]
+        public void PathJustShortEnough()
+        {
+            StringBuilder sb = new StringBuilder(TestDirectory + "\\");
+            while (sb.Length < 247)
+            {
+                sb.Append("a");
+            }
+
+            DirectoryInfo dir = new DirectoryInfo(sb.ToString());
+            dir.Create();
+
+            Assert.Equal(dir.FullName, sb.ToString());
+        }
+
+        [Fact]
+        public void AllowedSymbols()
+        {
+            string dirName = Path.Combine(TestDirectory, "!@#$%^&");
+            DirectoryInfo dir = new DirectoryInfo(dirName);
+            dir.Create();
+
+            Assert.Equal(dir.FullName, dirName);
+        }
+
+        [Fact]
+        public void CreateMultipleSubdirectories()
+        {
+            string dirName = Path.Combine(TestDirectory, "Test", "Test", "Test");
+            DirectoryInfo dir = new DirectoryInfo(dirName);
+            dir.Create();
+
+            Assert.Equal(dir.FullName, dirName);
+        }
+
+        [Fact]
+        public void CreateColon()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(":"));
+        }
+
+        [Fact]
+        public void WithRelativeDirectoryInMiddle()
+        {
+            string dirName = Path.Combine(TestDirectory, Path.GetRandomFileName(), "..", "TestDir");
+            DirectoryInfo dir = new DirectoryInfo(dirName);
+            dir.Create();
+            dir.Delete(true);
+        }
+
+
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    public partial class DirectoryInfo_CreateSubdirectory_str : FileSystemTest
+    {
+        [Fact]
+        public void NullArgument()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DirectoryInfo(".").CreateSubdirectory(null));
+        }
+
+        [Fact]
+        public void EmptyStringArgument()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(".").CreateSubdirectory(String.Empty));
+        }
+
+        [Fact]
+        [ActiveIssue(1222)]
+        public void Spaces()
+        {
+            string subDir = "         ";
+            DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(subDir);
+            Assert.Equal(dir.FullName, Path.Combine(TestDirectory, subDir));
+        }
+
+        [Fact]
+        public void Tab()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory("\t"));
+        }
+
+        [Fact]
+        public void CurrentDirectory()
+        {
+            Assert.Equal(
+                new DirectoryInfo(TestDirectory).CreateSubdirectory(".").FullName,
+                TestDirectory);
+        }
+
+        [Fact]
+        public void ParentDirectory()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(".."));
+        }
+
+        [Fact]
+        public void PathTooLong()
+        {
+            StringBuilder sb = new StringBuilder();
+            while (sb.Length + TestDirectory.Count() + 1 < 259)
+                sb.Append("a");
+
+            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(sb.ToString()));
+        }
+
+        [Fact]
+        public void PathJustTooLong()
+        {
+            StringBuilder sb = new StringBuilder();
+            while (sb.Length + TestDirectory.Count() + 1 < 248)
+                sb.Append("a");
+
+            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(sb.ToString()));
+        }
+
+        [Fact]
+        public void PathJustShortEnough()
+        {
+            StringBuilder sb = new StringBuilder();
+            while (sb.Length + TestDirectory.Count() + 1 < 247)
+                sb.Append("a");
+
+            DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(sb.ToString());
+
+            Assert.Equal(dir.FullName, Path.Combine(TestDirectory, sb.ToString()));
+        }
+
+        [Fact]
+        public void Symbols()
+        {
+            string subdirName = "!@#$%^&";
+
+            DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(subdirName);
+
+            Assert.Equal(dir.FullName, Path.Combine(TestDirectory, subdirName));
+        }
+
+        [Fact]
+        public void RegularDirectory()
+        {
+            string subdirName = "TestDirectory";
+
+            DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(subdirName);
+
+            Assert.Equal(dir.FullName, Path.Combine(TestDirectory, subdirName));
+        }
+
+        [Fact]
+        public void MultipleNewDirectories()
+        {
+            string subdirName = "Test\\Test\\Test";
+
+            DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(subdirName);
+
+            Assert.Equal(dir.FullName, Path.Combine(TestDirectory, subdirName));
+        }
+
+        [Fact]
+        public void Colon()
+        {
+            string[] subdirNames = { ":", ":t", ":test", "te:", "test:", "te:st" };
+
+            foreach (string subdirName in subdirNames)
+            {
+                Assert.Throws<NotSupportedException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(subdirName));
+            }
+        }
+
+        [Fact]
+        public void NetworkName()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory("\\\\contoso\\amusement\\device"));
+        }
+
+        [Fact]
+        [ActiveIssue(1222)]
+        public void DotDot()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(Path.Combine(TestDirectory, "scratch")).CreateSubdirectory(Path.Combine("..", "scratch2")));
+        }
+
+        [Fact]
+        public void LotsOfForwardSlashes()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(".").CreateSubdirectory("////////"));
+        }
+
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Delete.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Delete.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    public partial class DirectoryInfo_Delete : FileSystemTest
+    {
+        [Fact]
+        [ActiveIssue(1223)]
+        public void RegularDirectory()
+        {
+            DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(TestDirectory, Path.GetRandomFileName()));
+
+            Assert.True(dir.Exists);
+
+            dir.Delete();
+
+            Assert.False(dir.Exists);
+        }
+
+        [Fact]
+        public void NonEmptyDirectory()
+        {
+            string dirName = "NonEmptyDirectory";
+            string subDirName = "ExtraDir";
+            Directory.CreateDirectory(Path.Combine(TestDirectory, dirName, subDirName));
+
+            Assert.Throws<IOException>(() => new DirectoryInfo(Path.Combine(TestDirectory, dirName)).Delete());
+
+            new DirectoryInfo(Path.Combine(TestDirectory, dirName, subDirName)).Delete();
+            new DirectoryInfo(Path.Combine(TestDirectory, dirName)).Delete();
+            Assert.False(new DirectoryInfo(Path.Combine(TestDirectory, dirName)).Exists);
+        }
+
+        [Fact]
+        public void DeleteRoot()
+        {
+            Assert.Throws<IOException>(() => new DirectoryInfo("C:\\").Delete());
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Delete_bool.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Delete_bool.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    public partial class DirectoryInfo_Delete_bool : FileSystemTest
+    {
+        [Fact]
+        public void Dot()
+        {
+            Assert.Throws<IOException>(() => new DirectoryInfo(".").Delete(false));
+        }
+
+        [Fact]
+        public void DoesNotExist_false()
+        {
+            Assert.Throws<DirectoryNotFoundException>(() => new DirectoryInfo("ThisDoesNotExist").Delete(false));
+        }
+
+        [Fact]
+        public void DoesNotExist_true()
+        {
+            Assert.Throws<DirectoryNotFoundException>(() => new DirectoryInfo("ThisDoesNotExist").Delete(true));
+        }
+
+        [Fact]
+        public void RegularDirectory_false()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "Subdir")).Delete(false);
+        }
+
+        [Fact]
+        public void RegularDirectory_true()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "Subdir")).Delete(true);
+        }
+
+        [Fact]
+        public void WithSubdirectories()
+        {
+            string subdirRoot = "WithSubdirectories";
+            DirectoryInfo dir1 = Directory.CreateDirectory(Path.Combine(TestDirectory, subdirRoot, "Test1"));
+            DirectoryInfo dir2 = Directory.CreateDirectory(Path.Combine(TestDirectory, subdirRoot, "Test2"));
+
+            dir1.Delete(false);
+
+            Assert.Throws<IOException>(() => new DirectoryInfo(Path.Combine(TestDirectory, subdirRoot)).Delete(false));
+
+            dir2.Delete(true);
+        }
+
+        [Fact]
+        public void WithFile()
+        {
+            string subdirRoot = "WithFile";
+            DirectoryInfo dir1 = Directory.CreateDirectory(Path.Combine(TestDirectory, subdirRoot, "Test1"));
+            DirectoryInfo dir2 = Directory.CreateDirectory(Path.Combine(TestDirectory, subdirRoot, "Test2"));
+
+            new FileStream(Path.Combine(dir1.FullName, "Hello.tmp"), FileMode.Create).Dispose();
+
+            Assert.Throws<IOException>(() => new DirectoryInfo(Path.Combine(TestDirectory, subdirRoot)).Delete(false));
+
+            dir2.Delete(true);
+        }
+
+        [Fact]
+        public void FileInUse()
+        {
+            string subdirRoot = "FileInUse";
+            DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(TestDirectory, subdirRoot));
+            using(FileStream fs = new FileStream(Path.Combine(TestDirectory, subdirRoot, "Test.tmp"), FileMode.Create))
+            {
+                Assert.Throws<IOException>(() => dir.Delete(true));
+            } 
+            dir.Delete(true);
+        }
+
+        [Fact]
+        public void ReadOnly()
+        {
+            DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(TestDirectory, "ReadOnly"));
+            dir.Attributes = FileAttributes.ReadOnly;
+
+            Assert.Throws<IOException>(() => dir.Delete(false));   
+            Assert.Throws<IOException>(() => dir.Delete(true));
+
+            dir.Attributes = new FileAttributes();
+            dir.Delete(true);
+        }
+
+        [Fact]
+        public void Hidden()
+        {
+            DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(TestDirectory, "ReadOnly"));
+            dir.Attributes = FileAttributes.Hidden;
+            dir.Delete(true);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/DirectoryInfo_EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/DirectoryInfo_EnumerableAPIs.cs
@@ -1,0 +1,1036 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace EnumerableTests
+{
+    public class DirectoryInfo_EnumerableTests
+    {
+        private static EnumerableUtils s_utils;
+
+        [Fact]
+        public static void RunTests()
+        {
+            s_utils = new EnumerableUtils();
+
+            s_utils.CreateTestDirs();
+
+            TestDirectoryInfoAPIs();
+
+            TestExceptions();
+
+            TestWhileEnumerating();
+
+            s_utils.DeleteTestDirs();
+
+            Assert.True(s_utils.Passed);
+        }
+
+
+        // Directory tests
+        private static void TestDirectoryInfoAPIs()
+        {
+            DoDirectoryInfoGetXTests(s_utils.testDir);
+            DoDirectoryGetXTests(s_utils.testDir);
+            TestDirectoryInfoSubdirs();
+            TestSillySearchString();
+        }
+
+        private static void DoDirectoryGetXTests(String name)
+        {
+            DoDirectoryGetDirectoriesTest(name, "*", SearchOption.AllDirectories, s_utils.expected_Dirs_Deep_FSI);
+            DoDirectoryGetDirectoriesTest(name, "*", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Shallow_FSI);
+            DoDirectoryGetDirectoriesTest(name, ".", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Shallow_FSI);
+            DoDirectoryGetDirectoriesTest(name, "", SearchOption.AllDirectories, new HashSet<FSIEntry>());
+
+            DoDirectoryGetDirectoriesTest(name, @"lev1_a\*", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Subdir_FSI);
+
+            DoDirectoryGetFilesTest(name, "*", SearchOption.AllDirectories, s_utils.expected_Files_Deep_FSI);
+            DoDirectoryGetFilesTest(name, "*", SearchOption.TopDirectoryOnly, s_utils.expected_Files_Shallow_FSI);
+            DoDirectoryGetFilesTest(name, ".", SearchOption.TopDirectoryOnly, s_utils.expected_Files_Shallow_FSI);
+            DoDirectoryGetFilesTest(name, "", SearchOption.AllDirectories, new HashSet<FSIEntry>());
+        }
+
+        private static void DoDirectoryGetDirectoriesTest(String path, String searchPattern, SearchOption searchOption, HashSet<FSIEntry> expected)
+        {
+            String chkptFlag = "chkpt_dgd1_";
+            int failCount = 0;
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(path);
+            DirectoryInfo[] dis = di.GetDirectories(searchPattern, searchOption);
+            HashSet<FSIEntry> disAsHS = new HashSet<FSIEntry>();
+            foreach (DirectoryInfo d in dis)
+            {
+                disAsHS.Add(new FSIEntry(d.Name, d.FullName, null, d.ToString()));
+            }
+
+            if (!disAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                Console.WriteLine("Expected:");
+                foreach (FSIEntry d in expected)
+                {
+                    Console.WriteLine("   Name:       " + d.Name);
+                    Console.WriteLine("   FullName:   " + d.FullName);
+                    Console.WriteLine("   ToString(): " + d.ToStr);
+                }
+                Console.WriteLine("But got:");
+                foreach (FSIEntry d in disAsHS)
+                {
+                    Console.WriteLine("   Name        " + d.Name);
+                    Console.WriteLine("   FullName:   " + d.FullName);
+                    Console.WriteLine("   ToString(): " + d.ToStr);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.GetDirectories", failCount);
+        }
+
+        private static void DoDirectoryGetFilesTest(String path, String searchPattern, SearchOption searchOption, HashSet<FSIEntry> expected)
+        {
+            /*
+             * FileInfo check:
+             * Name
+             * FullName
+             * DirectoryName
+             * ToString
+             * Directory (properties of that)
+             */
+            String chkptFlag = "chkpt_dgf1_";
+            int failCount = 0;
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(path);
+            FileInfo[] fis = di.GetFiles(searchPattern, searchOption);
+            HashSet<FSIEntry> disAsHS = new HashSet<FSIEntry>();
+            foreach (FileInfo f in fis)
+            {
+                disAsHS.Add(new FSIEntry(f.Name, f.FullName, f.DirectoryName, f.ToString()));
+            }
+
+            if (!disAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                Console.WriteLine("Expected:");
+                foreach (FSIEntry f in expected)
+                {
+                    Console.WriteLine("   Name:          " + f.Name);
+                    Console.WriteLine("   FullName:      " + f.FullName);
+                    Console.WriteLine("   DirectoryName: " + f.DirectoryName);
+                    Console.WriteLine("   ToString():    " + f.ToStr);
+                }
+                Console.WriteLine("But got:");
+                foreach (FSIEntry f in disAsHS)
+                {
+                    Console.WriteLine("   Name:          " + f.Name);
+                    Console.WriteLine("   FullName:      " + f.FullName);
+                    Console.WriteLine("   DirectoryName: " + f.DirectoryName);
+                    Console.WriteLine("   ToString():    " + f.ToStr);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.GetFiles", failCount);
+        }
+
+
+        private static void DoDirectoryInfoGetXTests(String name)
+        {
+            DoDirectoryInfoGetDirectoriesTest(name, "*", SearchOption.AllDirectories, s_utils.expected_Dirs_Deep);
+            DoDirectoryInfoGetDirectoriesTest(name, "*", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Shallow);
+            DoDirectoryInfoGetDirectoriesTest(name, ".", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Shallow);
+            DoDirectoryInfoGetDirectoriesTest(name, "", SearchOption.AllDirectories, new HashSet<String>());
+
+            DoDirectoryInfoGetDirectoriesTest(name, "lev2_*", SearchOption.AllDirectories, s_utils.expected_Dirs_Lev2SearchPattern);
+            DoDirectoryInfoGetDirectoriesTest(name, "lev2_*", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryInfoGetDirectoriesTest(name, "lev2_f", SearchOption.AllDirectories, s_utils.expected_Dirs_ExactSearchPattern);
+            DoDirectoryInfoGetDirectoriesTest(name, "lev2_f", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryInfoGetDirectoriesTest(name, @"lev1_a\*", SearchOption.TopDirectoryOnly, s_utils.expected_Dirs_Subdir);
+
+            DoDirectoryInfoGetDirectoriesTest(Path.Combine(name, "lev1_c"), ".", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryInfoGetFilesTest(name, "*", SearchOption.AllDirectories, s_utils.expected_Files_Deep);
+            DoDirectoryInfoGetFilesTest(name, "*", SearchOption.TopDirectoryOnly, s_utils.expected_Files_Shallow);
+            DoDirectoryInfoGetFilesTest(name, ".", SearchOption.TopDirectoryOnly, s_utils.expected_Files_Shallow);
+            DoDirectoryInfoGetFilesTest(name, "", SearchOption.AllDirectories, new HashSet<String>());
+            DoDirectoryInfoGetFilesTest(name, "lev2_f", SearchOption.AllDirectories, new HashSet<String>());
+            DoDirectoryInfoGetFilesTest(name, "lev2_f", SearchOption.TopDirectoryOnly, new HashSet<String>());
+
+            DoDirectoryInfoGetFileSystemInfosTest(name, "*", SearchOption.AllDirectories, new HashSet<String>(s_utils.expected_Files_Deep.Union(s_utils.expected_Dirs_Deep)));
+            DoDirectoryInfoGetFileSystemInfosTest(name, "*", SearchOption.TopDirectoryOnly, new HashSet<String>(s_utils.expected_Files_Shallow.Union(s_utils.expected_Dirs_Shallow)));
+            DoDirectoryInfoGetFileSystemInfosTest(name, ".", SearchOption.TopDirectoryOnly, new HashSet<String>(s_utils.expected_Files_Shallow.Union(s_utils.expected_Dirs_Shallow)));
+            DoDirectoryInfoGetFileSystemInfosTest(name, "", SearchOption.AllDirectories, new HashSet<String>());
+            DoDirectoryInfoGetFileSystemInfosTest(name, "lev2_f", SearchOption.AllDirectories, s_utils.expected_Dirs_ExactSearchPattern);
+            DoDirectoryInfoGetFileSystemInfosTest(name, "lev2_f", SearchOption.TopDirectoryOnly, new HashSet<String>());
+            DoDirectoryInfoGetFileSystemInfosTest(name, "file1", SearchOption.AllDirectories, s_utils.expected_Files_Shallow);
+        }
+
+        private static void DoDirectoryInfoGetDirectoriesTest(String path, String searchPattern, SearchOption searchOption, HashSet<String> expected)
+        {
+            String chkptFlag = "chkpt_dgd1_";
+            int failCount = 0;
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(path);
+            IEnumerable<DirectoryInfo> dis = di.EnumerateDirectories(searchPattern, searchOption);
+            HashSet<String> disAsHS = new HashSet<string>();
+            foreach (DirectoryInfo d in dis)
+            {
+                disAsHS.Add(d.FullName);
+            }
+
+            if (!disAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                foreach (DirectoryInfo d in dis)
+                {
+                    Console.WriteLine(d.Name);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateDirectories", failCount);
+        }
+
+        private static void DoDirectoryInfoGetFilesTest(String path, String searchPattern, SearchOption searchOption, HashSet<String> expected)
+        {
+            String chkptFlag = "chkpt_dgf1_";
+            int failCount = 0;
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(path);
+            IEnumerable<FileInfo> fis = di.EnumerateFiles(searchPattern, searchOption);
+            HashSet<String> disAsHS = new HashSet<string>();
+            foreach (FileInfo d in fis)
+            {
+                disAsHS.Add(d.FullName);
+            }
+
+            if (!disAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                foreach (FileInfo f in fis)
+                {
+                    Console.WriteLine(f.Name);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateFiles", failCount);
+        }
+
+        private static void DoDirectoryInfoGetFileSystemInfosTest(String path, String searchPattern, SearchOption searchOption, HashSet<String> expected)
+        {
+            String chkptFlag = "chkpt_dgi1_";
+            int failCount = 0;
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(path);
+            IEnumerable<FileSystemInfo> fis = di.EnumerateFileSystemInfos(searchPattern, searchOption);
+            HashSet<String> disAsHS = new HashSet<string>();
+            foreach (FileSystemInfo d in fis)
+            {
+                disAsHS.Add(d.FullName);
+            }
+
+            if (!disAsHS.SetEquals(expected))
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                foreach (FileSystemInfo f in fis)
+                {
+                    Console.WriteLine(f.Name);
+                }
+            }
+
+            String testName = String.Format("SP={0}, SO={1}", searchPattern, searchOption);
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateFileSystemInfos", failCount);
+        }
+
+
+        private static void TestDirectoryInfoSubdirs()
+        {
+            String chkptFlag = "chkpt_disub_";
+            int failCount = 0;
+
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+
+            di.CreateSubdirectory("TestDir1");
+            di.CreateSubdirectory("TestDir2");
+            di.CreateSubdirectory("TestDir3");
+            di.CreateSubdirectory("Test1Dir1");
+            di.CreateSubdirectory("Test1Dir2");
+
+            DirectoryInfo[] dis = di.GetDirectories("TestDir*");
+            if (dis.Length != 3)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "1: didn't get expected dirs....");
+                foreach (DirectoryInfo d in dis)
+                {
+                    Console.WriteLine(d.Name);
+                }
+            }
+
+            s_utils.PrintTestStatus("DirectoryInfo subdirs", "GetDirs*", failCount);
+        }
+
+        private static void TestSillySearchString()
+        {
+            String chkptFlag = "chkpt_sss_";
+            int failCount = 0;
+
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            try
+            {
+                DirectoryInfo[] dis = di.GetDirectories("\n");
+                if (dis.Length != 0)
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: got results, didn't expect any....");
+                    foreach (DirectoryInfo d in dis)
+                    {
+                        Console.WriteLine(d.Name);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got unexpected exception");
+                Console.WriteLine(e);
+            }
+
+            s_utils.PrintTestStatus("silly search string", "GetDirectories", failCount);
+        }
+
+        // Exception tests
+        private static void TestExceptions()
+        {
+            TestSearchPatterns();
+
+            TestSearchOptionOutOfRange();
+            TestWeirdPaths();
+        }
+
+        private static void TestSearchPatterns()
+        {
+            TestSearchPatternIter(s_utils.testDir, null, "null SP", new ArgumentNullException());
+            TestSearchPatternIter(s_utils.testDir, "..", "invalid SP", new ArgumentException());
+        }
+
+        private static void TestSearchPatternIter(String path, String pattern, String patternDescription, Exception expectedException)
+        {
+            TestGetDirectories(path, pattern, patternDescription, expectedException);
+            TestGetFiles(path, pattern, patternDescription, expectedException);
+            TestGetFileSystemInfos(path, pattern, patternDescription, expectedException);
+            TestGetDirectoriesFast(path, pattern, patternDescription, expectedException);
+            TestGetFilesFast(path, pattern, patternDescription, expectedException);
+            TestGetFileSystemInfosFast(path, pattern, patternDescription, expectedException);
+        }
+
+        private static void TestWeirdPaths()
+        {
+            // null path
+            String nullPath = null;
+            TestWeirdPathIter(nullPath, "nullPath", new ArgumentNullException());
+
+            // empty path
+            String emptyPath = "";
+            TestWeirdPathIter(emptyPath, "emptyPath", new ArgumentException());
+
+            // whitespace-only path
+            char[] whitespacePathChars = { (char)0x9, (char)0xA };
+            String whitespacePath = new String(whitespacePathChars);
+            TestWeirdPathIter(whitespacePath, "whitespacePath", new ArgumentException());
+
+            // try to test a path that doesn't exist. Skip if can't find an unused drive
+            String pathNotExists = null;
+            String unusedDrive = EnumerableUtils.GetUnusedDrive();
+            if (unusedDrive != null)
+            {
+                pathNotExists = Path.Combine(unusedDrive, @"temp\dir");
+            }
+            if (pathNotExists != null)
+            {
+                TestWeirdPathIter(pathNotExists, "pathNotExists", new DirectoryNotFoundException());
+            }
+
+            // file (not dir) name. If we try to do GetFiles, GetDirs, etc in a file (not dir) we get IOException
+            String filePath = null;
+            foreach (String s in s_utils.expected_Files_Deep)
+            {
+                if (s != null)
+                {
+                    filePath = s;
+                    break;
+                }
+            }
+            TestWeirdPathIter(filePath, "pathIsFile", new IOException());
+
+            // PathTooLong
+            String longPath = new String('a', 240) + @"\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+            TestWeirdPathIter(longPath, "pathTooLong", new PathTooLongException());
+
+            // path invalid chars
+            String invalidCharPath = @"temp\fsd<sdsds";
+            TestWeirdPathIter(invalidCharPath, "invalidCharPath", new ArgumentException());
+        }
+
+        private static void TestWeirdPathIter(String path, String pathDescription, Exception expectedException)
+        {
+            String pattern = "*";
+            TestGetDirectories(path, pattern, pathDescription, expectedException);
+            TestGetFiles(path, pattern, pathDescription, expectedException);
+            TestGetFileSystemInfos(path, pattern, pathDescription, expectedException);
+            TestGetDirectoriesFast(path, pattern, pathDescription, expectedException);
+            TestGetFilesFast(path, pattern, pathDescription, expectedException);
+            TestGetFileSystemInfosFast(path, pattern, pathDescription, expectedException);
+        }
+
+
+        private static void TestGetDirectories(String path, String pattern, String testDescription, Exception expectedException)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_spgd_";
+            String methodName = "DirectoryInfo.GetDirectories";
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                DirectoryInfo[] dirs1 = di.GetDirectories(pattern);
+
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                DirectoryInfo[] dirs2 = di.GetDirectories(pattern, SearchOption.AllDirectories);
+
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            s_utils.PrintTestStatus(testDescription, methodName, failCount);
+        }
+
+        private static void TestGetFiles(String path, String pattern, String testDescription, Exception expectedException)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_spgf_";
+            String methodName = "DirectoryInfo.GetFiles";
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                FileInfo[] dirs1 = di.GetFiles(pattern);
+
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                FileInfo[] dirs2 = di.GetFiles(pattern, SearchOption.AllDirectories);
+
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            s_utils.PrintTestStatus(testDescription, methodName, failCount);
+        }
+
+        private static void TestGetFileSystemInfos(String path, String pattern, String testDescription, Exception expectedException)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_spgfse_";
+            String methodName = "DirectoryInfo.GetFileSystemInfos";
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                FileSystemInfo[] dirs1 = di.GetFileSystemInfos(pattern);
+
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                FileSystemInfo[] dirs2 = di.GetFileSystemInfos(pattern, SearchOption.AllDirectories);
+
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+
+            s_utils.PrintTestStatus(testDescription, methodName, failCount);
+        }
+
+
+        private static void TestGetDirectoriesFast(String path, String pattern, String testDescription, Exception expectedException)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_spgdf_";
+            String methodName = "DirectoryInfo.EnumerateDirectories";
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                IEnumerable<DirectoryInfo> dirs1 = di.EnumerateDirectories(pattern);
+
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                IEnumerable<DirectoryInfo> dirs2 = di.EnumerateDirectories(pattern, SearchOption.AllDirectories);
+
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            s_utils.PrintTestStatus(testDescription, methodName, failCount);
+        }
+
+        private static void TestGetFilesFast(String path, String pattern, String testDescription, Exception expectedException)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_spgff_";
+            String methodName = "DirectoryInfo.EnumerateFiles";
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                IEnumerable<FileInfo> dirs1 = di.EnumerateFiles(pattern);
+
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                IEnumerable<FileInfo> dirs2 = di.EnumerateFiles(pattern, SearchOption.AllDirectories);
+
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            s_utils.PrintTestStatus(testDescription, methodName, failCount);
+        }
+
+        private static void TestGetFileSystemInfosFast(String path, String pattern, String testDescription, Exception expectedException)
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_spgfse_";
+            String methodName = "DirectoryInfo.EnumerateFileSystemInfos";
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                IEnumerable<FileSystemInfo> dirs1 = di.EnumerateFileSystemInfos(pattern);
+
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                IEnumerable<FileSystemInfo> dirs2 = di.EnumerateFileSystemInfos(pattern, SearchOption.AllDirectories);
+
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            s_utils.PrintTestStatus(testDescription, methodName, failCount);
+        }
+
+        private static void TestSearchOptionOutOfRange()
+        {
+            TestSearchOptionOutOfRangeDirectoryInfo();
+            TestSearchOptionOutOfRangeDirectoryInfoFast();
+        }
+
+        private static void TestSearchOptionOutOfRangeDirectoryInfo()
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_soordi_";
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+
+            // get files
+            try
+            {
+                FileInfo[] s1 = di.GetFiles(s_utils.testDir, (SearchOption)5);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (ArgumentOutOfRangeException) { } // expected
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                Console.WriteLine(e);
+            }
+
+            // get directories
+            try
+            {
+                DirectoryInfo[] s1 = di.GetDirectories(s_utils.testDir, (SearchOption)5);
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (ArgumentOutOfRangeException) { } // expected
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                Console.WriteLine(e);
+            }
+
+            s_utils.PrintTestStatus("TestSearchOptionOutOfRangeDirectoryInfo", "DirectoryInfo*", failCount);
+        }
+
+        private static void TestSearchOptionOutOfRangeDirectoryInfoFast()
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_soordif_";
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+
+            // get files
+            try
+            {
+                IEnumerable<FileInfo> s1 = di.EnumerateFiles(s_utils.testDir, (SearchOption)5);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (ArgumentOutOfRangeException) { } // expected
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                Console.WriteLine(e);
+            }
+
+            // get directories
+            try
+            {
+                IEnumerable<DirectoryInfo> s1 = di.EnumerateDirectories(s_utils.testDir, (SearchOption)5);
+                Console.WriteLine(chkptFlag + "3: didn't throw");
+                failCount++;
+            }
+            catch (ArgumentOutOfRangeException) { } // expected
+            catch (Exception e)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "4: threw wrong exception");
+                Console.WriteLine(e);
+            }
+
+            s_utils.PrintTestStatus("TestSearchOptionOutOfRangeDirectoryInfoFast", "DirectoryInfo*", failCount);
+        }
+
+        private static void TestWhileEnumerating()
+        {
+            TestChangeWhileEnumerating();
+        }
+
+        private static void TestChangeWhileEnumerating()
+        {
+            DoGetDirectories_Add();
+            DoGetFiles_Add();
+            DoGetFileSystemInfos_Add();
+            DoGetDirectories_Delete();
+            DoGetFiles_Delete();
+            DoGetFileSystemInfos_Delete();
+        }
+
+        private static void DoGetDirectories_Add()
+        {
+            String chkptFlag = "chkpt_dgdm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            IEnumerable<DirectoryInfo> dis = di.EnumerateDirectories("*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (DirectoryInfo d in dis)
+                {
+                    disAsHS.Add(d.FullName);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSAdd();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Dirs_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                    foreach (DirectoryInfo d in dis)
+                    {
+                        Console.WriteLine(d.FullName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "addFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateDirectories", failCount);
+        }
+
+        private static void DoGetDirectories_Delete()
+        {
+            String chkptFlag = "chkpt_dgdm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            IEnumerable<DirectoryInfo> dis = di.EnumerateDirectories("*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (DirectoryInfo d in dis)
+                {
+                    disAsHS.Add(d.FullName);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSDelete();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Dirs_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected directories....");
+                    foreach (DirectoryInfo d in dis)
+                    {
+                        Console.WriteLine(d.Name);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "deleteFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateDirectories", failCount);
+        }
+
+        private static void DoGetFiles_Add()
+        {
+            String chkptFlag = "chkpt_dgfm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            IEnumerable<FileInfo> fis = di.EnumerateFiles("*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (FileInfo d in fis)
+                {
+                    disAsHS.Add(d.FullName);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSAdd();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Files_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (FileInfo f in fis)
+                    {
+                        Console.WriteLine(f.FullName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "addFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateFiles", failCount);
+        }
+
+        private static void DoGetFiles_Delete()
+        {
+            String chkptFlag = "chkpt_dgfm_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            IEnumerable<FileInfo> fis = di.EnumerateFiles("*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (FileInfo d in fis)
+                {
+                    disAsHS.Add(d.FullName);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSDelete();
+                }
+                if (!disAsHS.SetEquals(s_utils.expected_Files_Changed))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (FileInfo f in fis)
+                    {
+                        Console.WriteLine(f.Name);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "deleteFilesWhileEnumerating"; ;
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateFiles", failCount);
+        }
+
+        private static void DoGetFileSystemInfos_Add()
+        {
+            String chkptFlag = "chkpt_dgim_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            IEnumerable<FileSystemInfo> fis = di.EnumerateFileSystemInfos("*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (FileSystemInfo d in fis)
+                {
+                    disAsHS.Add(d.FullName);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSAdd();
+                }
+                if (!disAsHS.SetEquals(new HashSet<String>(s_utils.expected_Dirs_Changed.Union(s_utils.expected_Files_Changed))))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (FileSystemInfo f in fis)
+                    {
+                        Console.WriteLine(f.Name);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "addFilesWhileEnumerating";
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateFileSystemInfos", failCount);
+        }
+
+        private static void DoGetFileSystemInfos_Delete()
+        {
+            String chkptFlag = "chkpt_dgim_";
+            int failCount = 0;
+
+            s_utils.CreateTestDirs();
+
+            // directoryinfo
+            DirectoryInfo di = new DirectoryInfo(s_utils.testDir);
+            IEnumerable<FileSystemInfo> fis = di.EnumerateFileSystemInfos("*", SearchOption.AllDirectories);
+            HashSet<String> disAsHS = new HashSet<string>();
+            int count = 0;
+
+            try
+            {
+                foreach (FileSystemInfo d in fis)
+                {
+                    disAsHS.Add(d.FullName);
+                    count++;
+                    if (count == 2)
+                        s_utils.ChangeFSDelete();
+                }
+                if (!disAsHS.SetEquals(new HashSet<String>(s_utils.expected_Dirs_Changed.Union(s_utils.expected_Files_Changed))))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: didn't get expected files....");
+                    foreach (FileSystemInfo f in fis)
+                    {
+                        Console.WriteLine(f.Name);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: got wrong exception");
+                Console.WriteLine(ex);
+            }
+
+            String testName = "deleteFilesWhileEnumerating";
+            s_utils.PrintTestStatus(testName, "DirectoryInfo.EnumerateFileSystemInfos", failCount);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -4,12 +4,62 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace System.IO.FileSystem.Tests
 {
     public partial class DirectoryInfo_Exists : FileSystemTest
     {
+        [Fact]
+        public void ArgumentExceptionForEmptyPath()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo("").Exists);
+        }
+
+        [Fact]
+        public void DotPath()
+        {
+            Assert.True(new DirectoryInfo(Path.Combine(TestDirectory, ".")).Exists);
+        }
+
+        [Fact]
+        public void DotDotPath()
+        {
+            Assert.True(new DirectoryInfo(Path.Combine(TestDirectory, Path.GetRandomFileName(), ".." )).Exists);
+        }
+
+        [Fact]
+        public void NonExistantDirectories()
+        {
+            Assert.False(new DirectoryInfo("Da drar vi til fjells").Exists);
+        }
+
+        [Fact]
+        public void BadDriveLetterFormat()
+        {
+            Assert.Throws<NotSupportedException>(() => new DirectoryInfo("xx:\\"));
+        }
+
+        [Fact]
+        public void PathTooLong()
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 500; i++)
+            {
+                sb.Append(i);
+            }
+
+            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(sb.ToString()));
+        }
+
+        [Fact]
+        public void CaseInsensitivity()
+        {
+            Assert.True(new DirectoryInfo(TestDirectory.ToUpperInvariant()).Exists);
+            Assert.True(new DirectoryInfo(TestDirectory.ToLowerInvariant()).Exists);
+        }
+
         [Fact]
         public void TrueForCreatedDirectory()
         {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Extension.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Extension.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+public class DirectoryInfo_Extension
+{
+    public static String s_strClassMethod = "DirectoryInfo.Extension";
+    public static String s_strTFName = "Extension.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = "Testing";
+            DirectoryInfo dir;
+
+            strLoc = "Err_0001";
+            // With no extension
+            iCountTestcases++;
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_0002! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_0003";
+            // With an extension
+            iCountTestcases++;
+            fileName = "foo.bar";
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != ".bar")
+            {
+                iCountErrors++;
+                printerr("Error_0004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_1003";
+            // With valid extenstion but file name with special symbols.
+            iCountTestcases++;
+            fileName = "foo.bar.fkl;fkds92-509450-4359.$#%()#%().%#(%)_#(%_).cool";
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != ".cool")
+            {
+                iCountErrors++;
+                printerr("Error_1004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_2003";
+            // With a long extension	    
+            iCountTestcases++;
+            String extension = ".bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+            fileName = "AAAAAAAAAAAAAAAAAAAAAA" + extension;
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != extension)
+            {
+                iCountErrors++;
+                printerr("Error_2004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_3003";
+            // No characters after the extension
+            //INFO: This should return basically ".". But that really doesn't make sense. 
+            iCountTestcases++;
+            fileName = "foo.";
+            dir = new DirectoryInfo(fileName);
+            String test = Exten(fileName);
+            if (dir.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_3004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_4003";
+            // Symbol and special characters in extension	    
+            iCountTestcases++;
+            extension = ".$#@$_)+_)!@@!!@##&_$)#_";
+            fileName = "foo" + extension;
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != extension)
+            {
+                iCountErrors++;
+                printerr("Error_4004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_5003";
+            // Lots of dots at end of the directory name  
+            //INFO: This should return basically ".". But that really doesn't make sense.                               
+            iCountTestcases++;
+            extension = "..............";
+            fileName = "foo" + extension;
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_5004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            strLoc = "Err_6003";
+            // Extension with exactly one character. 
+            iCountTestcases++;
+            extension = "..............";
+            fileName = "foo . z" + extension;
+            dir = new DirectoryInfo(fileName);
+            if (dir.Extension != ". z")
+            {
+                iCountErrors++;
+                printerr("Error_6004! Incorrect extension , dir==" + dir.Extension);
+            }
+
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private static string RemoveIfDotExists(String str)
+    {
+        while (str.IndexOf(".") > -1)
+            str = str.Remove(str.IndexOf("."), 1);
+        return str;
+    }
+
+    public static String Exten(String str)
+    {
+        int length = str.Length;
+
+        for (int i = length; --i >= 0;)
+        {
+            char ch = str[i];
+            Console.WriteLine(ch);
+            if (ch == '.')
+                return str.Substring(i, length - i);
+            if (ch == Path.DirectorySeparatorChar || ch == Path.AltDirectorySeparatorChar || ch == Path.VolumeSeparatorChar)
+                break;
+        }
+        return String.Empty;
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetDirectories
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.GetDirectories()";
+    public static String s_strTFName = "GetDirectories.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = Path.GetRandomFileName();
+
+            DirectoryInfo[] dirArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dirArr = dir2.GetDirectories();
+            iCountTestcases++;
+            if (dirArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and get all the directories
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            new FileInfo(dir2.ToString() + "TestFile1");
+            new FileInfo(dir2.ToString() + "TestFile2");
+
+            iCountTestcases++;
+            dirArr = dir2.GetDirectories();
+            iCountTestcases++;
+            if (dirArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned");
+            }
+            iCountTestcases++;
+            if (!dirArr[0].Name.Equals("TestDir1"))
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + dirArr[0].Name);
+            }
+            iCountTestcases++;
+            if (!dirArr[1].Name.Equals("TestDir2"))
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + dirArr[1].Name);
+            }
+            iCountTestcases++;
+            if (!dirArr[2].Name.Equals("TestDir3"))
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + dirArr[2].Name);
+            }
+
+            Directory.Delete(dirName + "\\TestDir3");
+            Directory.Delete(dirName + "\\TestDir2");
+
+            dirArr = dir2.GetDirectories();
+            iCountTestcases++;
+            if (dirArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_4y28x! Incorrect number of directories returned");
+            }
+            iCountTestcases++;
+            if (!dirArr[0].Name.Equals("TestDir1"))
+            {
+                iCountErrors++;
+                printerr("Error_0975b! Incorrect name==" + dirArr[0].Name);
+            }
+
+
+            //-----------------------------------------------------------------
+
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            //bug ####### - DirectoryInfo.GetDirectories() uses relative path and thus the current directory rather than the full directory passed on 
+            //DirectoryInfos internally constructed
+            /**
+For folders under the root DirectoryInfo everything is fine, but any subfolder of that turns into <workingdir>\foldername
+             
+So for example if my working dir is 
+C:\wd
+             
+And Im looking at a directory structure
+C:\foo\bar\abc
+             
+If I do repro c:\foo
+It prints out something like
+C:\foo\bar
+C:\wd\bar\abc
+            **/
+
+            //@TODO!! use ManageFileSystem utility
+            String rootTempDir = @"\LaksTemp";
+            int dirSuffixNo = 0;
+            while (Directory.Exists(String.Format("{0}{1}", rootTempDir, dirSuffixNo++))) ;
+            rootTempDir = String.Format("{0}{1}", rootTempDir, (dirSuffixNo - 1));
+            String tempFullName = String.Format(@"{0}\laks1\laks2", rootTempDir);
+            Directory.CreateDirectory(tempFullName);
+            DirectoryInfo dir = new DirectoryInfo(rootTempDir);
+            AddFolders(dir);
+            Eval(s_directories.Count == 3, "Err_9347g! wrong count: {0}", s_directories.Count);
+            Eval(s_directories.Contains(Path.GetFullPath(rootTempDir)), "Err_3407tgs! PAth not found: {0}", Path.GetFullPath(rootTempDir));
+            Eval(s_directories.Contains(Path.Combine(Path.GetFullPath(rootTempDir), "laks1")), "Err_857sqi! PAth not found: {0}", Path.Combine(Path.GetFullPath(rootTempDir), "laks1"));
+            Eval(s_directories.Contains(Path.Combine(Path.GetFullPath(rootTempDir), @"laks1\laks2")), "Err_356slh! PAth not found: {0}", Path.Combine(Path.GetFullPath(rootTempDir), @"laks1\laks2"));
+
+            Directory.Delete(rootTempDir, true);
+
+            if (!s_pass)
+            {
+                iCountErrors++;
+                printerr("Error_32947eg! Relative directories not working");
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+
+
+    private static List<String> s_directories = new List<String>();
+    public static void AddFolders(DirectoryInfo info)
+    {
+        s_directories.Add(info.FullName);
+        //		Console.WriteLine("<{0}>", info.FullName);
+        foreach (DirectoryInfo i in info.GetDirectories())
+        {
+            AddFolders(i);
+        }
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetDirectories_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "DirectoryInfo.GetDirectories(String searchPattern)";
+    public static String s_strTFName = "GetDirectories_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir1, dir2;
+            String dirName = Path.GetRandomFileName();
+            DirectoryInfo[] dirA;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                dir2.GetDirectories(null);
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+            // [] ArgumentException for String.Empty
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                dirA = dir2.GetDirectories(String.Empty);
+                if (dirA.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_8ytbm! Expected exception not thrown");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for all whitespace
+            //-----------------------------------------------------------------
+            strLoc = "Loc_1190x";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                dirA = dir2.GetDirectories("\n");
+                if (dirA.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_2198y! Expected exception not thrown");
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+            //-----------------------------------------------------------------
+
+
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dirA = dir2.GetDirectories("*");
+            iCountTestcases++;
+            if (dirA.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // Regression test for Dev10 #540781 - passing "."
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_540781";
+
+            dirA = dir2.GetDirectories(".");
+            iCountTestcases++;
+            if (dirA.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_540781! Incorrect number of directories returned");
+                foreach (DirectoryInfo di in dirA)
+                {
+                    Console.WriteLine(di.FullName);
+                }
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and get all directories
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+            FileStream[] fs = new FileStream[2];
+            fs[0] = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            fs[1] = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            for (int iLoop = 0; iLoop < 2; iLoop++)
+                fs[iLoop].Dispose();
+
+
+            // Get all directories
+            strLoc = "Loc_249yv";
+
+            dirA = dir2.GetDirectories("*");
+            iCountTestcases++;
+            if (dirA.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of directories==" + dirA.Length);
+            }
+            String[] names = new String[dirA.Length];
+            int i = 0;
+            foreach (DirectoryInfo f in dirA)
+                names[i++] = f.FullName.Substring(f.FullName.LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + dirA[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + dirA[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + dirA[2].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + dirA[3].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + dirA[4].ToString());
+            }
+
+            Directory.Delete(dirName + "\\TestDir2");
+            Directory.Delete(dirName + "\\TestDir3");
+
+            dirA = dir2.GetDirectories("*");
+            iCountTestcases++;
+            if (dirA.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_0989b! Incorrec tnumber of directories==" + dirA.Length);
+            }
+            names = new String[dirA.Length];
+            i = 0;
+            foreach (DirectoryInfo f in dirA)
+                names[i++] = f.FullName.Substring(f.FullName.LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10938! Incorrect name==" + dirA[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_01c99! Incorrect name==" + dirA[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_176y7! Incorrect name==" + dirA[2].ToString());
+            }
+
+            dir1 = new DirectoryInfo(".");
+
+            dirA = dir1.GetDirectories(String.Format("{0}\\*", dirName));
+
+            if (dirA.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_0989b! Incorrec tnumber of directories==" + dirA.Length);
+            }
+            names = new String[dirA.Length];
+            i = 0;
+            foreach (DirectoryInfo f in dirA)
+                names[i++] = f.FullName.Substring(f.FullName.LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10938! Incorrect name==" + dirA[0]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_01c99! Incorrect name==" + dirA[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_176y7! Incorrect name==" + dirA[2].ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str_so.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str_so.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+We test this API's functionality comprehensively via Directory.GetDirectories(String, String, SearchOption). Here, we concentrate on the following
+ - vanilla
+ - parm validation, including non existent dir
+ - security
+**/
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections.Generic;
+using System.Security;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_GetDirectories_str_so
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void RunTest()
+    {
+        try
+        {
+            String dirName;
+            DirectoryInfo dirInfo;
+            String[] expectedDirs;
+            DirectoryInfo[] dirs;
+            List<String> list;
+
+            //Scenario 1: Vanilla
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    dirInfo = new DirectoryInfo(dirName);
+                    expectedDirs = fileManager.GetAllDirectories();
+                    list = new List<String>(expectedDirs);
+                    dirs = dirInfo.GetDirectories("*", SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_415mbz! wrong count {0} {1}", dirs.Length, list.Count);
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i].FullName), "Err_287kkm! No file found: {0}", dirs[i].FullName))
+                            list.Remove(dirs[i].FullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_921mhs! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 3: Parm Validation
+            try
+            {
+                // dir not present and then after creating
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                dirInfo = new DirectoryInfo(dirName);
+                CheckException<DirectoryNotFoundException>(delegate { dirs = dirInfo.GetDirectories("*", SearchOption.AllDirectories); }, "Err_326pgt! worng exception thrown");
+
+                // create the dir and then check that we dont cache this info
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    dirInfo = new DirectoryInfo(dirName);
+                    expectedDirs = fileManager.GetAllDirectories();
+                    list = new List<String>(expectedDirs);
+                    dirs = dirInfo.GetDirectories("*", SearchOption.AllDirectories);
+                    Eval(dirs.Length == list.Count, "Err_948kxt! wrong count");
+                    for (int i = 0; i < expectedDirs.Length; i++)
+                    {
+                        if (Eval(list.Contains(dirs[i].FullName), "Err_535xaj! No file found: {0}", dirs[i].FullName))
+                            list.Remove(dirs[i].FullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_370pjl! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                    CheckException<ArgumentNullException>(delegate { dirs = dirInfo.GetDirectories(null, SearchOption.TopDirectoryOnly); }, "Err_751mwu! worng exception thrown");
+                    CheckException<ArgumentOutOfRangeException>(delegate { dirs = dirInfo.GetDirectories("*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
+                    CheckException<ArgumentOutOfRangeException>(delegate { dirs = dirInfo.GetDirectories("*", (SearchOption)(-1)); }, "Err_359vcj! worng exception thrown - see bug #386545");
+                    String[] invalidValuesForSearch = { "..", @"..\" };
+                    for (int i = 0; i < invalidValuesForSearch.Length; i++)
+                    {
+                        CheckException<ArgumentException>(delegate { dirs = dirInfo.GetDirectories(invalidValuesForSearch[i], SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy! worng exception thrown: {1}", i, invalidValuesForSearch[i]));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_006dwq! Exception caught in scenario: {0}", ex);
+            }
+
+
+
+            //Scenario for bug #461014 - Getting files/directories of CurrentDirectory of drives are broken
+            /* Scenario disabled when porting because it relies on the contents of the current directory not changing during execution
+            try
+            {
+                string anotherDrive = IOServices.GetNtfsDriveOtherThanCurrent();
+                String[] paths = null == anotherDrive ? new String[] { Directory.GetCurrentDirectory() } : new String[] { anotherDrive, Directory.GetCurrentDirectory() };
+                String path;
+                for (int i = 0; i < paths.Length; i++)
+                {
+                    path = paths[i];
+                    if (path.Length > 1)
+                    {
+                        path = path.Substring(0, 2);
+
+                        DirectoryInfo[] f1 = new DirectoryInfo(Path.GetFullPath(path)).GetDirectories();
+                        DirectoryInfo[] f2 = new DirectoryInfo(path).GetDirectories();
+                        Eval<int>(f1.Length, f2.Length, "Err_2497gds! wrong value");
+                        for (int j = 0; j < f1.Length; j++)
+                        {
+                            Eval<String>(f1[j].FullName, f2[j].FullName, "Err_03284t! wrong value");
+                            Eval<String>(f1[j].Name, f2[j].Name, "Err_03284t! wrong value");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+            */
+        }
+        catch (Exception ex)
+        {
+            s_pass = false;
+            Console.WriteLine("Err_234rsgf! Uncaught exception in RunTest: {0}", ex);
+        }
+
+        Assert.True(s_pass);
+    }
+
+    private void DeleteFile(String fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+    private void DeleteDir(String dirName)
+    {
+        if (Directory.Exists(dirName))
+            Directory.Delete(dirName);
+    }
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (msgExpected != null && System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+}
+
+
+
+
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetFileSystemInfos
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.GetFiles()";
+    public static String s_strTFName = "GetFileSystemInfos .cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = Path.GetRandomFileName();
+            FileSystemInfo[] fsArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            fsArr = dir2.GetFileSystemInfos();
+            iCountTestcases++;
+            if (fsArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure get all the filesystementries
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            new FileInfo(dir2.ToString() + "TestFile1");
+            new FileInfo(dir2.ToString() + "TestFile2");
+            new FileInfo(dir2.ToString() + "Test.bat");
+            new FileInfo(dir2.ToString() + "Test.exe");
+
+            FileStream[] fs = new FileStream[4];
+            fs[0] = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            fs[1] = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            fs[2] = new FileInfo(dir2.FullName + "\\" + "Test.bat").Create();
+            fs[3] = new FileInfo(dir2.FullName + "\\" + "Test.exe").Create();
+            for (int iLoop = 0; iLoop < 4; iLoop++)
+                fs[iLoop].Dispose();
+
+            iCountTestcases++;
+            fsArr = dir2.GetFileSystemInfos();
+            iCountTestcases++;
+            if (fsArr.Length != 7)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned");
+            }
+
+            String[] names = new String[7];
+            int i = 0;
+            foreach (FileSystemInfo fse in fsArr)
+                names[i++] = fse.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4yg76! Incorrec tname==" + fsArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_1987y! Incorrect name==" + fsArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4yt76! Incorrect name==" + fsArr[2].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test.bat") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + fsArr[3].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test.exe") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + fsArr[4].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + fsArr[5].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_29894! Incorrect name==" + fsArr[6].Name);
+            }
+
+
+
+            //-----------------------------------------------------------------
+
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
@@ -1,0 +1,388 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetFileSystemInfos_str
+{
+    public static String s_strActiveBugNums = "28509";
+    public static String s_strClassMethod = "Directory.GetFiles()";
+    public static String s_strTFName = "GetFileSystemInfos _str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        //////////// Global Variables used for all tests
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = Path.GetRandomFileName();
+            FileSystemInfo[] fsArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                dir2.GetFileSystemInfos(null);
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] ArgumentException for String.Empty
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                FileSystemInfo[] strInfos = dir2.GetFileSystemInfos(String.Empty);
+                if (strInfos.Length != 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_8ytbm! Unexpected number of file infos returned" + strInfos.Length);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+            // [] ArgumentException for all whitespace
+            //-----------------------------------------------------------------
+            strLoc = "Loc_1190x";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                dir2.GetFileSystemInfos("..ab ab.. .. abc..d\abc..");
+                iCountErrors++;
+                printerr("Error_2198y! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_17888! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            fsArr = dir2.GetFileSystemInfos();
+            iCountTestcases++;
+            if (fsArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of files returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and try different searchcriterias
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+            new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
+            new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
+            new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+
+            // [] Search criteria ending with '*'
+
+            iCountTestcases++;
+            fsArr = dir2.GetFileSystemInfos("TestFile*");
+            iCountTestcases++;
+            if (fsArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of files returned");
+            }
+            String[] names = new String[fsArr.Length];
+            int i = 0;
+            foreach (FileSystemInfo f in fsArr)
+                names[i++] = f.Name;
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + fsArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + fsArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + fsArr[2].Name);
+            }
+
+
+            // [] Search criteria is '*'
+
+            fsArr = dir2.GetFileSystemInfos("*");
+            iCountTestcases++;
+            if (fsArr.Length != 10)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of files==" + fsArr.Length);
+            }
+            names = new String[fsArr.Length];
+            i = 0;
+            foreach (FileSystemInfo f in fsArr)
+                names[i++] = f.Name;
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + fsArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + fsArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + fsArr[2].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + fsArr[3].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + fsArr[4].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + fsArr[5].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + fsArr[6].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + fsArr[7].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + fsArr[8].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + fsArr[9].Name);
+            }
+
+            // [] Search criteria beginning with '*'
+
+            fsArr = dir2.GetFileSystemInfos("*2");
+            iCountTestcases++;
+            if (fsArr.Length != 4)
+            {
+                iCountErrors++;
+                printerr("Error_8019x! Incorrect number of files==" + fsArr.Length);
+            }
+            names = new String[fsArr.Length];
+            i = 0;
+            foreach (FileSystemInfo fs in fsArr)
+                names[i++] = fs.Name;
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_247yg! Incorrect name==" + fsArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_24gy7! Incorrect name==" + fsArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_167yb! Incorrect name==" + fsArr[2].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_49yb7! Incorrect name==" + fsArr[3].Name);
+            }
+
+
+
+            fsArr = dir2.GetFileSystemInfos("*Dir2");
+            iCountTestcases++;
+            if (fsArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_948yv! Incorrect number of files==" + fsArr.Length);
+            }
+            names = new String[fsArr.Length];
+            i = 0;
+            foreach (FileSystemInfo fs in fsArr)
+                names[i++] = fs.Name;
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1Dir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_247yg! Incorrect name==" + fsArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestDir2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_24gy7! Incorrect name==" + fsArr[1].Name);
+            }
+
+            // [] Search criteria Beginning and ending with '*'
+
+            new FileInfo(dir2.FullName + "\\" + "AAABB").Create();
+            Directory.CreateDirectory(dir2.FullName + "\\" + "aaabbcc");
+
+            fsArr = dir2.GetFileSystemInfos("*BB*");
+            iCountTestcases++;
+            if (fsArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y190! Incorrect number of files==" + fsArr.Length);
+            }
+            names = new String[fsArr.Length];
+            i = 0;
+            foreach (FileSystemInfo fs in fsArr)
+                names[i++] = fs.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "aaabbcc") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_956yb! Incorrect name==" + fsArr[0]);
+                foreach (FileSystemInfo s in fsArr)
+                    Console.WriteLine(s.Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "AAABB") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_48yg7! Incorrect name==" + fsArr[1]);
+                foreach (FileSystemInfo s in fsArr)
+                    Console.WriteLine(s.Name);
+            }
+            strLoc = "Loc_0001";
+
+            // [] Should not search on fullpath
+            // [] Search Criteria without match should return empty array
+
+            fsArr = dir2.GetFileSystemInfos("Directory");
+            iCountTestcases++;
+            if (fsArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_209v7! Incorrect number of files==" + fsArr.Length);
+            }
+
+            new FileInfo(dir2.FullName + "\\" + "TestDir1\\Test.tmp").Create();
+            fsArr = dir2.GetFileSystemInfos("TestDir1\\*");
+            iCountTestcases++;
+            if (fsArr.Length != 1)
+            {
+                iCountErrors++;
+                printerr("Error_28gyb! Incorrect number of files");
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetFiles
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.GetFiles()";
+    public static String s_strTFName = "GetFiles.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = Path.GetRandomFileName();
+            FileInfo[] filArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            filArr = dir2.GetFiles();
+            iCountTestcases++;
+            if (filArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of directories returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and get all the files
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            FileStream fs1 = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            FileStream fs2 = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            FileStream fs3 = new FileInfo(dir2.FullName + "\\" + "Test.bat").Create();
+            FileStream fs4 = new FileInfo(dir2.FullName + "\\" + "Test.exe").Create();
+            fs1.Dispose();
+            fs2.Dispose();
+            fs3.Dispose();
+            fs4.Dispose();
+
+            iCountTestcases++;
+            filArr = dir2.GetFiles();
+            iCountTestcases++;
+            if (filArr.Length != 4)
+            {
+                iCountErrors++;
+                printerr("Error_1yt75! Incorrect number of directories returned" + filArr.Length);
+            }
+
+            String[] names = new String[4];
+            int i = 0;
+            foreach (FileInfo f in filArr)
+                names[i++] = f.Name;
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test.bat") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_3y775! Incorrect name==" + filArr[0].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test.exe") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_90885! Incorrect name==" + filArr[1].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_879by! Incorrect name==" + filArr[2].Name);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_29894! Incorrect name==" + filArr[3].Name);
+            }
+
+            File.Delete(dirName + "\\TestFile1");
+            File.Delete(dirName + "\\TestFile2");
+
+            filArr = dir2.GetFiles();
+            iCountTestcases++;
+            if (filArr.Length != 2)
+            {
+                iCountErrors++;
+                printerr("Error_4y28x! Incorrect number of directories returned");
+            }
+
+            names = new String[2];
+            i = 0;
+            foreach (FileInfo f in filArr)
+                names[i++] = f.Name;
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test.bat") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_0975b! Incorrect name==" + filArr[0].Name);
+            }
+            if (Array.IndexOf(names, "Test.exe") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_928yb! Incorrect name==" + filArr[1].Name);
+            }
+
+
+            //-----------------------------------------------------------------
+
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str.cs
@@ -1,0 +1,318 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetFiles_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.GetFiles(String)";
+    public static String s_strTFName = "GetFiles_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String dirName = Path.GetRandomFileName();
+            String[] strArr;
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+            // [] Should throw ArgumentNullException for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_477g8";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(null);
+                iCountErrors++;
+                printerr("Error_2988b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0707t! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+
+            // [] ArgumentException for String.Empty
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4yg7b";
+
+            dir2 = new DirectoryInfo(".");
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(String.Empty);
+                iCountErrors++;
+                printerr("Error_8ytbm! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2908y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] ArgumentException for all whitespace
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2g87y";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles("\n");
+                iCountErrors++;
+                printerr("Error_29019! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9678g! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            // [] Should return zero length array for an empty directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4y982";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName);
+            iCountTestcases++;
+            if (strArr.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_207v7! Incorrect number of files returned");
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Create a directorystructure and get all the files
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2398c";
+            FileStream[] fs = new FileStream[5];
+            dir2.CreateSubdirectory("TestDir1");
+            dir2.CreateSubdirectory("TestDir2");
+            dir2.CreateSubdirectory("TestDir3");
+            dir2.CreateSubdirectory("Test1Dir1");
+            dir2.CreateSubdirectory("Test1Dir2");
+            fs[0] = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
+            fs[1] = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            fs[2] = new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
+            fs[3] = new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
+            fs[4] = new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+            for (int iLoop = 0; iLoop < 5; iLoop++)
+                fs[iLoop].Dispose();
+
+            // Get all files
+            strLoc = "Loc_4y7gb";
+
+            strArr = Directory.GetFiles(".\\" + dirName);
+            iCountTestcases++;
+            if (strArr.Length != 5)
+            {
+                iCountErrors++;
+                printerr("Error_t5792! Incorrect number of files==" + strArr.Length);
+            }
+            String[] names = new String[strArr.Length];
+            int i = 0;
+            foreach (String f in strArr)
+            {
+                names[i++] = f.Substring(f.LastIndexOf("\\") + 1);
+            }
+
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4898v! Incorrect name==" + strArr[0].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_4598c! Incorrect name==" + strArr[1].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile1") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_209d8! Incorrect name==" + strArr[2].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_10vtu! Incorrect name==" + strArr[3].ToString());
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_190vh! Incorrect name==" + strArr[4].ToString());
+            }
+
+            strLoc = "Loc_45500";
+            File.Delete(dirName + "\\TestFile1");
+            File.Delete(dirName + "\\Test1File1");
+
+            iCountTestcases++;
+            strArr = Directory.GetFiles(".\\" + dirName);
+            if (strArr.Length != 3)
+            {
+                iCountErrors++;
+                printerr("Error_176yb! Incorrect number of files==" + strArr.Length);
+            }
+            names = new String[strArr.Length];
+            i = 0;
+            foreach (String f in strArr)
+                names[i++] = f.Substring(f.LastIndexOf("\\") + 1);
+            iCountTestcases++;
+            if (Array.IndexOf(names, "Test1File2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_78657! Incorrect name==" + strArr[0]);
+            }
+
+            strLoc = "Loc_455434";
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile2") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_9y1bh! Incorrect name==" + strArr[1]);
+            }
+            iCountTestcases++;
+            if (Array.IndexOf(names, "TestFile3") < 0)
+            {
+                iCountErrors++;
+                printerr("Error_2178d! Incorrect name==" + strArr[2]);
+            }
+
+
+
+            //-----------------------------------------------------------------
+
+
+            // [] Some invalid directory testing
+            //-----------------------------------------------------------------
+            strLoc = "Loc_98yg5";
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles(",");
+                iCountErrors++;
+                printerr("Error_2y675! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_249y6! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            iCountTestcases++;
+            try
+            {
+                Directory.GetFiles("DoesNotExist");
+                iCountErrors++;
+                printerr("Error_2y76b! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_24y7g! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            //See VSWhidbey #104091
+            dir2 = new DirectoryInfo(".");
+            try
+            {
+                dir2.GetFiles("<>");
+
+                iCountErrors++;
+                Console.WriteLine("Err_32497gs! No exception thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234rd! Wrong exception thrown: {0}", ex);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str_so.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str_so.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+We test this API's functionality comprehensively via Directory.GetFiles(String, String, SearchOption). Here, we concentrate on the following
+ - vanilla
+ - parm validation, including non existent dir
+ - security
+**/
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections.Generic;
+using System.Security;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_FetFiles_str_so
+{
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void RunTest()
+    {
+        try
+        {
+            String dirName;
+            DirectoryInfo dirInfo;
+            String[] expectedFiles;
+            FileInfo[] files;
+            List<String> list;
+
+            //Scenario 1: Vanilla
+            try
+            {
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    dirInfo = new DirectoryInfo(dirName);
+                    expectedFiles = fileManager.GetAllFiles();
+                    list = new List<String>(expectedFiles);
+                    files = dirInfo.GetFiles("*.*", SearchOption.AllDirectories);
+                    Eval(files.Length == list.Count, "Err_415mbz! wrong count");
+                    for (int i = 0; i < expectedFiles.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i].FullName), "Err_287kkm! No file found: {0}", files[i].FullName))
+                            list.Remove(files[i].FullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_921mhs! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario 3: Parm Validation
+            try
+            {
+                // dir not present and then after creating
+                dirName = ManageFileSystem.GetNonExistingDir(Directory.GetCurrentDirectory(), ManageFileSystem.DirPrefixName);
+                dirInfo = new DirectoryInfo(dirName);
+                CheckException<DirectoryNotFoundException>(delegate { files = dirInfo.GetFiles("*.*", SearchOption.AllDirectories); }, "Err_326pgt! worng exception thrown");
+
+                // create the dir and then check that we dont cache this info
+                using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
+                {
+                    dirInfo = new DirectoryInfo(dirName);
+                    expectedFiles = fileManager.GetAllFiles();
+                    list = new List<String>(expectedFiles);
+                    files = dirInfo.GetFiles("*.*", SearchOption.AllDirectories);
+                    Eval(files.Length == list.Count, "Err_948kxt! wrong count");
+                    for (int i = 0; i < expectedFiles.Length; i++)
+                    {
+                        if (Eval(list.Contains(files[i].FullName), "Err_535xaj! No file found: {0}", files[i].FullName))
+                            list.Remove(files[i].FullName);
+                    }
+                    if (!Eval(list.Count == 0, "Err_370pjl! wrong count: {0}", list.Count))
+                    {
+                        Console.WriteLine();
+                        foreach (String fileName in list)
+                            Console.WriteLine(fileName);
+                    }
+                    CheckException<ArgumentNullException>(delegate { files = dirInfo.GetFiles(null, SearchOption.TopDirectoryOnly); }, "Err_751mwu! worng exception thrown");
+                    CheckException<ArgumentOutOfRangeException>(delegate { files = dirInfo.GetFiles("*.*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
+                    CheckException<ArgumentOutOfRangeException>(delegate { files = dirInfo.GetFiles("*.*", (SearchOption)(-1)); }, "Err_359vcj! worng exception thrown - see bug #386545");
+                    String[] invalidValuesForSearch = { "..", @"..\" };
+                    for (int i = 0; i < invalidValuesForSearch.Length; i++)
+                    {
+                        CheckException<ArgumentException>(delegate { files = dirInfo.GetFiles(invalidValuesForSearch[i], SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy! worng exception thrown: {1}", i, invalidValuesForSearch[i]));
+                    }
+                    Char[] invalidFileNames = Path.GetInvalidFileNameChars();
+                    for (int i = 0; i < invalidFileNames.Length; i++)
+                    {
+                        switch (invalidFileNames[i])
+                        {
+                            case '\\':
+                            case '/':
+                                CheckException<DirectoryNotFoundException>(delegate { files = dirInfo.GetFiles(String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy_{0}! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
+                                break;
+                            case ':':
+                                //History:
+                                // 1) we assumed that this will work in all non-9x machine
+                                // 2) Then only in XP
+                                // 3) NTFS?
+                                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                                    CheckException<IOException>(delegate { files = dirInfo.GetFiles(String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_997gqs! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
+                                else
+                                {
+                                    try
+                                    {
+                                        files = dirInfo.GetFiles(String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly);
+                                    }
+                                    catch (IOException)
+                                    {
+                                        Console.WriteLine(FileSystemDebugInfo.MachineInfo());
+                                        Eval(false, "Err_3947g! Another OS throwing for DI.GetFiles(). modify the above check after confirming the v1.x behavior in that machine");
+                                        /**
+                                                try
+                                                {
+                                                      DirectoryInfo dirInfo = new DirectoryInfo(".");
+                                                    FileInfo[] files = dirInfo.GetFiles("te:st"); 
+                                                pass=false;
+                                                Console.WriteLine("No exception thrown");
+                                                }
+                                            catch(IOException){}
+                                                catch (Exception ex)
+                                                {
+                                                pass=false;
+                                                Console.WriteLine("Err_723jvl! Different Exception caught in scenario: {0}", ex);
+                                                }
+
+                                        **/
+                                    }
+                                }
+                                break;
+                            case '*':
+                            case '?':
+                                files = dirInfo.GetFiles(String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly);
+                                break;
+                            default:
+                                CheckException<ArgumentException>(delegate { files = dirInfo.GetFiles(String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_036gza! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
+                                break;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_006dwq! Exception caught in scenario: {0}", ex);
+            }
+
+            //Scenario for bug #461014 - Getting files/directories of CurrentDirectory of drives are broken
+            /* Test disabled while porting because it relies on state outside of its working directory not changing over time
+            try
+            {
+                string anotherDrive = IOServices.GetNtfsDriveOtherThanCurrent();
+                String[] paths = null == anotherDrive ? new String[] { Directory.GetCurrentDirectory() } : new String[] { anotherDrive, Directory.GetCurrentDirectory() };
+                String path;
+
+                for (int i = 0; i < paths.Length; i++)
+                {
+                    path = paths[i];
+                    if (path.Length > 1)
+                    {
+                        path = path.Substring(0, 2);
+
+                        FileInfo[] f1 = new DirectoryInfo(Path.GetFullPath(path)).GetFiles();
+                        FileInfo[] f2 = new DirectoryInfo(path).GetFiles();
+                        Eval<int>(f1.Length, f2.Length, "Err_2497gds! wrong value");
+                        for (int j = 0; j < f1.Length; j++)
+                        {
+                            Eval<String>(f1[j].FullName, f2[j].FullName, "Err_03284t! wrong value");
+                            Eval<String>(f1[j].Name, f2[j].Name, "Err_03284t! wrong value");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+            */
+        }
+        catch (Exception ex)
+        {
+            s_pass = false;
+            Console.WriteLine("Err_234rsgf! Uncaught exception in RunTest: {0}", ex);
+        }
+
+
+        Assert.True(s_pass);
+    }
+
+    private void DeleteFile(String fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+    private void DeleteDir(String dirName)
+    {
+        if (Directory.Exists(dirName))
+            Directory.Delete(dirName);
+    }
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (msgExpected != null && System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+}
+
+
+
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_GetSetTimes
+{
+    private enum TimeProperty
+    {
+        CreationTime,
+        LastAccessTime,
+        LastWriteTime
+    }
+
+    [Fact]
+    public static void ConsistencyTest()
+    {
+        String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+        DirectoryInfo dir = new DirectoryInfo(fileName);
+        dir.Create();
+
+        foreach (TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
+        {
+            foreach (DateTimeKind kind in Enum.GetValues(typeof(DateTimeKind)))
+            {
+                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);
+                foreach (bool setUtc in new[] { false, true })
+                {
+                    if (setUtc)
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                dir.CreationTimeUtc = dt;
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                dir.LastAccessTimeUtc = dt;
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                dir.LastWriteTimeUtc = dt;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                dir.CreationTime = dt;
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                dir.LastAccessTime = dt;
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                dir.LastWriteTime = dt;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    DateTime actual, actualUtc;
+                    switch (timeProperty)
+                    {
+                        case TimeProperty.CreationTime:
+                            actual = dir.CreationTime;
+                            actualUtc = dir.CreationTimeUtc;
+                            break;
+                        case TimeProperty.LastAccessTime:
+                            actual = dir.LastAccessTime;
+                            actualUtc = dir.LastAccessTimeUtc;
+                            break;
+                        case TimeProperty.LastWriteTime:
+                            actual = dir.LastWriteTime;
+                            actualUtc = dir.LastWriteTimeUtc;
+                            break;
+                        default:
+                            throw new ArgumentException("Invalid time property type");
+                    }
+
+                    DateTime expected = dt.ToLocalTime();
+                    DateTime expectedUtc = dt.ToUniversalTime();
+
+                    if (dt.Kind == DateTimeKind.Unspecified)
+                    {
+                        if (setUtc)
+                        {
+                            expectedUtc = dt;
+                        }
+                        else
+                        {
+                            expected = dt;
+                        }
+                    }
+
+                    Assert.Equal(expected, actual); //"Local {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                    Assert.Equal(expectedUtc, actualUtc); //"Universal {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                }
+            }
+        }
+
+        dir.Delete();
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
@@ -1,0 +1,474 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_Move_str
+{
+    public static String s_strActiveBugNums = "34383";
+    public static String s_strClassMethod = "Directory.Move(String)";
+    public static String s_strTFName = "Move_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2 = null;
+            DirectoryInfo dir2 = null;
+
+            // [] Pass in null argument
+
+            strLoc = "Loc_099u8";
+            string testDir = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo(null);
+                iCountErrors++;
+                printerr("Error_298dy! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209xj! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+            // [] Pass in empty String should throw ArgumentException
+
+            strLoc = "Loc_098gt";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo(String.Empty);
+                iCountErrors++;
+                printerr("Error_3987c! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9092c! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+            // [] Vanilla move to new name
+
+            strLoc = "Loc_98hvc";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            dir2.MoveTo(Path.Combine(TestInfo.CurrentDirectory, "Test3"));
+            try
+            {
+                dir2 = new DirectoryInfo(Path.Combine(TestInfo.CurrentDirectory, "Test3"));
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2881s! Directory not moved, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+            // [] Try to move it on top of current dir
+
+            strLoc = "Loc_2908x";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo(Path.Combine(TestInfo.CurrentDirectory, "."));
+                iCountErrors++;
+                printerr("Error_2091z! Expected exception not thrown,");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2100s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+            // [] Try to move it on top of parent dir
+
+            strLoc = "Loc_1999s";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo(Path.Combine(TestInfo.CurrentDirectory, ".."));
+                iCountErrors++;
+                printerr("Error_2091b! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_01990! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+
+            // [] Pass in string with spaces should throw ArgumentException
+
+            strLoc = "Loc_498vy";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo("         ");
+                iCountErrors++;
+                printerr("Error_209uc! Expected exception not thrown");
+                fil2.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28829! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+            // [] Mvoe to the same directory
+
+            strLoc = "Loc_498vy";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo(testDir);
+                iCountErrors++;
+                printerr("Error_209uc! Expected exception not thrown");
+                fil2.Delete();
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28829! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+#if !TEST_WINRT // Can't access other root drives
+            // [] Move to different drive will throw AccessException
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00025";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                if (dir2.FullName.Substring(0, 3) == @"d:\" || dir2.FullName.Substring(0, 3) == @"D:\")
+                    dir2.MoveTo("C:\\TempDirectory");
+                else
+                    dir2.MoveTo("D:\\TempDirectory");
+                Console.WriteLine("Root directory..." + dir2.FullName.Substring(0, 3));
+                iCountErrors++;
+                printerr("Error_00078! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_23r0g! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+#endif
+
+            // [] Move non-existent directory
+            dir2 = new DirectoryInfo(testDir);
+            try
+            {
+                dir2.MoveTo(Path.Combine(TestInfo.CurrentDirectory, "Test5526"));
+                iCountErrors++;
+                Console.WriteLine("Err_34gs! Exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34gs! Wrong Exception thrown: {0}", ex);
+            }
+
+
+            // [] Pass in string with tabs 
+
+            strLoc = "Loc_98399";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo("\t");
+                iCountErrors++;
+                printerr("Error_2091c! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_8374v! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+
+
+            // [] Create a long filename directory
+
+
+            strLoc = "Loc_2908y";
+
+            StringBuilder sb = new StringBuilder(TestInfo.CurrentDirectory);
+            while (sb.Length < 260)
+                sb.Append("a");
+
+            iCountTestcases++;
+            dir2 = Directory.CreateDirectory(testDir);
+            try
+            {
+                dir2.MoveTo(sb.ToString());
+                iCountErrors++;
+                printerr("Error_109ty! Expected exception not thrown");
+            }
+            catch (PathTooLongException)
+            { // This should really be PathTooLongException
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109dv! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+            // [] Too long filename
+
+            strLoc = "Loc_48fyf";
+
+            sb = new StringBuilder();
+            for (int i = 0; i < 260; i++)
+                sb.Append("a");
+
+            iCountTestcases++;
+            dir2 = Directory.CreateDirectory(testDir);
+            try
+            {
+                dir2.MoveTo(sb.ToString());
+                iCountErrors++;
+                printerr("Error_109ty! Expected exception not thrown");
+            }
+            catch (PathTooLongException)
+            { // This should really be PathTooLongException
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109dv! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+            // [] specifying subdirectories should fail unless they exist
+
+            strLoc = "Loc_209ud";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo(Path.Combine(testDir, "Test\\Test\\Test"));
+                iCountErrors++;
+                printerr("Error_1039s! Expected exception not thrown");
+                fil2.Delete();
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2019u! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+            // [] Exception if directory already exists
+
+            strLoc = "Loc_2498x";
+
+            iCountTestcases++;
+            Directory.CreateDirectory(testDir + "a");
+            dir2 = Directory.CreateDirectory(testDir);
+            try
+            {
+                dir2.MoveTo(testDir + "a");
+                iCountErrors++;
+                printerr("Error_2498h! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_289vt! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+            new DirectoryInfo(testDir + "a").Delete(true);
+
+
+
+            // [] Illiegal chars in new DirectoryInfo name
+
+            strLoc = "Loc_2798r";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            iCountTestcases++;
+            try
+            {
+                dir2.MoveTo("******.***");
+                iCountErrors++;
+                printerr("Error_298hv! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2199d! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+            // [] Move a directory with subdirs
+
+            strLoc = "Loc_209ux";
+
+            dir2 = Directory.CreateDirectory(testDir);
+            DirectoryInfo subdir = dir2.CreateSubdirectory("Test5525");
+
+            //			dir2.MoveTo("NewTest5525");
+            FailSafeDirectoryOperations.MoveDirectoryInfo(dir2, Path.Combine(TestInfo.CurrentDirectory, "NewTest5525"));
+
+            iCountTestcases++;
+            try
+            {
+                subdir = new DirectoryInfo(Path.Combine(TestInfo.CurrentDirectory, "NewTest5525\\Test5525"));
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_290u1! Failed to move Folder, exc==" + exc.ToString());
+            }
+            subdir.Delete(true);
+            dir2.Delete(true);
+
+
+            // [] 
+
+
+            //problems with trailing slashes and stuff - #431574
+            /**
+             - We need to remove the trailing slash when we get the parent directory (we call Path.GetDirectoryName on the full path and having the slash will not work)
+             - Root drive always have the trailing slash
+             - MoveTo adds a trailing slash
+            **/
+
+            String subDir = Path.Combine(TestInfo.CurrentDirectory, "LaksTemp");
+            DeleteFileDir(subDir);
+            String[] values = { "TestDir", @"TestDir\" };
+            String moveDir = Path.Combine(TestInfo.CurrentDirectory, values[1]);
+            foreach (String value in values)
+            {
+                dir2 = new DirectoryInfo(subDir);
+                dir2.Create();
+                dir2.MoveTo(TestInfo.CurrentDirectory + "\\" + value);
+                if (!dir2.FullName.Equals(moveDir))
+                {
+                    Console.WriteLine("moveDir: <{0}>", moveDir);
+                    iCountErrors++;
+                    Console.WriteLine("Err_374g! wrong vlaue returned: {0}", dir2.FullName);
+                }
+                dir2.Delete();
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    private static void DeleteFileDir(String path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+        if (Directory.Exists(path))
+            Directory.Delete(path);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Refresh.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Refresh.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_Refresh
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.Refresh()";
+    public static String s_strTFName = "Refresh.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            DirectoryInfo dir2;
+            String dirName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName);
+
+
+            // [] Delete directory and refresh
+            //----------------------------------------------------------------
+            strLoc = "Loc_00001";
+
+            Directory.CreateDirectory(dirName);
+            dir2 = new DirectoryInfo(dirName);
+            Directory.Delete(dirName);
+            iCountTestcases++;
+            dir2.Refresh();
+
+            //----------------------------------------------------------------
+
+            // [] Change name of directory and refresh
+            //----------------------------------------------------------------
+            strLoc = "Loc_00005";
+
+            string newDirName = Path.Combine(TestInfo.CurrentDirectory, "Temp001");
+            if (Directory.Exists(newDirName))
+                Directory.Delete(newDirName);
+
+            iCountTestcases++;
+            Directory.CreateDirectory(dirName);
+            dir2 = new DirectoryInfo(dirName);
+            dir2.MoveTo(newDirName);
+            dir2.Refresh();
+            Directory.Delete(newDirName);
+            //----------------------------------------------------------------
+
+            // [] Change Attributes and refresh
+            //----------------------------------------------------------------
+            strLoc = "Loc_00006";
+            iCountTestcases++;
+
+            Directory.CreateDirectory(dirName);
+            dir2 = new DirectoryInfo(dirName);
+
+            if (((Int32)dir2.Attributes & (Int32)FileAttributes.ReadOnly) != 0)
+            {
+                Console.WriteLine(dir2.Attributes);
+                iCountErrors++;
+                printerr("Error_00007! Attribute set before refresh");
+            }
+            dir2.Attributes = FileAttributes.ReadOnly;
+            dir2.Refresh();
+            iCountTestcases++;
+            if (((Int32)dir2.Attributes & (Int32)FileAttributes.ReadOnly) <= 0)
+            {
+                iCountErrors++;
+                printerr("Error_00008! Object not refreshed after setting readonly");
+            }
+
+            dir2.Attributes = new FileAttributes();
+            dir2.Refresh();
+            if (((Int32)dir2.Attributes & (Int32)FileAttributes.ReadOnly) != 0)
+            {
+                iCountErrors++;
+                printerr("Error_00009! Object not refreshed after removing readonly");
+            }
+
+            //----------------------------------------------------------------
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/SetCreationTime_dt.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/SetCreationTime_dt.cs
@@ -1,0 +1,249 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_set_CreationTime_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "DirectoryInfo.CreationTime";
+    public static String s_strTFName = "set_CreationTime_dt.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = Path.GetRandomFileName();
+
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            DirectoryInfo dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Today;
+                if ((dir2.CreationTime - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Now.AddYears(1);
+                if ((dir2.CreationTime - DateTime.Now.AddYears(1)).Days > 1)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Now.AddYears(-1);
+                if ((dir2.CreationTime - DateTime.Now.AddYears(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Now.AddMonths(1);
+                if ((dir2.CreationTime - DateTime.Now.AddMonths(1)).Seconds > 2)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Now.AddMonths(-1);
+                if ((dir2.CreationTime - DateTime.Now.AddMonths(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Now.AddDays(1);
+                if ((dir2.CreationTime - DateTime.Now.AddDays(1)).Seconds > 2)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = DateTime.Now.AddDays(-1);
+                if ((dir2.CreationTime - DateTime.Now.AddDays(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.CreationTime = new DateTime(2001, 332, 20, 50, 50, 50);
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                dir2.CreationTime = dt;
+                if ((dir2.CreationTime - dt).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/SetLastAccessTime_dt.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/SetLastAccessTime_dt.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_set_LastAccessTime_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "DirectoryInfo.LastAccessTime";
+    public static String s_strTFName = "set_LastAccessTime_dt.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = Path.GetRandomFileName();
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            DirectoryInfo dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = DateTime.Today;
+                if ((dir2.LastAccessTime - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = DateTime.Now.AddYears(1);
+                if ((dir2.LastAccessTime - DateTime.Now.AddYears(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = DateTime.Now.AddYears(-1);
+                dir2.LastAccessTime = dt;
+                if (!CompareDates(dt, dir2.LastAccessTime))
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct" + CompareDates(dt, dir2.LastAccessTime));
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = DateTime.Now.AddMonths(1);
+                if ((dir2.LastAccessTime - DateTime.Now.AddMonths(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = DateTime.Now.AddMonths(-1);
+                if ((dir2.LastAccessTime - DateTime.Now.AddMonths(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = DateTime.Now.AddDays(1);
+                if ((dir2.LastAccessTime - DateTime.Now.AddDays(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = DateTime.Now.AddDays(-1);
+                if ((dir2.LastAccessTime - DateTime.Now.AddDays(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastAccessTime = new DateTime(2001, 332, 20, 50, 50, 50);
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                dir2.LastAccessTime = dt;
+                if ((dir2.LastAccessTime - dt).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+
+    private static bool CompareDates(DateTime dt1, DateTime dt2)
+    {
+        if ((dt1.Year == dt2.Year) && (dt1.Month == dt2.Month) && (dt1.Day == dt2.Day))
+            return true;
+        else
+            return false;
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/SetLastWriteTime_dt.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/SetLastWriteTime_dt.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_set_LastWriteTime_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "DirectoryInfo.LastWriteTime";
+    public static String s_strTFName = "set_LastWriteTime_dt.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = Path.GetRandomFileName();
+
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            DirectoryInfo dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastWriteTime = DateTime.Today;
+                if (!CompareDates(dir2.LastWriteTime, DateTime.Now))
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastWriteTime = DateTime.Now.AddYears(1);
+                dir2.Refresh();
+                if ((dir2.LastWriteTime - DateTime.Now.AddYears(1)).Minutes > 0)
+                {
+                    iCountErrors++;
+                    printerr(String.Format("Error_0010! Creation time cannot be correct. {0}, Now: {1}", dir2.LastWriteTime, DateTime.Now.AddYears(1)));
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = DateTime.Now.AddYears(-1);
+                dir2.LastWriteTime = dt;
+                if (!CompareDates(dt, dir2.LastWriteTime))
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastWriteTime = DateTime.Now.AddMonths(1);
+                dir2.Refresh();
+                if ((dir2.LastWriteTime - DateTime.Now.AddMonths(1)).Minutes > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = DateTime.Now.AddMonths(-1);
+                dir2.LastWriteTime = dt;
+                if (!CompareDates(dt, dir2.LastWriteTime))
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastWriteTime = DateTime.Now.AddDays(1);
+                dir2.Refresh();
+                if ((dir2.LastWriteTime - DateTime.Now.AddDays(1)).Minutes > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = DateTime.Now.AddDays(-1);
+                dir2.LastWriteTime = dt;
+                if (!CompareDates(dt, dir2.LastWriteTime))
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                dir2.LastWriteTime = new DateTime(2001, 332, 20, 50, 50, 50);
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+
+            dir2 = new DirectoryInfo(fileName);
+            dir2.Create();
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                dir2.LastWriteTime = dt;
+                if (!CompareDates(dt, dir2.LastWriteTime))
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            FailSafeDirectoryOperations.DeleteDirectoryInfo(dir2, false);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+
+
+    private static bool CompareDates(DateTime dt1, DateTime dt2)
+    {
+        if ((dt1.Year == dt2.Year) && (dt1.Month == dt2.Month) && (dt1.Day == dt2.Day))
+        {
+            return true;
+        }
+        else
+        {
+            Console.WriteLine(dt1);
+            Console.WriteLine(dt2);
+            return false;
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_ToString
+{
+    public static String s_strActiveBugNums = "14866";
+    public static String s_strClassMethod = "Directory.ToString";
+    public static String s_strTFName = "ToString.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        string dirName = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dirName);
+
+
+        try
+        {
+            DirectoryInfo dir = null;
+
+
+            // [] Do the current dir
+
+
+            strLoc = "Loc_909d9";
+
+            dir = new DirectoryInfo(dirName);
+            iCountTestcases++;
+            if (!dir.ToString().Equals(Path.GetFileName(dirName)))
+            {
+                iCountErrors++;
+                printerr("Error_209xu! Incorrect Directory returned , dir==" + dir.ToString());
+                Console.WriteLine(dirName);
+                Console.WriteLine(dir == null);
+                Console.WriteLine(dir);
+            }
+            // [] Root drive
+
+            strLoc = "Loc_20u9x";
+
+            dir = new DirectoryInfo("c:\\");
+            iCountTestcases++;
+            if (!dir.ToString().Equals("c:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_2098x! Incorrect dir returned==" + dir.ToString());
+            }
+
+            string testDir = Path.Combine(dirName, "TestDir");
+            Directory.CreateDirectory(testDir);
+            dir = new DirectoryInfo(testDir);
+            iCountTestcases++;
+
+            if (!dir.FullName.Equals(testDir))
+            {
+                iCountErrors++;
+                printerr("Error_298yx! Incorrect dir constructed, dir==" + dir.ToString());
+            }
+            dir.Delete();
+
+            // [] Whitespace string
+
+            strLoc = "Loc_298yb";
+
+            iCountTestcases++;
+            try
+            {
+                dir = new DirectoryInfo("      ");
+                dir.Create();
+                iCountErrors++;
+                printerr("Error_09rux! Expected exception not thrown, dir==" + dir.ToString());
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14866 Error_4577c! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Go for same dir
+
+            strLoc = "Loc_949gg";
+
+            dir = new DirectoryInfo(".");
+            iCountTestcases++;
+            if (!dir.FullName.Equals(Directory.GetCurrentDirectory()))
+            {
+                iCountErrors++;
+                printerr("Error_299xu! Incorrect dir constructed, dir==" + dir.ToString());
+            }
+
+            // [] go one dir up
+
+            strLoc = "Loc_9937a";
+
+            dir = new DirectoryInfo("..");
+            iCountTestcases++;
+            if (!dir.FullName.Equals(Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().LastIndexOf("\\"))))
+            {
+                iCountErrors++;
+                printerr("Error_298xy! Incorrect dir returned, dir==" + dir.ToString());
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    public partial class DirectoryInfo_ctor_str : FileSystemTest
+    {
+        [Fact]
+        public void NullParameter()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DirectoryInfo(null));
+        }
+
+        [Fact]
+        public void EmptyParameter()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(""));
+        }
+
+        [Fact]
+        public void Spaces()
+        {
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo("      "));
+        }
+
+        [Fact]
+        public void CurrentDirectory()
+        {
+            Assert.Equal(new DirectoryInfo(Directory.GetCurrentDirectory()).FullName, Directory.GetCurrentDirectory());
+        }
+
+        [Fact]
+        public void CDrive()
+        {
+            string dirName = "c:\\";
+            DirectoryInfo dir = new DirectoryInfo(dirName);
+            Assert.Equal(dir.FullName, dirName);
+        }
+
+        [Fact]
+        public void CDriveCase()
+        {
+            DirectoryInfo dir = new DirectoryInfo("c:\\");
+            DirectoryInfo dir2 = new DirectoryInfo("C:\\");
+            Assert.NotEqual(dir.FullName, dir2.FullName);
+        }
+
+        [Fact]
+        [ActiveIssue(1222)]
+        public void TrailingWhitespace()
+        {
+            new DirectoryInfo(Path.Combine(TestDirectory, "Testing\t\t\t\n")).Create();
+        }
+
+        [Fact]
+        public void CurrentDirectoryWithDot()
+        {
+            Assert.Equal(new DirectoryInfo(".").FullName, Directory.GetCurrentDirectory());
+        }
+
+        [Fact]
+        public void ParentDirectoryWithDotDot()
+        {
+            Assert.Equal(new DirectoryInfo("..").FullName, Directory.GetParent(Directory.GetCurrentDirectory()).FullName);
+        }
+
+        [Fact]
+        public void NetworkShare()
+        {
+            string dirName = "\\\\contoso\\amusement\\device";
+            Assert.Equal(new DirectoryInfo(dirName).FullName, dirName);
+        }
+
+        [Fact]
+        public void TrailingSlash()
+        {
+            DirectoryInfo dir1 = new DirectoryInfo("C:\\hello");
+            DirectoryInfo dir2 = new DirectoryInfo("C:\\hello\\");
+
+            Assert.Equal(dir1.Name, dir2.Name);
+            Assert.Equal(dir1.Parent.FullName, dir2.Parent.FullName);
+            Assert.Equal(dir1.Root.FullName, dir2.Root.FullName);
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Attributes.cs
@@ -1,0 +1,327 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_get_Attributes
+{
+    public static String s_strActiveBugNums = "14952";
+    public static String s_strClassMethod = "Directory.Attributes";
+    public static String s_strTFName = "get_Attributes.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        string testDirectory = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+        Directory.CreateDirectory(testDirectory);
+
+        try
+        {
+            DirectoryInfo dir = null;
+            FileAttributes diratt;
+
+            new DirectoryInfo(testDirectory).Attributes = new FileAttributes();
+
+            // [] Invalid value
+
+            strLoc = "Loc_09t77";
+
+            dir = new DirectoryInfo(testDirectory);
+            iCountTestcases++;
+            try
+            {
+                dir.Attributes = ~FileAttributes.ReadOnly;
+                iCountErrors++;
+                printerr("Error_78t59! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_97678! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] Try on current directory
+
+            strLoc = "Loc_20hx9";
+
+            dir = new DirectoryInfo(testDirectory);
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & FileAttributes.Directory) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_1092x! Incorrect directory attributes, diratt==" + diratt.ToString("G"));
+            }
+
+            // [] Set the attributes
+
+            strLoc = "Loc_039ux";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.ReadOnly;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.ReadOnly | FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_2989d! Incorrect directory attribute set");
+            }
+            dir.Attributes = new FileAttributes();
+
+
+            // [] Set hidden only
+
+            strLoc = "Loc_209cu";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.Hidden;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support hidden
+            if((diratt & (FileAttributes.Hidden|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+#else
+            if ((diratt & (FileAttributes.Hidden | FileAttributes.Directory)) != (FileAttributes.Hidden | FileAttributes.Directory))
+            {
+#endif
+                iCountErrors++;
+                printerr("Error_3091h! Incorrect directory attribute set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Set readonly only
+
+            strLoc = "Loc_739dx";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.ReadOnly;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.ReadOnly | FileAttributes.Directory)) != (FileAttributes.ReadOnly | FileAttributes.Directory))
+            {
+                iCountErrors++;
+                printerr("Error_3091h! Incorrect directory attribute set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Set hidden and readonly
+
+            strLoc = "Loc_390uv";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.Hidden | FileAttributes.ReadOnly;
+#if !TEST_WINRT  // WinRT doesn't support hidden
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((int)(diratt & FileAttributes.Hidden) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_20x97! Hidden attribute not set");
+            }
+#endif
+            iCountTestcases++;
+            if ((int)(diratt & FileAttributes.ReadOnly) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_1990c! ReadOnly attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Set system
+
+            strLoc = "Loc_8gy0b";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.System;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support system
+            if((diratt & (FileAttributes.System|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+#else
+            if ((diratt & (FileAttributes.System | FileAttributes.Directory)) != (FileAttributes.System | FileAttributes.Directory))
+            {
+#endif
+                iCountErrors++;
+                printerr("Error_7t87y! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] set archive
+
+            strLoc = "Loc_29d88";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.Archive;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support archive
+            if((diratt & (FileAttributes.Archive|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+#else
+            if ((diratt & (FileAttributes.Archive | FileAttributes.Directory)) != (FileAttributes.Archive | FileAttributes.Directory))
+            {
+#endif
+                iCountErrors++;
+                printerr("Error_f487b! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Encrypted can't be set on directory
+
+            strLoc = "Loc_t78yg";
+
+            /*			dir = new DirectoryInfo(".");
+                        dir.Attributes = FileAttributes.Encrypted;
+                        diratt = dir.Attributes;
+                        iCountTestcases++;
+                        if(diratt != FileAttributes.Directory) {
+                            iCountErrors++;
+                            printerr( "Error_09828! System attribute not set");
+                        } 
+                        dir.Attributes = new FileAttributes();     */
+
+            // [] Normal can't be set on directory
+
+            strLoc = "Loc_90v77";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.Normal;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & FileAttributes.Directory) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_2t09b! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+
+            // [] Temporary can't be set on directory
+
+            strLoc = "Loc_99g94";
+
+            /*			dir = new DirectoryInfo(".");
+                        iCountTestcases++;
+                        try {
+                            dir.Attributes = FileAttributes.Temporary;
+                            iCountErrors++;
+                            printerr( "Error_247tb! Expected exception not thrown");
+                        } catch (ArgumentException aexc) {
+                        } catch (Exception exc) {
+                            iCountErrors++;
+                            printerr( "Error_758bh! Incorrect exception thrown, exc=="+exc.ToString());
+                        }
+                        dir.Attributes = new FileAttributes();              */
+
+
+            // [] Sparsefile can't be set on directory
+
+            strLoc = "Loc_8gy0b";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.SparseFile;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_1300g! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+
+            // [] ReparsePoint can't be set on directory
+
+
+            strLoc = "Loc_9180c";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.ReparsePoint;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0199c! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Compressed can't be set on directory
+
+
+            strLoc = "Loc_0200d";
+
+            dir = new DirectoryInfo(testDirectory);
+            dir.Attributes = FileAttributes.Compressed;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_9010c! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Offline
+            iCountTestcases++;
+            /* Does not work on FAT filesystem
+                        strLoc = "Loc_109tg";
+
+                        dir = new DirectoryInfo(".");
+                        dir.Attributes = FileAttributes.Offline;
+                        diratt = dir.Attributes;
+                        iCountTestcases++;
+                        if(diratt != (FileAttributes.Offline|FileAttributes.Directory)) {
+                            iCountErrors++;
+                            printerr( "Error_010vy! System attribute not set");
+                        } 
+                        dir.Attributes = new FileAttributes();
+
+
+                        // [] NotContectIndexed
+
+                        strLoc = "Loc_t0698";
+
+                        dir = new DirectoryInfo(".");
+                        dir.Attributes = FileAttributes.NotContentIndexed;
+                        diratt = dir.Attributes;
+                        iCountTestcases++;
+                        if(diratt != (FileAttributes.NotContentIndexed|FileAttributes.Directory)) {
+                            iCountErrors++;
+                            printerr( "Error_23047! System attribute not set");
+                        } 
+                        dir.Attributes = new FileAttributes();
+            */
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_CreationTime.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_CreationTime.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Threading.Tasks;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_get_CreationTime
+{
+    public static String s_strActiveBugNums = "14952";
+    public static String s_strClassMethod = "Directory.CreationTime";
+    public static String s_strTFName = "get_CreationTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir = null;
+
+
+
+
+            // [] Create a directory and check the creation time
+
+            strLoc = "Loc_r8r7j";
+
+
+            dir = Directory.CreateDirectory(Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName()));
+            iCountTestcases++;
+            try
+            {
+                if (Math.Abs((dir.CreationTime - DateTime.Now).TotalSeconds) > 3)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Error_20hjx! Creation time cannot be correct: <{0}>", dir.CreationTime);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14952 Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            dir.Delete(true);
+
+
+            // [] Do some sleeps and check the creation time
+
+            strLoc = "Loc_20yxc";
+
+            dir = Directory.CreateDirectory(Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName()));
+            Task.Delay(2000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - dir.CreationTime).Seconds > 3)
+                {
+                    iCountErrors++;
+                    printerr("Eror_209x9! Creation time is off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            dir.Delete(true);
+
+            //See VSWhidbey # 92050
+            String path = TestInfo.CurrentDirectory + "\\";
+            String tempPath;
+            int count = 0;
+            while (true)
+            {
+                tempPath = path + "foo_" + count++;
+                if (!Directory.Exists(tempPath))
+                    break;
+            }
+            dir = new DirectoryInfo(tempPath);
+            try
+            {
+                DateTime d1 = dir.CreationTime;
+                if (d1 != DateTime.FromFileTime(0))
+                {
+                    iCountErrors++;
+                    printerr("Error_20hjx! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_FullName.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_FullName.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class DirectoryInfo_Co5511get_FullName
+{
+    public static String s_strActiveBugNums = "14866, 14849";
+    public static String s_strClassMethod = "Directory.FullName";
+    public static String s_strTFName = "Co5511get_FullName.cs";
+    public static String s_strTFAbbrev = "Co5511";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+        try
+        {
+            DirectoryInfo dir = null;
+            strLoc = "Loc_2908x";
+
+            iCountTestcases++;
+            try
+            {
+                dir = new DirectoryInfo(null);
+                iCountErrors++;
+                printerr("Error_2908x! Expected exception not thrown, dir==" + dir.ToString());
+            }
+            catch (ArgumentNullException)
+            {
+                // Expected exception
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209ux! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Do the current dir
+
+
+            strLoc = "Loc_909d9";
+
+            string currentDir = Directory.GetCurrentDirectory();
+            dir = new DirectoryInfo(currentDir);
+            iCountTestcases++;
+            if (!dir.FullName.Equals(currentDir))
+            {
+                iCountErrors++;
+                printerr("Error_209xu! Incorrect Directory returned , dir==" + dir.FullName);
+            }
+
+            // [] Give a non-existent directory
+
+            strLoc = "Loc_2999s";
+
+            iCountTestcases++;
+            dir = new DirectoryInfo("This directory does not exist");
+            if (!dir.FullName.Equals(Directory.GetCurrentDirectory() + "\\This directory does not exist"))
+            {
+                iCountErrors++;
+                printerr("Error_109z9! Incorrect directory name, dir==" + dir.ToString());
+            }
+
+
+            // [] Root drive
+
+            strLoc = "Loc_20u9x";
+
+            dir = new DirectoryInfo("c:\\");
+            iCountTestcases++;
+            if (!dir.FullName.Equals("c:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_2098x! Incorrect dir returned==" + dir.FullName);
+            }
+
+            // [] Capital letter root drive
+
+            strLoc = "Loc_099s8";
+
+            dir = new DirectoryInfo("C:\\");
+            DirectoryInfo dir2 = new DirectoryInfo("C:\\");
+
+            iCountTestcases++;
+            if (!dir.FullName.Equals(dir2.FullName))
+            {
+                iCountErrors++;
+                printerr("Bug 14849 Error_2982y! dir==" + dir.FullName + " , dir2==" + dir2.FullName);
+            }
+
+            string dirPath = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            Directory.CreateDirectory(dirPath);
+            dir = new DirectoryInfo(dirPath);
+            iCountTestcases++;
+            if (!dir.FullName.Equals(dirPath))
+            {
+                iCountErrors++;
+                printerr("Error_298yx! Incorrect dir constructed, dir==" + dir.FullName);
+            }
+            dir.Delete();
+
+            strLoc = "Loc_298yb";
+
+            iCountTestcases++;
+            try
+            {
+                dir = new DirectoryInfo("      ");
+                dir.Create();
+                iCountErrors++;
+                printerr("Error_0919x! Expected exception not thrown, dir==" + dir.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_4577c! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Go for current dir with "."
+
+            strLoc = "Loc_949gg";
+
+            dir = new DirectoryInfo(".");
+            iCountTestcases++;
+            if (!dir.FullName.Equals(Directory.GetCurrentDirectory()))
+            {
+                iCountErrors++;
+                printerr("Error_299xu! Incorrect dir constructed, dir==" + dir.FullName);
+            }
+
+            // [] go one dir up with ".."
+
+            strLoc = "Loc_9937a";
+
+            dir = new DirectoryInfo("..");
+            iCountTestcases++;
+            String strParent = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().LastIndexOf("\\"));
+            if (strParent.IndexOf("\\") == -1 && strParent.IndexOf("/") == -1)
+                strParent = strParent + "\\";
+            if (!dir.FullName.Equals(strParent))
+            {
+                iCountErrors++;
+                Console.WriteLine(strParent);
+                printerr("Error_298xy! Incorrect dir returned, dir==" + dir.FullName);
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_LastAccessTime.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_LastAccessTime.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class DirectoryInfo_get_LastAccessTime
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.LastAccessTime";
+    public static String s_strTFName = "get_LastAccessTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String dirName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            DirectoryInfo dir2;
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+
+            // [] Create a directory and check the last access time 
+
+            strLoc = "Loc_r8r7j";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dir2.Refresh();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - dir2.LastAccessTime).Days != 0)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(dir2.LastAccessTime);
+                    Console.WriteLine((DateTime.Now - dir2.LastAccessTime).Days);
+                    printerr("Error_20hjx! Access time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14952 Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] access the directory and check the time
+
+            strLoc = "Loc_20yxc";
+
+            dir2.Refresh();
+            Task.Delay(1000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - dir2.LastAccessTime).Days != 0)
+                {
+                    iCountErrors++;
+                    Console.WriteLine((DateTime.Now - dir2.LastAccessTime).Days);
+                    printerr("Eror_209x9! LastAccessTime is way off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            dir2.Delete();
+
+
+            //-----------------------------------------------------------
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_LastWriteTime.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_LastWriteTime.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class DirectoryInfo_get_LastWriteTime
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.LastWriteTime";
+    public static String s_strTFName = "get_LastWriteTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String dirName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            DirectoryInfo dir2;
+
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+
+
+            // [] Create a directory and check the last access time 
+
+            strLoc = "Loc_r8r7j";
+
+            dir2 = Directory.CreateDirectory(dirName);
+            dir2.Refresh();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - dir2.LastWriteTime).TotalMilliseconds < -5000 ||
+                   (DateTime.Now - dir2.LastWriteTime).TotalMilliseconds > 5000)
+                {
+                    Console.WriteLine("dir2.LastWriteTime: " + dir2.LastWriteTime);
+                    Console.WriteLine("DateTime.Now: " + DateTime.Now);
+
+                    iCountErrors++;
+                    Console.WriteLine((DateTime.Now - dir2.LastWriteTime).TotalMilliseconds);
+                    printerr("Error_20hjx! LastWriteTime time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14952 Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+
+            // [] access the directory and check the time
+
+            strLoc = "Loc_20yxc";
+
+            dir2.CreateSubdirectory("Sub");
+            dir2.Refresh();
+            Task.Delay(1000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - dir2.LastWriteTime).TotalMilliseconds < -5000 ||
+                    (DateTime.Now - dir2.LastWriteTime).TotalMilliseconds > 5000)
+                {
+                    iCountErrors++;
+                    Console.WriteLine((DateTime.Now - dir2.LastWriteTime).TotalMilliseconds);
+                    printerr("Eror_209x9! LastWriteTime is way off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            dir2.Delete(true);
+
+
+            //-----------------------------------------------------------
+
+            if (Directory.Exists(dirName))
+                Directory.Delete(dirName, true);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Name.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Name.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_get_Name
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.Exists(String)";
+    public static String s_strTFName = "get_Name.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2 = null;
+
+
+            // [] Current Directory
+            //-----------------------------------------------------------------
+            strLoc = "Loc_276t8";
+
+            iCountTestcases++;
+            dir2 = new DirectoryInfo(".");
+            if (!dir2.Name.Equals(Directory.GetCurrentDirectory().Substring(Directory.GetCurrentDirectory().LastIndexOf("\\") + 1)))
+            {
+                iCountErrors++;
+                printerr("Error_69v8j! Incorrect Name on directory, dir2.Name==" + dir2.Name);
+            }
+
+            iCountTestcases++;
+            dir2 = new DirectoryInfo(Directory.GetCurrentDirectory());
+            if (!dir2.Name.Equals(Directory.GetCurrentDirectory().Substring(Directory.GetCurrentDirectory().LastIndexOf("\\") + 1)))
+            {
+                iCountErrors++;
+                printerr("Error_97t67! Incorrect Name on directory, dir2.Name==" + dir2.Name);
+            }
+            //-----------------------------------------------------------------
+
+
+
+            // [] UNC share
+            //-----------------------------------------------------------------
+            strLoc = "Loc_99084";
+
+            dir2 = new DirectoryInfo("\\\\contoso\\amusement\\device");
+            if (!dir2.Name.Equals("device"))
+            {
+                iCountErrors++;
+                printerr("Error_02099! Incorrect name==" + dir2.Name);
+            }
+
+            // [] Root directory
+
+            iCountTestcases++;
+            dir2 = new DirectoryInfo("C:\\");
+
+            if (!dir2.Name.Equals("C:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_50210! Incorrect name==" + dir2.Name);
+            }
+            //-----------------------------------------------------------------
+
+            // [] Case insensitivity
+            //-----------------------------------------------------------------
+            strLoc = "Loc_t97g8";
+
+            string currentDir = Directory.GetCurrentDirectory();
+            dir2 = new DirectoryInfo(currentDir.ToUpper());
+            iCountTestcases++;
+            if (!dir2.Name.Equals(currentDir.Substring(currentDir.LastIndexOf("\\") + 1).ToUpper()))
+            {
+                iCountErrors++;
+                Console.WriteLine(dir2.Name);
+                printerr("Error_15787! Incorrect return");
+            }
+
+            dir2 = new DirectoryInfo(currentDir.ToLower());
+            iCountTestcases++;
+            if (!dir2.Name.Equals(currentDir.Substring(currentDir.LastIndexOf("\\") + 1).ToLower()))
+            {
+                iCountErrors++;
+                Console.WriteLine(dir2.Name);
+                printerr("Error_2yg77! Incorrect return");
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+
+
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Parent.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Parent.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_get_Parent
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strClassMethod = "Directory.Parent";
+    public static String s_strTFName = "get_Parent.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String str2;
+
+            // COMMENT: Simple string parsing of existing fullpath
+
+
+            // [] Get parent of root
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_49b78";
+
+            dir2 = new DirectoryInfo("C:\\").Parent;
+            iCountTestcases++;
+            if (dir2 != null)
+            {
+                iCountErrors++;
+                printerr("Error_69y7b! Unexpected parent==" + dir2.FullName);
+            }
+
+            // [] Get parent of \Directory
+
+            strLoc = "Loc_98ygg";
+
+            dir2 = new DirectoryInfo("\\Machine\\Test").Parent;
+            str2 = dir2.Name;
+            iCountTestcases++;
+            if (!str2.Equals("Machine"))
+            {
+                iCountErrors++;
+                printerr("Error_91y7b! Unexpected parent==" + str2);
+            }
+
+            // [] Get parent of UNC share root
+
+            strLoc = "Loc_yg7bk";
+
+            dir2 = new DirectoryInfo("\\\\Machine\\Test").Parent;
+            iCountTestcases++;
+            if (dir2 != null)
+            {
+                iCountErrors++;
+                printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
+            }
+
+
+            // [] Get parent of directory string ending with \
+
+            strLoc = "Loc_9876b";
+            dir2 = new DirectoryInfo("X:\\a\\b\\c\\d").Parent;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\a\\b\\c"))
+            {
+                iCountErrors++;
+                printerr("Error_298yg! Unexpected parent==" + str2);
+            }
+
+            // [] Get parent of nested directories
+
+            strLoc = "Loc_75y7b";
+            dir2 = new DirectoryInfo("X:\\a\\b\\c").Parent;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\a\\b"))
+            {
+                iCountErrors++;
+                printerr("Error_9887b! Unexpected parent==" + str2);
+            }
+
+            // [] Get parent of subdirectories on UNC share
+
+            strLoc = "Loc_y7t98";
+
+            dir2 = new DirectoryInfo("\\\\Machine\\Test1\\Test2").Parent;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("\\\\Machine\\Test1"))
+            {
+                iCountErrors++;
+                printerr("Error_69929! Unexpected parent==" + str2);
+            }
+
+            // [] play with ".." and "." in the string
+
+            strLoc = "Loc_2984y";
+
+            dir2 = new DirectoryInfo("X:\\Test\\..\\.\\Test").Parent;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_20928! Unexpected parent==" + str2);
+            }
+
+
+
+            strLoc = "Loc_8y76y";
+
+            dir2 = new DirectoryInfo("X:\\My Samples\\Hello To The World\\Test").Parent;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\My Samples\\Hello To The World"))
+            {
+                iCountErrors++;
+                printerr("Error_9019c! Unexpected parent==" + str2);
+            }
+
+
+            //-----------------------------------------------------------------
+
+            //problems with trailing slashes and stuff - #431574
+            /**
+             - We need to remove the trailing slash when we get the parent directory (we call Path.GetDirectoryName on the full path and having the slash will not work)
+             - Root drive always have the trailing slash
+             - MoveTo adds a trailing slash
+
+            **/
+
+            String parent = Directory.GetCurrentDirectory();
+            String[] values = { "testDir", @"TestDir\" };
+            foreach (String value in values)
+            {
+                dir2 = new DirectoryInfo(value);
+                if (!dir2.Parent.FullName.Equals(parent))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_374g! wrong vlaue returned: {0}", dir2.Parent.FullName);
+                }
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Root.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Root.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class DirectoryInfo_get_Root
+{
+    public static String s_strActiveBugNums = "28196";
+    public static String s_strClassMethod = "Directory.Root";
+    public static String s_strTFName = "get_Root.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            DirectoryInfo dir2;
+            String str2;
+
+            // [] COMMENT: Simple string parsing of existing fullpath
+            iCountTestcases++; // To make maddog happy 
+
+            // [] get root of root 
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_49b78";
+
+            dir2 = new DirectoryInfo("C:\\").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("C:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_69y7b! Unexpected parent==" + dir2.FullName);
+            }
+
+            // [] Get root of \Directory
+
+            strLoc = "Loc_98ygg";
+
+            dir2 = new DirectoryInfo("\\Machine\\Test").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            String root = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().IndexOf('\\') + 1);
+            if (!str2.Equals(root))
+            {
+                iCountErrors++;
+                printerr("Error_91y7b! Unexpected parent==" + str2);
+            }
+
+            // [] Get root of UNC share
+
+            strLoc = "Loc_yg7bk";
+
+            dir2 = new DirectoryInfo("\\\\Machine\\Test").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("\\\\Machine\\Test"))
+            {
+                iCountErrors++;
+                printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
+            }
+
+            // [] get root of subdirectories endning with \
+
+            strLoc = "Loc_9876b";
+            dir2 = new DirectoryInfo("X:\\a\\b\\c\\d\\").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_298yg! Unexpected parent==" + str2);
+            }
+
+            // [] get root of subdirectories
+
+            strLoc = "Loc_75y7b";
+            dir2 = new DirectoryInfo("X:\\a\\b\\c").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_9887b! Unexpected parent==" + str2);
+            }
+
+
+            // [] Get root of nested subdirs on UNC share
+
+            strLoc = "Loc_y7t98";
+
+            dir2 = new DirectoryInfo("\\\\Machine\\Test1\\Test2\\Test3").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("\\\\Machine\\Test1"))
+            {
+                iCountErrors++;
+                printerr("Error_69929! Unexpected parent==" + str2);
+            }
+
+            // [] Include ".." and "." in directory string
+
+            strLoc = "Loc_2984y";
+
+            dir2 = new DirectoryInfo("X:\\Test\\..\\.\\Test\\Test").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_20928! Unexpected parent==" + str2);
+            }
+
+
+            // [] Include spaces in directory string.
+
+            strLoc = "Loc_8y76y";
+
+            dir2 = new DirectoryInfo("X:\\My Samples\\Hello To The World\\Test").Root;
+            str2 = dir2.FullName;
+            iCountTestcases++;
+            if (!str2.Equals("X:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_9019c! Unexpected parent==" + str2);
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/set_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/set_Attributes.cs
@@ -1,0 +1,302 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class DirectoryInfo_set_Attributes
+{
+    public static String s_strActiveBugNums = "14952";
+    public static String s_strClassMethod = "Directory.CreationTime";
+    public static String s_strTFName = "set_Attributes.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+        string dirName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+        Directory.CreateDirectory(dirName);
+
+        try
+        {
+            DirectoryInfo dir = null;
+            FileAttributes diratt;
+
+            new DirectoryInfo(dirName).Attributes = new FileAttributes();
+
+            // [] Invalid value
+
+            strLoc = "Loc_09t77";
+
+            dir = new DirectoryInfo(dirName);
+            iCountTestcases++;
+            try
+            {
+                dir.Attributes = ~FileAttributes.ReadOnly;
+                iCountErrors++;
+                printerr("Error_78t59! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_97678! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Set the ReadOnly attribute
+
+            strLoc = "Loc_039ux";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.ReadOnly;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.ReadOnly | FileAttributes.Directory)) != (FileAttributes.ReadOnly | FileAttributes.Directory))
+            {
+                iCountErrors++;
+                printerr("Error_2989d! Incorrect directory attribute set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Set hidden only
+
+            strLoc = "Loc_209cu";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.Hidden;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support hidden
+            if((diratt & (FileAttributes.Hidden|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+#else
+            if ((diratt & (FileAttributes.Hidden | FileAttributes.Directory)) != (FileAttributes.Hidden | FileAttributes.Directory))
+            {
+#endif
+                iCountErrors++;
+                printerr("Error_3091h! Incorrect direcotory attribute set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Set hidden and readonly
+
+            strLoc = "Loc_390uv";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.Hidden | FileAttributes.ReadOnly;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if !TEST_WINRT  // WinRT doesn't support hidden
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((int)(diratt & FileAttributes.Hidden) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_20x97! Hidden attribute not set");
+            }
+#endif
+            iCountTestcases++;
+            if ((int)(diratt & FileAttributes.ReadOnly) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_1990c! ReadOnly attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Set system
+
+            strLoc = "Loc_8gy0b";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.System;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support system
+            if((diratt & (FileAttributes.System|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+#else
+            if ((diratt & (FileAttributes.System | FileAttributes.Directory)) != (FileAttributes.System | FileAttributes.Directory))
+            {
+#endif
+                iCountErrors++;
+                printerr("Error_7t87y! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] set archive
+
+            strLoc = "Loc_29d88";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.Archive;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support archive
+            if((diratt & (FileAttributes.Archive|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+#else
+            if ((diratt & (FileAttributes.Archive | FileAttributes.Directory)) != (FileAttributes.Archive | FileAttributes.Directory))
+            {
+#endif
+                iCountErrors++;
+                printerr("Error_f487b! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Encrypted can't be set on directory
+
+            strLoc = "Loc_t78yg";
+
+            /*			dir = new DirectoryInfo(".");
+                        dir.Attributes = FileAttributes.Encrypted;
+                        diratt = dir.Attributes;
+                        iCountTestcases++;
+                        if(diratt != FileAttributes.Directory) {
+                            iCountErrors++;
+                            printerr( "Error_09828! System attribute not set");
+                        } 
+                        dir.Attributes = new FileAttributes();                   */
+
+            // [] Normal can't be set on directory
+
+            strLoc = "Loc_90v77";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.Normal;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & FileAttributes.Directory) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_2t09b! System attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+
+            /*       		// [] Temporary can't be set on directory
+
+                       strLoc = "Loc_99g94";
+
+                       dir = new DirectoryInfo(".");
+                       iCountTestcases++;
+                       try {
+                           dir.Attributes = FileAttributes.Temporary;
+                           iCountErrors++;
+                           printerr( "Error_247tb! Expected exception not thrown");
+                       } catch (ArgumentException aexc) {
+                       } catch (Exception exc) {
+                           iCountErrors++;
+                           printerr( "Error_758bh! Incorrect exception thrown, exc=="+exc.ToString());
+                       }
+                       dir.Attributes = new FileAttributes();   */
+
+
+            // [] Sparsefile can't be set on directory
+
+            strLoc = "Loc_8gy0b";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.SparseFile;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_1300g! SparseFile attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+
+            // [] ReparsePoint can't be set on directory
+
+
+            strLoc = "Loc_9180c";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.ReparsePoint;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0199c! ReparsePoint attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Compressed can't be set on directory
+
+
+            strLoc = "Loc_0200d";
+
+            dir = new DirectoryInfo(dirName);
+            dir.Attributes = FileAttributes.Compressed;
+            diratt = dir.Attributes;
+            iCountTestcases++;
+            if ((diratt & (FileAttributes.Directory)) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_9010c! Compressed attribute not set");
+            }
+            dir.Attributes = new FileAttributes();
+
+            // [] Offline
+            iCountTestcases++;
+            /* Does not work on FAT filesystems
+                        strLoc = "Loc_109tg";
+
+                        dir = new DirectoryInfo(".");
+                        dir.Attributes = FileAttributes.Offline;
+                        diratt = dir.Attributes;
+                        iCountTestcases++;
+                        if(diratt != (FileAttributes.Offline|FileAttributes.Directory)) {
+                            iCountErrors++;
+                            printerr( "Error_010vy! Offline attribute not set");
+                        } 
+                        dir.Attributes = new FileAttributes();
+
+
+                        // [] NotContectIndexed
+
+                        strLoc = "Loc_t0698";
+
+                        dir = new DirectoryInfo(".");
+                        dir.Attributes = FileAttributes.NotContentIndexed;
+                        diratt = dir.Attributes;
+                        iCountTestcases++;
+                        if(diratt != (FileAttributes.NotContentIndexed|FileAttributes.Directory)) {
+                            iCountErrors++;
+                            printerr( "Error_23047! NotContentIndexed attribute not set");
+                        } 
+                        dir.Attributes = new FileAttributes();
+            */
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/AppendAll_all.cs
+++ b/src/System.IO.FileSystem/tests/File/AppendAll_all.cs
@@ -1,0 +1,285 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class File_AppendAll_all
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2002/09/30 19:25";
+    public static String s_strClassMethod = "File.AppendAllText- All the methods";
+    public static String s_strTFName = "AppendAll_all.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        String path;
+        Encoding encoding;
+        String content;
+
+        String all;
+        StringBuilder builder;
+        StringBuilder builder1;
+        StreamReader reader;
+        FileStream stream;
+
+
+        try
+        {
+            //This TestCase tests the following methods that have been added to File for RAD purposes. These methods are thin wrappers for already 
+            //defined methods in the IO namespace. We do not aim to test the underlying APIs here
+
+            //void AppendAllText(String path, String contents)
+            //void void AppendAllText(String path, String contents, Encoding encoding)
+
+            //Argument 
+
+            strLoc = "Loc_001oo";
+
+            iCountTestcases++;
+
+            path = null;
+            content = "";
+            try
+            {
+                File.AppendAllText(path, content);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = null;
+            encoding = Encoding.UTF8;
+            try
+            {
+                File.AppendAllText(path, content, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            encoding = null;
+            try
+            {
+                File.AppendAllText(path, content, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+
+            //vanilla: Non existent paths, writing null
+
+            strLoc = "Loc_002oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            if (File.Exists(path))
+                File.Delete(path);
+
+            content = null;
+            File.AppendAllText(path, content);
+            //We know that the below API throws for non-existent file names
+            all = File.ReadAllText(path);
+
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            encoding = Encoding.UTF8;
+            File.AppendAllText(path, content, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //Vanilla - make sure that normal behavior is seen for all the methods
+
+            strLoc = "Loc_003oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+
+            builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            File.AppendAllText(path, content);
+            all = File.ReadAllText(path);
+
+            if (all != content)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            //Another AppendAllText should not overwrite 
+            builder1 = new StringBuilder(all);
+            builder = new StringBuilder();
+            for (int i = 500; i < 600; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                builder1.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            File.AppendAllText(path, content);
+            all = File.ReadAllText(path);
+
+            if (all != builder1.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_2495sg! Wrong value returned: {0}", all);
+            }
+
+            builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                builder1.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            encoding = Encoding.GetEncoding("US-ASCII");
+            File.AppendAllText(path, content, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != builder1.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_234afd! Wrong value returned: {0}", all);
+            }
+
+            //Another writeall overwrite not appends
+            builder = new StringBuilder();
+            for (int i = 500; i < 600; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                builder1.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            File.AppendAllText(path, content, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != builder1.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4356sdg! Wrong value returned: {0}", all);
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //Open issues - file already opened, We've closed the file after write etc
+            //That we are closing the file after append is imlictly tested above
+
+            path = Path.GetTempFileName();
+            stream = new FileStream(path, FileMode.Open);
+            reader = new StreamReader(stream);
+
+            content = "";
+            try
+            {
+                File.AppendAllText(path, content);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            encoding = Encoding.UTF8;
+            try
+            {
+                File.AppendAllText(path, content, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            reader.Dispose();
+            stream.Dispose();
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/AppendText_str.cs
+++ b/src/System.IO.FileSystem/tests/File/AppendText_str.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_AppendText_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/03 20:19";
+    public static String s_strClassMethod = "File.AppendText(String)";
+    public static String s_strTFName = "AppendText_str.cool";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            StreamWriter sw2;
+            StreamReader sr2;
+            String str2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] ArgumentNullException if arg is null
+            //-----------------------------------------------------------------
+            strLoc = "Loc_789s9";
+
+            iCountTestcases++;
+            try
+            {
+                File.AppendText(null);
+                iCountErrors++;
+                printerr("Error_10198! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_19ygb! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Exception if string.empty is passed
+            //-----------------------------------------------------------------
+            strLoc = "Loc_t768c";
+
+            iCountTestcases++;
+            try
+            {
+                File.AppendText(String.Empty);
+                iCountErrors++;
+                printerr("Error_y7g53! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_217tb! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            // [] AppendText on a file that does not exist should create it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2y78b";
+
+            sw2 = File.AppendText(filName);
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            FileStream fs = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(fs);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorld"))
+            {
+                iCountErrors++;
+                printerr("Error_21y77! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            fs.Dispose();
+
+            // [] AppendText should open existing file
+
+            strLoc = "Loc_2gy7b";
+
+            sw2 = File.AppendText(filName);
+            sw2.Write("You Big Globe");
+            sw2.Dispose();
+            FileStream fs2 = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(fs2);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorldYou Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_12ytb! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            fs2.Dispose();
+
+            //-----------------------------------------------------------------
+
+
+            // [] AccessException if file is readonly
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yv";
+#if !TEST_WINRT // BUG:1038057 Enable once we implement WinRT file attributes
+            FileInfo fil2 = new FileInfo(filName);
+            fil2.Attributes = FileAttributes.ReadOnly;
+            iCountTestcases++;
+            try
+            {
+                File.AppendText(filName);
+                iCountErrors++;
+                printerr("Error_fg489! Expected exception not thrown");
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_3498v! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Attributes = new FileAttributes();
+#endif
+            //-----------------------------------------------------------------
+
+
+
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/ChangeExtension_str_str.cs
+++ b/src/System.IO.FileSystem/tests/File/ChangeExtension_str_str.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_ChangeExtension_str_Str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/03 20:26";
+    public static String s_strClassMethod = "Path.AppendText(String)";
+    public static String s_strTFName = "ChangeExtension_str_Str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = s_strTFName.Substring(0, s_strTFName.IndexOf('.')) + "_test_" + "TestFile";
+            String str2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            iCountTestcases++;
+            str2 = Path.ChangeExtension(String.Empty, ".tmp");
+            if (!str2.Equals(String.Empty))
+            {
+                iCountErrors++;
+                printerr("Error_18v88! Expected exception not thrown, str2==" + str2);
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] Some trivial test cases.
+            //-----------------------------------------------------------------	
+            strLoc = "Loc_2y9x8";
+
+            // [] Change extension to ...
+            str2 = Path.ChangeExtension("Path.tmp", "...");
+            iCountTestcases++;
+            if (!str2.Equals("Path..."))
+            {
+                iCountErrors++;
+                printerr("Error_98ygf7! Incorrect string returned, str2==" + str2);
+            }
+
+            // [] Vanilla change from .tmp to .doc
+            str2 = Path.ChangeExtension("Path.temporary.tmp", ".doc");
+            iCountTestcases++;
+            if (!str2.Equals("Path.temporary.doc"))
+            {
+                iCountErrors++;
+                printerr("Error_187yg! Incorrect string returned, str2==" + str2);
+            }
+
+            // [] Change to null (nothing)
+            str2 = Path.ChangeExtension("File.tmp", null);
+            iCountTestcases++;
+            if (!str2.Equals("File"))
+            {
+                iCountErrors++;
+                printerr("Error_198cf! Incorrect string returned, str2==" + str2);
+            }
+
+            // [] String away everything after . by passing in Empty
+            str2 = Path.ChangeExtension("File.tmp", String.Empty);
+            iCountTestcases++;
+            if (!str2.Equals("File."))
+            {
+                iCountErrors++;
+                printerr("Error_290wd! Incorrect string returned, str2==" + str2);
+            }
+
+
+            // [] Add extension to a filename that doesn't have one
+            str2 = Path.ChangeExtension("File", ".tmp");
+            iCountTestcases++;
+            if (!str2.Equals("File.tmp"))
+            {
+                iCountErrors++;
+                printerr("Error_19yg7! Incorrect string returned, str2==" + str2);
+            }
+
+
+            //-----------------------------------------------------------------
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Copy_str_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy_str_str.cs
@@ -1,0 +1,439 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using Xunit;
+
+public class File_Copy_str_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2009/02/18";
+    public static String s_strClassMethod = "File.CopyTo(String, Boolean)";
+    public static String s_strTFName = "Copy_str_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2 = null;
+            FileInfo fil1 = null;
+            Char[] cWriteArr, cReadArr;
+            StreamWriter sw2;
+            StreamReader sr2;
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            try
+            {
+                new FileInfo(filName).Delete();
+            }
+            catch (Exception) { }
+            // [] ArgumentNullException if null is passed in for source file
+
+            strLoc = "Loc_498yg";
+
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(null, fil2.FullName);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+            // [] ArgumentNullException if null is passed in for destination file
+
+            strLoc = "Loc_898gc";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, null);
+                iCountErrors++;
+                printerr("Error_8yt85! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1298s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] String.Empty should throw ArgumentException
+
+            strLoc = "Loc_298vy";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, String.Empty);
+                iCountErrors++;
+                printerr("Error_092u9! Expected exception not thrown, fil2==" + fil1.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109uc! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Try to copy onto directory
+
+            strLoc = "Loc_289vy";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, TestInfo.CurrentDirectory);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil1.FullName);
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209us! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Copy onto itself should fail
+
+
+            strLoc = "Loc_r7yd9";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, fil2.FullName);
+                iCountErrors++;
+                printerr("Error_209us! Expected exception not thrown, fil2==" + fil1.FullName);
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_f588y! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+
+            // [] Vanilla copy operation
+
+            strLoc = "Loc_f548y";
+            string destFile = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, destFile);
+                fil1 = new FileInfo(destFile);
+                if (!File.Exists(fil1.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_2978y! File not copied");
+                }
+                if (!File.Exists(fil2.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_239vr! Source file gone");
+                }
+                fil1.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2987v! Unexpected exception, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            fil1.Delete();
+
+            // [] Filename with illiegal characters
+
+
+            strLoc = "Loc_984hg";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, "**");
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Move a file containing data
+
+
+            strLoc = "Loc_f888m";
+            string destFile2 = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            try
+            {
+                new FileInfo(destFile2).Delete();
+            }
+            catch (Exception) { }
+            try
+            {
+                sw2 = new StreamWriter(File.Create(filName));
+                cWriteArr = new Char[26];
+                int j = 0;
+                for (Char i = 'A'; i <= 'Z'; i++)
+                    cWriteArr[j++] = i;
+                sw2.Write(cWriteArr, 0, cWriteArr.Length);
+                sw2.Flush();
+                sw2.Dispose();
+
+                fil2 = new FileInfo(filName);
+                File.Copy(fil2.FullName, destFile2);
+                fil1 = new FileInfo(destFile2);
+                iCountTestcases++;
+                if (!File.Exists(fil1.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_9u99s! File not copied correctly: " + fil1.FullName);
+                }
+                if (!File.Exists(fil2.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_29h7b! Source file gone");
+                }
+
+                FileStream fileStream = new FileStream(destFile2, FileMode.Open);
+                sr2 = new StreamReader(fileStream);
+                cReadArr = new Char[cWriteArr.Length];
+                sr2.Read(cReadArr, 0, cReadArr.Length);
+
+                iCountTestcases++;
+                for (int i = 0; i < cReadArr.Length; i++)
+                {
+                    iCountTestcases++;
+                    if (cReadArr[i] != cWriteArr[i])
+                    {
+                        iCountErrors++;
+                        printerr("Error_98yv7! Expected==" + cWriteArr[i] + ", got value==" + cReadArr[i]);
+                    }
+                }
+                sr2.Dispose();
+                fileStream.Dispose();
+
+                fil1.Delete();
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28vc8! Unexpected exception, exc==" + exc.ToString());
+            }
+
+/* Scenario disabled while porting because it modifies state outside the test's working directory
+#if !TEST_WINRT
+            String tmpFile;
+            // [] Interesting case:
+
+            strLoc = "Loc_478yb";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            File.Delete("\\TestFile.tmp");
+            fil2 = new FileInfo(filName);
+
+            //Cleanup root files
+            tmpFile = "..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\TestFile.tmp";
+            File.Copy(fil2.Name, tmpFile);
+            fil1 = new FileInfo(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name);
+            iCountTestcases++;
+            if (!fil1.FullName.Equals(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name))
+            {
+                iCountErrors++;
+                Console.WriteLine("[{0}][{1}]", fil1.FullName, Path.GetFullPath(tmpFile));
+                printerr("Error_298gc! Incorrect fullname set during copy");
+            }
+            new FileInfo(filName).Delete();
+            fil1.Delete();
+            if (File.Exists(tmpFile))
+                File.Delete(tmpFile);
+#endif
+*/
+
+            // [] Vanilla copy operation
+
+            strLoc = "Loc_090jd";
+            destFile = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(filName, destFile, true);
+                fil1 = new FileInfo(destFile);
+                fil2 = new FileInfo(filName);
+                if (!File.Exists(fil1.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_378ce! File not copied");
+                }
+                if (!File.Exists(fil2.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_t948v! Source file gone");
+                }
+                fil1.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2987v! Unexpected exception, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            fil1.Delete();
+
+            // [] Filename with wildchars
+
+
+            strLoc = "Loc_100s8";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+
+            iCountTestcases++;
+            try
+            {
+                File.Copy("**", fil2.FullName, false);
+                iCountErrors++;
+                printerr("Error_43987! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_3989v! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+/* Scenario disabled while porting because it modifies state outside the test's working directory
+#if !TEST_WINRT
+            // [] Interesting case: See if it rips off the unessary directory traversal
+
+            strLoc = "Loc_2489y";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+            tmpFile = "..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\TestFile.tmp";
+            File.Copy(fil2.Name, tmpFile, true);
+            iCountTestcases++;
+            fil1 = new FileInfo(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name);
+            if (!fil1.FullName.Equals(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name))
+            {
+                Console.WriteLine(fil1.FullName);
+                iCountErrors++;
+                printerr("Error_892su! Incorrect fullname set during copy");
+            }
+            fil1.Delete();
+            if (File.Exists(tmpFile))
+                File.Delete(tmpFile);
+#endif
+*/
+            // network path scenarios moved to RemoteIOTests.cs
+
+            try
+            {
+                new FileInfo(filName).Delete();
+                new FileInfo(destFile).Delete();
+                new FileInfo(destFile2).Delete();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Failed to delete temp files:");
+                Console.WriteLine(ex);
+                Console.WriteLine("Not failing test.");
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Copy_str_str_b.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy_str_str_b.cs
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class File_Copy_str_str_b
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/03/11 14:37";
+    public static String s_strClassMethod = "File.CopyTo(String, Boolean)";
+    public static String s_strTFName = "Copy_str_str_b.cool";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2 = null;
+            FileInfo fil1 = null;
+            Char[] cWriteArr, cReadArr;
+            StreamWriter sw2;
+            StreamReader sr2;
+            FileStream fs2;
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            try
+            {
+                new FileInfo(filName).Delete();
+            }
+            catch (Exception) { }
+            // [] ArgumentNullException if null is passed in for source file
+
+            strLoc = "Loc_498yg";
+
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(null, fil2.FullName, false);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+            // [] ArgumentNullException if null is passed in for destination file
+
+            strLoc = "Loc_898gc";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, null, false);
+                iCountErrors++;
+                printerr("Error_8yt85! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1298s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] String.Empty should throw ArgumentException
+
+            strLoc = "Loc_298vy";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, String.Empty, false);
+                iCountErrors++;
+                printerr("Error_092u9! Expected exception not thrown, fil2==" + fil1.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109uc! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Try to copy onto directory
+
+            strLoc = "Loc_289vy";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, TestInfo.CurrentDirectory, false);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil1.FullName);
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_23r78af! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Copy onto itself should fail
+
+
+            strLoc = "Loc_r7yd9";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, fil2.FullName, false);
+                iCountErrors++;
+                printerr("Error_2387ag! Expected exception not thrown, fil2==" + fil1.FullName);
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_f588y! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+
+            // [] Vanilla copy operation
+
+            strLoc = "Loc_f548y";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            string destFile = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            try
+            {
+                File.Copy(fil2.FullName, destFile, false);
+                fil1 = new FileInfo(destFile);
+                if (!File.Exists(fil1.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_2978y! File not copied");
+                }
+                if (!File.Exists(fil2.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_239vr! Source file gone");
+                }
+                fil1.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2987v! Unexpected exception, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            fil1.Delete();
+
+            // [] Filename with illiegal characters
+
+
+            strLoc = "Loc_984hg";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+            iCountTestcases++;
+            try
+            {
+                File.Copy(fil2.FullName, "**", false);
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Move a file containing data
+
+
+            strLoc = "Loc_f888m";
+
+            try
+            {
+                new FileInfo(destFile).Delete();
+            }
+            catch (Exception) { }
+            try
+            {
+                sw2 = new StreamWriter(File.Create(filName));
+                cWriteArr = new Char[26];
+                int j = 0;
+                for (Char i = 'A'; i <= 'Z'; i++)
+                    cWriteArr[j++] = i;
+                sw2.Write(cWriteArr, 0, cWriteArr.Length);
+                sw2.Flush();
+                sw2.Dispose();
+
+                fil2 = new FileInfo(filName);
+                File.Copy(fil2.FullName, destFile, false);
+                fil1 = new FileInfo(destFile);
+                iCountTestcases++;
+                if (!File.Exists(fil1.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_9u99s! File not copied correctly: " + fil1.FullName);
+                }
+                if (!File.Exists(fil2.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_29h7b! Source file gone");
+                }
+
+                FileStream fs = new FileStream(destFile, FileMode.Open);
+                sr2 = new StreamReader(fs);
+                cReadArr = new Char[cWriteArr.Length];
+                sr2.Read(cReadArr, 0, cReadArr.Length);
+
+                iCountTestcases++;
+                for (int i = 0; i < cReadArr.Length; i++)
+                {
+                    iCountTestcases++;
+                    if (cReadArr[i] != cWriteArr[i])
+                    {
+                        iCountErrors++;
+                        printerr("Error_98yv7! Expected==" + cWriteArr[i] + ", got value==" + cReadArr[i]);
+                    }
+                }
+                sr2.Dispose();
+                fs.Dispose();
+
+                fil1.Delete();
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28vc8! Unexpected exception, exc==" + exc.ToString());
+            }
+
+/* Scenario disabled while porting because it accesses a file outside the test's working directory
+#if !TEST_WINRT  // Cannot access root
+            // [] Unecessary long but valid string
+
+            strLoc = "Loc_478yb";
+
+            File.Delete("\\TestFile.tmp");
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+            File.Copy(fil2.Name, "..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\TestFile.tmp", false);
+            fil1 = new FileInfo(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name);
+            iCountTestcases++;
+            if (!fil1.FullName.Equals(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name))
+            {
+                Console.WriteLine(fil1.FullName);
+                iCountErrors++;
+                printerr("Error_298gc! Incorrect fullname set during copy");
+            }
+            new FileInfo(filName).Delete();
+            fil1.Delete();
+            File.Delete("\\TestFile.tmp");
+#endif
+*/
+
+            // [] Copy over a file that already exists
+
+            strLoc = "Loc_37tgy";
+            destFile = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            sw2 = new StreamWriter(fs2);
+            for (Char i = (Char)65; i < (Char)75; i++)
+                sw2.Write(i);
+            sw2.Flush();
+            sw2.Dispose();
+
+            fs2 = new FileStream(destFile, FileMode.Create);
+            sw2 = new StreamWriter(fs2);
+            for (Char i = (Char)74; i >= (Char)65; i--)
+                sw2.Write(i);
+            sw2.Flush();
+            sw2.Dispose();
+            fil2 = new FileInfo(destFile);
+            File.Copy(fil2.FullName, Path.ChangeExtension(destFile, ".tmp"), true);
+            fil1 = new FileInfo(Path.ChangeExtension(destFile, ".tmp"));
+            fil2.Delete();
+
+            FileStream fs3 = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(fs3);
+            int tmp = 0;
+            for (Char i = (Char)65; i < (Char)75; i++)
+            {
+                iCountTestcases++;
+                if ((tmp = sr2.Read()) != i)
+                {
+                    iCountErrors++;
+                    printerr("Error_498vy! Expected==" + i + ", got==" + tmp);
+                }
+            }
+            sr2.Dispose();
+            fs3.Dispose();
+            fil2.Delete();
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/CreateText_str.cs
+++ b/src/System.IO.FileSystem/tests/File/CreateText_str.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_CreateText_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/03 20:41";
+    public static String s_strClassMethod = "File.CreateText(String)";
+    public static String s_strTFName = "CreateText_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            StreamWriter sw2;
+            StreamReader sr2;
+            String str2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] ArgumentNullException if arg is null
+            //-----------------------------------------------------------------
+            strLoc = "Loc_789s9";
+
+            iCountTestcases++;
+            try
+            {
+                File.CreateText(null);
+                iCountErrors++;
+                printerr("Error_10198! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_19ygb! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Exception if string.empty is passed
+            //-----------------------------------------------------------------
+            strLoc = "Loc_t768c";
+
+            iCountTestcases++;
+            try
+            {
+                File.CreateText(String.Empty);
+                iCountErrors++;
+                printerr("Error_y7g53! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_217tb! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            // [] CreateText on a file that does not exist should create it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2y78b";
+
+            sw2 = File.CreateText(filName);
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            FileStream stream = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorld"))
+            {
+                iCountErrors++;
+                printerr("Error_21y77! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            // [] CreateText should overwrite exisiting file
+
+            strLoc = "Loc_2gy7b";
+
+            sw2 = File.CreateText(filName);
+            sw2.Write("You Big Globe");
+            sw2.Dispose();
+            stream = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("You Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_12ytb! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            //-----------------------------------------------------------------
+
+
+            // [] Wildcard in filename should throw
+            //-----------------------------------------------------------------
+            strLoc = "Loc_48yv8";
+
+            iCountTestcases++;
+            try
+            {
+                File.CreateText("Test*");
+                iCountErrors++;
+                printerr("Error_4y8vv! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_489v7! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Create_str_i.cs
+++ b/src/System.IO.FileSystem/tests/File/Create_str_i.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using Xunit;
+
+public class File_Create_str_i
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2009/02/18";
+    public static String s_strClassMethod = "File.Create(String,Int32)";
+    public static String s_strTFName = "Create_str_i.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+        try
+        {
+            Stream fs2;
+
+            // [] ArgumentNullException for null argument
+            //----------------------------------------------------------------
+            strLoc = "Loc_89y8b";
+
+            iCountTestcases++;
+            try
+            {
+                fs2 = File.Create(null, 1);
+                iCountErrors++;
+                printerr("Error_298yr! Expected exception not thrown");
+                fs2.Dispose();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_987b7! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //----------------------------------------------------------------
+
+            // [] AccessException if passing in currentdirectory
+            //----------------------------------------------------------------
+            strLoc = "Loc_t7y84";
+
+            iCountTestcases++;
+            try
+            {
+                fs2 = File.Create(".", 1);
+                iCountErrors++;
+                printerr("Error_7858c! Expected exception not thrown");
+                fs2.Dispose();
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_958vy! Incorrect exception thrown, ex==" + exc.ToString());
+            }
+            //----------------------------------------------------------------
+
+            // [] ArgumentException if zero length string is passed in
+            //----------------------------------------------------------------
+            strLoc = "Loc_8t87b";
+
+            iCountTestcases++;
+            try
+            {
+                fs2 = File.Create(String.Empty, 1);
+                iCountErrors++;
+                printerr("Error_598yb! Expected exception not thrown");
+                fs2.Dispose();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9t5y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] ArgumentOutOfRangeException if buffer is negative
+            strLoc = "Loc_t98x9";
+
+            iCountTestcases++;
+            try
+            {
+                fs2 = File.Create(filName, -10);
+                iCountErrors++;
+                printerr("Error_598cy! Expected exception not thrown");
+                fs2.Dispose();
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_928xy! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Create a file
+            strLoc = "Loc_887th";
+
+            fs2 = File.Create(filName, 1000);
+            iCountTestcases++;
+            if (!File.Exists(filName))
+            {
+                iCountErrors++;
+                printerr("Error_2876g! File not created, file==" + filName);
+            }
+            iCountTestcases++;
+            if (fs2.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_t598v! Incorrect file length==" + fs2.Length);
+            }
+            if (fs2.Position != 0)
+            {
+                iCountErrors++;
+                printerr("Error_958bh! Incorrect file position==" + fs2.Position);
+            }
+            fs2.Dispose();
+
+            // [] Create a file in root
+            /* Test disabled because it modifies state outside the current working directory
+            strLoc = "Loc_89ytb";
+
+            iCountTestcases++;
+            bool expectSuccess = true;
+#if TEST_WINRT
+            expectSuccess = false;  // We will not have access to root
+#endif
+            String currentdir = TestInfo.CurrentDirectory;
+            filName = currentdir.Substring(0, currentdir.IndexOf('\\') + 1) + Path.GetFileName(filName);
+            try
+            {
+                fs2 = File.Create(filName, 1000);
+                if (expectSuccess)
+                {
+                    if (!File.Exists(filName))
+                    {
+                        iCountErrors++;
+                        printerr("Error_t78g7! File not created, file==" + filName);
+                    }
+                }
+                else
+                {
+                    iCountErrors++;
+                    printerr("Error_254d!  User is not Administrator but no exception thrown, file==" + filName);
+                }
+                fs2.Dispose();
+                if (File.Exists(filName))
+                    File.Delete(filName);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                if (expectSuccess)
+                {
+                    iCountErrors++;
+                    printerr("Error_409t!  User is Administrator but exception was thrown:" + ex.ToString());
+                }
+            }
+            */
+
+            // [] Create file in current dir by giving full directory check casing as well
+            strLoc = "loc_89tbh";
+
+            filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            fs2 = File.Create(filName, 100);
+            iCountTestcases++;
+            if (!File.Exists(filName))
+            {
+                iCountErrors++;
+                printerr("Error_t87gy! File not created, file==" + filName);
+            }
+            fs2.Dispose();
+
+            strLoc = "loc_89tbh_1";
+
+            //see VSWhidbey bug 103341
+            filName = String.Format(@"{0}\{1}", TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            if (File.Exists(filName))
+                File.Delete(filName);
+            fs2 = File.Create(String.Format(" {0}", filName), 100);
+            iCountTestcases++;
+            if (!File.Exists(filName))
+            {
+                iCountErrors++;
+                printerr("Error_t87gy_1! File not created, file==" + filName);
+            }
+            fs2.Dispose();
+
+            strLoc = "loc_89tbh_3";
+
+            //see VSWhidbey bug 103341
+            filName = String.Format(@" {0}\ {1}", TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            if (File.Exists(filName))
+                File.Delete(filName);
+            fs2 = File.Create(filName, 100);
+            iCountTestcases++;
+            if (!File.Exists(filName))
+            {
+                iCountErrors++;
+                printerr("Error_t87gy_3! File not created, file==" + filName);
+            }
+            fs2.Dispose();
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+#if !TEST_WINRT  // Leading spaces in a relative path: relative path will not actually go through WinRT & we'll get access denied
+            strLoc = "loc_89tbh_2";
+            filName = String.Format(" {0}", Path.GetRandomFileName());
+            if (File.Exists(filName))
+                File.Delete(filName);
+            fs2 = File.Create(filName, 100);
+            iCountTestcases++;
+            filName = String.Format(@"{0}\{1}", Directory.GetCurrentDirectory(), filName);
+            if (!File.Exists(filName))
+            {
+                iCountErrors++;
+                Console.WriteLine("Error_t87gy_2! File not created, file==<{0}>", filName);
+            }
+            fs2.Dispose();
+            if (File.Exists(filName))
+                File.Delete(filName);
+#endif
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Delete_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete_str.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_Delete_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 11:38";
+    public static String s_strClassMethod = "File.CreateText";
+    public static String s_strTFName = "Delete_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            StreamWriter sw2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Exception if argument is null
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2yc81";
+
+            iCountTestcases++;
+            try
+            {
+                File.Delete(null);
+                iCountErrors++;
+                printerr("Error_1u9by! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_19d4b! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] ArgumentException if argument is *.*
+            //-----------------------------------------------------------------
+            strLoc = "Loc_32453";
+
+            iCountTestcases++;
+            try
+            {
+                File.Delete("*.*");
+                iCountErrors++;
+                printerr("Error_4342! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_7777! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Exception for "."
+            //-----------------------------------------------------------------
+            strLoc = "Loc_90187";
+
+            iCountTestcases++;
+            try
+            {
+                File.Delete(".");
+                iCountErrors++;
+                printerr("Error_19yb7! Expected exception not thrown");
+#if TEST_WINRT // WinRT returns E_INVALIDARG instead of Access denied, BUG: TODO
+            } catch (IOException) {
+#endif
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_19gyb! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Delete an existing file
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2g79b";
+
+            string shortFilName = Path.GetFileName(filName);
+#if !TEST_WINRT  // Cannot access current directory
+            new FileStream(shortFilName, FileMode.Create).Dispose();
+            File.Delete(shortFilName);
+            iCountTestcases++;
+            if (File.Exists(shortFilName))
+            {
+                iCountErrors++;
+                printerr("Error_y7gbs! File not deleted");
+            }
+#endif
+            string fullFilName = Path.Combine(TestInfo.CurrentDirectory, shortFilName);
+            new FileStream(fullFilName, FileMode.Create).Dispose();
+            File.Delete(fullFilName);
+            iCountTestcases++;
+            if (File.Exists(fullFilName))
+            {
+                iCountErrors++;
+                printerr("Error_94t7b! File not deleted");
+            }
+
+            //-----------------------------------------------------------------
+
+            // []Try to delete a non-existing file
+            //-----------------------------------------------------------------
+            strLoc = "Loc_278yb";
+
+            iCountTestcases++;
+            try
+            {
+                File.Delete("FileDoesNotExist");
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_218b9! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            try
+            {
+                File.Delete(Path.Combine(TestInfo.CurrentDirectory, "This file doesnt exist - supercalifragilisticexpialodoscious.txt"));
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_ewsdf! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] Delete a file with contents
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298c8";
+
+            FileStream stream = new FileStream(filName, FileMode.Create);
+            sw2 = new StreamWriter(stream);
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            stream.Dispose();
+
+            File.Delete(filName);
+            iCountTestcases++;
+            if (File.Exists(filName))
+            {
+                iCountErrors++;
+                printerr("Error_4017v! File not deleted");
+            }
+
+            //-----------------------------------------------------------------
+
+
+#if !TEST_WINRT  // TODO: Enable once we bring up file attributes
+            // [] Deleting a ReadOnly file should not work
+            //-----------------------------------------------------------------
+            strLoc = "Loc_298b7";
+            fil2 = new FileInfo(filName);
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2.Attributes = FileAttributes.ReadOnly;
+            iCountTestcases++;
+            try
+            {
+                File.Delete(filName);
+                iCountErrors++;
+                printerr("Error_487bg! Expected exception not thrown");
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2467y! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Attributes = new FileAttributes();
+            fil2.Delete();
+
+            //-----------------------------------------------------------------
+#endif
+
+            // ][ Filename starting with wildcard
+            // ][ Filename ending with wildcard
+            // ][ Filename with internal wildcard
+
+
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Exists_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists_str.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class File_FileExists_str
+{
+    public static String s_strDtTmVer = "2009/02/18";
+    public static String s_strClassMethod = "File.Exists(String)";
+    public static String s_strTFName = "FileExists_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        try
+        {
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Exception for null argument
+            strLoc = "Loc_t987b";
+
+            iCountTestcases++;
+            try
+            {
+                if (File.Exists(null))
+                {
+                    iCountErrors++;
+                    printerr("Error_49939! Expected exception not thrown");
+                }
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_6019b! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] ArgumentException for empty path
+            strLoc = "Loc_199gb";
+
+            iCountTestcases++;
+            try
+            {
+                if (File.Exists(String.Empty))
+                {
+                    iCountErrors++;
+                    printerr("Error_109tg! Expected exception not thrown");
+                }
+                if (File.Exists("\0"))
+                {
+                    iCountErrors++;
+                    printerr("Error_123af! Expected exception not thrown");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_6t69b! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Current Directory
+            strLoc = "Loc_276t8";
+
+            iCountTestcases++;
+            if (File.Exists("."))
+            {
+                iCountErrors++;
+                printerr("Error_95428! Incorrect return value");
+            }
+
+            iCountTestcases++;
+            if (File.Exists(Directory.GetCurrentDirectory()))
+            {
+                iCountErrors++;
+                printerr("Error_97t67! Incorrect return value");
+            }
+
+            // [] Parent Directory
+            strLoc = "Loc_y7t03";
+
+            iCountTestcases++;
+            if (File.Exists(".."))
+            {
+                iCountErrors++;
+                printerr("Error_290bb! Incorrect return value");
+            }
+
+            /* Scenario disabled when porting because it modifies global process state and can not be run in parallel with other tests
+#if !TEST_WINRT  // SetCurrentDirectory is not allowed in AppX
+            String tmpDir = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory("C:\\");
+            iCountTestcases++;
+            if (File.Exists(".."))
+            {
+                iCountErrors++;
+                printerr("Error_t987y! Incorrect return value");
+            }
+            Directory.SetCurrentDirectory(tmpDir);
+#endif
+            */
+
+            // network path scenario moved to RemoteIOTests.cs
+
+            // [] Non-existent directories
+            strLoc = "Loc_t993c";
+
+            iCountTestcases++;
+            if (File.Exists("Da drar vi til fjells"))
+            {
+                iCountErrors++;
+                printerr("Error_6895b! Incorrect return value");
+            }
+
+            // [] Path too long
+            strLoc = "Loc_t899t";
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 500; i++)
+                sb.Append(i);
+
+            iCountTestcases++;
+            try
+            {
+                if (File.Exists(sb.ToString()))
+                {
+                    iCountErrors++;
+                    printerr("Error_20937! Expected exception not thrown");
+                }
+            }
+            catch (PathTooLongException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_7159s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] File that does exist
+            strLoc = "Loc_2y78g";
+
+            string shortFilName = Path.GetFileName(filName);
+#if !TEST_WINRT  // Current dir is not writable
+            new FileStream(shortFilName, FileMode.Create).Dispose();
+            iCountTestcases++;
+            if (!File.Exists(shortFilName))
+            {
+                iCountErrors++;
+                printerr("Error_9t821! Returned false for existing file");
+            }
+#endif
+            string fullFilName = Path.Combine(TestInfo.CurrentDirectory, shortFilName);
+            new FileStream(fullFilName, FileMode.Create).Dispose();
+            iCountTestcases++;
+            if (!File.Exists(fullFilName))
+            {
+                iCountErrors++;
+                printerr("Error_9198v! Returned false for existing file");
+            }
+
+            File.Delete(fullFilName);
+
+
+            iCountTestcases++;
+            if (File.Exists(fullFilName))
+            {
+                iCountErrors++;
+                printerr("Errro_197bb! Returned true for deleted file");
+            }
+
+            // [] Filename with spaces
+            strLoc = "Loc_298g7";
+
+            String tmp = filName + "   " + Path.GetFileName(filName);
+            new FileStream(tmp, FileMode.Create).Dispose();
+            iCountTestcases++;
+            if (!File.Exists(tmp))
+            {
+                iCountErrors++;
+                printerr("Error_01y8v! Returned incorrect value");
+            }
+
+            // [] Wildcards in filename should return false
+
+            strLoc = "Loc_398vy8";
+            iCountTestcases++;
+            try
+            {
+                if (File.Exists("*"))
+                {
+                    iCountErrors++;
+                    printerr("Error_4979c! File with wildcard exist");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_498u9! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/File_EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/File/File_EnumerableAPIs.cs
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Security;
+using Xunit;
+
+namespace EnumerableTests
+{
+    class File_FileEnumerableTests
+    {
+        private static EnumerableUtils utils;
+
+        [Fact]
+        public static void RunTests()
+        {
+            utils = new EnumerableUtils();
+
+            utils.CreateTestDirs();
+
+            TestFileAPIs();
+
+            TestFileExceptions();
+
+            utils.DeleteTestDirs();
+            
+            Assert.True(utils.Passed);
+        }
+
+        // file tests
+        private static void TestFileAPIs()
+        {
+            TestFileReadAllLinesFast(false);
+            TestFileReadAllLinesFast(true);
+            TestFileWriteAllLines(false, false);
+            TestFileWriteAllLines(true, false);
+            TestFileWriteAllLines(false, true);
+            TestFileWriteAllLines(true, true);
+            TestFileReadAllLinesIterator();
+        }
+        
+        private static void TestFileReadAllLinesIterator()
+        {
+            IEnumerable<string> lines = File.ReadLines(Path.Combine(utils.testDir, "file1"));
+            foreach (var line in lines)
+            {
+            }
+
+            try
+            {
+                foreach (var line in lines)
+                { 
+                }
+            }
+            catch(ObjectDisposedException)
+            {
+                // Currently the test is not hooked to report in case of failures. It is best if we rethrow an exception until we rewrite the harness
+                Console.WriteLine("We should not get an ObjectDisposedException but got one ; Dev10 864262 regressed");
+                throw;
+            }
+            
+        }
+
+        private static void TestFileWriteAllLines(bool useEncodingOverload, bool append)
+        {
+            String chkptFlag = "chkpt_wal_";
+            int failCount = 0;
+
+            String encodingPart = useEncodingOverload ? ", Encoding" : "";
+            String writePart = append ? "Append" : "Write";
+            String testname = String.Format("File.{0}AllLines(path{1})", writePart, encodingPart);
+
+
+            String lineContent = "This is another line";
+            String firstLineContent = "This is the first line";
+            String[] contents = new String[10];
+            for (int i=0; i<contents.Length; i++) 
+            {
+                contents[i] = lineContent;
+            }
+
+            String file1 = Path.Combine(utils.testDir, "file1.out");
+            if (append)
+            {
+                File.WriteAllLines(file1, new String[] {firstLineContent});
+            }
+
+
+            if (useEncodingOverload)
+            {
+                if (append)
+                {
+                    File.AppendAllLines(file1, (IEnumerable<String>)contents, Encoding.UTF8);
+                }
+                else
+                {
+
+                    File.WriteAllLines(file1, (IEnumerable<String>)contents, Encoding.UTF8);
+                }
+            }
+            else
+            {
+                if (append)
+                {
+                    File.AppendAllLines(file1, (IEnumerable<String>)contents);
+                }
+                else
+                {
+                    File.WriteAllLines(file1, (IEnumerable<String>)contents);
+                }
+            }
+
+
+            int expectedCount = append ? 11 : 10;
+
+            IEnumerable<String> fileContents = null;
+            if (useEncodingOverload)
+            {
+                fileContents = File.ReadLines(file1, Encoding.UTF8);
+            }
+            else
+            {
+                fileContents = File.ReadLines(file1);
+            }
+
+            int count = 0;
+            foreach (String line in fileContents)
+            {
+                if (append && count == 0)
+                {
+                    if (!firstLineContent.Equals(line))
+                    {
+                        failCount++;
+                        Console.WriteLine(chkptFlag + "1: {0} FAILED at first line", testname);
+                        Console.WriteLine("got unexpected line: " + line);
+                    }
+                    count++;
+                    continue;
+                }
+
+                count++;
+                if (!lineContent.Equals(line))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: {0} FAILED", testname);
+                    Console.WriteLine("got unexpected line: " + line);
+
+                }
+            }
+            if (count != expectedCount)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "3: {0} FAILED. Line count didn't equal expected", testname);
+                Console.WriteLine("expected {0} but got {1}", expectedCount, count);
+            }
+
+            utils.PrintTestStatus(testname, "WriteAllLines", failCount);
+
+            File.Delete(file1);
+
+        }
+
+        private static void TestFileReadAllLinesFast(bool useEncodingOverload)
+        {
+            String chkptFlag = "chkpt_ralf_";
+            int failCount = 0;
+
+            string testname = null;
+            if (useEncodingOverload)
+            {
+                testname = "File.ReadLines(path, Encoding)"; 
+            }
+            else
+            {
+                testname = "File.ReadLines(path)"; 
+            }
+            String file1 = Path.Combine(utils.testDir, "file1.out");
+            String lineContent = "This is a line of test file content";
+            String[] contents = new String[10];
+            for (int i=0; i<contents.Length; i++) 
+            {
+                contents[i] = lineContent;
+            }
+
+            if (useEncodingOverload)
+            {
+                File.WriteAllLines(file1, contents, Encoding.UTF8);
+            }
+            else
+            {
+
+                File.WriteAllLines(file1, contents);
+            }
+
+            IEnumerable<String> fileContents = null;
+            if (useEncodingOverload)
+            {
+                fileContents = File.ReadLines(file1, Encoding.UTF8);
+            }
+            else
+            {
+                fileContents = File.ReadLines(file1);
+            }
+
+            int count = 0;
+            foreach (String line in fileContents)
+            {
+                count++;
+                if (!lineContent.Equals(line))
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "1: {0} FAILED", testname);
+                    Console.WriteLine("got unexpected line: " + line);
+                }
+            }
+
+            if (count != 10)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "2: {0} FAILED. Line count didn't equal expected", testname);
+                Console.WriteLine("expected {0} but got {1}", 10, count);
+            }
+
+            File.Delete(file1);
+
+            // empty file
+            file1 = Path.Combine(utils.testDir, "empty.out");
+            FileStream fs = File.Create(file1);
+            fs.Dispose();
+
+            fileContents = null;
+            if (useEncodingOverload)
+            {
+                fileContents = File.ReadLines(file1, Encoding.UTF8);
+            }
+            else
+            {
+                fileContents = File.ReadLines(file1);
+            }
+
+            foreach (String line in fileContents)
+            {
+                failCount++;
+                Console.WriteLine(chkptFlag + "3: {0} FAILED", testname);
+                Console.WriteLine("got unexpected line: " + line);
+            }
+
+            File.Delete(file1);
+
+            utils.PrintTestStatus(testname, "ReadLines", failCount);
+
+        }
+
+        private static void TestFileExceptions()
+        {
+            // Create common file and dir names
+            String nullFileName = null;
+            String emptyFileName1 = "";
+            String emptyFileName2 = " ";
+            String longPath = new String('a', 240) + @"\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\test.txt";
+
+            String notExistsFileName = null;
+            String unusedDrive = EnumerableUtils.GetUnusedDrive();
+            if (unusedDrive != null)
+            {
+                notExistsFileName = Path.Combine(unusedDrive, @"temp\notExists\temp.txt"); // just skip otherwise
+            }
+            String[] lines = { "test line 1", "test line 2" };
+            IEnumerable<String> contents = (IEnumerable<String>)lines;
+
+            // Read exceptions
+            TestReadFileExceptions(nullFileName, "null path", Encoding.UTF8, new ArgumentNullException());
+            TestReadFileExceptions(emptyFileName1, "empty path 1", Encoding.UTF8, new ArgumentException());
+            TestReadFileExceptions(emptyFileName2, "empty path 2", Encoding.UTF8, new ArgumentException());
+            TestReadFileExceptions(longPath, "long path", Encoding.UTF8, new PathTooLongException());
+            if (notExistsFileName != null)
+            {
+                TestReadFileExceptions(notExistsFileName, "not exists", Encoding.UTF8, new DirectoryNotFoundException());
+            }
+            TestReadFileExceptionsWithEncoding("temp.txt", "null encoding", null, new ArgumentNullException(), File.ReadLines, File.ReadLines, "File.ReadLines");
+
+            // Write exceptions
+            TestWriteFileExceptions(nullFileName, "null path", contents, Encoding.UTF8, new ArgumentNullException());
+            TestWriteFileExceptions(emptyFileName1, "empty path 1", contents, Encoding.UTF8, new ArgumentException());
+            TestWriteFileExceptions(emptyFileName2, "empty path 2", contents, Encoding.UTF8, new ArgumentException());
+            TestWriteFileExceptions(longPath, "long path", contents, Encoding.UTF8, new PathTooLongException());
+            if (notExistsFileName != null)
+            {
+                TestWriteFileExceptions(notExistsFileName, "not exists", contents, Encoding.UTF8, new DirectoryNotFoundException());
+            }
+            TestWriteFileExceptions("temp.txt", "null contents", null, Encoding.UTF8, new ArgumentNullException());
+
+            TestWriteFileExceptionsWithEncoding("temp.txt", "null encoding", contents, null, new ArgumentNullException(), File.WriteAllLines, File.WriteAllLines, "File.WriteAllLines");
+            TestWriteFileExceptionsWithEncoding("temp.txt", "null encoding", contents, null, new ArgumentNullException(), File.AppendAllLines, File.AppendAllLines, "File.AppendAllLines");
+
+        }
+
+        private static void TestReadFileExceptions(String fileName, String fileNameDescription, Encoding encoding, Exception expectedException)
+        {
+            TestReadFileExceptionsDefaultEncoding(fileName, fileNameDescription, expectedException, File.ReadLines, File.ReadLines, "File.ReadLines");
+            TestReadFileExceptionsWithEncoding(fileName, fileNameDescription, encoding, expectedException, File.ReadLines, File.ReadLines, "File.ReadLines");
+        }
+
+        private static void TestReadFileExceptionsDefaultEncoding(String path, String pathDescription, Exception expectedException, 
+                                                                    EnumerableUtils.ReadFastDelegate1 readDelegate, EnumerableUtils.ReadFastDelegate2 readDelegate2, String methodName )
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_rfede_";
+
+            try
+            {
+                IEnumerable<String> lines = readDelegate(path);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            String testName = String.Format("TestReadFileExceptions({0})", pathDescription);
+            utils.PrintTestStatus(testName, methodName, failCount);
+        }
+      
+        private static void TestReadFileExceptionsWithEncoding(String path, String pathDescription, Encoding encoding, Exception expectedException, 
+                                                                    EnumerableUtils.ReadFastDelegate1 readDelegate, EnumerableUtils.ReadFastDelegate2 readDelegate2, String methodName )
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_rfewe_";
+
+            try
+            {
+                IEnumerable<String> lines = readDelegate2(path, encoding);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            String testName = String.Format("TestReadFileExceptions_Encoding({0})", pathDescription);
+            utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+        private static void TestWriteFileExceptions(String fileName, String fileNameDescription, IEnumerable<String> contents, Encoding encoding, Exception expectedException)
+        {
+            TestWriteFileExceptionsDefaultEncoding(fileName, fileNameDescription, contents, expectedException, File.WriteAllLines, File.WriteAllLines, "File.WriteAllLines");
+            TestWriteFileExceptionsWithEncoding(fileName, fileNameDescription, contents, encoding, expectedException, File.WriteAllLines, File.WriteAllLines, "File.WriteAllLines");
+            TestWriteFileExceptionsDefaultEncoding(fileName, fileNameDescription, contents, expectedException, File.AppendAllLines, File.AppendAllLines, "File.AppendAllLines");
+            TestWriteFileExceptionsWithEncoding(fileName, fileNameDescription, contents, encoding, expectedException, File.AppendAllLines, File.AppendAllLines, "File.AppendAllLines");
+        }
+        
+        private static void TestWriteFileExceptionsDefaultEncoding(String path, String pathDescription, IEnumerable<String> contents, Exception expectedException, 
+                                                                    EnumerableUtils.WriteFastDelegate1 writeDelegate, EnumerableUtils.WriteFastDelegate2 writeDelegate2, String methodName )
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_wfede_";
+            
+            try
+            {
+                writeDelegate(path, contents);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            String testName = String.Format("TestWriteFileExceptions({0})", pathDescription);
+            utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+        private static void TestWriteFileExceptionsWithEncoding(String path, String pathDescription, IEnumerable<String> contents, Encoding encoding, Exception expectedException, 
+                                                                    EnumerableUtils.WriteFastDelegate1 writeDelegate, EnumerableUtils.WriteFastDelegate2 writeDelegate2, String methodName )
+        {
+            int failCount = 0;
+            String chkptFlag = "chkpt_wfewe_";
+
+            try
+            {
+                writeDelegate2(path, contents, encoding);
+                Console.WriteLine(chkptFlag + "1: didn't throw");
+                failCount++;
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() != expectedException.GetType())
+                {
+                    failCount++;
+                    Console.WriteLine(chkptFlag + "2: threw wrong exception");
+                    Console.WriteLine(e);
+                }
+            }
+
+            String testName = String.Format("TestWriteFileExceptions_Encoding({0})", pathDescription);
+            utils.PrintTestStatus(testName, methodName, failCount);
+        }
+
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/GetAttributes_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetAttributes_str.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_GetAttributes_str
+{
+    public static String s_strDtTmVer = "2006/11/10";
+    public static String s_strClassMethod = "File.GetAttributes()";
+    public static String s_strTFName = "GetAttributes_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "";
+
+        try
+        {
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo file1;
+
+            // [] With an empty string
+            strLoc = "loc_0000";
+
+            iCountTestcases++;
+            try
+            {
+                FileAttributes fa = File.GetAttributes(strValue);
+                iCountErrors++;
+                printerr("Error_0001! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] By passing a null argument.
+            strLoc = "loc_0004";
+
+            iCountTestcases++;
+            try
+            {
+                FileAttributes fa = File.GetAttributes(null);
+                iCountErrors++;
+                printerr("Error_0005! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0007! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] By passing an invalid path name.
+            //See #515184
+            strLoc = "loc_0015";
+
+            iCountTestcases++;
+            String[] paths = { @"\Foo8235378\Bar", "Bar2342385", "c:\\this is a invalid testing directory\\test\\test\\" };
+            foreach (String path in paths)
+            {
+                if (Directory.Exists(path))
+                    Directory.Delete(path, true);
+
+                try
+                {
+                    FileAttributes fa = File.GetAttributes(path);
+                    Console.WriteLine(fa);
+                    iCountErrors++;
+                    printerr("Error_0016! Expected exception not thrown for path " + path);
+                }
+                catch (FileNotFoundException)
+                {
+                }
+                catch (DirectoryNotFoundException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_0018! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+            }
+
+            // [] valid data
+            //-----------------------------------------------------------------
+            strLoc = "Loc_0009";
+
+            file1 = new FileInfo(fileName);
+            FileStream fs = file1.Create();
+
+#if !TEST_WINRT
+            iCountTestcases++;
+            file1.Attributes = FileAttributes.Hidden;
+            if ((file1.Attributes & FileAttributes.Hidden) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0010! Hidden not set");
+            }
+
+            iCountTestcases++;
+            file1.Refresh();
+            file1.Attributes = FileAttributes.System;
+            if ((File.GetAttributes(fileName) & FileAttributes.System) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0011! System not set");
+            }
+#endif
+
+            iCountTestcases++;
+            file1.Refresh();
+            FileAttributes current = File.GetAttributes(fileName);
+
+            file1.Attributes = FileAttributes.Normal;
+            if ((File.GetAttributes(fileName) & FileAttributes.Normal) == 0)
+            {
+                //NOTE: Normal is only allowed on its own. So, if there is already another attribute, this will not work
+                //@TODO!! This might have to be modified
+                if ((File.GetAttributes(fileName) & FileAttributes.Compressed) == 0)
+#if TEST_WINRT
+                if((File.GetAttributes(fileName) & FileAttributes.Archive) == 0)
+#endif
+                {
+                    Console.WriteLine("Attributes before setting Normal: {0}", current);
+                    iCountErrors++;
+                    Console.WriteLine("Error_0012! Normal not set: {0}", File.GetAttributes(fileName));
+                }
+            }
+
+            iCountTestcases++;
+            file1.Refresh();
+            file1.Attributes = FileAttributes.Temporary;
+            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0013! Temporary not set");
+            }
+
+            file1.Attributes = file1.Attributes | FileAttributes.SparseFile;
+            file1.Attributes = file1.Attributes | FileAttributes.ReparsePoint;
+            iCountTestcases++;
+            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) != FileAttributes.Temporary)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Temporary not set");
+            }
+
+            file1.Refresh();
+            file1.Attributes = FileAttributes.Archive;
+            file1.Attributes = FileAttributes.ReadOnly | file1.Attributes;
+            iCountTestcases++;
+            if ((File.GetAttributes(fileName) & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
+            {
+                iCountErrors++;
+                printerr("Error_0020! ReadOnly attribute not set");
+            }
+
+            iCountTestcases++;
+            if ((File.GetAttributes(fileName) & FileAttributes.Archive) != FileAttributes.Archive)
+            {
+                iCountErrors++;
+                printerr("Error_0021! Archive attribute not set");
+            }
+
+            File.SetAttributes(fileName, FileAttributes.Normal);
+            fs.Dispose();
+            file1.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/GetCreationTime_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetCreationTime_str.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class File_GetCreationTime_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2001/01/31 13:19";
+    public static String s_strClassMethod = "File.GetCreationTime()";
+    public static String s_strTFName = "GetCreationTime_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            // [] Exception for null string
+            //-----------------------------------------------------------
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = File.GetCreationTime(null);
+                iCountErrors++;
+                printerr("Error_0009! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0010! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Create a file and check the creation time
+
+            strLoc = "Loc_0002";
+
+            FileInfo file1 = new FileInfo(fileName);
+            FileStream fs = file1.Create();
+            fs.Dispose();
+            iCountTestcases++;
+            try
+            {
+                if (Math.Abs((File.GetCreationTime(fileName) - DateTime.Now).TotalSeconds) > 3)
+                {
+                    Console.WriteLine("{0}, {1}", File.GetCreationTime(fileName), DateTime.Now);
+
+                    iCountErrors++;
+                    printerr("Error_0003! Creation time should be within 3 seconds of now");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0004! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file1.Delete();
+
+
+            // [] Create file, sleep for a while and check the creation time.
+            // Update: 2005/09/07. This fails when run repeatedly. It looks like the the creation time reported is the one at first time run creation.
+            // I suspect the OS caches this information. Modifying to get a random file
+
+            strLoc = "Loc_0005";
+            fileName = Path.GetTempFileName();
+            FileInfo file2 = new FileInfo(fileName);
+            FileStream fs2 = file2.Create();
+            fs2.Dispose();
+            Task.Delay(2000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - File.GetCreationTime(fileName)).Seconds > 3)
+                {
+                    Console.WriteLine(DateTime.Now);
+                    Console.WriteLine((DateTime.Now - File.GetCreationTime(fileName)).Seconds.ToString());
+                    Console.WriteLine(file2.CreationTime);
+
+                    iCountErrors++;
+                    printerr("Eror_0006! Creation time is off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0007! Unexpected exception thrown: " + exc.ToString());
+            }
+            file2.Delete();
+            file2.Refresh();
+
+            strLoc = "Loc_0012";
+            iCountTestcases++;
+            try
+            {
+                if (File.Exists(s_strTFName))
+                {
+                    Console.WriteLine("File date :: " + File.GetCreationTime(s_strTFName));
+                    Console.WriteLine("Today :: " + DateTime.Today);
+                    //When you are running from Maddog it should work because it copies down the file just before running
+                    //it. The creation time should be less than a minute. 
+                    if ((DateTime.Today - File.GetCreationTime(s_strTFName)).Seconds > 60)
+                    {
+                        iCountErrors++;
+                        printerr("Eror_0013! Creation time is off");
+                    }
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exception thrown: " + exc.ToString());
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/GetLastAccessTime_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetLastAccessTime_str.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class File_GetLastAccessTime_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2001/01/31 18:25";
+    public static String s_strClassMethod = "File.GetLastAccessTime()";
+    public static String s_strTFName = "GetLastAccessTime_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            Stream stream;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            // [] Test with null string
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = File.GetLastAccessTime(null);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Test with an empty string
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = File.GetLastAccessTime("");
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Create a file and check the creation time
+            strLoc = "Loc_0006";
+
+            FileStream fs = new FileStream(filName, FileMode.Create);
+            fs.Dispose();
+            fil2 = new FileInfo(filName);
+            stream = fil2.OpenWrite();
+            stream.Write(new Byte[] { 10 }, 0, 1);
+            stream.Dispose();
+            Task.Delay(4000).Wait();
+            fil2.Refresh();
+            iCountTestcases++;
+            try
+            {
+                DateTime d1 = fil2.LastAccessTime;
+                DateTime d2 = DateTime.Today;
+                if (d1.Year != d2.Year || d1.Month != d2.Month || d1.Day != d2.Day)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct.. Expected:::" + DateTime.Today.ToString() + ", Actual:::" + fil2.LastAccessTime.ToString());
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Verify lastaccesstime for an old file.
+            strLoc = "Loc_0009";
+            iCountTestcases++;
+            try
+            {
+                //When you are running from Maddog it should work because it copies down the file just before running
+                //it. The creation time should be less than a minute. 
+                if (File.Exists(s_strTFName))
+                {
+                    if ((DateTime.Today - File.GetLastAccessTime(s_strTFName)).Seconds > 60)
+                    {
+                        iCountErrors++;
+                        printerr("Eror_0010! LastAccess time is not correct");
+                    }
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exception thrown: " + exc.ToString());
+            }
+            fil2.Delete();
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/GetLastWriteTime_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetLastWriteTime_str.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_GetLastWriteTime_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2001/1/31 19:00";
+    public static String s_strClassMethod = "File.GetLastWriteTime()";
+    public static String s_strTFName = "GetLastWriteTime_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo file2;
+            Stream stream;
+
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+
+            // [] Test with null string
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = File.GetLastWriteTime(null);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Test with an empty string
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = File.GetLastWriteTime("");
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+            // [] Create a new file and verify the lastwrite time.
+            strLoc = "Loc_0006";
+
+            file2 = new FileInfo(fileName);
+            FileStream fs = file2.Create();
+            fs.Write(new Byte[] { 10 }, 0, 1);
+            fs.Dispose();
+
+            double lMilliSecs = (DateTime.Now - File.GetLastWriteTime(fileName)).TotalMilliseconds;
+
+            //file2.Refresh();
+            iCountTestcases++;
+
+            if ((DateTime.Now - File.GetLastWriteTime(fileName)).Minutes > 6)
+            {
+                Console.WriteLine("Millis.. " + lMilliSecs);
+                Console.WriteLine("FileName ... " + (DateTime.Now - File.GetLastWriteTime(fileName)).Minutes);
+                Console.WriteLine(DateTime.Now);
+                Console.WriteLine(File.GetLastWriteTime(fileName));
+
+                iCountErrors++;
+                Console.WriteLine((DateTime.Now - File.GetLastWriteTime(fileName)).TotalMilliseconds);
+                printerr("Error_0007! Last Write Time time cannot be correct");
+            }
+
+            // Re-open the file and write some more info and verify.
+            strLoc = "Loc_0008";
+
+            stream = file2.Open(FileMode.Open, FileAccess.Read);
+            stream.Read(new Byte[1], 0, 1);
+            stream.Dispose();
+            file2.Refresh();
+            iCountTestcases++;
+            if ((DateTime.Now - File.GetLastWriteTime(fileName)).TotalMinutes > 6)
+            {
+                iCountErrors++;
+                Console.WriteLine((DateTime.Now - File.GetLastWriteTime(fileName)).TotalMilliseconds);
+                printerr("Eror_0009! LastWriteTime is way off");
+            }
+            file2.Delete();
+
+            // [] Verify lastwritetime for an old file.
+            strLoc = "Loc_0010";
+            iCountTestcases++;
+            try
+            {
+                if (File.Exists(s_strTFName))
+                {
+                    //When you are running from Maddog it should work because it copies down the file just before running
+                    //it. The creation time should be less than a minute. 
+                    Console.WriteLine(File.GetLastWriteTime(s_strTFName));
+                    if ((DateTime.Today - File.GetLastWriteTime(s_strTFName)).Seconds > 60)
+                    {
+                        iCountErrors++;
+                        printerr("Eror_0011! LastWrite time is not correct");
+                    }
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0012! Unexpected exception thrown: " + exc.ToString());
+            }
+
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_GetSetTimes
+{
+    enum TimeProperty
+    {
+        CreationTime,
+        LastAccessTime,
+        LastWriteTime
+    }
+    
+    [Fact]
+    public static void ConsistencyTest()
+    {
+        String fileName = Path.Combine(TestInfo.CurrentDirectory, "File_GetSetTimes");
+
+        File.Create(fileName).Dispose();
+        
+        foreach(TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
+        {
+            foreach (DateTimeKind kind in  Enum.GetValues(typeof(DateTimeKind)))
+            {
+                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);
+                foreach (bool setUtc in new [] { false, true } )
+                {
+                    if (setUtc)
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                File.SetCreationTimeUtc(fileName, dt);
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                File.SetLastAccessTimeUtc(fileName, dt);
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                File.SetLastWriteTimeUtc(fileName, dt);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                File.SetCreationTime(fileName, dt);
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                File.SetLastAccessTime(fileName, dt);
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                File.SetLastWriteTime(fileName, dt);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    DateTime actual, actualUtc;
+                    switch (timeProperty)
+                    {
+                        case TimeProperty.CreationTime:
+                            actual = File.GetCreationTime(fileName);
+                            actualUtc = File.GetCreationTimeUtc(fileName);
+                            break;
+                        case TimeProperty.LastAccessTime:
+                            actual = File.GetLastAccessTime(fileName);
+                            actualUtc = File.GetLastAccessTimeUtc(fileName);
+                            break;
+                        case TimeProperty.LastWriteTime:
+                            actual = File.GetLastWriteTime(fileName);
+                            actualUtc = File.GetLastWriteTimeUtc(fileName);
+                            break;
+                        default:
+                            throw new ArgumentException("Invalid time property type");
+                    }
+
+                    DateTime expected = dt.ToLocalTime();
+                    DateTime expectedUtc = dt.ToUniversalTime();
+
+                    if (dt.Kind == DateTimeKind.Unspecified)
+                    {
+                        if (setUtc)
+                        {
+                            expectedUtc = dt;
+                        }
+                        else
+                        {
+                            expected = dt;
+                        }
+                    }
+
+                    Assert.Equal(expected, actual); //, "Local {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                    Assert.Equal(expectedUtc, actualUtc); //, "Universal {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                }
+            }
+        }
+
+        File.Delete(fileName);
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/Move_str_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Move_str_str.cs
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_Move_str_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "Move_str_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil1, fil2;
+            StreamWriter sw2;
+            Char[] cWriteArr, cReadArr;
+            StreamReader sr2;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Exception for null arguments
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_498yg";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Move(null, fil2.FullName);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+            // [] ArgumentNullException if null is passed in for destination file
+
+            strLoc = "Loc_898gc";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Move(fil2.FullName, null);
+                iCountErrors++;
+                printerr("Error_8yt85! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1298s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+            // [] String.Empty should throw ArgumentException
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_298vy";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Move(fil2.FullName, String.Empty);
+                iCountErrors++;
+                printerr("Error_092u9! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109uc! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Try to Move onto directory
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_289vy";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.Move(fil2.FullName, TestInfo.CurrentDirectory);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209us! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Move onto existing file should fail
+
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_r7yd9";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            File.Move(fil2.FullName, fil2.FullName);
+            if (!File.Exists(fil2.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_r8g7b! Expected exception not thrown");
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+            // [] Vanilla Move operation
+
+            //-----------------------------------------------------------------
+            strLoc = "Loc_f548y";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            string destFile = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            File.Move(fil2.FullName, destFile);
+            fil1 = new FileInfo(destFile);
+            fil2.Refresh();
+            if (!File.Exists(fil1.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_2978y! File not copied");
+            }
+            if (File.Exists(fil2.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_239vr! Source file still there");
+            }
+            fil1.Delete();
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Filename with illiegal characters
+            //-----------------------------------------------------------------
+            strLoc = "Loc_984hg";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+            iCountTestcases++;
+            try
+            {
+                File.Move(fil2.FullName, "**");
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
+                fil2.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Move a file containing data
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_f888m";
+
+            destFile = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            File.Delete(destFile);
+            try
+            {
+                sw2 = new StreamWriter(File.Create(filName));
+                cWriteArr = new Char[26];
+                int j = 0;
+                for (Char i = 'A'; i <= 'Z'; i++)
+                    cWriteArr[j++] = i;
+                sw2.Write(cWriteArr, 0, cWriteArr.Length);
+                sw2.Flush();
+                sw2.Dispose();
+
+                fil2 = new FileInfo(filName);
+                File.Move(fil2.FullName, destFile);
+                fil1 = new FileInfo(destFile);
+                fil2.Refresh();
+                iCountTestcases++;
+                if (!File.Exists(fil1.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_9u99s! File not copied correctly: " + fil1.FullName);
+                }
+                if (File.Exists(fil2.FullName))
+                {
+                    iCountErrors++;
+                    printerr("Error_29h7b! Source file gone");
+                }
+
+                FileStream stream = new FileStream(destFile, FileMode.Open);
+                sr2 = new StreamReader(stream);
+                cReadArr = new Char[cWriteArr.Length];
+                sr2.Read(cReadArr, 0, cReadArr.Length);
+
+                iCountTestcases++;
+                for (int i = 0; i < cReadArr.Length; i++)
+                {
+                    iCountTestcases++;
+                    if (cReadArr[i] != cWriteArr[i])
+                    {
+                        iCountErrors++;
+                        printerr("Error_98yv7! Expected==" + cWriteArr[i] + ", got value==" + cReadArr[i]);
+                    }
+                }
+                sr2.Dispose();
+                stream.Dispose();
+
+                fil1.Delete();
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28vc8! Unexpected exception, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+/* Scenario disabled when porting because it accesses the file system outside of the test's working directory
+#if !TEST_WINRT
+            // [] Move up to root dir
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_478yb";
+            String strTmp = "..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\TestFile.tmp";
+            File.Delete(strTmp);
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+
+            File.Move(fil2.Name, strTmp);
+            fil1 = new FileInfo(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name);
+            iCountTestcases++;
+            if (!fil1.FullName.Equals(fil2.FullName.Substring(0, fil2.FullName.IndexOf("\\") + 1) + fil2.Name))
+            {
+                Console.WriteLine(fil1.FullName);
+                iCountErrors++;
+                printerr("Error_298gc! Incorrect fullname set during Move");
+            }
+            new FileInfo(filName).Delete();
+            fil1.Delete();
+            //-----------------------------------------------------------------
+
+            fil1.Delete();
+            fil2.Delete();
+
+            if (File.Exists(strTmp))
+                File.Delete(strTmp);
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+#endif
+*/
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/OpenRead_str.cs
+++ b/src/System.IO.FileSystem/tests/File/OpenRead_str.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_OpenRead_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/07/11 18:26";
+    public static String s_strClassMethod = "File.OpenRead(String)";
+    public static String s_strTFName = "OpenRead_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            Stream s2;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+
+            // [] File does not exist
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00001";
+
+            iCountTestcases++;
+            try
+            {
+                File.OpenRead(filName);
+                iCountErrors++;
+                printerr("Error_00002! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00004! Incorrect exception caught, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] Open file and check for canread
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00005";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            iCountTestcases++;
+            s2 = File.OpenRead(filName);
+            iCountTestcases++;
+            if (!s2.CanRead)
+            {
+                iCountErrors++;
+                printerr("Error_00006! File not opened canread");
+            }
+
+            // [] Check file for canwrite
+
+            iCountTestcases++;
+            if (s2.CanWrite)
+            {
+                iCountErrors++;
+                printerr("Error_00007! File was opened canWrite");
+            }
+
+            s2.Dispose();
+            //-----------------------------------------------------------------
+
+
+
+            // [] Check for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00008";
+
+            iCountTestcases++;
+            try
+            {
+                s2 = File.OpenRead(null);
+                iCountErrors++;
+                printerr("Error_00009! Expected exeption not thrown");
+                s2.Dispose();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00011! Incorrect exception, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Check for empty string
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00012";
+
+            iCountTestcases++;
+            try
+            {
+                s2 = File.OpenRead(String.Empty);
+                iCountErrors++;
+                printerr("Error_10013! Expected exception not thrown");
+                s2.Dispose();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00015! Incorrect exception, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/OpenText_str.cs
+++ b/src/System.IO.FileSystem/tests/File/OpenText_str.cs
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_OpenText_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 11:52";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "OpenText_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            StreamWriter sw2;
+            StreamReader sr2;
+            String str2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Open file that does not exists should thrown 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_27gyb";
+
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.OpenText(filName);
+                iCountErrors++;
+                printerr("Error_29g7b! Expected exception not thrown");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_286by! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                File.OpenText(null);
+                iCountErrors++;
+                printerr("Error_29g7b! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_286by! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] Open directory should throw
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4g894";
+
+            iCountTestcases++;
+            try
+            {
+                File.OpenText(".");
+                iCountErrors++;
+                printerr("Error_2099c! Expected exception not thrown");
+            }
+            catch (UnauthorizedAccessException)
+            {
+#if TEST_WINRT // WinRT returns E_INVALIDARG instead of ACCESS_DENIED
+            } catch (IOException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_t749x! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+            // [] Open a text file and read the content.
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2y78b";
+
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            sw2 = fil2.CreateText();
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            sr2 = File.OpenText(filName);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorld"))
+            {
+                iCountErrors++;
+                printerr("Error_21y77! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+
+            // [] OpenText on a file that does exist should open it.
+
+            strLoc = "Loc_2gy7b";
+
+            sw2 = fil2.CreateText();
+            sw2.Write("You Big Globe");
+            sw2.Dispose();
+            sr2 = File.OpenText(filName);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("You Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_12ytb! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+
+            //-----------------------------------------------------------------
+
+            // [] OpenText on a file that is readonly should work fine
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yv";
+#if !TEST_WINRT // TODO: Enable once we implement WinRT file attributes
+            fil2.Attributes = FileAttributes.ReadOnly;
+            sr2 = File.OpenText(filName);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("You Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_8fgyv! Incorrect string read, str2==" + str2);
+            }
+            sr2.Dispose();
+            fil2.Attributes = new FileAttributes();
+#endif
+            //-----------------------------------------------------------------
+
+
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/OpenWrite_str.cs
+++ b/src/System.IO.FileSystem/tests/File/OpenWrite_str.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_OpenWrite_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/07/11 18:24";
+    public static String s_strClassMethod = "File.OpenWrite(String)";
+    public static String s_strTFName = "OpenWrite_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            Stream s2;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Open file and check for canread
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00005";
+
+            iCountTestcases++;
+            s2 = File.OpenWrite(filName);
+            iCountTestcases++;
+            if (s2.CanRead)
+            {
+                iCountErrors++;
+                printerr("Error_00006! File not opened canread");
+            }
+
+            // [] Check file for canwrite
+
+            iCountTestcases++;
+            if (!s2.CanWrite)
+            {
+                iCountErrors++;
+                printerr("Error_00007! File was opened canWrite");
+            }
+
+            s2.Dispose();
+            //-----------------------------------------------------------------
+
+
+
+            // [] Check for null argument
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00008";
+
+            iCountTestcases++;
+            try
+            {
+                s2 = File.OpenWrite(null);
+                iCountErrors++;
+                printerr("Error_00009! Expected exeption not thrown");
+                s2.Dispose();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00011! Incorrect exception, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Check for empty string
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00012";
+
+            iCountTestcases++;
+            try
+            {
+                s2 = File.OpenWrite(String.Empty);
+                iCountErrors++;
+                printerr("Error_10013! Expected exception not thrown");
+                s2.Dispose();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00015! Incorrect exception, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Open_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/File/Open_str_fm.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_Open_str_fm
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2001/02/02 10;00";
+    public static String s_strClassMethod = "File.Open(String,FileMode)";
+    public static String s_strTFName = "Open_str_fm.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_0001";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            // CreateNew
+            // Create
+            // Open
+            // OpenOrCreate
+            // Truncate
+            // Append
+
+            // Simple call throughs to FileStream, just test functionality
+            // [] FileMode.CreateNew
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Create
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Open
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.OpenOrCreate
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Truncate
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Append
+            // [][] File Exists
+            // [][] File does not exist
+
+            TestMethod(FileMode.CreateNew);
+            TestMethod(FileMode.Create);
+            TestMethod(FileMode.Open);
+            TestMethod(FileMode.OpenOrCreate);
+            TestMethod(FileMode.Truncate);
+            TestMethod(FileMode.Append);
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+    public static void TestMethod(FileMode fm)
+    {
+        String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+        FileInfo fil2;
+        StreamWriter sw2;
+        Stream fs2 = null;
+        String str2;
+
+
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+
+        // [] File does not exist
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_0001";
+
+        fil2 = new FileInfo(fileName);
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+            case FileMode.Create:
+            case FileMode.OpenOrCreate:
+
+                //With a null string
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(null, fm);
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_0002! File not created, FileMode==" + fm.ToString());
+                    }
+                }
+                catch (ArgumentNullException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0003! Unexpected exception thrown :: " + ex.ToString());
+                }
+
+                //with anempty string
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open("", fm);
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_0004! File not created, FileMode==" + fm.ToString());
+                    }
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0005! Unexpected exception thrown :: " + ex.ToString());
+                }
+
+                fs2 = File.Open(fileName, fm);
+                s_iCountTestcases++;
+                if (!File.Exists(fileName))
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0006! File not created, FileMode==" + fm.ToString());
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Open:
+            case FileMode.Truncate:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(fileName, fm);
+                    s_iCountErrors++;
+                    printerr("Error_0007! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (FileNotFoundException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0009! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Append:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(fileName, fm);
+                    fs2.Write(new Byte[] { 54, 65, 54, 90 }, 0, 4);
+                    if (fs2.Length != 4)
+                    {
+                        s_iCountErrors++;
+                        Console.WriteLine("Unexpected file length .... " + fs2.Length);
+                    }
+                    fs2.Dispose();
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0012! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_27tbv! This should not be....");
+                break;
+        }
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+
+        //------------------------------------------------------------------
+
+
+        // [] File already exists
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_4yg7b";
+
+        FileStream stream = new FileStream(fileName, FileMode.Create);
+        sw2 = new StreamWriter(stream);
+        str2 = "Du er en ape";
+        sw2.Write(str2);
+        sw2.Dispose();
+        stream.Dispose();
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(fileName, fm);
+                    s_iCountErrors++;
+                    printerr("Error_27b98! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_g8782! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Create:
+                fs2 = File.Open(fileName, fm);
+                if (fs2.Length != 0)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_287vb! Incorrect length of file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.OpenOrCreate:
+            case FileMode.Open:
+                fs2 = File.Open(fileName, fm);
+                if (fs2.Length != str2.Length)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2gy78! Incorrect length on file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Truncate:
+                fs2 = File.Open(fileName, fm);
+                if (fs2.Length != 0)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_29gv9! Incorrect length on file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Append:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(fileName, fm);
+                    fs2.Write(new Byte[] { 54, 65, 54, 90 }, 0, 4);
+                    if (fs2.Length != 16)
+                    {  // already 12 characters are written to the file.
+                        s_iCountErrors++;
+                        Console.WriteLine("Unexpected file length .... " + fs2.Length);
+                    }
+                    fs2.Dispose();
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_27878! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_587yb! This should not be...");
+                break;
+        }
+
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/Open_str_fm_fa.cs
+++ b/src/System.IO.FileSystem/tests/File/Open_str_fm_fa.cs
@@ -1,0 +1,513 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_Open_fm_fa
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "Open_fm_fa.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_000oo";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            // CreateNew
+            // Create
+            // Open
+            // OpenOrCreate
+            // Truncate
+            // Append
+
+            // [] FileMode.CreateNew and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.CreateNew and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.CreateNew and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Create and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Create and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Create and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Open and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Open and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Open and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.OpenOrCreate and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.OpenOrCreate and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.OpenOrCreate and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Truncate and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Truncate and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Truncate and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Append and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Append and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Append and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+
+            // Simple call throughs to FileStream, just test functionality
+
+            TestMethod(FileMode.CreateNew, FileAccess.Read);
+            TestMethod(FileMode.CreateNew, FileAccess.Write);
+            TestMethod(FileMode.CreateNew, FileAccess.ReadWrite);
+            TestMethod(FileMode.Create, FileAccess.Read);
+            TestMethod(FileMode.Create, FileAccess.Write);
+            TestMethod(FileMode.Create, FileAccess.ReadWrite);
+            TestMethod(FileMode.Open, FileAccess.Read);
+            TestMethod(FileMode.Open, FileAccess.Write);
+            TestMethod(FileMode.Open, FileAccess.ReadWrite);
+            TestMethod(FileMode.OpenOrCreate, FileAccess.Read);
+            TestMethod(FileMode.OpenOrCreate, FileAccess.Write);
+            TestMethod(FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            TestMethod(FileMode.Truncate, FileAccess.Read);
+            TestMethod(FileMode.Truncate, FileAccess.Write);
+            TestMethod(FileMode.Truncate, FileAccess.ReadWrite);
+            TestMethod(FileMode.Append, FileAccess.Read);
+            TestMethod(FileMode.Append, FileAccess.Write);
+            TestMethod(FileMode.Append, FileAccess.ReadWrite);
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+    public static void TestMethod(FileMode fm, FileAccess fa)
+    {
+        String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+        StreamWriter sw2;
+        FileStream fs2;
+        String str2;
+
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+
+        // File does not exist
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_234yg";
+
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+            case FileMode.Create:
+            case FileMode.OpenOrCreate:
+                try
+                {
+                    fs2 = File.Open(null, fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_0001! File not created, FileMode==" + fm.ToString("G"));
+                    }
+                    fs2.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0004! Incorrect exception thrown, exc==" + exc);
+                }
+                try
+                {
+                    fs2 = File.Open("", fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_0005! File not created, FileMode==" + fm.ToString("G"));
+                    }
+                    fs2.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_0008! Incorrect exception thrown, exc==" + exc);
+                }
+                try
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_48gb7! File not created, FileMode==" + fm.ToString("G"));
+                    }
+                    fs2.Dispose();
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (!((fm == FileMode.Create && fa == FileAccess.Read) || (fm == FileMode.CreateNew && fa == FileAccess.Read)))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_478v8! Unexpected exception, aexc==" + aexc);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_4879v! Incorrect exception thrown, exc==" + exc);
+                }
+                break;
+            case FileMode.Open:
+            case FileMode.Truncate:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(null, fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_1001! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (IOException)
+                {
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_1005! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open("", fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_1006! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (IOException)
+                {
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_1010! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_2yg8b! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (IOException)
+                {
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (fa != FileAccess.Read)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_v48y8! Unexpected exception thrown, aexc==" + aexc);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2y7gf! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Append:
+                if (fa == FileAccess.Write)
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_2498y! File not created");
+                    }
+                    fs2.Dispose();
+                }
+                else
+                {
+                    s_iCountTestcases++;
+                    try
+                    {
+                        fs2 = File.Open(fileName, fm, fa);
+                        s_iCountErrors++;
+                        printerr("Error_2g78b! Expected exception not thrown");
+                        fs2.Dispose();
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (Exception exc)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_g77b7! Incorrect exception thrown, exc==" + exc.ToString());
+                    }
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_27tbv! This should not be....");
+                break;
+        }
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+
+        //------------------------------------------------------------------
+
+
+        //  File already exists
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_4yg7b";
+
+        FileStream stream = new FileStream(fileName, FileMode.Create);
+        sw2 = new StreamWriter(stream);
+        str2 = "Du er en ape";
+        sw2.Write(str2);
+        sw2.Dispose();
+        stream.Dispose();
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(null, fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_2001! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2005! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open("", fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_2006! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2010! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_27b98! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (fa != FileAccess.Read)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_4387v! Unexpected exception, aexc==" + aexc);
+                    }
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_g8782! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Create:
+                try
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    if (fs2.Length != 0)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_287vb! Incorrect length of file==" + fs2.Length);
+                    }
+                    fs2.Dispose();
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (fa != FileAccess.Read)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_48vy7! Unexpected exception, aexc==" + aexc);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_47yv3! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.OpenOrCreate:
+            case FileMode.Open:
+                fs2 = File.Open(fileName, fm, fa);
+                if (fs2.Length != str2.Length)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2gy78! Incorrect length on file==" + fs2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Truncate:
+                if (fa == FileAccess.Read)
+                {
+                    s_iCountTestcases++;
+                    try
+                    {
+                        fs2 = File.Open(fileName, fm, fa);
+                        s_iCountErrors++;
+                        printerr("Error_g95y8! Expected exception not thrown");
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (Exception exc)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_98y4v! Incorrect exception thrown, exc==" + exc.ToString());
+                    }
+                }
+                else
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    if (fs2.Length != 0)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_29gv9! Incorrect length on file==" + fs2.Length);
+                    }
+                    fs2.Dispose();
+                }
+                break;
+            case FileMode.Append:
+                if (fa == FileAccess.Write)
+                {
+                    fs2 = File.Open(fileName, fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(fileName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_4089v! File not created");
+                    }
+                    fs2.Dispose();
+                }
+                else
+                {
+                    s_iCountTestcases++;
+                    try
+                    {
+                        fs2 = File.Open(fileName, fm, fa);
+                        s_iCountErrors++;
+                        printerr("Error_287yb! Expected exception not thrown");
+                        fs2.Dispose();
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (Exception exc)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_27878! Incorrect exception thrown, exc==" + exc.ToString());
+                    }
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_587yb! This should not be...");
+                break;
+        }
+
+
+        //------------------------------------------------------------------
+
+
+
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/Open_str_fm_fa_fs.cs
+++ b/src/System.IO.FileSystem/tests/File/Open_str_fm_fa_fs.cs
@@ -1,0 +1,305 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_Open_fm_fa_fs
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "Open_fm_fa_fs.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        try
+        {
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            Stream fs2 = null, fs3;
+
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+
+            // [] FileSharing.None -- Should not be able to access the file
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2498V";
+
+            fs2 = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            iCountTestcases++;
+            try
+            {
+                fs3 = File.Open(fileName, FileMode.Open);
+                iCountErrors++;
+                printerr("Error_209uv! Shouldn't be able to open an open file");
+                fs3.Dispose();
+#if TEST_WINRT
+            } catch (UnauthorizedAccessException) {
+#endif
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_287gv! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+
+            // [] FileSharing.Read
+            //-----------------------------------------------------------------
+            strLoc = "Loc_f5498";
+
+            // create test file
+            fs2 = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+            fs2.Write(new Byte[] { 10 }, 0, 1);
+            fs2.Flush();
+            fs2.Dispose();
+
+            // FileShare is not supported by WINRT, sharing is controlled by access.
+            // It allows concurrent readers, and write after read, but not vice-versa.
+            // Reopen file as only Read to test concurrent read behavior.
+            fs2 = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            iCountTestcases++;
+            fs3 = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            fs2.Read(new Byte[1], 0, 1);
+            fs3.Read(new Byte[1], 0, 1);
+            iCountTestcases++;
+            try
+            {
+                fs3.Write(new Byte[] { 10 }, 0, 1);
+                iCountErrors++;
+                printerr("Error_958vc! Expected exception not thrown");
+            }
+            catch (NotSupportedException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20939! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            fs2.Dispose();
+            fs3.Dispose();
+
+            //-----------------------------------------------------------------
+
+            // [] With null file name
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2498x";
+
+            iCountTestcases++;
+            try
+            {
+                fs3 = File.Open(null, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+                iCountErrors++;
+                printerr("Error_0001! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fs3.Dispose();
+
+            // [] empty string file name
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2498x";
+
+            iCountTestcases++;
+            try
+            {
+                fs3 = File.Open("", FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+                iCountErrors++;
+                printerr("Error_1001! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2003! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fs3.Dispose();
+
+            // [] FileSharing.Write
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2498x";
+
+            fs2 = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.Write);
+            iCountTestcases++;
+            try
+            {
+                fs3 = File.Open(fileName, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+                fs3.Write(new Byte[] { 1, 2 }, 0, 2);
+#if TEST_WINRT // WinRT's sharing model does not support concurrent write
+                printerr( "Error_209uv! Shouldn't be able to open concurrent writers");
+            } catch (UnauthorizedAccessException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2980x! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+            fs3.Dispose();
+
+#if !TEST_WINRT // WinRT's sharing model doesn't support concurrent write
+            // [] FileSharing.ReadWrite
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4897y";
+
+            fs2 = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+            iCountTestcases++;
+            try
+            {
+                fs3 = File.Open(fileName, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+                fs2.Write(new Byte[] { 1 }, 0, 1);
+                fs3.Dispose();
+                fs3 = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                fs2.Write(new Byte[] { 2 }, 0, 1);
+                fs3.Dispose();
+                fs3 = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+                fs2.Write(new Byte[] { 3 }, 0, 1);
+                fs3.Dispose();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_287g9! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+#endif
+
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+
+            const String sourceString = "This is the source File";
+
+            //First we look at the drives of this machine to be sure that we can proceed
+            String sourceFileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            //Scenario 1: Vanilla - create a filestream with this flag in FileShare parameter and then delete the file (using File.Delete or FileInfo.Delete) before closing the 
+            //FileStream. Ensure that the delete operation succeeds but the file is not deleted till the FileStream is closed
+            try
+            {
+                Byte[] outbits = Encoding.Unicode.GetBytes(sourceString);
+
+                FileStream stream = File.Open(sourceFileName, FileMode.Create, FileAccess.Write, FileShare.Delete);
+
+                stream.Write(outbits, 0, outbits.Length);
+
+                //This should succeed
+                File.Delete(sourceFileName);
+
+                //But we shold still be able to call the file
+                Eval(File.Exists(sourceFileName), "Err_3947sg! File doesn't exists");
+
+                stream.Write(outbits, 0, outbits.Length);
+
+                stream.Dispose();
+
+                //Now it shouldn't exists - is there any OS delay
+                Eval(!File.Exists(sourceFileName), "Err_2397g! File doesn't exists");
+
+                if (!s_pass)
+                    iCountErrors++;
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+
+
+    //Checks for error
+    private static void Eval(bool expression, String msg, params Object[] values)
+    {
+        Eval(expression, String.Format(msg, values));
+    }
+
+    private static void Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (msgExpected != null && System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/File/ReadAllBytes_Str.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadAllBytes_Str.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class File_ReadAllBytes_Str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2002/10/01 09:43";
+    public static String s_strClassMethod = "File.ReadAllBytes(String path)";
+    public static String s_strTFName = "ReadAllBytes_Str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        String path;
+        Byte[] bits;
+        Byte[] rbits;
+        int count;
+        //		FileStream stream;
+        //		BinaryReader reader;
+
+
+        try
+        {
+            //Argument 
+
+            strLoc = "Loc_001oo";
+
+            iCountTestcases++;
+
+            path = null;
+            try
+            {
+                rbits = File.ReadAllBytes(path);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            //@TODO Non-existent
+
+            //Vanilla - make sure that the normal works!
+
+            strLoc = "Loc_002oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            bits = new Byte[0];
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != 0)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3456gsd! Wrong value returned. {0}", rbits.Length);
+            }
+
+            count = 200;
+            bits = new Byte[count];
+            for (int i = 0; i < count; i++)
+                bits[i] = (byte)i;
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            for (int i = 0; i < count; i++)
+            {
+                if (rbits[i] != i)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_93457gs_{0}! Wrong value returned. {1}", i, rbits[i]);
+                }
+            }
+
+            //Writing again overwrites
+            count = 20;
+            bits = new Byte[count];
+            for (int i = 100; i < 100 + count; i++)
+                bits[i - 100] = (byte)i;
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != count)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34sg! Wrong value returned. {0}", rbits.Length);
+            }
+            for (int i = 100; i < 100 + count; i++)
+            {
+                if (rbits[i - 100] != i)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_93457gs_{0}! Wrong value returned. {1}", i, rbits[i]);
+                }
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //large values
+            path = Path.GetTempFileName();
+            count = 1 << 24;
+            while (count > 0)
+            {
+                try
+                {
+                    bits = new Byte[count];
+                    break;
+                }
+                catch (OutOfMemoryException)
+                {
+                    count /= 10;
+                    GC.Collect();
+                }
+            }
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != count)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34sg! Wrong value returned. {0}", rbits.Length);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/ReadAll_all.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadAll_all.cs
@@ -1,0 +1,474 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using System.Linq;
+using Xunit;
+
+public class File_ReadAll_all
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2002/09/30 11:31";
+    public static String s_strClassMethod = "File.ReadAllText - All the methods";
+    public static String s_strTFName = "ReadAll_all.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        String path;
+        Encoding encoding;
+        String all;
+        String[] allLines;
+        StreamWriter writer;
+        StringBuilder builder;
+        BinaryWriter bin;
+        FileStream stream;
+
+
+
+        try
+        {
+            //This TestCase tests the following methods that have been added to File for RAD purposes. These methods are thin wrappers for already 
+            //defined methods in the IO namespace. We do not aim to test the underlying APIs here
+
+            //String ReadAllText(String path)
+            //String ReadAllText(String path, Encoding encoding)
+            //IEnumerable<String> ReadLines(String path)
+            //IEnumerable<String> ReadLines(String path, Encoding encoding)
+
+            //Argument 
+
+            strLoc = "Loc_001oo";
+
+            iCountTestcases++;
+
+            path = null;
+            try
+            {
+                all = File.ReadAllText(path);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = null;
+            encoding = Encoding.UTF8;
+            try
+            {
+                all = File.ReadAllText(path, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            encoding = null;
+            try
+            {
+                all = File.ReadAllText(path, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            path = null;
+            try
+            {
+                allLines = File.ReadLines(path).ToArray();
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = null;
+            encoding = Encoding.UTF8;
+            try
+            {
+                allLines = File.ReadLines(path, encoding).ToArray();
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            encoding = null;
+            try
+            {
+                allLines = File.ReadLines(path, encoding).ToArray();
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+
+            //vanilla: Non existent paths
+
+            strLoc = "Loc_002oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            if (File.Exists(path))
+                File.Delete(path);
+
+            try
+            {
+                all = File.ReadAllText(path);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_0347tsfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            encoding = Encoding.UTF8;
+            try
+            {
+                all = File.ReadAllText(path, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_0347tsfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            try
+            {
+                allLines = File.ReadLines(path).ToArray();
+
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_0347tsfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            encoding = Encoding.UTF8;
+            try
+            {
+                allLines = File.ReadLines(path, encoding).ToArray();
+
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_0347tsfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+
+
+            //Vanilla - make sure that normal behavior is seen for all the methods
+
+            strLoc = "Loc_003oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            stream = new FileStream(path, FileMode.Create);
+            writer = new StreamWriter(stream);
+            builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                writer.WriteLine(i.ToString());
+                builder.Append(i.ToString() + Environment.NewLine);
+            }
+            writer.Dispose();
+            stream.Dispose();
+
+            all = File.ReadAllText(path);
+
+            if (all != builder.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_56sgf! Wrong result returned. {0}", all);
+            }
+
+
+            //This is an implicit test to ensure that the previous call released the file handle!
+            all = File.ReadAllText(path, Encoding.GetEncoding("US-ASCII"));
+            if (all != builder.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_436sdg! Wrong result returned. {0}", all);
+            }
+
+            allLines = File.ReadLines(path).ToArray();
+            for (int i = 0; i < 100; i++)
+            {
+                if (allLines[i] != i.ToString())
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_8364sg! Wrong result returned. {0}", allLines[i]);
+                }
+            }
+
+            allLines = File.ReadLines(path, Encoding.GetEncoding("utf-7")).ToArray();
+            for (int i = 0; i < 100; i++)
+            {
+                if (allLines[i] != i.ToString())
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_8364sg! Wrong result returned. {0}", allLines[i]);
+                }
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //Zero length, binary file tests
+
+            strLoc = "Loc_03245oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            all = File.ReadAllText(path);
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4328r6sgf! Wrong result returned. {0}", all);
+            }
+
+
+            all = File.ReadAllText(path, Encoding.GetEncoding("US-ASCII"));
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_4328r6sgf! Wrong result returned. {0}", all);
+            }
+
+            allLines = File.ReadLines(path).ToArray();
+            if (allLines.Length != 0)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3457tsg! Wrong result returned. {0}", allLines.Length);
+            }
+
+            allLines = File.ReadLines(path, Encoding.GetEncoding("US-ASCII")).ToArray();
+
+            if (allLines.Length != 0)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3457tsg! Wrong result returned. {0}", allLines.Length);
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            path = Path.GetTempFileName();
+
+            bin = new BinaryWriter(new FileStream(path, FileMode.Open, FileAccess.Write));
+            for (int i = 0; i < 50; i++)
+            {
+                bin.Write((byte)i);
+            }
+            bin.Dispose();
+
+            all = File.ReadAllText(path);
+            if (all.Length != 50)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3758tsg! Wrong value returned: {0}", all.Length);
+            }
+
+            all = File.ReadAllText(path, Encoding.Unicode);
+            if (all.Length != 25)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3758tsg! Wrong value returned: {0}", all.Length);
+            }
+
+            allLines = File.ReadLines(path).ToArray();
+            if (allLines.Length != 3)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3758tsg! Wrong value returned: {0}", allLines.Length);
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //Open issues - file already opened, We've closed the file after read etc
+            //That we are closing the file is imlictly tested above
+
+            path = Path.GetTempFileName();
+            stream = new FileStream(path, FileMode.Create);
+            writer = new StreamWriter(stream);
+            builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                writer.WriteLine(i.ToString());
+            }
+
+            try
+            {
+                all = File.ReadAllText(path);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            encoding = Encoding.UTF8;
+            try
+            {
+                all = File.ReadAllText(path, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            try
+            {
+                allLines = File.ReadLines(path).ToArray();
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            try
+            {
+                allLines = File.ReadLines(path, encoding).ToArray();
+
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            writer.Dispose();
+            stream.Dispose();
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/SetAttributes_str_attrs.cs
+++ b/src/System.IO.FileSystem/tests/File/SetAttributes_str_attrs.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_SetAttributes_str_attrs
+{
+    public static String s_strDtTmVer = "2001/01/31 5:30";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "SetAttributes_str_attrs.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "";
+
+        try
+        {
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo file1;
+
+            // [] With an empty string
+            strLoc = "loc_0000";
+
+            iCountTestcases++;
+            try
+            {
+                File.SetAttributes(strValue, FileAttributes.Hidden);
+                iCountErrors++;
+                printerr("Error_0001! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] By passing a null argument.
+            strLoc = "loc_0004";
+
+            iCountTestcases++;
+            try
+            {
+                File.SetAttributes(null, FileAttributes.Hidden);
+                iCountErrors++;
+                printerr("Error_0005! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0007! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] By passing an invalid path name.
+            strLoc = "loc_0005";
+
+            iCountTestcases++;
+            try
+            {
+                File.SetAttributes("c:\\this is a invalid testing directory\\test\\test", FileAttributes.Hidden);
+                iCountErrors++;
+                printerr("Error_0006! Expected exception not thrown");
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] valid data
+            //-----------------------------------------------------------------
+            strLoc = "Loc_0009";
+
+            file1 = new FileInfo(fileName);
+            FileStream fs = file1.Create();
+
+#if !TEST_WINRT
+            iCountTestcases++;
+            File.SetAttributes(fileName, FileAttributes.Hidden);
+            if ((File.GetAttributes(fileName) & FileAttributes.Hidden) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0010! Hidden not set");
+            }
+
+            iCountTestcases++;
+            file1.Refresh();
+            File.SetAttributes(fileName, FileAttributes.System);
+            if ((File.GetAttributes(fileName) & FileAttributes.System) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0011! System not set");
+            }
+#endif
+
+            iCountTestcases++;
+            file1.Refresh();
+            File.SetAttributes(fileName, FileAttributes.Normal);
+            if ((File.GetAttributes(fileName) & FileAttributes.Normal) != FileAttributes.Normal)
+            {
+                //NOTE: Normal is only allowed on its own. So, if there is already another attribute, this will not work
+                //@TODO!! This might have to be modified
+                if ((File.GetAttributes(fileName) & FileAttributes.Compressed) == 0)
+#if TEST_WINRT
+                if((File.GetAttributes(fileName) & FileAttributes.Archive) == 0)
+#endif
+                {
+                    iCountErrors++;
+                    printerr("Error_0012! Normal not set");
+                }
+            }
+
+            iCountTestcases++;
+            file1.Refresh();
+            File.SetAttributes(fileName, FileAttributes.Temporary);
+            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) == 0)
+            {
+                iCountErrors++;
+                printerr("Error_0013! Temporary not set");
+            }
+
+            File.SetAttributes(fileName, FileAttributes.Archive);
+            file1.Refresh();
+            File.SetAttributes(fileName, FileAttributes.ReadOnly | file1.Attributes);
+            file1.Refresh();
+            iCountTestcases++;
+            if ((File.GetAttributes(fileName) & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
+            {
+                iCountErrors++;
+                printerr("Error_0020! ReadOnly attribute not set");
+            }
+
+            iCountTestcases++;
+            if ((File.GetAttributes(fileName) & FileAttributes.Archive) != FileAttributes.Archive)
+            {
+                iCountErrors++;
+                printerr("Error_0021! Archive attribute not set");
+            }
+            File.SetAttributes(fileName, FileAttributes.Normal);
+            fs.Dispose();
+            file1.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/SetCreationTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/File/SetCreationTime_str_dt.cs
@@ -1,0 +1,294 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_SetCreationTime_str_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer       = "2001/01/31 17.04";
+    public static String s_strClassMethod   = "File.GetCreationTime()";
+    public static String s_strTFName        = "SetCreationTime_str_dt.cs";
+    public static String s_strTFPath        = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = s_strTFName.Substring(0, s_strTFName.IndexOf('.')) + "_test_" + "TestFile";			
+
+            // [] With null string
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(null, DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+                        
+            // [] With an empty string.
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime("", DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0005! Unexpected exceptiont thrown: " + exc.ToString());
+            }                      
+            
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006" ;
+            FileInfo file2 = new FileInfo(fileName);
+            FileStream fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Today);
+                if((File.GetCreationTime(fileName) - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Now.AddYears(1));
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddYears(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Now.AddYears(-1));
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddYears(-1)).Seconds > 0 )
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Now.AddMonths(1));
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddMonths(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Now.AddMonths(-1));
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Now.AddDays(1));
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddDays(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, DateTime.Now.AddDays(-1));
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddDays(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+            
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetCreationTime(fileName, new DateTime(2001, 332, 20, 50, 50, 50));
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                File.SetCreationTime(fileName, dt );
+                if((File.GetCreationTime(fileName) - dt ).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/SetLastAccessTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/File/SetLastAccessTime_str_dt.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_SetLastAccessTime_str_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer       = "2001/01/31 18.45";
+    public static String s_strClassMethod   = "File.GetLastAccessTime()";
+    public static String s_strTFName        = "SetLastAccessTime_str_dt.cs";
+    public static String s_strTFPath        = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = s_strTFName.Substring(0, s_strTFName.IndexOf('.')) + "_test_" +"TestFile";			
+
+            // [] With null string
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(null, DateTime.Today);
+                iCountErrors++;
+                printerr( "Error_0002! Expected exception not thrown");
+            } catch (ArgumentNullException ){
+                        } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0003! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        
+            // [] With an empty string.
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime("", DateTime.Today);
+                iCountErrors++;
+                printerr( "Error_0004! Expected exception not thrown");
+            } catch (ArgumentException ){
+                        } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0005! Unexpected exceptiont thrown: "+exc.ToString());
+            }                      
+            
+                        // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006" ;
+                        FileInfo file2 = new FileInfo(fileName);
+            FileStream fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Today) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0007! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0008! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Now.AddYears(1)) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddYears(1)).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0010! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0011! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Now.AddYears(-1)) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddYears(-1)).Seconds > 0 ) {
+                    Console.WriteLine(File.GetLastAccessTime(fileName));
+                    Console.WriteLine(DateTime.Now.AddYears(-1));
+                    iCountErrors++;
+                    printerr( "Error_0013! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0014! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Now.AddMonths(1)) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(1)).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0016! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0017! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Now.AddMonths(-1)) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0019! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0020! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Now.AddDays(1)) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddDays(1)).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0022! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0023! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , DateTime.Now.AddDays(-1)) ;
+                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddDays(-1)).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0025! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0026! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+                        
+                        //With invalid datetime object.
+            strLoc = "Loc_0025";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastAccessTime(fileName , new DateTime(2001,332,20,50,50,50)) ;
+                                iCountErrors++;
+                                printerr( "Error_0026! Creation time cannot be correct");
+            } catch (ArgumentOutOfRangeException ){
+                        } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0027! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+                        //With valid date and time. 
+            strLoc = "Loc_0028";
+                        
+                        file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                DateTime dt =  new DateTime( 2001,2,2,20,20,20) ;
+                                File.SetLastAccessTime(fileName , dt ) ;
+                if((File.GetLastAccessTime(fileName) - dt ).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0029! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0030! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        file2.Delete();
+
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/SetLastWriteTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/File/SetLastWriteTime_str_dt.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class File_SetLastWriteTime_str_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer       = "2001/01/31 18.45";
+    public static String s_strClassMethod   = "File.GetLastAccessTime()";
+    public static String s_strTFName        = "SetLastWriteTime_str_dt.cs";
+    public static String s_strTFPath        = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = s_strTFName.Substring(0, s_strTFName.IndexOf('.')) + "_test_" +"TestFile";			
+
+            // [] With null string
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(null, DateTime.Today);
+                iCountErrors++;
+                printerr( "Error_0002! Expected exception not thrown");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0003! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+                        
+            // [] With an empty string.
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime("", DateTime.Today);
+                iCountErrors++;
+                printerr("Error_0004! Expected exception not thrown");
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr( "Error_0005! Unexpected exceptiont thrown: "+exc.ToString());
+            }                      
+            
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006";
+            FileInfo file2 = new FileInfo(fileName);
+            FileStream fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try {
+                File.SetLastWriteTime(fileName , DateTime.Today) ;
+                if((File.GetLastWriteTime(fileName) - DateTime.Now).Seconds > 0) {
+                    iCountErrors++;
+                    printerr( "Error_0007! Creation time cannot be correct");
+                }
+            } catch (Exception exc) {
+                iCountErrors++;
+                printerr( "Error_0008! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName , DateTime.Now.AddYears(1)) ;
+                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(1)).Seconds > 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddYears(1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(1)).Seconds  );
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName, DateTime.Now.AddYears(-1));
+                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(-1)).Seconds > 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddYears(-1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(-1)).Seconds  );
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName, DateTime.Now.AddMonths(1));
+                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(1)).Seconds > 1)
+                {
+                    Console.WriteLine(DateTime.Now.AddMonths(1));
+                
+                    Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddMonths(1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(1)).Seconds  );
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName, DateTime.Now.AddMonths(-1));
+                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds > 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddMonths(-1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds  );
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName, DateTime.Now.AddDays(1));
+                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(1)).Seconds > 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddDays(1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(-1)).Seconds  );
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName, DateTime.Now.AddDays(-1));
+                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(-1)).Seconds > 1)
+                {
+                    iCountErrors++;
+                    Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddDays(-1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(-1)).Seconds  );
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+            
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                File.SetLastWriteTime(fileName, new DateTime(2001, 332, 20, 50, 50, 50));
+                iCountErrors++;
+                printerr( "Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            } catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0027! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                File.SetLastWriteTime(fileName, dt );
+                if((File.GetLastWriteTime(fileName) - dt ).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr( "Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/WriteAllBytes_StrBtA.cs
+++ b/src/System.IO.FileSystem/tests/File/WriteAllBytes_StrBtA.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class File_WriteAllBytes_StrBtA
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2002/10/01 08:59";
+    public static String s_strClassMethod = "File.WriteAllBytes(String path, Byte[])";
+    public static String s_strTFName = "WriteAllBytes_StrBtA.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        String path;
+        Byte[] bits;
+        Byte[] rbits;
+        int count;
+        //		FileStream stream;
+        //		BinaryReader reader;
+
+
+        try
+        {
+            //Argument 
+
+            strLoc = "Loc_001oo";
+
+            iCountTestcases++;
+
+            path = null;
+            bits = new Byte[0];
+            try
+            {
+                File.WriteAllBytes(path, bits);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            bits = null;
+            try
+            {
+                File.WriteAllBytes(path, bits);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //Vanilla - make sure that the normal works!
+
+            strLoc = "Loc_002oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            if (File.Exists(path))
+                File.Delete(path);
+            bits = new Byte[0];
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != 0)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3456gsd! Wrong value returned. {0}", rbits.Length);
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            path = Path.GetTempFileName();
+            bits = new Byte[0];
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != 0)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3456gsd! Wrong value returned. {0}", rbits.Length);
+            }
+            count = 200;
+            bits = new Byte[count];
+            for (int i = 0; i < count; i++)
+                bits[i] = (byte)i;
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            for (int i = 0; i < count; i++)
+            {
+                if (rbits[i] != i)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_93457gs_{0}! Wrong value returned. {1}", i, rbits[i]);
+                }
+            }
+
+            //Writing again overwrites
+            count = 20;
+            bits = new Byte[count];
+            for (int i = 100; i < 100 + count; i++)
+                bits[i - 100] = (byte)i;
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != count)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34sg! Wrong value returned. {0}", rbits.Length);
+            }
+            for (int i = 100; i < 100 + count; i++)
+            {
+                if (rbits[i - 100] != i)
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_93457gs_{0}! Wrong value returned. {1}", i, rbits[i]);
+                }
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //large values
+            path = Path.GetTempFileName();
+            count = 1 << 16;
+            while (count > 1000)
+            {
+                try
+                {
+                    bits = new Byte[count];
+                    break;
+                }
+                catch (OutOfMemoryException)
+                {
+                    count /= 10;
+                }
+            }
+            File.WriteAllBytes(path, bits);
+            rbits = File.ReadAllBytes(path);
+            if (rbits.Length != count)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_34sg! Wrong value returned. {0}", rbits.Length);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/File/WriteAll_all.cs
+++ b/src/System.IO.FileSystem/tests/File/WriteAll_all.cs
@@ -1,0 +1,532 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class File_WriteAll_all
+{
+    public static String s_strActiveBugNums = "184664";
+    public static String s_strClassMethod = "File.WriteAllText- All the methods";
+    public static String s_strTFName = "WriteAll_all.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        String path;
+        Encoding encoding;
+        String content;
+        String[] contents;
+
+        String all;
+        StringBuilder builder;
+        int count;
+        StreamReader reader;
+        FileStream stream;
+
+
+
+        try
+        {
+            //This TestCase tests the following methods that have been added to File for RAD purposes. These methods are thin wrappers for already 
+            //defined methods in the IO namespace. We do not aim to test the underlying APIs here
+
+            //void WriteAllText(String path, String contents)
+            //void WriteAllText(String path, String contents, Encoding encoding)
+            //void WriteAllLines(String path, String[] contents)
+            //void WriteAllLines(String path, String[] contents, Encoding encoding)
+
+            //Argument 
+
+            strLoc = "Loc_001oo";
+
+            iCountTestcases++;
+
+            path = null;
+            content = "";
+            try
+            {
+                File.WriteAllText(path, content);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = null;
+            encoding = Encoding.UTF8;
+            try
+            {
+                File.WriteAllText(path, content, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            encoding = null;
+            try
+            {
+                File.WriteAllText(path, content, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            path = null;
+            contents = new String[0];
+            try
+            {
+                File.WriteAllLines(path, contents);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            contents = null;
+            try
+            {
+                File.WriteAllLines(path, contents);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+
+            path = null;
+            encoding = Encoding.UTF8;
+            try
+            {
+                File.WriteAllLines(path, contents, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            path = Path.GetTempFileName();
+            encoding = null;
+            try
+            {
+                File.WriteAllLines(path, contents, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+
+            // Non existent paths, writing null
+
+            strLoc = "Loc_002oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+            if (File.Exists(path))
+                File.Delete(path);
+
+            content = null;
+            File.WriteAllText(path, content);
+            //We know that the below API throws for non-existent file names
+            all = File.ReadAllText(path);
+
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            encoding = Encoding.UTF8;
+            File.WriteAllText(path, content, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            contents = new String[0];
+            File.WriteAllLines(path, contents);
+            all = File.ReadAllText(path);
+
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+            File.WriteAllLines(path, contents, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != String.Empty)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+            if (File.Exists(path))
+                File.Delete(path);
+
+
+            //Vanilla - make sure that normal behavior is seen for all the methods
+
+            strLoc = "Loc_003oo";
+
+            iCountTestcases++;
+
+            path = Path.GetTempFileName();
+
+            builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            File.WriteAllText(path, content);
+            all = File.ReadAllText(path);
+
+            if (all != content)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            //Another writeall overwrite not appends
+            builder = new StringBuilder();
+            for (int i = 500; i < 600; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            File.WriteAllText(path, content);
+            all = File.ReadAllText(path);
+
+            if (all != content)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            encoding = Encoding.GetEncoding("US-ASCII");
+            File.WriteAllText(path, content, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != content)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            //Another writeall overwrite not appends
+            builder = new StringBuilder();
+            for (int i = 500; i < 600; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+            }
+            content = builder.ToString();
+            File.WriteAllText(path, content, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != content)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            count = 100;
+            contents = new String[count];
+            builder = new StringBuilder();
+            for (int i = 0; i < count; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                contents[i] = i.ToString();
+            }
+            File.WriteAllLines(path, contents);
+            all = File.ReadAllText(path);
+
+            if (all != builder.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            //Another writeall overwrite not appends
+            builder = new StringBuilder();
+            contents = new String[count];
+            for (int i = 500; i < (500 + count); i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                contents[i - 500] = i.ToString();
+            }
+            File.WriteAllLines(path, contents);
+            all = File.ReadAllText(path);
+
+            if (all != builder.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+
+            encoding = Encoding.UTF8;
+            count = 100;
+            contents = new String[count];
+            builder = new StringBuilder();
+            for (int i = 0; i < count; i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                contents[i] = i.ToString();
+            }
+            File.WriteAllLines(path, contents, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != builder.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            //Another writeall overwrite not appends
+            builder = new StringBuilder();
+            contents = new String[count];
+            for (int i = 500; i < (500 + count); i++)
+            {
+                builder.Append(i.ToString() + Environment.NewLine);
+                contents[i - 500] = i.ToString();
+            }
+            File.WriteAllLines(path, contents, encoding);
+            all = File.ReadAllText(path);
+
+            if (all != builder.ToString())
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_3486sgd! Expected Exception here.");
+            }
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //Open issues - file already opened, We've closed the file after write etc
+            //That we are closing the file after write is imlictly tested above
+
+            path = Path.GetTempFileName();
+            stream = new FileStream(path, FileMode.Open);
+            reader = new StreamReader(stream);
+
+            content = "";
+            try
+            {
+                File.WriteAllText(path, content);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            encoding = Encoding.UTF8;
+            try
+            {
+                File.WriteAllText(path, content, encoding);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            contents = new String[0];
+            try
+            {
+                File.WriteAllLines(path, contents);
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+            try
+            {
+                File.WriteAllLines(path, contents, encoding);
+
+
+                iCountErrors++;
+                Console.WriteLine("Err_3947sgd! Expected Exception here.");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception ex)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_9734sfg! Unexoected exception thrown; {0}", ex.GetType().Name);
+            }
+
+            reader.Dispose();
+            stream.Dispose();
+            if (File.Exists(path))
+                File.Delete(path);
+
+            //See VSwhidbey # 104086
+            string strFile1 = Path.GetTempFileName();
+            String strFile2 = Path.GetTempFileName();
+            string[] strArr = new String[10];
+            for (int i = 0; i < 10; i++)
+                strArr[i] = "Line number...:" + i; ;
+
+            TextWriter w = File.CreateText(strFile1);
+            for (int i = 0; i < strArr.Length; i++)
+                w.WriteLine(strArr[i]);
+            w.Dispose();
+
+            File.WriteAllLines(strFile2, strArr);
+
+            if (new FileInfo(strFile1).Length != new FileInfo(strFile2).Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_23rf! File length not equal possible BOM issue");
+            }
+            if (File.Exists(strFile1))
+                File.Delete(strFile1);
+            if (File.Exists(strFile2))
+                File.Delete(strFile2);
+
+
+            strFile1 = Path.GetTempFileName();
+            strFile2 = Path.GetTempFileName();
+            String str1 = "Line number...:1";
+
+            w = File.CreateText(strFile1);
+            w.Write(str1);
+            w.Dispose();
+
+            File.WriteAllText(strFile2, str1);
+
+            if (new FileInfo(strFile1).Length != new FileInfo(strFile2).Length)
+            {
+                iCountErrors++;
+                Console.WriteLine("Err_23rf! File length not equal possible BOM issue {0} {1}", new FileInfo(strFile1).Length, new FileInfo(strFile2).Length);
+            }
+            if (File.Exists(strFile1))
+                File.Delete(strFile1);
+            if (File.Exists(strFile2))
+                File.Delete(strFile2);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/AppendText.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/AppendText.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_AppendText
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/03 20:02";
+    public static String s_strClassMethod = "File.AppendText";
+    public static String s_strTFName = "AppendText.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            StreamWriter sw2;
+            StreamReader sr2;
+            String str2;
+            FileStream stream;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] AppendText on a file that does not exist should create it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2y78b";
+
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            sw2 = fil2.AppendText();
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            stream = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorld"))
+            {
+                iCountErrors++;
+                printerr("Error_21y77! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            // [] AppendText should just open exisiting file
+
+            strLoc = "Loc_2gy7b";
+
+            sw2 = fil2.AppendText();
+            sw2.Write("You Big Globe");
+            sw2.Dispose();
+            stream = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorldYou Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_12ytb! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            //-----------------------------------------------------------------
+            // [] AccessException if file is readonly
+            //-----------------------------------------------------------------
+            strLoc = "Loc_498yv";
+
+            fil2.Attributes = FileAttributes.ReadOnly;
+            iCountTestcases++;
+            try
+            {
+                fil2.AppendText();
+                iCountErrors++;
+                printerr("Error_fg489! Expected exception not thrown");
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_3498v! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Attributes = new FileAttributes();
+            //-----------------------------------------------------------------
+            if (File.Exists(filName))
+                File.Delete(filName);
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class FileInfo_CopyTo_str
+{
+    public static String s_strActiveBugNums = "16134";
+    public static String s_strDtTmVer = "2000/03/11 14:37";
+    public static String s_strClassMethod = "File.CopyTo(String)";
+    public static String s_strTFName = "CopyTo_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        //////////// Global Variables used for all tests
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2 = null;
+            FileInfo fil1 = null;
+            Char[] cWriteArr, cReadArr;
+            StreamWriter sw2;
+            StreamReader sr2;
+            FileStream fs2;
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            String testFilName;
+
+            try
+            {
+                new FileInfo(filName).Delete();
+            }
+            catch (Exception) { }
+            // [] ArgumentNullException if null is passed in
+
+            strLoc = "Loc_498yg";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(null);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] String.Empty should throw ArgumentException
+
+            strLoc = "Loc_298vy";
+
+            FileStream fs = new FileStream(filName, FileMode.Create);
+            fs.Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(String.Empty);
+                iCountErrors++;
+                printerr("Error_092u9! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109uc! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Try to copy onto directory
+
+            strLoc = "Loc_289vy";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(TestInfo.CurrentDirectory);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_545345! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Copy onto itself should fail
+
+
+            strLoc = "Loc_r7yd9";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(fil2.FullName);
+                iCountErrors++;
+                printerr("Error_54534! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_f588y! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+
+            // [] Vanilla copy operation
+
+            strLoc = "Loc_f548y";
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                String tempFileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+                fil1 = fil2.CopyTo(tempFileName);
+                if (!fil1.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_2978y! File not copied");
+                }
+
+                if (!fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_239vr! Source file gone");
+                }
+
+                fil1.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2987v! Unexpected exception, exc==" + exc.ToString());
+            }
+            if (fil2.Exists)
+                fil2.Delete();
+
+            // [] Filename with illiegal characters
+
+
+            strLoc = "Loc_984hg";
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo("**");
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Move a file containing data
+
+
+            strLoc = "Loc_t98ck";
+
+            try
+            {
+                testFilName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+                File.Delete(testFilName);
+                FileStream fs4 = new FileStream(filName, FileMode.Append);
+                sw2 = new StreamWriter(fs4);
+                cWriteArr = new Char[26];
+                int j = 0;
+                for (Char i = 'A'; i <= 'Z'; i++)
+                    cWriteArr[j++] = i;
+                sw2.Write(cWriteArr, 0, cWriteArr.Length);
+                sw2.Flush();
+                sw2.Dispose();
+                fs4.Dispose();
+
+                fil2 = new FileInfo(filName);
+                fil1 = fil2.CopyTo(testFilName);
+                iCountTestcases++;
+                if (!fil1.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_9u99s! File not copied correctly: " + fil1.FullName);
+                }
+                if (!fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_29h7b! Source file gone");
+                }
+                FileStream fs3 = new FileStream(testFilName, FileMode.Open);
+                sr2 = new StreamReader(fs3);
+                cReadArr = new Char[cWriteArr.Length];
+                sr2.Read(cReadArr, 0, cReadArr.Length);
+
+                iCountTestcases++;
+                for (int i = 0; i < cReadArr.Length; i++)
+                {
+                    iCountTestcases++;
+                    if (cReadArr[i] != cWriteArr[i])
+                    {
+                        iCountErrors++;
+                        printerr("Error_98yv7! Expected==" + cWriteArr[i] + ", got value==" + cReadArr[i]);
+                    }
+                }
+                sr2.Dispose();
+                fs3.Dispose();
+
+                fil1.Delete();
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28vc8! Unexpected exception, exc==" + exc.ToString());
+            }
+
+            // [] Unecessary long (over MAX_PATH) but valid directory name
+            strLoc = "Loc_48ygv";
+            testFilName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            File.Delete(testFilName);
+            fil1 = fil2.CopyTo(Path.GetDirectoryName(testFilName) + "\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\" + Path.GetFileName(testFilName));
+            iCountTestcases++;
+            if (!fil1.FullName.Equals(testFilName))
+            {
+                Console.WriteLine(fil1.FullName);
+                Console.WriteLine(fil2.FullName);
+                iCountErrors++;
+                printerr("Error_298gc! Incorrect fullname set during copy");
+            }
+            fil1.Delete();
+            new FileInfo(filName).Delete();
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str_b.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str_b.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class FileInfo_CopyTo_str_b
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/03/11 14:37";
+    public static String s_strClassMethod = "File.CopyTo(String, Boolean)";
+    public static String s_strTFName = "CopyTo_str_b.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2 = null;
+            FileInfo fil1 = null;
+            Char[] cWriteArr, cReadArr;
+            StreamWriter sw2;
+            StreamReader sr2;
+            FileStream fs2;
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            String testFilName;
+
+            try
+            {
+                new FileInfo(filName).Delete();
+            }
+            catch (Exception) { }
+            // [] ArgumentNullException if null is passed in
+
+            strLoc = "Loc_498yg";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(null, false);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] String.Empty should throw ArgumentException
+
+            strLoc = "Loc_298vy";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(String.Empty, false);
+                iCountErrors++;
+                printerr("Error_092u9! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109uc! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Try to copy onto directory
+
+            strLoc = "Loc_289vy";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(TestInfo.CurrentDirectory, false);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209us! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Copy onto itself should fail
+
+
+            strLoc = "Loc_r7yd9";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(fil2.FullName, false);
+                iCountErrors++;
+                printerr("Error_209us! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_f588y! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+
+            // [] Vanilla copy operation
+
+            strLoc = "Loc_f548y";
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo(Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName()), false);
+                if (!fil1.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_2978y! File not copied");
+                }
+                if (!fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_239vr! Source file gone");
+                }
+                fil1.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2987v! Unexpected exception, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            fil1.Delete();
+
+            // [] Filename with illiegal characters
+
+
+            strLoc = "Loc_984hg";
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil1 = fil2.CopyTo("**", false);
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
+                fil1.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Move a file containing data
+
+
+            strLoc = "Loc_f888m";
+            try
+            {
+                testFilName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+                FileStream stream = new FileStream(filName, FileMode.Append);
+                sw2 = new StreamWriter(stream);
+                cWriteArr = new Char[26];
+                int j = 0;
+                for (Char i = 'A'; i <= 'Z'; i++)
+                    cWriteArr[j++] = i;
+                sw2.Write(cWriteArr, 0, cWriteArr.Length);
+                sw2.Flush();
+                sw2.Dispose();
+                stream.Dispose();
+
+                fil2 = new FileInfo(filName);
+                fil1 = fil2.CopyTo(testFilName, false);
+                iCountTestcases++;
+                if (!fil1.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_9u99s! File not copied correctly: " + fil1.FullName);
+                }
+                if (!fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_29h7b! Source file gone");
+                }
+
+                stream = new FileStream(testFilName, FileMode.Open);
+                sr2 = new StreamReader(stream);
+                cReadArr = new Char[cWriteArr.Length];
+                sr2.Read(cReadArr, 0, cReadArr.Length);
+
+                iCountTestcases++;
+                for (int i = 0; i < cReadArr.Length; i++)
+                {
+                    iCountTestcases++;
+                    if (cReadArr[i] != cWriteArr[i])
+                    {
+                        iCountErrors++;
+                        printerr("Error_98yv7! Expected==" + cWriteArr[i] + ", got value==" + cReadArr[i]);
+                    }
+                }
+                sr2.Dispose();
+                stream.Dispose();
+
+                fil1.Delete();
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28vc8! Unexpected exception, exc==" + exc.ToString());
+            }
+
+            // [] Interesting case:
+
+            strLoc = "Loc_478yb";
+
+            testFilName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            if (File.Exists(testFilName))
+                File.Delete(testFilName);
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            fil1 = fil2.CopyTo(Path.GetDirectoryName(testFilName) + "\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\" + Path.GetFileName(testFilName), false);
+            iCountTestcases++;
+            if (!fil1.FullName.Equals(testFilName))
+            {
+                Console.WriteLine(fil1.FullName);
+                Console.WriteLine(fil2.FullName);
+                iCountErrors++;
+                printerr("Error_298gc! Incorrect fullname set during copy");
+            }
+            new FileInfo(filName).Delete();
+            fil1.Delete();
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using Xunit;
+
+public class FileInfo_Create
+{
+    public static String s_strDtTmVer = "2009/02/18";
+    public static String s_strClassMethod = "FileInfo.Create";
+    public static String s_strTFName = "Create.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        try
+        {
+            FileInfo file2 = null;
+            FileStream fs;
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            try
+            {
+                new FileInfo(fileName).Delete();
+            }
+            catch (Exception) { }
+
+            strLoc = "Loc_099u8";
+
+            // [] Create a File with '.'.
+            iCountTestcases++;
+            file2 = new FileInfo(".");
+
+            try
+            {
+                file2.Create();
+                iCountErrors++;
+                printerr("Error_298dy! Expected exception not thrown, file2==" + file2.FullName);
+                file2.Delete();
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209xj! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Try to create an existing file.
+
+            strLoc = "Loc_209xc";
+
+            iCountTestcases++;
+            fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            file2 = new FileInfo(fileName);
+            fs = file2.Create();
+            fs.Dispose();
+            file2 = new FileInfo(fileName);
+            try
+            {
+                fs = file2.Create();
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_6566! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Pass valid File name
+
+            strLoc = "Loc_498vy";
+
+            iCountTestcases++;
+            fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName()); ;
+            file2 = new FileInfo(fileName);
+            try
+            {
+                fs = file2.Create();
+                if (file2.FullName != fileName)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Unexpected File name :: " + file2.FullName);
+                }
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28829! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+            // [] Try to create the file in the parent directory
+
+            strLoc = "Loc_09t83";
+
+            iCountTestcases++;
+            fileName = Path.Combine(TestInfo.CurrentDirectory, "abc\\..", Path.GetRandomFileName());
+            file2 = new FileInfo(fileName);
+            try
+            {
+                fs = file2.Create();
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0980! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Create a file with symbols.
+
+            strLoc = "Loc_87yg7";
+
+            iCountTestcases++;
+            fileName = Path.Combine(TestInfo.CurrentDirectory, "!@#$%^&");
+            file2 = new FileInfo(fileName);
+            fs = file2.Create();
+            fs.Dispose();
+            if (!file2.FullName.Equals(fileName))
+            {
+                iCountErrors++;
+                printerr("Error_0109x! Incorrect File name, file2==" + file2.FullName);
+            }
+            file2.Delete();
+
+            // [] Create a file in nested sub directory
+
+            strLoc = "Loc_209ud";
+
+            iCountTestcases++;
+            fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "Test", "Test", "Test", fileName));
+            try
+            {
+                file2.Create();
+                if (file2.FullName.IndexOf(Path.Combine("Test", "Test", "Test", fileName)) == -1)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Unexpected File name :: " + file2.FullName);
+                }
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2019u! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Try invalid File name
+
+            strLoc = "Loc_2089x";
+
+            iCountTestcases++;
+            try
+            {
+                file2 = new FileInfo(":");
+                file2.Create();
+                iCountErrors++;
+                printerr("Error_19883! Expected exception not thrown, file2==" + file2.FullName);
+                file2.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0198xu! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Pass nested level File structure.
+
+            strLoc = "Loc_098gt";
+
+            iCountTestcases++;
+            fileName = Path.GetRandomFileName();
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "abc", "xyz", "..", "..", fileName));
+            try
+            {
+                fs = file2.Create();
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9092c! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+            /* Test disabled because it modifies state outside the current working directory
+            // [] Create a file in root
+            strLoc = "Loc_89ytb";
+
+            String CurrentDirectory2 = Directory.GetCurrentDirectory();
+            fileName = Path.GetRandomFileName();
+            String tempPath = CurrentDirectory2.Substring(0, CurrentDirectory2.IndexOf("\\") + 1) + fileName;
+            if (!File.Exists(tempPath) && !Directory.Exists(tempPath))
+            {
+                file2 = new FileInfo(tempPath);
+                fs = file2.Create();
+                fs.Dispose();
+                iCountTestcases++;
+                if (!file2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_t78g7! File not created, file==" + file2.FullName);
+                }
+                file2.Delete();
+            }
+            */
+
+            // [] Create file in current file2 by giving full File check casing as well
+            strLoc = "loc_89tbh";
+            fileName = Path.GetRandomFileName();
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToLowerInvariant(), fileName));
+            fs = file2.Create();
+            fs.Dispose();
+            iCountTestcases++;
+            if (!file2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_t87gy! File not created, file==" + file2.FullName);
+            }
+            file2.Delete();
+
+            strLoc = "loc_89mjd";
+            fileName = Path.GetRandomFileName();
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToUpperInvariant(), fileName));
+            fs = file2.Create();
+            fs.Dispose();
+            iCountTestcases++;
+            if (!file2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_hf3t4! File not created, file==" + file2.FullName);
+            }
+            file2.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/CreateText.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CreateText.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_CreateText
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/03 20:43";
+    public static String s_strClassMethod = "File.CreateText";
+    public static String s_strTFName = "CreateText.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            StreamWriter sw2;
+            StreamReader sr2;
+            String str2;
+            FileStream stream;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] CreateText on a file that does not exist should create it
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2y78b";
+
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            sw2 = fil2.CreateText();
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            stream = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorld"))
+            {
+                iCountErrors++;
+                printerr("Error_21y77! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            // [] CreateText should overwrite existing file
+
+            strLoc = "Loc_2gy7b";
+
+            sw2 = fil2.CreateText();
+            sw2.Write("You Big Globe");
+            sw2.Dispose();
+            stream = new FileStream(filName, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("You Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_12ytb! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            //-----------------------------------------------------------------
+
+
+            // [] AccessException if file exists and is readonly
+
+            strLoc = "Loc_498yv";
+
+            fil2.Attributes = FileAttributes.ReadOnly;
+            iCountTestcases++;
+            try
+            {
+                sw2 = fil2.CreateText();
+                iCountErrors++;
+                printerr("Error_398fy! Expected exception not thrown");
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_8gy8g! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Attributes = new FileAttributes();
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class FileInfo_Create_str
+{
+    public static String s_strDtTmVer = "2009/02/18";
+    public static String s_strClassMethod = "FileInfo.Create";
+    public static String s_strTFName = "Create_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        try
+        {
+            FileInfo file2 = null;
+            Stream fs2;
+            String fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            try
+            {
+                new FileInfo(fileName).Delete();
+            }
+            catch (Exception) { }
+
+            strLoc = "Loc_099u8";
+
+            // [] Create a File with '.'.
+            iCountTestcases++;
+            file2 = new FileInfo(".");
+            try
+            {
+                file2.Create();
+                iCountErrors++;
+                printerr("Error_298dy! Expected exception not thrown, file2==" + file2.FullName);
+                file2.Delete();
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209xj! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Try to create an existing file.
+            strLoc = "Loc_209xc";
+
+            //Create a file.
+            String testDir = Path.Combine(TestInfo.CurrentDirectory, "TestDir");
+            Directory.CreateDirectory(testDir);
+            fileName = Path.Combine(testDir, "foobar.cs");
+            FileStream fstream = File.Create(fileName);
+            fstream.Dispose();
+
+            iCountTestcases++;
+
+            file2 = new FileInfo(fileName);
+            try
+            {
+                FileStream fs = file2.Create();
+                fs.Dispose();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_6566! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            file2.Delete();
+            Directory.Delete(testDir);
+
+            // [] Pass valid File name
+
+            strLoc = "Loc_498vy";
+
+            iCountTestcases++;
+            fileName = Path.Combine(TestInfo.CurrentDirectory, "UniqueFileName_28829");
+            file2 = new FileInfo(fileName);
+            try
+            {
+                FileStream fs = file2.Create();
+                if (file2.Name != Path.GetFileName(fileName))
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Unexpected File name :: " + file2.Name);
+                }
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_28829! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] Try to create the file in the parent directory
+
+            strLoc = "Loc_09t83";
+
+            iCountTestcases++;
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "abc\\..\\Test.txt"));
+            try
+            {
+                FileStream fs = file2.Create();
+                fs.Dispose();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0980! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            file2.Delete();
+
+
+            // [] Create a long filename File
+
+            strLoc = "Loc_2908y";
+
+            StringBuilder sb = new StringBuilder(TestInfo.CurrentDirectory);
+            while (sb.Length < 260)
+                sb.Append("a");
+
+            iCountTestcases++;
+            try
+            {
+                file2 = new FileInfo(sb.ToString());
+                file2.Create();
+                file2.Delete();
+                iCountErrors++;
+                printerr("Error_109ty! Expected exception not thrown, file2==" + file2.FullName);
+            }
+            catch (PathTooLongException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109dv! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Do some symbols
+
+            strLoc = "Loc_87yg7";
+
+            fileName = Path.Combine(TestInfo.CurrentDirectory, "!@#$%^&");
+            iCountTestcases++;
+            try
+            {
+                file2 = new FileInfo(fileName);
+                FileStream fs = file2.Create();
+                if (!file2.FullName.Equals(fileName))
+                {
+                    iCountErrors++;
+                    printerr("Error_0109x! Incorrect File name, file2==" + file2.FullName);
+                }
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception e)
+            {
+                iCountErrors++;
+                printerr("Unexpected exception occured... " + e.ToString());
+            }
+
+            // [] specifying subfile2ectories should fail unless they exist
+
+            strLoc = "Loc_209ud";
+
+            iCountTestcases++;
+            file2 = new FileInfo(TestInfo.CurrentDirectory + "\\" + "Test\\Test\\Test\\test.cs");
+            try
+            {
+                file2.Create();
+                if (file2.FullName.IndexOf("Test\\Test\\Test") == -1)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Unexpected File name :: " + file2.FullName);
+                }
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2019u! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // [] Try incorrect File name
+
+            strLoc = "Loc_2089x";
+
+            iCountTestcases++;
+            try
+            {
+                file2 = new FileInfo(":");
+                file2.Create();
+                iCountErrors++;
+                printerr("Error_19883! Expected exception not thrown, file2==" + file2.FullName);
+                file2.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0198xu! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            // network path test moved to RemoteIOTests.cs
+
+            // [] Pass nested level File structure.
+
+            strLoc = "Loc_098gt";
+
+            iCountTestcases++;
+            file2 = new FileInfo(TestInfo.CurrentDirectory + "abc\\xyz\\..\\..\\test.txt");
+            try
+            {
+                FileStream fs = file2.Create();
+                fs.Dispose();
+                file2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_9092c! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            /* Test disabled because it modifies state outside the current working directory
+            // [] Create a file in root
+            strLoc = "Loc_89ytb";
+
+            try
+            {
+                String CurrentDirectory2 = Directory.GetCurrentDirectory();
+                String tempPath = CurrentDirectory2.Substring(0, CurrentDirectory2.IndexOf("\\") + 1) + Path.GetFileName(fileName);
+
+                if (!File.Exists(tempPath) && !Directory.Exists(tempPath))
+                {
+                    file2 = new FileInfo(tempPath);
+                    FileStream fs = file2.Create();
+                    fs.Dispose();
+                    iCountTestcases++;
+                    if (!file2.Exists)
+                    {
+                        iCountErrors++;
+                        printerr("Error_t78g7! File not created, file==" + file2.FullName);
+                    }
+                    file2.Delete();
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_h38d9! Unexpected exception, exc==" + exc.ToString());
+            }
+            */
+
+            // [] Create file in current file2 by giving full File check casing as well
+            strLoc = "loc_89tbh";
+
+            string fileName2 = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            fs2 = File.Create(fileName2);
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToLowerInvariant(), Path.GetFileNameWithoutExtension(fileName2).ToLowerInvariant() + Path.GetExtension(fileName2).ToUpperInvariant()));
+            iCountTestcases++;
+            if (!file2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_t87gy! File not created, file==" + file2.FullName);
+            }
+            fs2.Dispose();
+            file2.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Delete.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Delete.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Diagnostics;
+using Xunit;
+
+public class FileInfo_Delete
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/01 16:27";
+    public static String s_strClassMethod = "Directory.Root";
+    public static String s_strTFName = "Delete.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileStream fs2;
+            FileInfo fil2;
+
+
+            // COMMENT: Simple string parsing of existing fullpath
+
+
+            // [] Delete a file that does not exist should just return
+            //-----------------------------------------------------------------		   
+            strLoc = "Loc_7198c";
+
+            iCountTestcases++;
+            fil2 = new FileInfo("AkkarBurger");
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Deleting a file in use should cause IOException
+            //-----------------------------------------------------------------
+            strLoc = "Loc_29yc7";
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil2.Delete();
+#if !TEST_WINRT  // WINRT always sets FILE_SHARE_DELETE
+                iCountErrors++;
+                printerr("Error_1y678! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+#endif
+            }
+            catch (UnauthorizedAccessException iexc)
+            {
+                iCountErrors++;
+                printerr("Error_1213! This excepton shouldn't occur on Win9X platforms" + iexc.Message);
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_16709! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+#if !TEST_WINRT
+            iCountTestcases++;
+            if (!fil2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_768bc! File does not exist==" + fil2.FullName);
+            }
+            fil2.Delete();
+#endif
+            fil2.Refresh();
+            iCountTestcases++;
+            if (fil2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_810x8! File not deleted==" + fil2.FullName);
+            }
+
+            //-----------------------------------------------------------------
+
+
+            // [] Deleting a file should remove it
+            //-----------------------------------------------------------------
+            //-----------------------------------------------------------------
+
+            // ][ Deleting a filename with wildcard should work
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class FileInfo_Exists
+{
+    public static String s_strDtTmVer = "2001/02/03 19:50";
+    public static String s_strClassMethod = "FileInfo.Exists()";
+    public static String s_strTFName = "Exists.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+
+        try
+        {
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Current Directory
+            strLoc = "Loc_276t8";
+
+            iCountTestcases++;
+            fil2 = new FileInfo(".");
+            if (fil2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_95428! Incorrect return value");
+            }
+
+            iCountTestcases++;
+            fil2 = new FileInfo(Directory.GetCurrentDirectory());
+            if (fil2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_97t67! Incorrect return value");
+            }
+
+            // [] Non-existent file
+            strLoc = "Loc_t993c";
+            try
+            {
+                iCountTestcases++;
+                fil2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName()));
+                if (fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_6895b! Incorrect return value");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_1y908! Unexpected exception, exc==" + exc.ToString());
+            }
+
+            // [] File that does exist
+            strLoc = "Loc_2y78g";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            if (!fil2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_9t821! Returned false for existing file");
+            }
+
+            File.Delete(filName);
+
+            // [] Filename with spaces
+            strLoc = "Loc_298g7";
+
+            String tmp = Path.ChangeExtension(filName, "   space space space" + Path.GetExtension(filName));
+            new FileStream(tmp, FileMode.Create).Dispose();
+            fil2 = new FileInfo(tmp);
+            iCountTestcases++;
+            if (!fil2.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_01y8v! Returned incorrect value");
+            }
+            fil2.Delete();
+
+            // [] Wildcards in filename should return false
+
+            strLoc = "Loc_398vy8";
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo("*");
+                if (fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_4979c! File with wildcard exists: " + fil2.FullName);
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_498u9! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Extension.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Extension.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+public class FileInfo_Extension
+{
+    public static String s_strDtTmVer = "2001/02/13 14:19";
+    public static String s_strClassMethod = "FileInfo.Extension";
+    public static String s_strTFName = "Extension.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = "Testing";
+            FileInfo file;
+
+            strLoc = "Err_0001";
+            // With no extension
+            iCountTestcases++;
+            file = new FileInfo(fileName);
+            if (file.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_0002! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_0003";
+            // With an extension
+            iCountTestcases++;
+            fileName = "foo.bar";
+            file = new FileInfo(fileName);
+            if (file.Extension != ".bar")
+            {
+                iCountErrors++;
+                printerr("Error_0004! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_0006";
+            // Verify extension for the current fileectory
+            iCountTestcases++;
+            file = new FileInfo("FileWithoutExtension");
+            if (file.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_0007! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_1003";
+            // With valid extenstion but file name with special symbols.
+            iCountTestcases++;
+            fileName = "foo.bar.fkl;fkds92-509450-4359.$#%()#%().%#(%)_#(%_).cool";
+            file = new FileInfo(fileName);
+            if (file.Extension != ".cool")
+            {
+                iCountErrors++;
+                printerr("Error_1004! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_2003";
+            // With a long extension	    
+            iCountTestcases++;
+            String extension = ".bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+            fileName = "AAAAAAAAAAAAAAAAAAAAAA" + extension;
+            file = new FileInfo(fileName);
+            if (file.Extension != extension)
+            {
+                iCountErrors++;
+                printerr("Error_2004! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_3003";
+            // No characters after the extension
+            //INFO: This should return basically ".". But that really doesn't make sense. 
+            iCountTestcases++;
+            fileName = "foo.";
+            file = new FileInfo(fileName);
+            if (file.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_3004! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_4003";
+            // Symbol and special characters in extension	    
+            iCountTestcases++;
+            extension = ".$#@$_)+_)!@@!!@##&_$)#_";
+            fileName = "foo" + extension;
+            file = new FileInfo(fileName);
+            if (file.Extension != extension)
+            {
+                iCountErrors++;
+                printerr("Error_4004! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_5003";
+            // Lots of dots at end of the fileectory name  
+            //INFO: This should return basically ".". But that really doesn't make sense.                               
+            iCountTestcases++;
+            extension = "..............";
+            fileName = "foo" + extension;
+            file = new FileInfo(fileName);
+            if (file.Extension != "")
+            {
+                iCountErrors++;
+                printerr("Error_5004! Incorrect extension , file==" + file.Extension);
+            }
+
+            strLoc = "Err_6003";
+            // Extension with exactly one characters. 
+            iCountTestcases++;
+            extension = "..............";
+            fileName = "foo.z" + extension;
+            file = new FileInfo(fileName);
+            if (file.Extension != ".z")
+            {
+                iCountErrors++;
+                printerr("Error_6004! Incorrect extension , file==" + file.Extension);
+            }
+
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    //INFO: this is a helper function that we are going to use when we are convering this testcases 
+    // to work genstrings.
+    private static string RemoveIfDotExists(String str)
+    {
+        while (str.IndexOf(".") > -1)
+            str = str.Remove(str.IndexOf("."), 1);
+        return str;
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileInfo/FullName.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/FullName.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+public class FileInfo_FullName
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "FullName .cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_000oo";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            FileInfo fil2;
+            String strFileName = "";
+
+            // [] Vanilla case
+            //-----------------------------------------------------------------
+            s_strLoc = "Loc_2723d";
+
+            strFileName = "Hello\\file.tmp";
+            fil2 = new FileInfo(strFileName);
+            s_iCountTestcases++;
+            if (!fil2.FullName.Equals(s_strTFPath + "\\" + strFileName))
+            {
+                s_iCountErrors++;
+                printerr("Error_5yb87! Incorrect name==" + fil2.FullName);
+            }
+
+            // [] \Directory\File
+            strFileName = "\\Directory\\File";
+            fil2 = new FileInfo(strFileName);
+            s_iCountTestcases++;
+            if (fil2.FullName.IndexOf(strFileName) != 2)
+            {
+                s_iCountErrors++;
+                printerr("Error_78288! Incorrect name==" + fil2.FullName);
+            }
+
+            // [] UNC share
+            strFileName = "\\\\Machine\\Directory\\File";
+            fil2 = new FileInfo(strFileName);
+            s_iCountTestcases++;
+            if (!fil2.FullName.Equals(strFileName))
+            {
+                s_iCountErrors++;
+                printerr("Error_67y8b! Incorrect name==" + fil2.FullName);
+            }
+
+            // [] Multiple spaces and dots in filename
+            strFileName = "C:\\File.tmp hello.blah";
+            fil2 = new FileInfo(strFileName);
+            s_iCountTestcases++;
+            if (!fil2.FullName.Equals(strFileName))
+            {
+                s_iCountErrors++;
+                printerr("Error_2987b! Incorrect name==" + fil2.FullName);
+            }
+
+            strFileName = "C://Directory//File";
+            fil2 = new FileInfo(strFileName);
+            s_iCountTestcases++;
+
+            if (!fil2.FullName.Equals("C:\\Directory\\File"))
+            {
+                s_iCountErrors++;
+                Console.WriteLine("strFileName: " + strFileName);
+                printerr("Error_2y78d! Incorrect name==" + fil2.FullName);
+            }
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_GetSetTimes
+{
+    enum TimeProperty
+    {
+        CreationTime,
+        LastAccessTime,
+        LastWriteTime
+    }
+    
+    [Fact]
+    public static void ConsistencyTest()
+    {
+        String fileName = Path.Combine(TestInfo.CurrentDirectory, "FileInfo_GetSetTimes");
+
+        FileInfo file = new FileInfo(fileName);
+        file.Create().Dispose();
+        
+        foreach(TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
+        {
+            foreach (DateTimeKind kind in  Enum.GetValues(typeof(DateTimeKind)))
+            {
+                DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);
+                foreach (bool setUtc in new [] { false, true } )
+                {
+                    if (setUtc)
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                file.CreationTimeUtc = dt;
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                file.LastAccessTimeUtc = dt;
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                file.LastWriteTimeUtc = dt;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        switch (timeProperty)
+                        {
+                            case TimeProperty.CreationTime:
+                                file.CreationTime = dt;
+                                break;
+                            case TimeProperty.LastAccessTime:
+                                file.LastAccessTime = dt;
+                                break;
+                            case TimeProperty.LastWriteTime:
+                                file.LastWriteTime = dt;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    DateTime actual, actualUtc;
+                    switch (timeProperty)
+                    {
+                        case TimeProperty.CreationTime:
+                            actual = file.CreationTime;
+                            actualUtc = file.CreationTimeUtc;
+                            break;
+                        case TimeProperty.LastAccessTime:
+                            actual = file.LastAccessTime;
+                            actualUtc = file.LastAccessTimeUtc;
+                            break;
+                        case TimeProperty.LastWriteTime:
+                            actual = file.LastWriteTime;
+                            actualUtc = file.LastWriteTimeUtc;
+                            break;
+                        default:
+                            throw new ArgumentException("Invalid time property type");
+                    }
+
+                    DateTime expected = dt.ToLocalTime();
+                    DateTime expectedUtc = dt.ToUniversalTime();
+
+                    if (dt.Kind == DateTimeKind.Unspecified)
+                    {
+                        if (setUtc)
+                        {
+                            expectedUtc = dt;
+                        }
+                        else
+                        {
+                            expected = dt;
+                        }
+                    }
+
+                    Assert.Equal(expected, actual); //, "Local {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                    Assert.Equal(expectedUtc, actualUtc); //, "Universal {0} should be correct for DateTimeKind.{1} when set with Set{0}{2}", timeProperty, kind, setUtc ? "Utc" : "");
+                }
+            }
+        }
+
+        file.Delete();
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileInfo/MoveTo_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/MoveTo_str.cs
@@ -1,0 +1,330 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Linq;
+using Xunit;
+
+public class FileInfo_MoveTo_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/10 11:30";
+    public static String s_strClassMethod = "File.MoveTo(String)";
+    public static String s_strTFName = "MoveTo_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil1, fil2;
+            StreamWriter sw2;
+            Char[] cWriteArr, cReadArr;
+            StreamReader sr2;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+
+            // [] Exception for null arguments
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_498yg";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil2.MoveTo(null);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+
+            //-----------------------------------------------------------------
+
+
+            // [] String.Empty should throw ArgumentException
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_298vy";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil2.MoveTo(String.Empty);
+                iCountErrors++;
+                printerr("Error_092u9! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_109uc! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Try to Move onto directory
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_289vy";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil2.MoveTo(TestInfo.CurrentDirectory);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209us! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Move onto itself should fail
+
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_r7yd9";
+
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            fil2.MoveTo(fil2.FullName);
+            if (!File.Exists(fil2.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_r8g7b! Expected exception not thrown");
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+
+            // [] Vanilla Move operation
+
+            //-----------------------------------------------------------------
+            strLoc = "Loc_f548y";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            String filNameDest = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            fil2.MoveTo(filNameDest);
+            fil1 = new FileInfo(filNameDest);
+            fil2.Refresh();
+            if (File.Exists(filName))
+            {
+                iCountErrors++;
+                printerr("Error_2978y! File not copied");
+            }
+            if (!File.Exists(fil2.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_239vr! Source file still there");
+            }
+            fil1.Delete();
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Filename with illiegal characters
+            //-----------------------------------------------------------------
+            strLoc = "Loc_984hg";
+
+            File.Create(filName).Dispose();
+            fil2 = new FileInfo(filName);
+
+            iCountTestcases++;
+            try
+            {
+                fil2.MoveTo("**");
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
+                fil2.Delete();
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] Move a file containing data
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_f888m";
+            filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            filNameDest = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            File.Delete(filNameDest);
+            sw2 = new StreamWriter(File.Create(filName));
+            cWriteArr = new Char[26];
+            int j = 0;
+            for (Char i = 'A'; i <= 'Z'; i++)
+                cWriteArr[j++] = i;
+            sw2.Write(cWriteArr, 0, cWriteArr.Length);
+            sw2.Flush();
+            sw2.Dispose();
+
+            fil2 = new FileInfo(filName);
+            fil2.MoveTo(filNameDest);
+            fil1 = new FileInfo(filName);
+            iCountTestcases++;
+            if (fil1.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_9u99s! File not moved: " + fil1.FullName);
+            }
+            iCountTestcases++;
+            if (!fil2.FullName.Equals(filNameDest))
+            {
+                iCountErrors++;
+                printerr("Error_2488g! Incorrect name==" + fil2.FullName);
+            }
+            if (!File.Exists(fil2.FullName))
+            {
+                iCountErrors++;
+                printerr("Error_29h7b! Source still there");
+            }
+
+            FileStream stream = new FileStream(filNameDest, FileMode.Open);
+            sr2 = new StreamReader(stream);
+            cReadArr = new Char[cWriteArr.Length];
+            sr2.Read(cReadArr, 0, cReadArr.Length);
+
+            iCountTestcases++;
+            for (int i = 0; i < cReadArr.Length; i++)
+            {
+                iCountTestcases++;
+                if (cReadArr[i] != cWriteArr[i])
+                {
+                    iCountErrors++;
+                    printerr("Error_98yv7! Expected==" + cWriteArr[i] + ", got value==" + cReadArr[i]);
+                }
+            }
+            sr2.Dispose();
+            stream.Dispose();
+
+            fil1.Delete();
+            fil2.Delete();
+
+            //-----------------------------------------------------------------
+
+
+
+
+            // [] Interesting case:
+            //-----------------------------------------------------------------
+
+            strLoc = "Loc_478yb";
+            filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            filNameDest = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            if (File.Exists(filNameDest))
+                File.Delete(filNameDest);
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            string pathDest = Path.Combine(Path.GetDirectoryName(filNameDest), Path.Combine(Enumerable.Repeat(".", 125).Concat(new string[] { Path.GetFileName(filNameDest) }).ToArray()));
+
+            fil2.MoveTo(pathDest);
+
+            fil1 = new FileInfo(filNameDest);
+            iCountTestcases++;
+            if (!fil1.Exists)
+            {
+                iCountErrors++;
+                printerr("Error_hs84fs! File does not exist in expected destination after move");
+            }
+            if (!fil2.FullName.Equals(fil1.FullName))
+            {
+                iCountErrors++;
+                printerr(string.Format("Error_298gc! Incorrect fullname set during Move (expected {0}, actual {1}",
+                    fil1.FullName, fil2.FullName));
+            }
+            new FileInfo(filName).Delete();
+            File.Delete(filNameDest);
+            //-----------------------------------------------------------------
+
+            fil1.Delete();
+            fil2.Delete();
+
+
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/OpenRead.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/OpenRead.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_OpenRead
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/07/10 18:07";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "OpenRead.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            Stream s2;
+            FileInfo fil2;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            // [] File does not exist
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00001";
+
+            fil2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName()));
+            iCountTestcases++;
+            try
+            {
+                fil2.OpenRead();
+                iCountErrors++;
+                printerr("Error_00002! Expected exception not thrown");
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_00004! Incorrect exception caught, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+            // [] Open file and check for canread
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00005";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            iCountTestcases++;
+            fil2 = new FileInfo(filName);
+            s2 = fil2.OpenRead();
+            iCountTestcases++;
+            if (!s2.CanRead)
+            {
+                iCountErrors++;
+                printerr("Error_00006! File not opened canread");
+            }
+
+            // [] Check file for canwrite
+
+            iCountTestcases++;
+            if (s2.CanWrite)
+            {
+                iCountErrors++;
+                printerr("Error_00007! File was opened canWrite");
+            }
+
+            s2.Dispose();
+            //-----------------------------------------------------------------
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/OpenText.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/OpenText.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_OpenText
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 11:46";
+    public static String s_strClassMethod = "File.CreateText";
+    public static String s_strTFName = "OpenText.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            StreamWriter sw2;
+            StreamReader sr2;
+            String str2;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Open file that does not exists should throw
+            //-----------------------------------------------------------------
+            strLoc = "Loc_27gyb";
+
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            try
+            {
+                fil2.OpenText();
+                iCountErrors++;
+                printerr("Error_29g7b! Expected exception not thrown");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_286by! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+            // [] Open directory should throw
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4g894";
+
+            fil2 = new FileInfo(TestInfo.CurrentDirectory);
+            iCountTestcases++;
+            try
+            {
+                fil2.OpenText();
+                iCountErrors++;
+                printerr("Error_2099c! Expected exception not thrown");
+            }
+            catch (UnauthorizedAccessException)
+            {
+#if TEST_WINRT // WinRT returns E_INVALIDARG instead of ACCESS_DENIED
+            } catch (IOException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_t749x! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+            // [] Open the file and verify the content 
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2y78b";
+
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            sw2 = fil2.CreateText();
+            sw2.Write("HelloWorld");
+            sw2.Dispose();
+            sr2 = fil2.OpenText();
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("HelloWorld"))
+            {
+                iCountErrors++;
+                printerr("Error_21y77! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+
+            // reopen the fil and mess with it
+
+            strLoc = "Loc_2gy7b";
+
+            sw2 = fil2.CreateText();
+            sw2.Write("You Big Globe");
+            sw2.Dispose();
+            sr2 = fil2.OpenText();
+            str2 = sr2.ReadToEnd();
+            iCountTestcases++;
+            if (!str2.Equals("You Big Globe"))
+            {
+                iCountErrors++;
+                printerr("Error_12ytb! Incorrect string written, str2==" + str2);
+            }
+            sr2.Dispose();
+
+            //-----------------------------------------------------------------
+
+
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/OpenWrite.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/OpenWrite.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_OpenWrite
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/07/11 20:26";
+    public static String s_strClassMethod = "File.OpenWrite()";
+    public static String s_strTFName = "OpenWrite.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            Stream s2;
+            FileInfo fil2;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            // [] Open file and check for canread
+            //-----------------------------------------------------------------
+            strLoc = "Loc_00005";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            iCountTestcases++;
+            fil2 = new FileInfo(filName);
+            s2 = fil2.OpenWrite();
+            iCountTestcases++;
+            if (s2.CanRead)
+            {
+                iCountErrors++;
+                printerr("Error_00006! File not opened canread");
+            }
+
+            // [] Check file for canwrite
+
+            iCountTestcases++;
+            if (!s2.CanWrite)
+            {
+                iCountErrors++;
+                printerr("Error_00007! File was opened canWrite");
+            }
+
+            s2.Dispose();
+            //-----------------------------------------------------------------
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Open_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Open_fm.cs
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_Open_fm
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "Open_fm.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_000oo";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+
+            // CreateNew
+            // Create
+            // Open
+            // OpenOrCreate
+            // Truncate
+            // Append
+
+            // Simple call throughs to FileStream, just test functionality
+
+
+            // [] FileMode.CreateNew
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Create
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Open
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.OpenOrCreate
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Truncate
+            // [][] File Exists
+            // [][] File does not exist
+            // [] FileMode.Append
+            // [][] File Exists
+            // [][] File does not exist
+
+            TestMethod(FileMode.CreateNew);
+            TestMethod(FileMode.Create);
+            TestMethod(FileMode.Open);
+            TestMethod(FileMode.OpenOrCreate);
+            TestMethod(FileMode.Truncate);
+            TestMethod(FileMode.Append);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+
+    public static void TestMethod(FileMode fm)
+    {
+        String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+        FileInfo fil2;
+        StreamWriter sw2;
+        Stream fs2;
+        String str2;
+
+
+        if (File.Exists(filName))
+            File.Delete(filName);
+
+        // [] File does not exist
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_234yg";
+
+        fil2 = new FileInfo(filName);
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+            case FileMode.Create:
+            case FileMode.OpenOrCreate:
+                fs2 = fil2.Open(fm);
+                s_iCountTestcases++;
+                if (!File.Exists(filName))
+                {
+                    s_iCountErrors++;
+                    //TODO: uncomment the following.
+                    //printerr( "Error_48gb7! File not created, FileMode=="+ Enum.ToString(typeof(FileMode), fm, "G"));
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Open:
+            case FileMode.Truncate:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = fil2.Open(fm);
+                    s_iCountErrors++;
+                    printerr("Error_2yg8b! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (FileNotFoundException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2y7gf! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Append:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = fil2.Open(fm);
+                    s_iCountErrors++;
+                    printerr("Error_2g78b! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_g77b7! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_27tbv! This should not be....");
+                break;
+        }
+        if (File.Exists(filName))
+            File.Delete(filName);
+
+        //------------------------------------------------------------------
+
+
+        // [] File already exists
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_4yg7b";
+
+        FileStream stream = new FileStream(filName, FileMode.Create);
+        sw2 = new StreamWriter(stream);
+        str2 = "Du er en ape";
+        sw2.Write(str2);
+        sw2.Dispose();
+        stream.Dispose();
+        fil2 = new FileInfo(filName);
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = fil2.Open(fm);
+                    s_iCountErrors++;
+                    printerr("Error_27b98! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_g8782! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Create:
+                fs2 = fil2.Open(fm);
+                if (fs2.Length != 0)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_287vb! Incorrect length of file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.OpenOrCreate:
+            case FileMode.Open:
+                fs2 = fil2.Open(fm);
+                if (fs2.Length != str2.Length)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2gy78! Incorrect length on file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Truncate:
+                fs2 = fil2.Open(fm);
+                if (fs2.Length != 0)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_29gv9! Incorrect length on file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Append:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = fil2.Open(fm);
+                    s_iCountErrors++;
+                    printerr("Error_287yb! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_27878! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_587yb! This should not be...");
+                break;
+        }
+
+
+        //------------------------------------------------------------------
+
+
+
+        if (File.Exists(filName))
+            File.Delete(filName);
+    }
+
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Open_fm_fa.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Open_fm_fa.cs
@@ -1,0 +1,414 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_Open_fm_fa
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "Open_fm_fa.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_000oo";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+
+            // CreateNew
+            // Create
+            // Open
+            // OpenOrCreate
+            // Truncate
+            // Append
+
+            // [] FileMode.CreateNew and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.CreateNew and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.CreateNew and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Create and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Create and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Create and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Open and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Open and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Open and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.OpenOrCreate and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.OpenOrCreate and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.OpenOrCreate and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Truncate and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Truncate and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Truncate and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Append and FileAccess.Read
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Append and FileAccess.Write
+            // [][] File does not exist
+            // [][] File already exists
+            // [] FileMode.Append and FileAccess.ReadWrite
+            // [][] File does not exist
+            // [][] File already exists
+
+            // Simple call throughs to FileStream, just test functionality
+
+            TestMethod(FileMode.CreateNew, FileAccess.Read);
+            TestMethod(FileMode.CreateNew, FileAccess.Write);
+            TestMethod(FileMode.CreateNew, FileAccess.ReadWrite);
+            TestMethod(FileMode.Create, FileAccess.Read);
+            TestMethod(FileMode.Create, FileAccess.Write);
+            TestMethod(FileMode.Create, FileAccess.ReadWrite);
+            TestMethod(FileMode.Open, FileAccess.Read);
+            TestMethod(FileMode.Open, FileAccess.Write);
+            TestMethod(FileMode.Open, FileAccess.ReadWrite);
+            TestMethod(FileMode.OpenOrCreate, FileAccess.Read);
+            TestMethod(FileMode.OpenOrCreate, FileAccess.Write);
+            TestMethod(FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            TestMethod(FileMode.Truncate, FileAccess.Read);
+            TestMethod(FileMode.Truncate, FileAccess.Write);
+            TestMethod(FileMode.Truncate, FileAccess.ReadWrite);
+            TestMethod(FileMode.Append, FileAccess.Read);
+            TestMethod(FileMode.Append, FileAccess.Write);
+            TestMethod(FileMode.Append, FileAccess.ReadWrite);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+
+
+    public static void TestMethod(FileMode fm, FileAccess fa)
+    {
+        String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+        FileInfo fil2;
+        StreamWriter sw2;
+        Stream fs2;
+        String str2;
+
+        //			Console.WriteLine("FileMode: "+Enum.ToString(typeof(FileMode), fm, "G"));
+        //			Console.WriteLine("FileAccess: "+Enum.ToString(typeof(FileAccess), fa, "G"));
+
+        if (File.Exists(filName))
+            File.Delete(filName);
+
+        // File does not exist
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_234yg";
+
+        fil2 = new FileInfo(filName);
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+            case FileMode.Create:
+            case FileMode.OpenOrCreate:
+                try
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(filName))
+                    {
+                        s_iCountErrors++;
+                        //TODO:
+                        //printerr( "Error_48gb7! File not created, FileMode=="+Enum.ToString(typeof(FileMode), fm, "G"));
+                    }
+                    fs2.Dispose();
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (!((fm == FileMode.Create && fa == FileAccess.Read) || (fm == FileMode.CreateNew && fa == FileAccess.Read)))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_478v8! Unexpected exception, aexc==" + aexc);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_4879v! Incorrect exception thrown, exc==" + exc);
+                }
+                break;
+            case FileMode.Open:
+            case FileMode.Truncate:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_2yg8b! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (IOException)
+                {
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (fa != FileAccess.Read)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_v48y8! Unexpected exception thrown, aexc==" + aexc);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2y7gf! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Append:
+                if (fa == FileAccess.Write)
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(filName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_2498y! File not created");
+                    }
+                    fs2.Dispose();
+                }
+                else
+                {
+                    s_iCountTestcases++;
+                    try
+                    {
+                        fs2 = fil2.Open(fm, fa);
+                        s_iCountErrors++;
+                        printerr("Error_2g78b! Expected exception not thrown");
+                        fs2.Dispose();
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (Exception exc)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_g77b7! Incorrect exception thrown, exc==" + exc.ToString());
+                    }
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_27tbv! This should not be....");
+                break;
+        }
+        if (File.Exists(filName))
+            File.Delete(filName);
+
+        //------------------------------------------------------------------
+
+
+        //  File already exists
+        //------------------------------------------------------------------
+        s_strLoc = "Loc_4yg7b";
+
+        FileStream stream = new FileStream(filName, FileMode.Create);
+        sw2 = new StreamWriter(stream);
+        str2 = "Du er en ape";
+        sw2.Write(str2);
+        sw2.Dispose();
+        stream.Dispose();
+        fil2 = new FileInfo(filName);
+        switch (fm)
+        {
+            case FileMode.CreateNew:
+                s_iCountTestcases++;
+                try
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    s_iCountErrors++;
+                    printerr("Error_27b98! Expected exception not thrown");
+                    fs2.Dispose();
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (fa != FileAccess.Read)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_4387v! Unexpected exception, aexc==" + aexc);
+                    }
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_g8782! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.Create:
+                try
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    if (fs2.Length != 0)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_287vb! Incorrect length of file==" + fil2.Length);
+                    }
+                    fs2.Dispose();
+                }
+                catch (ArgumentException aexc)
+                {
+                    if (fa != FileAccess.Read)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_48vy7! Unexpected exception, aexc==" + aexc);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_47yv3! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                break;
+            case FileMode.OpenOrCreate:
+            case FileMode.Open:
+                fs2 = fil2.Open(fm, fa);
+                if (fs2.Length != str2.Length)
+                {
+                    s_iCountErrors++;
+                    printerr("Error_2gy78! Incorrect length on file==" + fil2.Length);
+                }
+                fs2.Dispose();
+                break;
+            case FileMode.Truncate:
+                if (fa == FileAccess.Read)
+                {
+                    s_iCountTestcases++;
+                    try
+                    {
+                        fs2 = fil2.Open(fm, fa);
+                        s_iCountErrors++;
+                        printerr("Error_g95y8! Expected exception not thrown");
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (Exception exc)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_98y4v! Incorrect exception thrown, exc==" + exc.ToString());
+                    }
+                }
+                else
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    if (fs2.Length != 0)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_29gv9! Incorrect length on file==" + fil2.Length);
+                    }
+                    fs2.Dispose();
+                }
+                break;
+            case FileMode.Append:
+                if (fa == FileAccess.Write)
+                {
+                    fs2 = fil2.Open(fm, fa);
+                    s_iCountTestcases++;
+                    if (!File.Exists(filName))
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_4089v! File not created");
+                    }
+                    fs2.Dispose();
+                }
+                else
+                {
+                    s_iCountTestcases++;
+                    try
+                    {
+                        fs2 = fil2.Open(fm, fa);
+                        s_iCountErrors++;
+                        printerr("Error_287yb! Expected exception not thrown");
+                        fs2.Dispose();
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (Exception exc)
+                    {
+                        s_iCountErrors++;
+                        printerr("Error_27878! Incorrect exception thrown, exc==" + exc.ToString());
+                    }
+                }
+                break;
+            default:
+                s_iCountErrors++;
+                printerr("Error_587yb! This should not be...");
+                break;
+        }
+
+
+        //------------------------------------------------------------------
+
+
+
+        if (File.Exists(filName))
+            File.Delete(filName);
+    }
+
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Open_fm_fa_fs.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Open_fm_fa_fs.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_Open_fm_fa_fs
+{
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "Open_fm_fa_fs.cs";
+    public static String s_strTFPath = "FileInfo";
+
+    private delegate void ExceptionCode();
+    private static bool s_pass = true;
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            Stream fs2, fs3;
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            // [] FileSharing.None -- Should not be able to access the file
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2498V";
+
+            fil2 = new FileInfo(filName);
+            fs2 = fil2.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            iCountTestcases++;
+            try
+            {
+                fs3 = fil2.Open(FileMode.Open);
+                iCountErrors++;
+                printerr("Error_209uv! Shouldn't be able to open an open file");
+                fs3.Dispose();
+#if TEST_WINRT
+            } catch (UnauthorizedAccessException) {
+#endif
+            }
+            catch (IOException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_287gv! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+            // [] FileSharing.Read
+            //-----------------------------------------------------------------
+            strLoc = "Loc_f5498";
+
+            fil2 = new FileInfo(filName);
+            fs2 = fil2.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+            fs2.Write(new Byte[] { 10 }, 0, 1);
+            fs2.Flush();
+            fs2.Dispose();
+
+            // FileShare is not supported by WINRT, sharing is controlled by access.
+            // It allows concurrent readers, and write after read, but not vice-versa.
+            // Reopen file as only Read to test concurrent read behavior.
+            fs2 = fil2.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
+            iCountTestcases++;
+            fs3 = fil2.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            fs3.Read(new Byte[1], 0, 1);
+            try
+            {
+                fs3.Write(new Byte[] { 10 }, 0, 1);
+                iCountErrors++;
+                printerr("Error_958vc! Expected exception not thrown");
+            }
+            catch (NotSupportedException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20939! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            fs2.Dispose();
+            fs3.Dispose();
+            fil2.Delete();
+
+            //-----------------------------------------------------------------
+
+            // [] FileSharing.Write
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2498x";
+
+            fil2 = new FileInfo(filName);
+            fs2 = fil2.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.Write);
+            iCountTestcases++;
+            try
+            {
+                fs3 = fil2.Open(FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+                fs3.Write(new Byte[] { 1, 2 }, 0, 2);
+#if TEST_WINRT // WinRT's sharing model does not support concurrent write
+                printerr( "Error_209uv! Shouldn't be able to open concurrent writers");
+            } catch (UnauthorizedAccessException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2980x! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+            fs3.Dispose();
+            fil2.Delete();
+            //-----------------------------------------------------------------
+
+
+
+            // [] FileSharing.ReadWrite
+            //-----------------------------------------------------------------
+            strLoc = "Loc_4897y";
+
+            fil2 = new FileInfo(filName);
+            fs2 = fil2.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+            iCountTestcases++;
+            try
+            {
+                fs3 = fil2.Open(FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+#if TEST_WINRT // WinRT's sharing model does not support concurrent write
+                printerr( "Error_209uv! Shouldn't be able to open concurrent writers");
+#endif
+                fs2.Write(new Byte[] { 1 }, 0, 1);
+                fs3.Dispose();
+                fs3 = fil2.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                fs2.Write(new Byte[] { 2 }, 0, 1);
+                fs3.Dispose();
+                fs3 = fil2.Open(FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+                fs2.Write(new Byte[] { 3 }, 0, 1);
+                fs3.Dispose();
+#if TEST_WINRT // WinRT's sharing model does not support concurrent write
+            } catch (UnauthorizedAccessException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_287g9! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+            fs2.Dispose();
+            fs3.Dispose();
+            fil2.Delete();
+
+            //-----------------------------------------------------------------
+            const String sourceString = "This is the source File";
+
+            //First we look at the drives of this machine to be sure that we can proceed
+            String sourceFileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            //Scenario 1: Vanilla - create a filestream with this flag in FileShare parameter and then delete the file (using File.Delete or FileInfo.Delete) before closing the 
+            //FileStream. Ensure that the delete operation succeeds but the file is not deleted till the FileStream is closed
+            try
+            {
+                Byte[] outbits = Encoding.Unicode.GetBytes(sourceString);
+
+                FileInfo file = new FileInfo(sourceFileName);
+                FileStream stream = file.Open(FileMode.Create, FileAccess.Write, FileShare.Delete);
+
+                stream.Write(outbits, 0, outbits.Length);
+
+                //This should succeed
+                File.Delete(sourceFileName);
+
+                //But we shold still be able to call the file
+                Eval(File.Exists(sourceFileName), "Err_3947sg! File doesn't exists");
+
+                stream.Write(outbits, 0, outbits.Length);
+
+                stream.Dispose();
+
+                //Now it shouldn't exist - is there any OS delay
+                Eval(!File.Exists(sourceFileName), "Err_2397g! File doesn't exists");
+            }
+            catch (Exception ex)
+            {
+                s_pass = false;
+                Console.WriteLine("Err_349t7g! Exception caught in scenario: {0}", ex);
+            }
+
+            if (!s_pass)
+                iCountErrors++;
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    //Checks for error
+    private static void Eval(bool expression, String msg, params Object[] values)
+    {
+        Eval(expression, String.Format(msg, values));
+    }
+
+    private static void Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            s_pass = false;
+            Console.WriteLine(msg);
+        }
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg in the English locale
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (msgExpected != null && System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/Refresh.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Refresh.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class FileInfo_Refresh
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/07/12 19:34";
+    public static String s_strClassMethod = "File.Refresh()";
+    public static String s_strTFName = "Refresh.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            FileInfo fil2;
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+            // [] Delete File and refresh
+            //----------------------------------------------------------------
+            strLoc = "Loc_00001";
+
+            File.Open(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            File.Delete(filName);
+            iCountTestcases++;
+            fil2.Refresh();
+
+            //----------------------------------------------------------------
+
+            // [] Change name of File and refresh
+            //----------------------------------------------------------------
+            strLoc = "Loc_00005";
+
+            string tempFilName = Path.Combine(TestInfo.CurrentDirectory, "Temp001");
+            if (File.Exists(tempFilName))
+                File.Delete(tempFilName);
+
+            iCountTestcases++;
+
+            File.Open(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            fil2.MoveTo(tempFilName);
+            fil2.Refresh();
+            File.Delete(tempFilName);
+            //----------------------------------------------------------------
+
+            // [] Change Attributes and refresh
+            //----------------------------------------------------------------
+            strLoc = "Loc_00006";
+
+            iCountTestcases++;
+            File.Open(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            if (((Int32)fil2.Attributes & (Int32)FileAttributes.ReadOnly) != 0)
+            {
+                Console.WriteLine(fil2.Attributes);
+                iCountErrors++;
+                printerr("Error_00007! Attribute set before refresh");
+            }
+
+            fil2.Attributes = FileAttributes.ReadOnly;
+            fil2.Refresh();
+            iCountTestcases++;
+            if (((Int32)fil2.Attributes & (Int32)FileAttributes.ReadOnly) <= 0)
+            {
+                iCountErrors++;
+                printerr("Error_00008! Object not refreshed after setting readonly");
+            }
+
+            fil2.Attributes = new FileAttributes();
+            fil2.Refresh();
+            if (((Int32)fil2.Attributes & (Int32)FileAttributes.ReadOnly) != 0)
+            {
+                iCountErrors++;
+                printerr("Error_00009! Object not refreshed after removing readonly");
+            }
+
+            //----------------------------------------------------------------
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/ToString.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_ToString
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "ToString.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_000oo";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2;
+
+            // [] Check commonly used file formats
+            //-----------------------------------------------------------------
+            s_strLoc = "Loc_2723d";
+
+            fil2 = new FileInfo("Hello\\file.tmp");
+            s_iCountTestcases++;
+            if (!fil2.ToString().Equals("Hello\\file.tmp"))
+            {
+                s_iCountErrors++;
+                printerr("Error_5yb87! Incorrect name==" + fil2.ToString());
+            }
+
+
+            fil2 = new FileInfo("\\Directory\\File");
+            s_iCountTestcases++;
+            if (!fil2.ToString().Equals("\\Directory\\File"))
+            {
+                s_iCountErrors++;
+                printerr("Error_78288! Incorrect name==" + fil2.ToString());
+            }
+
+            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            s_iCountTestcases++;
+            if (!fil2.ToString().Equals("\\\\Machine\\Directory\\File"))
+            {
+                s_iCountErrors++;
+                printerr("Error_67y8b! Incorrect name==" + fil2.ToString());
+            }
+
+            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            s_iCountTestcases++;
+            if (!fil2.ToString().Equals("C:\\File.tmp hello.blah"))
+            {
+                s_iCountErrors++;
+                printerr("Error_2987b! Incorrect name==" + fil2.ToString());
+            }
+            fil2 = new FileInfo("C://Directory//File");
+            s_iCountTestcases++;
+            if (!fil2.ToString().Equals("C://Directory//File"))
+            {
+                s_iCountErrors++;
+                printerr("Error_2y78d! Incorrect name==" + fil2.ToString());
+            }
+            //-----------------------------------------------------------------
+
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/ctor_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/ctor_str.cs
@@ -1,0 +1,252 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using Xunit;
+
+public class FileInfo_ctor_str
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/03/07 14:12";
+    public static String s_strClassMethod = "Directory.ToString";
+    public static String s_strTFName = "ctor_str.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2;
+            string filName;
+
+            // [] ArgumentNullException if null is passed in
+
+            strLoc = "Loc_498yg";
+
+
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo(null);
+                iCountErrors++;
+                printerr("Error_209uz! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentNullException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21x99! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+            // [] Construct fil object
+
+            strLoc = "Loc_7h7g7";
+
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo("ThisFileDoesNotExist");
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20g9u! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+            // [] Try to get current directory with CurrentDirectory property
+
+            strLoc = "Loc_289vy";
+
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo(Directory.GetCurrentDirectory());
+                fil2.Open(FileMode.Open);
+                iCountErrors++;
+                printerr("Error_301ju! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (UnauthorizedAccessException)
+            {
+#if TEST_WINRT // WinRT returns E_INVALIDARG instead of ACCESS_DENIED
+            } catch (IOException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209us! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+            // [] Try to get current directory with "."
+
+            strLoc = "Loc_fd348";
+
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo(".");
+                fil2.Open(FileMode.Open);
+                iCountErrors++;
+                printerr("Error_398vh! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (UnauthorizedAccessException)
+            {
+#if TEST_WINRT // WinRT returns E_INVALIDARG instead of ACCESS_DENIED
+            } catch (IOException) {
+#endif
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_27h72! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+
+
+            // [] Find a real file using full path
+
+            strLoc = "Loc_r7yd9";
+            filName = Path.Combine(TestInfo.CurrentDirectory, "MyTestFile");
+            File.Create(filName).Dispose();
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo(filName);
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_f588y! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+#if !TEST_WINRT // WinRT cannot write to current dir
+            // [] Find the same file using relative path;
+
+            strLoc = "Loc_f548y";
+
+            File.Create("MyTestFile").Dispose();
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo("MyTestFile");
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_298gv! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+#endif
+
+
+
+            // [] File with bunch of periods
+
+            strLoc = "Loc_298dy";
+            filName = Path.Combine(TestInfo.CurrentDirectory, "Hello.there.you.have.an.extension");
+            File.Create(filName).Dispose();
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo(filName);
+                fil2.Delete();
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2901s! Unexpected exception thrown, exc==" + exc.ToString());
+            }
+
+
+
+            // [] Filename with wildchar characters
+
+
+            strLoc = "Loc_984hg";
+
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo("**");
+                iCountErrors++;
+                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+
+            // [] String.Empty should throw exception
+
+            strLoc = "Loc_948jk";
+
+
+            iCountTestcases++;
+            try
+            {
+                fil2 = new FileInfo(String.Empty);
+                iCountErrors++;
+                printerr("Error_0199z! Expected exception not thrown, fil2==" + fil2.FullName);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_20109! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Attributes.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_get_Attributes
+{
+    public static String s_strActiveBugNums = "38078";
+    public static String s_strDtTmVer = "2000/05/09 11:28";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "get_Attributes.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+
+            /*
+              ReadOnly = 0x1,
+              Hidden = 0x2,
+              System = 0x4,
+              Directory = 0x10,
+              Archive = 0x20,
+              Encrypted = 0x40,
+              Normal = 0x80,
+              Temporary = 0x100,
+              SparseFile = 0x200,
+              ReparsePoint = 0x400,
+              Compressed = 0x800,
+              Offline = 0x1000,
+              NotContentIndexed = 0x2000
+            */
+
+
+            if (File.Exists(filName))
+            {
+                fil2 = new FileInfo(filName);
+                fil2.Attributes = new FileAttributes();
+                File.Delete(filName);
+            }
+
+            // [] File does not exist
+            //--------------------------------------------------------
+            strLoc = "loc_2yg8c";
+
+            fil2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "FileDoesNotExist"));
+            iCountTestcases++;
+            try
+            {
+                fil2.Attributes = new FileAttributes();
+                iCountErrors++;
+                printerr("Error_27t8b! Expected exception not thrown");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21409! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            File.Create(filName).Dispose();
+
+            /*
+                        // [] Invalid enum value
+                        //-----------------------------------------------------------------
+                        strLoc = "Loc_298g8";
+
+                        fil2 = new FileInfo(filName);
+                        iCountTestcases++;
+                        try {
+                            fil2.Attributes = (FileAttributes)(-1);
+                            iCountErrors++;
+                            printerr( "Error_28g8b! Expected exception not thrown");
+                        } catch (ArgumentException aexc) {
+                        } catch (Exception exc) {
+                            iCountErrors++;
+                            printerr( "Error_t94u9! Incorrect exception thrown, exc=="+exc.ToString());
+                        }
+
+                        //-----------------------------------------------------------------
+            */
+
+            try
+            {
+                // [] valid data
+                //-----------------------------------------------------------------
+                strLoc = "Loc_48yx9";
+
+                fil2 = new FileInfo(filName);
+                fil2.Attributes = FileAttributes.Hidden;
+                iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support hidden
+            if((fil2.Attributes & FileAttributes.Hidden)!=0) {
+#else
+                if ((fil2.Attributes & FileAttributes.Hidden) == 0)
+                {
+#endif
+                    iCountErrors++;
+                    printerr("ERror_2g985! Hidden not set");
+                }
+                fil2.Refresh();
+                fil2.Attributes = FileAttributes.System;
+                iCountTestcases++;
+                fil2.Refresh();
+#if TEST_WINRT  // WinRT doesn't support system
+            if((fil2.Attributes & FileAttributes.System) == FileAttributes.System) {
+#else
+                if ((fil2.Attributes & FileAttributes.System) != FileAttributes.System)
+                {
+#endif
+                    iCountErrors++;
+                    printerr("Error_298g7! System not set");
+                }
+                fil2.Attributes = FileAttributes.Normal;
+                fil2.Refresh();
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.Normal) != FileAttributes.Normal)
+                {
+                    if ((fil2.Attributes & FileAttributes.Compressed) == 0)
+#if TEST_WINRT
+                if ((fil2.Attributes & FileAttributes.Archive) == 0) 
+#endif
+                    {
+                        iCountErrors++;
+                        printerr("Error_286b7! Normal not set");
+                    }
+                }
+                fil2.Attributes = FileAttributes.Temporary;
+                fil2.Refresh();
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.Temporary) == 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_87tg8! Temporary not set");
+                }
+                //-----------------------------------------------------------------
+
+
+
+                // [] 
+                //-----------------------------------------------------------------
+                strLoc = "Loc_29gy7";
+
+                fil2 = new FileInfo(filName);
+
+                fil2.Attributes = FileAttributes.Archive;
+                fil2.Refresh();
+                fil2.Attributes = FileAttributes.ReadOnly | fil2.Attributes;
+                fil2.Refresh();
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
+                {
+                    iCountErrors++;
+                    printerr("Error_g58y8! ReadOnly attribute not set");
+                }
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.Archive) != FileAttributes.Archive)
+                {
+                    iCountErrors++;
+                    printerr("Error_2g78b! Archive attribute not set");
+                }
+
+                fil2.Attributes = new FileAttributes();
+                //-----------------------------------------------------------------
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_284y8! Unexpected exception thrown, bug 29808, exc==" + exc.ToString());
+            }
+            if (File.Exists(filName))
+            {
+                fil2 = new FileInfo(filName);
+                fil2.Attributes = new FileAttributes();
+
+                File.Delete(filName);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_CreationTime.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_CreationTime.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class FileInfo_get_CreationTime
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/09 13:19";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "get_CreationTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String filName = s_strTFName.Substring(0, s_strTFName.IndexOf('.')) + "_test_" + "TestFile";
+            FileInfo fil2;
+
+            // [] Exception for null string
+            //-----------------------------------------------------------
+            iCountTestcases++;
+
+            // This really isn't an issue. Just incrementing to keep the mad dog happy
+
+
+            // [] Create a file and check the creation time - if the file does not exist,we should throw
+
+            strLoc = "Loc_r8r7j";
+
+
+            //We should make sure that the file doesn't exist
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            DirectoryInfo newDirectory = new DirectoryInfo(".");
+            fil2 = new FileInfo(newDirectory + filName);
+            iCountTestcases++;
+            try
+            {
+                DateTime d1 = fil2.CreationTime;
+                //We threw in Whidbey upto 50606 but V1.1 behavior is as below
+                if (d1 != DateTime.FromFileTime(0))
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Error_20hjx! Creation time cannot be correct: {0}", d1);
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14952 - Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            // [] Create file, sleep for a while and check the creation time.
+
+            strLoc = "Loc_20yxc";
+            fil2 = new FileInfo(Path.GetTempFileName());
+            FileStream fs = fil2.Create();
+            Task.Delay(2000).Wait();
+            iCountTestcases++;
+            try
+            {
+                if ((DateTime.Now - fil2.CreationTime).Minutes > 1)
+                {
+                    Console.WriteLine(DateTime.Now);
+                    Console.WriteLine(DateTime.Now - fil2.CreationTime);
+                    Console.WriteLine(fil2.CreationTime);
+
+                    iCountErrors++;
+                    printerr("Eror_209x9! Creation time is off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            fs.Dispose();
+            fil2.Delete();
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Directory.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Directory.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_get_Directory
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 20:09";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "get_Directory.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2;
+            DirectoryInfo dir2;
+
+
+            // [] Vanilla case
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2723d";
+
+            fil2 = new FileInfo("Hello\\file.tmp");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals(Directory.GetCurrentDirectory() + "\\Hello"))
+            {
+                iCountErrors++;
+                printerr("Error_5yb87! Incorrect name==" + dir2.FullName);
+            }
+
+            // [] Directory string starting with \
+            fil2 = new FileInfo("\\Directory\\File");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals(Directory.GetCurrentDirectory().Substring(0, 2) + "\\Directory"))
+            {
+                iCountErrors++;
+                printerr("Error_78288! Incorrect name==" + dir2.FullName);
+            }
+
+            // [] UNC share
+            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals("\\\\Machine\\Directory"))
+            {
+                iCountErrors++;
+                printerr("Error_67y8b! Incorrect name==" + dir2.FullName);
+            }
+
+            // [] 
+            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals("C:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_2987b! Incorrect name==" + dir2.FullName);
+            }
+
+            // [] C:/Directory/File
+            fil2 = new FileInfo("C:/Directory/File");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals("C:\\Directory"))
+            {
+                iCountErrors++;
+                printerr("Error_2y78d! Incorrect name==" + dir2.FullName);
+            }
+
+
+            // [] Multiple subdireactories
+            fil2 = new FileInfo("C:\\Dir1\\Dir2\\Dir3\\Dir4\\File1");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals("C:\\Dir1\\Dir2\\Dir3\\Dir4"))
+            {
+                iCountErrors++;
+                printerr("Error_283fy! Incorrect name==" + dir2.FullName);
+            }
+
+
+
+            // [] Just name should return currentdirectory
+            fil2 = new FileInfo("Dir1");
+            dir2 = fil2.Directory;
+            iCountTestcases++;
+            if (!dir2.FullName.Equals(Directory.GetCurrentDirectory()))
+            {
+                iCountErrors++;
+                printerr("Error_758bb! Incorrect name==" + dir2.FullName);
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_DirectoryName.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_DirectoryName.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_get_DirectoryName
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 20:00";
+    public static String s_strClassMethod = "File.DirectoryName()";
+    public static String s_strTFName = "get_DirectoryName.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2;
+
+
+
+            // [] Vanilla case
+            //-----------------------------------------------------------------
+            strLoc = "Loc_2723d";
+
+            fil2 = new FileInfo("Hello\\file.tmp");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals(Directory.GetCurrentDirectory() + "\\Hello"))
+            {
+                iCountErrors++;
+                printerr("Error_5yb87! Incorrect name==" + fil2.DirectoryName);
+            }
+
+            // [] \Directory\File
+            fil2 = new FileInfo("\\Directory\\File");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals(Directory.GetCurrentDirectory().Substring(0, 2) + "\\Directory"))
+            {
+                iCountErrors++;
+                printerr("Error_78288! Incorrect name==" + fil2.DirectoryName);
+            }
+
+            // [] UNC share
+            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals("\\\\Machine\\Directory"))
+            {
+                iCountErrors++;
+                printerr("Error_67y8b! Incorrect name==" + fil2.DirectoryName);
+            }
+
+            // [] Names with spaces
+            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals("C:\\"))
+            {
+                iCountErrors++;
+                printerr("Error_2987b! Incorrect name==" + fil2.DirectoryName);
+            }
+
+            // [] C:/Directory/File
+            fil2 = new FileInfo("C:/Directory/File");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals("C:\\Directory"))
+            {
+                iCountErrors++;
+                printerr("Error_2y78d! Incorrect name==" + fil2.DirectoryName);
+            }
+            /*
+                        // [] Ending with \\
+                        fil2 = new FileInfo("C:\\Dir1\\Dir2\\");
+                        iCountTestcases++;
+                        if(!fil2.DirectoryName.Equals("C:\\Dir1\\Dir2")) {
+                            iCountErrors++;
+                            printerr( "Error_287gy! Incorrect name=="+fil2.DirectoryName);
+                        } 
+            */
+
+            // [] Multiple Subdirectories
+            fil2 = new FileInfo("C:\\Dir1\\Dir2\\Dir3\\Dir4\\File1");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals("C:\\Dir1\\Dir2\\Dir3\\Dir4"))
+            {
+                iCountErrors++;
+                printerr("Error_283fy! Incorrect name==" + fil2.DirectoryName);
+            }
+
+
+            fil2 = new FileInfo("Dir1");
+            iCountTestcases++;
+            if (!fil2.DirectoryName.Equals(Directory.GetCurrentDirectory()))
+            {
+                iCountErrors++;
+                printerr("Error_758bb! Incorrect name==" + fil2.DirectoryName);
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_LastAccessTime.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_LastAccessTime.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class FileInfo_get_LastAccessTime
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/09 13:19";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "get_LastAccessTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            Stream stream;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+
+            // [] Exception for null string
+            //-----------------------------------------------------------
+
+            // [] Create a directory and check the creation time
+
+            strLoc = "Loc_r8r7j";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            stream = fil2.OpenWrite();
+            stream.Write(new Byte[] { 10 }, 0, 1);
+            stream.Dispose();
+            Task.Delay(4000).Wait();
+            fil2.Refresh();
+            iCountTestcases++;
+            try
+            {
+                // Access time is always shows the midday. For example if you create the file on 3/5/2000. 
+                // The access time should be some thing like... 3/5/2000 12:00:00 AM.
+                DateTime d1 = DateTime.Now;
+                DateTime d2 = fil2.LastAccessTime;
+                if (d1.Year != d2.Year || d1.Month != d2.Month || d1.Month != d2.Month)
+                {
+                    iCountErrors++;
+                    printerr("Error_20hjx! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Bug 14952 Error_20fhd! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+
+
+            // [] 
+
+            strLoc = "Loc_20yxc";
+
+            stream = fil2.Open(FileMode.Open);
+            stream.Read(new Byte[1], 0, 1);
+            stream.Dispose();
+            fil2.Refresh();
+            Task.Delay(1000).Wait();
+            iCountTestcases++;
+            try
+            {
+                DateTime d1 = DateTime.Now;
+                DateTime d2 = fil2.LastAccessTime;
+                if (d1.Year != d2.Year || d1.Month != d2.Month || d1.Month != d2.Month)
+                {
+                    iCountErrors++;
+                    Console.WriteLine((DateTime.Now - fil2.LastAccessTime).TotalMilliseconds);
+                    printerr("Eror_209x9! LastAccessTime is way off");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_209jx! Unexpected exception thrown: " + exc.ToString());
+            }
+            fil2.Delete();
+
+
+            //-----------------------------------------------------------
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_LastWriteTime.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_LastWriteTime.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class FileInfo_get_LastWriteTime
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/09 13:19";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "get_LastWriteTime.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    [OuterLoop]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            Stream stream;
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+
+
+            // [] Exception for null string
+            //-----------------------------------------------------------
+
+            // [] Create a directory and check the creation time
+
+            strLoc = "Loc_r8r7j";
+
+            new FileStream(filName, FileMode.Create).Dispose();
+            fil2 = new FileInfo(filName);
+            stream = fil2.OpenWrite();
+            stream.Write(new Byte[] { 10 }, 0, 1);
+            stream.Dispose();
+            Task.Delay(4000).Wait();
+            fil2.Refresh();
+            iCountTestcases++;
+            if ((DateTime.Now - fil2.LastWriteTime).TotalMilliseconds < 2000 ||
+               (DateTime.Now - fil2.LastWriteTime).TotalMilliseconds > 5000)
+            {
+                iCountErrors++;
+                Console.WriteLine(fil2.LastWriteTime);
+                Console.WriteLine((DateTime.Now - fil2.LastWriteTime).TotalMilliseconds);
+                printerr("Error_20hjx! Last Write Time time cannot be correct");
+            }
+
+
+            // [] 
+
+            strLoc = "Loc_20yxc";
+
+            stream = fil2.Open(FileMode.Open, FileAccess.Read);
+            stream.Read(new Byte[1], 0, 1);
+            stream.Dispose();
+            fil2.Refresh();
+            Task.Delay(2000).Wait();
+            iCountTestcases++;
+            if ((DateTime.Now - fil2.LastWriteTime).TotalMilliseconds < 4000 ||
+               (DateTime.Now - fil2.LastWriteTime).TotalMilliseconds > 7000)
+            {
+                iCountErrors++;
+                Console.WriteLine((DateTime.Now - fil2.LastWriteTime).TotalMilliseconds);
+                printerr("Eror_209x9! LastWriteTime is way off");
+            }
+
+            stream = fil2.Open(FileMode.Open);
+            stream.Write(new Byte[] { 10 }, 0, 1);
+            stream.Dispose();
+            Task.Delay(3000).Wait();
+            fil2.Refresh();
+            iCountTestcases++;
+            if ((DateTime.Now - fil2.LastWriteTime).TotalMilliseconds < 1000 ||
+               (DateTime.Now - fil2.LastWriteTime).TotalMilliseconds > 5000)
+            {
+                iCountErrors++;
+                Console.WriteLine((DateTime.Now - fil2.LastWriteTime).TotalMilliseconds);
+                printerr("Eror_f984f! LastWriteTime is way off");
+            }
+
+
+
+
+            //-----------------------------------------------------------
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Length.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Length.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_get_Length
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/09 11:28";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "get_Length.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+            FileStream fs2;
+            StreamWriter sw2;
+
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            // [] Set negative length
+            //--------------------------------------------------------
+            strLoc = "Loc_98yc8";
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.Dispose();
+            fil2 = new FileInfo(filName);
+            iCountTestcases++;
+            if (fil2.Length != 0)
+            {
+                iCountErrors++;
+                printerr("Error_2898t! Incorrect length==" + fs2.Length);
+            }
+            //--------------------------------------------------------
+
+
+            // [] Set position after end of stream and write a bit
+            //--------------------------------------------------------
+            strLoc = "Loc_27yxc";
+
+            fs2 = new FileStream(filName, FileMode.Create);
+            fs2.SetLength(50);
+            fs2.Position = 50;
+            sw2 = new StreamWriter(fs2);
+            for (char c = 'a'; c < 'f'; c++)
+                sw2.Write(c);
+            sw2.Flush();
+            iCountTestcases++;
+            fil2 = new FileInfo(filName);
+            fs2.Dispose();
+            if (fil2.Length != 55)
+            {
+                iCountErrors++;
+                printerr("Error_389xd! Incorrect stream length==" + fs2.Length + ", filelength==" + fil2.Length);
+            }
+
+            // [] Truncate file by setting length in middle of file
+            strLoc = "Loc_f47yv";
+
+            fs2 = new FileStream(filName, FileMode.Open);
+            fs2.SetLength(30);
+            fs2.Flush();
+            iCountTestcases++;
+            fs2.Dispose();
+            fil2.Refresh();
+            if (fil2.Length != 30)
+            {
+                iCountErrors++;
+                printerr("Error_28xye! Incorrect, filelength==" + fil2.Length);
+            }
+
+            // [] Increase the length by setting the length after end
+
+            strLoc = "Loc_487yv";
+            fs2 = new FileStream(filName, FileMode.Open);
+            fs2.SetLength(100);
+            fs2.Flush();
+            fs2.Dispose();
+            fil2.Refresh();
+            iCountTestcases++;
+            if (fil2.Length != 100)
+            {
+                iCountErrors++;
+                printerr("Error_2090x! Incorrect filelength==" + fil2.Length);
+            }
+            fs2.Dispose();
+            fil2.Refresh();
+            iCountTestcases++;
+            if (fil2.Length != 100)
+            {
+                iCountErrors++;
+                printerr("Error_297ty! Incorrect length==" + fs2.Length);
+            }
+            //--------------------------------------------------------
+
+
+
+
+            //-----------------------------------------------------------------
+
+
+            if (File.Exists(filName))
+                File.Delete(filName);
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Name.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Name.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_get_Name
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/08 12:18";
+    public static String s_strClassMethod = "File.OpenText(String)";
+    public static String s_strTFName = "get_Name.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+    private static String s_strLoc = "Loc_000oo";
+    private static int s_iCountErrors = 0;
+    private static int s_iCountTestcases = 0;
+
+    [Fact]
+    public static void runTest()
+    {
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+            FileInfo fil2;
+
+            // [] Vanilla case
+            //-----------------------------------------------------------------
+            s_strLoc = "Loc_2723d";
+
+            fil2 = new FileInfo("Hello\\file.tmp");
+            s_iCountTestcases++;
+            if (!fil2.Name.Equals("file.tmp"))
+            {
+                s_iCountErrors++;
+                printerr("Error_5yb87! Incorrect name==" + fil2.Name);
+            }
+
+
+            // [] \Directory\File
+            fil2 = new FileInfo("\\Directory\\File");
+            s_iCountTestcases++;
+            if (!fil2.Name.Equals("File"))
+            {
+                s_iCountErrors++;
+                printerr("Error_78288! Incorrect name==" + fil2.Name);
+            }
+
+
+            // [] UNC share
+            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            s_iCountTestcases++;
+            if (!fil2.Name.Equals("File"))
+            {
+                s_iCountErrors++;
+                printerr("Error_67y8b! Incorrect name==" + fil2.Name);
+            }
+
+            // [] Multiple spaces and dots in filename
+            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            s_iCountTestcases++;
+            if (!fil2.Name.Equals("File.tmp hello.blah"))
+            {
+                s_iCountErrors++;
+                printerr("Error_2987b! Incorrect name==" + fil2.Name);
+            }
+
+
+            fil2 = new FileInfo("C://Directory//File");
+            s_iCountTestcases++;
+            if (!fil2.Name.Equals("File"))
+            {
+                s_iCountErrors++;
+                printerr("Error_2y78d! Incorrect name==" + fil2.Name);
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++s_iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + s_strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (s_iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + s_iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, s_iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/set_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/set_Attributes.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_set_Attributes
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer = "2000/05/09 11:28";
+    public static String s_strClassMethod = "File.Directory()";
+    public static String s_strTFName = "set_Attributes.cs";
+    public static String s_strTFPath = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+        String strLoc = "Loc_000oo";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+
+        try
+        {
+            /////////////////////////  START TESTS ////////////////////////////
+            ///////////////////////////////////////////////////////////////////
+
+
+            String filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            FileInfo fil2;
+
+            /*
+              ReadOnly = 0x1,
+              Hidden = 0x2,
+              System = 0x4,
+              Directory = 0x10,
+              Archive = 0x20,
+              Encrypted = 0x40,
+              Normal = 0x80,
+              Temporary = 0x100,
+              SparseFile = 0x200,
+              ReparsePoint = 0x400,
+              Compressed = 0x800,
+              Offline = 0x1000,
+              NotContentIndexed = 0x2000
+            */
+
+            if (File.Exists(filName))
+            {
+                fil2 = new FileInfo(filName);
+                fil2.Attributes = new FileAttributes();
+                File.Delete(filName);
+            }
+
+
+            // [] File does not exist
+            //--------------------------------------------------------
+            strLoc = "loc_2yg8c";
+
+            fil2 = new FileInfo("FileDoesNotExist");
+            iCountTestcases++;
+            try
+            {
+                fil2.Attributes = new FileAttributes();
+                iCountErrors++;
+                printerr("Error_27t8b! Expected exception not thrown");
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_21409! Incorrect exception thrown, exc==" + exc.ToString());
+            }
+
+            //-----------------------------------------------------------------
+
+
+
+
+            File.Create(filName).Dispose();
+
+            /*
+                        // [] Invalid enum value
+                        //-----------------------------------------------------------------
+                        strLoc = "Loc_298g8";
+
+                        fil2 = new FileInfo(filName);
+                        iCountTestcases++;
+                        try {
+                            fil2.Attributes = (FileAttributes)0x4000;
+                            iCountErrors++;
+                            printerr( "Error_28g8b! Expected exception not thrown");
+                        } catch (ArgumentException aexc) {
+                        } catch (Exception exc) {
+                            iCountErrors++;
+                            printerr( "Error_t94u9! Incorrect exception thrown, exc=="+exc.ToString());
+                        }
+
+                        //-----------------------------------------------------------------
+            */
+
+            try
+            {
+                // [] valid data
+                //-----------------------------------------------------------------
+                strLoc = "Loc_48yx9";
+
+                fil2 = new FileInfo(filName);
+                fil2.Attributes = FileAttributes.Hidden;
+                iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support hidden
+            if((fil2.Attributes & FileAttributes.Hidden)!=0) {
+#else
+                if ((fil2.Attributes & FileAttributes.Hidden) == 0)
+                {
+#endif
+                    iCountErrors++;
+                    printerr("ERror_2g985! Hidden not set");
+                }
+                fil2.Attributes = FileAttributes.System | FileAttributes.Normal;
+                fil2.Refresh();
+                iCountTestcases++;
+#if TEST_WINRT  // WinRT doesn't support system
+            if((fil2.Attributes & FileAttributes.System) == FileAttributes.System) {
+#else
+                if ((fil2.Attributes & FileAttributes.System) != FileAttributes.System)
+                {
+#endif
+                    iCountErrors++;
+                    printerr("Error_298g7! System not set");
+                }
+                fil2.Attributes = FileAttributes.Temporary;
+                fil2.Refresh();
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.Temporary) == 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_87tg8! Temporary not set");
+                }
+                //-----------------------------------------------------------------
+
+
+
+                // [] 
+                //-----------------------------------------------------------------
+                strLoc = "Loc_29gy7";
+                fil2 = new FileInfo(filName);
+
+                fil2.Attributes = FileAttributes.ReadOnly;
+                fil2.Refresh();
+                fil2.Attributes = fil2.Attributes | FileAttributes.Encrypted | FileAttributes.Archive;
+                fil2.Refresh();
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
+                {
+                    iCountErrors++;
+                    printerr("Error_g58y8! ReadOnly attribute not set");
+                }
+
+                iCountTestcases++;
+                if ((fil2.Attributes & FileAttributes.Archive) != FileAttributes.Archive)
+                {
+                    iCountErrors++;
+                    printerr("Error_2g78b! Archive attribute not set");
+                }
+                fil2.Attributes = new FileAttributes();
+                //-----------------------------------------------------------------
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_284y8! Unexpected exception thrown, bug 29808, exc==" + exc.ToString());
+            }
+
+            if (File.Exists(filName))
+            {
+                fil2 = new FileInfo(filName);
+                fil2.Attributes = new FileAttributes();
+                File.Delete(filName);
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            /////////////////////////// END TESTS /////////////////////////////
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/FileInfo/set_CreationTime_dt.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/set_CreationTime_dt.cs
@@ -1,0 +1,262 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Collections;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class FileInfo_SetCreationTime_dt
+{
+    public static String s_strActiveBugNums = "";
+    public static String s_strDtTmVer       = "2001/02/13 16.04";
+    public static String s_strClassMethod   = "FileInfo.SetCreationTime";
+    public static String s_strTFName        = "SetCreationTime_dt.cs";
+    public static String s_strTFPath        = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public static void runTest()
+    {
+
+        String strLoc = "Loc_0001";
+        String strValue = String.Empty;
+        int iCountErrors = 0;
+        int iCountTestcases = 0;
+
+        try
+        {
+            String fileName = s_strTFName.Substring(0, s_strTFName.IndexOf('.')) + "_test_" +"TestFile";			                 
+            
+            // [] Valid file name and datetime(Today)
+            strLoc = "Loc_0006" ;
+            FileInfo file2 = new FileInfo(fileName);
+            FileStream fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Today ;
+                if ((File.GetCreationTime(fileName) - DateTime.Now).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0007! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0008! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one year from DateTime.today.
+            strLoc = "Loc_0009";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+                        iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Now.AddYears(1) ;
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddYears(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0010! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0011! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one year from DateTime.today.
+            strLoc = "Loc_0012";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Now.AddYears(-1) ;
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddYears(-1)).Seconds > 0 )
+                {
+                    iCountErrors++;
+                    printerr("Error_0013! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0014! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one month from DateTime.today.
+            strLoc = "Loc_0015";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Now.AddMonths(1);
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddMonths(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0016! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0017! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one month from DateTime.today.
+            strLoc = "Loc_0018";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Now.AddMonths(-1) ;
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0019! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0020! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+            //Add one day from DateTime.today.
+            strLoc = "Loc_0021";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Now.AddDays(1) ;
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddDays(1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0022! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0023! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+            //Subtract one day from DateTime.today.
+            strLoc = "Loc_0024";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = DateTime.Now.AddDays(-1) ;
+                if((File.GetCreationTime(fileName) - DateTime.Now.AddDays(-1)).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_0025! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0026! Unexpected exceptiont thrown: " + exc.ToString());
+            }
+            file2.Delete();
+            
+            //With invalid datetime object.
+            strLoc = "Loc_0025";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                file2.CreationTime = new DateTime(2001,332,20,50,50,50);
+                iCountErrors++;
+                printerr("Error_0026! Creation time cannot be correct");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr( "Error_0027! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+            //With valid date and time. 
+            strLoc = "Loc_0028";
+                        
+            file2 = new FileInfo(fileName);
+            fs2 = file2.Create();
+            fs2.Dispose();                        
+            iCountTestcases++;
+            try
+            {
+                DateTime dt = new DateTime(2001, 2, 2, 20, 20, 20);
+                file2.CreationTime = dt;
+                if((File.GetCreationTime(fileName) - dt ).Seconds > 0)
+                {
+                    iCountErrors++;
+                    printerr( "Error_0029! Creation time cannot be correct");
+                }
+            }
+            catch (Exception exc)
+            {
+                iCountErrors++;
+                printerr("Error_0030! Unexpected exceptiont thrown: "+exc.ToString());
+            }
+            file2.Delete();
+
+        }
+        catch (Exception exc_general)
+        {
+            ++iCountErrors;
+            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+        }
+        ////  Finish Diagnostics
+
+        if (iCountErrors != 0)
+        {
+            Console.WriteLine("FAiL! " + s_strTFName + " ,iCountErrors==" + iCountErrors.ToString());
+        }
+
+        Assert.Equal(0, iCountErrors);
+    }
+
+    public static void printerr(String err, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
+    {
+        Console.WriteLine("ERROR: ({0}, {1}, {2}) {3}", memberName, filePath, lineNumber, err);
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/PortedCommon/CommonUtilities.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/CommonUtilities.cs
@@ -1,0 +1,457 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+This is meant to contain useful utilities for IO related work
+**/
+
+#define TRACE
+#define DEBUG
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+//machine information
+public static class FileSystemDebugInfo
+{
+    public static String MachineInfo()
+    {
+        StringBuilder builder = new StringBuilder(String.Format("{0}/////////Machine Info///////////{0}", Environment.NewLine));
+        builder.AppendLine(String.Format("CurrentDrive NTFS?: {0}", IsCurrentDriveNTFS()));
+        builder.AppendLine(String.Format("////////////////////{0}", Environment.NewLine));
+
+        return builder.ToString();
+    }
+
+    public static bool IsCurrentDriveNTFS()
+    {
+        return IOServices.IsDriveNTFS(IOServices.GetCurrentDrive());
+    }
+
+    public static bool IsPathAdminAccessOnly(String path, bool treatPathAsFilePath)
+    {
+        //we leave invalid paths as valid testcase scenarios and dont filter these
+        //1) We check if the path is root on a system drive
+        //2) @TODO WinDir?
+        String systemDrive = Environment.GetEnvironmentVariable("SystemDrive");
+        Char systemDriveLetter = systemDrive.ToLower()[0];
+        try
+        {
+            String dirName = Path.GetFullPath(path);
+            if (treatPathAsFilePath)
+                dirName = Path.GetDirectoryName(dirName);
+            if ((new DirectoryInfo(dirName)).Parent == null)
+            {
+                if (Path.GetPathRoot(dirName).StartsWith(systemDriveLetter.ToString(), StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+        catch (Exception) { }
+        return false;
+    }
+}
+
+/// <summary>
+/// Due to the increasing number of context indexing services (mssearch.exe, etrust) operating in our test run machines, Directory operations like Delete and Move
+/// are not guaranteed to work in first attempt. This utility class do these operations in a fail safe manner
+/// Possible solutions
+///  - Set FileAttributes.NotContentIndex on the directory. But there is a race between creating the directory and setting this property. Other than using ACL, can't see a good solution
+///  - encourage labs to stop these services before a test run. This is under review by CLRLab but there are lots of other labs that do these too
+///  - fail and retry attempt: which is what this class does
+/// VSW 446086 and 473287 have more information on this.
+/// </summary>
+public static class FailSafeDirectoryOperations
+{
+    /// <summary>
+    /// Deleting
+    /// </summary>
+    /// <param name="path"></param>
+    /// <param name="recursive"></param>
+    private const int MAX_ATTEMPT = 10;
+    public static void DeleteDirectory(String path, bool recursive)
+    {
+        DeleteDirectoryInfo(new DirectoryInfo(path), recursive);
+    }
+
+    public static void DeleteDirectoryInfo(DirectoryInfo dirInfo, bool recursive)
+    {
+        int dirModificationAttemptCount;
+        bool dirModificationOperationThrew;
+        dirModificationAttemptCount = 0;
+        do
+        {
+            dirModificationOperationThrew = false;
+            try
+            {
+                if (dirInfo.Exists)
+                    dirInfo.Delete(recursive);
+            }
+            catch (IOException)
+            {
+                Console.Write("|");
+                dirModificationOperationThrew = true;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Console.Write("}");
+                dirModificationOperationThrew = true;
+            }
+            if (dirModificationOperationThrew)
+            {
+                Task.Delay(5000).Wait();
+            }
+        } while (dirModificationOperationThrew && dirModificationAttemptCount++ < MAX_ATTEMPT);
+        EnsureDirectoryNotExist(dirInfo.FullName);
+        //We want to thrown if the operation failed
+        if (Directory.Exists(dirInfo.FullName))
+            throw new ArgumentException("Throwing from FailSafeDirectoryOperations.DeleteDirectoryInfo. Delete unsucccesfull");
+    }
+
+
+    /// <summary>
+    /// Moving
+    /// </summary>
+    /// <param name="sourceName"></param>
+    /// <param name="destName"></param>
+    public static void MoveDirectory(String sourceName, String destName)
+    {
+        MoveDirectoryInfo(new DirectoryInfo(sourceName), destName);
+    }
+
+    public static DirectoryInfo MoveDirectoryInfo(DirectoryInfo dirInfo, String dirToMove)
+    {
+        int dirModificationAttemptCount;
+        bool dirModificationOperationThrew;
+        dirModificationAttemptCount = 0;
+        String originalDirName = dirInfo.FullName;
+        do
+        {
+            dirModificationOperationThrew = false;
+            try
+            {
+                dirInfo.MoveTo(dirToMove);
+            }
+            catch (IOException)
+            {
+                Console.Write(">");
+                Task.Delay(5000).Wait();
+                dirModificationOperationThrew = true;
+            }
+        } while (dirModificationOperationThrew && dirModificationAttemptCount++ < MAX_ATTEMPT);
+        EnsureDirectoryNotExist(originalDirName);
+        //We want to thrown if the operation failed
+        if (Directory.Exists(originalDirName))
+            throw new ArgumentException("Throwing from FailSafeDirectoryOperations.MoveDirectory. Move unsucccesfull");
+        return dirInfo;
+    }
+
+    /// <summary>
+    /// It can take some time before the Directory.Exists will return false after a direcotry delete/Move
+    /// </summary>
+    /// <param name="path"></param>
+    private static void EnsureDirectoryNotExist(String path)
+    {
+        int dirModificationAttemptCount;
+        dirModificationAttemptCount = 0;
+        while (Directory.Exists(path) && dirModificationAttemptCount++ < MAX_ATTEMPT)
+        {
+            // This is because something like antivirus software or
+            // some disk indexing service has a handle to the directory.  The directory
+            // won't be deleted until all of the handles are closed.
+            Task.Delay(5000).Wait();
+            Console.Write("<");
+        }
+    }
+}
+
+
+
+/// <summary>
+/// This class is meant to create directory and files under it
+/// </summary>
+public class ManageFileSystem : IDisposable
+{
+    private const int DefaultDirectoryDepth = 3;
+    private const int DefaultNumberofFiles = 100;
+    private const int MaxNumberOfSubDirsPerDir = 2;
+    //@TODO
+    public const String DirPrefixName = "Laks_";
+
+    private int _directoryLevel;
+    private int _numberOfFiles;
+    private string _startDir;
+
+    private Random _random;
+
+    private List<String> _listOfFiles;
+    private List<String> _listOfAllDirs;
+    private Dictionary<int, Dictionary<String, List<String>>> _allDirs;
+
+
+    public ManageFileSystem()
+    {
+        Init(GetNonExistingDir(Directory.GetCurrentDirectory(), DirPrefixName), DefaultDirectoryDepth, DefaultNumberofFiles);
+    }
+    public ManageFileSystem(String startDirName)
+        : this(startDirName, DefaultDirectoryDepth, DefaultNumberofFiles)
+    {
+    }
+    public ManageFileSystem(String startDirName, int dirDepth, int numFiles)
+    {
+        Init(startDirName, dirDepth, numFiles);
+    }
+
+    public static String GetNonExistingDir(String parentDir, String prefix)
+    {
+        String tempPath;
+        while (true)
+        {
+            tempPath = Path.Combine(parentDir, String.Format("{0}{1}", prefix, Path.GetFileNameWithoutExtension(Path.GetRandomFileName())));
+            if (!Directory.Exists(tempPath) && !File.Exists(tempPath))
+                break;
+        }
+        return tempPath;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // free other state (managed objects)
+            // set interesting (large) fields to null
+        }
+        // free your own state (unmanaged objects)
+        FailSafeDirectoryOperations.DeleteDirectory(_startDir, true);
+    }
+
+    ~ManageFileSystem()
+    {
+        Dispose(false);
+    }
+
+    private void Init(String startDirName, int dirDepth, int numFiles)
+    {
+        if (Directory.Exists(Path.GetFullPath(startDirName)))
+            throw new ArgumentException(String.Format("ERROR: Directory exists : {0}", _startDir));
+        _startDir = Path.GetFullPath(startDirName);
+        _directoryLevel = dirDepth;
+        _numberOfFiles = numFiles;
+        _random = new Random(-55);
+        CreateFileSystem();
+    }
+
+    /// <summary>
+    /// This API creates a file system under m_startDir, m_DirectoryLevel deep with m_numberOfFiles
+    /// We will store the created information on collections so as to get to them later
+    /// </summary>
+    private void CreateFileSystem()
+    {
+        _listOfFiles = new List<String>();
+        _listOfAllDirs = new List<String>();
+        Directory.CreateDirectory(_startDir);
+        //we will not include this directory
+        //        m_listOfAllDirs.Add(m_startDir);
+
+        String currentWorkingDir = _startDir;
+        String parentDir = _startDir;
+
+        _allDirs = new Dictionary<int, Dictionary<String, List<String>>>();
+        //        List<String> dirsForOneLevel = new List<String>();
+        //        List<String> tempDirsForOneLevel;
+        List<String> filesForThisDir;
+        Dictionary<String, List<String>> dirsForOneLevel = new Dictionary<String, List<String>>();
+        Dictionary<String, List<String>> tempDirsForOneLevel;
+        dirsForOneLevel.Add(_startDir, new List<String>());
+        _allDirs.Add(0, dirsForOneLevel);
+
+        //First we create the directories
+        for (int i = 0; i < (_directoryLevel - 1); i++)
+        {
+            dirsForOneLevel = _allDirs[i];
+            int numOfDirForThisLevel = _random.Next((MaxNumberOfSubDirsPerDir + 1));
+            int numOfDirPerDir = numOfDirForThisLevel / dirsForOneLevel.Count;
+            //@TODO!! we should handle this situation in a better way
+            if (numOfDirPerDir == 0)
+                numOfDirPerDir = 1;
+            //            Trace.Assert(numOfDirPerDir > 0, "Err_897324g! @TODO handle this scenaior");
+            tempDirsForOneLevel = new Dictionary<String, List<String>>();
+            foreach (String dir in dirsForOneLevel.Keys)
+            //                for (int j = 0; j < dirsForOneLevel.Count; j++)
+            {
+                for (int k = 0; k < numOfDirPerDir; k++)
+                {
+                    String dirName = GetNonExistingDir(dir, DirPrefixName);
+                    Debug.Assert(!Directory.Exists(dirName), String.Format("ERR_93472g! Directory exists: {0}", dirName));
+                    tempDirsForOneLevel.Add(dirName, new List<String>());
+                    _listOfAllDirs.Add(dirName);
+                    Directory.CreateDirectory(dirName);
+                }
+            }
+            _allDirs.Add(i + 1, tempDirsForOneLevel);
+        }
+        //Then we add the files 
+        //@TODO!! random or fixed?
+        int numberOfFilePerDirLevel = _numberOfFiles / _directoryLevel;
+        Byte[] bits;
+        for (int i = 0; i < _directoryLevel; i++)
+        {
+            dirsForOneLevel = _allDirs[i];
+            int numOfFilesForThisLevel = _random.Next(numberOfFilePerDirLevel + 1);
+            int numOFilesPerDir = numOfFilesForThisLevel / dirsForOneLevel.Count;
+            //UPDATE: 2/1/2005, we will add at least 1
+            if (numOFilesPerDir == 0)
+                numOFilesPerDir = 1;
+            //            for (int j = 0; j < dirsForOneLevel.Count; j++)
+            foreach (String dir in dirsForOneLevel.Keys)
+            {
+                filesForThisDir = dirsForOneLevel[dir];
+                for (int k = 0; k < numOFilesPerDir; k++)
+                {
+                    String fileName = Path.Combine(dir, Path.GetFileName(Path.GetRandomFileName()));
+                    bits = new Byte[_random.Next(10)];
+                    _random.NextBytes(bits);
+                    File.WriteAllBytes(fileName, bits);
+                    _listOfFiles.Add(fileName);
+                    filesForThisDir.Add(fileName);
+                }
+            }
+        }
+    }
+
+    public String StartDirectory
+    {
+        get { return _startDir; }
+    }
+
+    //some methods to help us
+    public String[] GetDirectories(int level)
+    {
+        Dictionary<String, List<String>> dirsForThisLevel = null;
+        if (_allDirs.TryGetValue(level, out dirsForThisLevel))
+        {
+            //        Dictionary<String, List<String>> dirsForThisLevel = m_allDirs[level];
+            ICollection<String> keys = dirsForThisLevel.Keys;
+            String[] values = new String[keys.Count];
+            keys.CopyTo(values, 0);
+            return values;
+        }
+        else
+            return new String[0];
+    }
+
+    /// <summary>
+    /// Note that this doesn't return the m_startDir
+    /// </summary>
+    /// <returns></returns>
+    public String[] GetAllDirectories()
+    {
+        return _listOfAllDirs.ToArray();
+    }
+
+
+    public String[] GetFiles(String dirName, int level)
+    {
+        String dirFullName = Path.GetFullPath(dirName);
+        Dictionary<String, List<String>> dirsForThisLevel = _allDirs[level];
+        foreach (String dir in dirsForThisLevel.Keys)
+        {
+            if (dir.Equals(dirFullName, StringComparison.CurrentCultureIgnoreCase))
+                return dirsForThisLevel[dir].ToArray();
+        }
+        return null;
+    }
+
+    public String[] GetAllFiles()
+    {
+        return _listOfFiles.ToArray();
+    }
+}
+
+
+public class TestInfo
+{
+    static TestInfo()
+    {
+        CurrentDirectory = Directory.GetCurrentDirectory();
+    }
+
+    public static string CurrentDirectory { get; set; }
+
+    private delegate void ExceptionCode();
+
+    private void DeleteFile(String fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+    }
+
+
+    //Checks for error
+    private static bool Eval(bool expression, String msg, params Object[] values)
+    {
+        return Eval(expression, String.Format(msg, values));
+    }
+
+    private static bool Eval<T>(T actual, T expected, String errorMsg)
+    {
+        bool retValue = expected == null ? actual == null : expected.Equals(actual);
+
+        if (!retValue)
+            Eval(retValue, errorMsg +
+            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
+            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
+
+        return retValue;
+    }
+
+    private static bool Eval(bool expression, String msg)
+    {
+        if (!expression)
+        {
+            Console.WriteLine(msg);
+        }
+        return expression;
+    }
+
+    //Checks for a particular type of exception
+    private static void CheckException<E>(ExceptionCode test, string error)
+    {
+        CheckException<E>(test, error, null);
+    }
+
+    //Checks for a particular type of exception and an Exception msg
+    private static void CheckException<E>(ExceptionCode test, string error, String msgExpected)
+    {
+        bool exception = false;
+        try
+        {
+            test();
+            error = String.Format("{0} Exception NOT thrown ", error);
+        }
+        catch (Exception e)
+        {
+            if (e.GetType() == typeof(E))
+            {
+                exception = true;
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
+                {
+                    exception = false;
+                    error = String.Format("{0} Message Different: <{1}>", error, e.Message);
+                }
+            }
+            else
+                error = String.Format("{0} Exception type: {1}", error, e.GetType().Name);
+        }
+        Eval(exception, error);
+    }
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/DllImports.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/DllImports.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static class DllImports
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern int GetLogicalDrives();
+
+    [DllImport("kernel32.dll", EntryPoint = "GetDiskFreeSpaceExW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+    internal static extern bool GetDiskFreeSpaceEx(String drive, out long freeBytesForUser, out long totalBytes, out long freeBytes);
+
+    [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+    internal static extern bool GetVolumeInformation(String drive, [Out]StringBuilder volumeName, int volumeNameBufLen, out int volSerialNumber, out int maxFileNameLen, out int fileSystemFlags, [Out]StringBuilder fileSystemName, int fileSystemNameBufLen);
+
+    [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "GetDriveTypeW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+    internal static extern int GetDriveType(string drive);
+}
+

--- a/src/System.IO.FileSystem/tests/PortedCommon/EnumerableUtils.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/EnumerableUtils.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EnumerableTests
+{
+    internal class EnumerableUtils
+    {
+        private int _totalFailCount = 0;
+        private int _totalCount = 0;
+
+        public bool Passed
+        {
+            get { return _totalFailCount == 0; }
+        }
+
+        public void PrintTestStatus(String testName, String methodName, int failCount)
+        {
+            _totalCount++;
+
+            Console.WriteLine();
+            Console.WriteLine("--------------------------------");
+            Console.WriteLine("Running Inner Test: {0} ({1})", methodName, testName);
+
+            if (failCount == 0)
+            {
+                Console.WriteLine("---- Inner Test PASSED ---------");
+            }
+            else
+            {
+                _totalFailCount++;
+                Console.WriteLine("---- Inner Test FAILED ---------");
+            }
+        }
+
+        // test setup and tear-down
+        public void CreateTestDirs()
+        {
+            String currentDir = Directory.GetCurrentDirectory();
+            testDir = Path.Combine(currentDir, "FSEnumeratorTest", Path.GetRandomFileName());
+
+            if (Directory.Exists(testDir))
+                Directory.Delete(testDir, true);
+
+            Directory.CreateDirectory(testDir);
+
+            String subDir_a = Path.Combine(testDir, "lev1_a");
+            String subDir_b = Path.Combine(testDir, "lev1_b");
+            String subDir_c = Path.Combine(testDir, "lev1_c");
+
+            Directory.CreateDirectory(subDir_a);
+            Directory.CreateDirectory(subDir_b);
+            Directory.CreateDirectory(subDir_c);
+
+            String subDir_d = Path.Combine(subDir_a, "lev2_d");
+            String subDir_e = Path.Combine(subDir_a, "lev2_e");
+            String subDir_f = Path.Combine(subDir_b, "lev2_f");
+            deepDir = subDir_b;
+
+            Directory.CreateDirectory(subDir_d);
+            Directory.CreateDirectory(subDir_e);
+            Directory.CreateDirectory(subDir_f);
+
+            String file1 = Path.Combine(testDir, "file1");
+            String file2 = Path.Combine(subDir_b, "file2");
+            String file3 = Path.Combine(subDir_f, "file3");
+            deepFile = file2;
+
+            File.WriteAllText(file1, "this is file 1" + Environment.NewLine + "Line 2 in file 1" + Environment.NewLine + "Line 3 in file 1" + Environment.NewLine + "Line 4 in file 1");
+            File.WriteAllText(file2, "this is file 2");
+            File.WriteAllText(file3, "this is file 3");
+
+            expected_Dirs_Deep = new HashSet<String>();
+            expected_Dirs_Deep.Add(subDir_a);
+            expected_Dirs_Deep.Add(subDir_b);
+            expected_Dirs_Deep.Add(subDir_c);
+            expected_Dirs_Deep.Add(subDir_d);
+            expected_Dirs_Deep.Add(subDir_e);
+            expected_Dirs_Deep.Add(subDir_f);
+
+            expected_Dirs_Shallow = new HashSet<String>();
+            expected_Dirs_Shallow.Add(subDir_a);
+            expected_Dirs_Shallow.Add(subDir_b);
+            expected_Dirs_Shallow.Add(subDir_c);
+
+            expected_Files_Deep = new HashSet<String>();
+            expected_Files_Deep.Add(file1);
+            expected_Files_Deep.Add(file2);
+            expected_Files_Deep.Add(file3);
+
+            expected_Files_Shallow = new HashSet<String>();
+            expected_Files_Shallow.Add(file1);
+
+            expected_Dirs_Subdir = new HashSet<String>();
+            expected_Dirs_Subdir.Add(subDir_d);
+            expected_Dirs_Subdir.Add(subDir_e);
+
+            expected_Dirs_Lev2SearchPattern = new HashSet<String>();
+            expected_Dirs_Lev2SearchPattern.Add(subDir_d);
+            expected_Dirs_Lev2SearchPattern.Add(subDir_e);
+            expected_Dirs_Lev2SearchPattern.Add(subDir_f);
+
+            expected_Dirs_ExactSearchPattern = new HashSet<String>();
+            expected_Dirs_ExactSearchPattern.Add(subDir_f);
+
+            FSIEntry entry_a = new FSIEntry("lev1_a", subDir_a, null, "lev1_a");
+            FSIEntry entry_b = new FSIEntry("lev1_b", subDir_b, null, "lev1_b");
+            FSIEntry entry_c = new FSIEntry("lev1_c", subDir_c, null, "lev1_c");
+            FSIEntry entry_d = new FSIEntry("lev2_d", subDir_d, null, "lev2_d");
+            FSIEntry entry_e = new FSIEntry("lev2_e", subDir_e, null, "lev2_e");
+            FSIEntry entry_f = new FSIEntry("lev2_f", subDir_f, null, "lev2_f");
+
+            FSIEntry entry_1 = new FSIEntry("file1", file1, testDir, "file1");
+            FSIEntry entry_2 = new FSIEntry("file2", file2, subDir_b, "file2");
+            FSIEntry entry_3 = new FSIEntry("file3", file3, subDir_f, "file3");
+
+            expected_Dirs_Deep_FSI = new HashSet<FSIEntry>();
+            expected_Dirs_Deep_FSI.Add(entry_a);
+            expected_Dirs_Deep_FSI.Add(entry_b);
+            expected_Dirs_Deep_FSI.Add(entry_c);
+            expected_Dirs_Deep_FSI.Add(entry_d);
+            expected_Dirs_Deep_FSI.Add(entry_e);
+            expected_Dirs_Deep_FSI.Add(entry_f);
+
+            expected_Dirs_Shallow_FSI = new HashSet<FSIEntry>();
+            expected_Dirs_Shallow_FSI.Add(entry_a);
+            expected_Dirs_Shallow_FSI.Add(entry_b);
+            expected_Dirs_Shallow_FSI.Add(entry_c);
+
+            expected_Files_Deep_FSI = new HashSet<FSIEntry>();
+            expected_Files_Deep_FSI.Add(entry_1);
+            expected_Files_Deep_FSI.Add(entry_2);
+            expected_Files_Deep_FSI.Add(entry_3);
+
+            expected_Files_Shallow_FSI = new HashSet<FSIEntry>();
+            expected_Files_Shallow_FSI.Add(entry_1);
+
+            expected_Dirs_Subdir_FSI = new HashSet<FSIEntry>();
+            expected_Dirs_Subdir_FSI.Add(entry_d);
+            expected_Dirs_Subdir_FSI.Add(entry_e);
+        }
+
+        public static string GetUnusedDrive()
+        {
+            return IOServices.GetNonExistentDrive();
+        }
+
+        public void DeleteTestDirs()
+        {
+            bool deleted = false; int attemptsRemaining = 5;
+            while (!deleted && attemptsRemaining > 0)
+            {
+                try
+                {
+                    if (Directory.Exists(testDir))
+                        Directory.Delete(testDir, true);
+                    deleted = true;
+                    break;
+                }
+                catch (IOException)
+                {
+                    if (-attemptsRemaining == 0)
+                        throw;
+                    else
+                        Task.Delay(200).Wait();
+                }
+            }
+        }
+
+        public void ChangeFSAdd()
+        {
+            String subDir_a = Path.Combine(testDir, "lev1_a");
+            String subDir_b = Path.Combine(testDir, "lev1_b");
+            String subDir_c = Path.Combine(testDir, "lev1_c");
+            String subDir_d = Path.Combine(subDir_a, "lev2_d");
+            String subDir_e = Path.Combine(subDir_a, "lev2_e");
+            String subDir_f = Path.Combine(subDir_b, "lev2_f");
+
+            String file1 = Path.Combine(testDir, "file1");
+            String file2 = Path.Combine(subDir_b, "file2");
+            String file3 = Path.Combine(subDir_f, "file3");
+
+            String newDir = Path.Combine(subDir_b, "newDir");
+            String newFile = Path.Combine(subDir_c, "newFile");
+
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(newFile, "new file");
+
+            expected_Dirs_Changed = new HashSet<String>();
+            expected_Dirs_Changed.Add(subDir_a);
+            expected_Dirs_Changed.Add(subDir_b);
+            expected_Dirs_Changed.Add(subDir_c);
+            expected_Dirs_Changed.Add(subDir_d);
+            expected_Dirs_Changed.Add(subDir_e);
+            expected_Dirs_Changed.Add(subDir_f);
+            expected_Dirs_Changed.Add(newDir);
+
+            expected_Files_Changed = new HashSet<String>();
+            expected_Files_Changed.Add(file1);
+            expected_Files_Changed.Add(file2);
+            expected_Files_Changed.Add(newFile);
+            expected_Files_Changed.Add(file3);
+        }
+
+        public void ChangeFSDelete()
+        {
+            String subDir_a = Path.Combine(testDir, "lev1_a");
+            String subDir_b = Path.Combine(testDir, "lev1_b");
+            String subDir_c = Path.Combine(testDir, "lev1_c");
+            String subDir_f = Path.Combine(subDir_b, "lev2_f");
+
+            String file1 = Path.Combine(testDir, "file1");
+            String file2 = Path.Combine(subDir_b, "file2");
+            String file3 = Path.Combine(subDir_f, "file3");
+
+            Directory.Delete(subDir_a, true); // also deletes d and e
+            File.Delete(file1);
+            File.Delete(file3);
+
+            expected_Dirs_Changed = new HashSet<String>();
+            expected_Dirs_Changed.Add(subDir_a); // enumerated before delete
+            expected_Dirs_Changed.Add(subDir_b);
+            expected_Dirs_Changed.Add(subDir_c);
+            expected_Dirs_Changed.Add(subDir_f);
+
+            expected_Files_Changed = new HashSet<String>();
+            expected_Files_Changed.Add(file1);  // enumerated before delete
+            expected_Files_Changed.Add(file2);
+        }
+
+        public String testDir;
+        public String deepDir;
+        public String deepFile;
+        public HashSet<String> expected_Dirs_Deep;
+        public HashSet<String> expected_Dirs_Shallow;
+        public HashSet<String> expected_Dirs_Subdir;
+        public HashSet<String> expected_Dirs_Lev2SearchPattern;
+        public HashSet<String> expected_Files_Deep;
+        public HashSet<String> expected_Files_Shallow;
+        public HashSet<String> expected_Dirs_ExactSearchPattern;
+        public HashSet<String> expected_Dirs_Changed;
+        public HashSet<String> expected_Files_Changed;
+
+        public HashSet<FSIEntry> expected_Dirs_Deep_FSI;
+        public HashSet<FSIEntry> expected_Dirs_Shallow_FSI;
+        public HashSet<FSIEntry> expected_Dirs_Subdir_FSI;
+        public HashSet<FSIEntry> expected_Files_Deep_FSI;
+        public HashSet<FSIEntry> expected_Files_Shallow_FSI;
+
+        public delegate IEnumerable<String> ReadFastDelegate1(String path);
+        public delegate IEnumerable<String> ReadFastDelegate2(String path, Encoding encoding);
+        public delegate void WriteFastDelegate1(String path, IEnumerable<String> contents);
+        public delegate void WriteFastDelegate2(String path, IEnumerable<String> contents, Encoding encoding);
+        public delegate void AppendFastDelegate1(String path, IEnumerable<String> contents);
+        public delegate void AppendFastDelegate2(String path, IEnumerable<String> contents, Encoding encoding);
+
+        public delegate String[] GetFSEs0(String path);
+        public delegate String[] GetFSEs1(String path, String pattern);
+        public delegate String[] GetFSEs2(String path, String pattern, SearchOption option);
+        public delegate IEnumerable<String> GetFSEsFast0(String path);
+        public delegate IEnumerable<String> GetFSEsFast1(String path, String pattern);
+        public delegate IEnumerable<String> GetFSEsFast2(String path, String pattern, SearchOption option);
+    }
+
+    public sealed class FSIEntry
+    {
+        public FSIEntry(String Name, String FullName, String DirectoryName, String ToString)
+        {
+            this.Name = Name;
+            this.FullName = FullName;
+            this.DirectoryName = DirectoryName;
+            this.ToStr = ToString;
+        }
+
+        public String Name;
+        public String FullName;
+        public String DirectoryName;
+        public String ToStr;
+
+        public override bool Equals(Object o)
+        {
+            FSIEntry other = o as FSIEntry;
+            if (other == null) return false;
+            return this.Name == other.Name &&
+                this.FullName == other.FullName &&
+                this.DirectoryName == other.DirectoryName &&
+                this.ToStr == other.ToStr;
+        }
+
+        public override int GetHashCode()
+        {
+            int hc = Name.GetHashCode() + FullName.GetHashCode() + ToStr.GetHashCode();
+            if (DirectoryName != null)
+            {
+                hc += DirectoryName.GetHashCode();
+            }
+            return hc;
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+internal static class IOInputs
+{
+    // see: http://msdn.microsoft.com/en-us/library/aa365247.aspx
+    private static readonly char[] s_invalidFileNameCharsInvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+    private static readonly char[] s_invalidFileNameChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31, ':', '*', '?' };
+
+
+    public const int MaxDirectory = 247; // Does not include trailing \0. This the maximum length that can be passed to APIs taking directory names, such as Directory.CreateDirectory, Directory.Move
+    public const int MaxPath = 259;      // Does not include trailing \0.
+    public const int MaxComponent = 255;
+
+    public static IEnumerable<string> GetValidPathComponentNames()
+    {
+        yield return Path.GetRandomFileName();
+        yield return "!@#$%^&";
+        yield return "\x65e5\x672c\x8a9e";
+        yield return "A";
+        yield return " A";
+        yield return "  A";
+        yield return "FileName";
+        yield return "FileName.txt";
+        yield return " FileName";
+        yield return " FileName.txt";
+        yield return "  FileName";
+        yield return "  FileName.txt";
+        yield return "This is a valid component name";
+        yield return "This is a valid component name.txt";
+        yield return "V1.0.0.0000";
+    }
+
+    public static IEnumerable<string> GetNonSignificantTrailingWhiteSpace()
+    {
+        yield return " ";
+        yield return "  ";
+        yield return "   ";
+        yield return "    ";
+        yield return "     ";
+        yield return "\t";
+        yield return "\t\t";
+        yield return "\t\t\t";
+        yield return "\n";
+        yield return "\n\n";
+        yield return "\n\n\n";
+        yield return "\t\n";
+        yield return "\t\n\t\n";
+        yield return "\n\t\n";
+        yield return "\n\t\n\t";
+    }
+
+    public static IEnumerable<string> GetUncPathsWithoutShareName()
+    {
+        yield return @"\\";
+        yield return @"\\ ";
+        yield return @"\\\\\\\\\\\\";
+        yield return @"\\S";
+        yield return @"\\S ";
+        yield return @"\\Server";
+        yield return @"\\Server \";
+        yield return @"\\Server \\";
+        yield return @"\\Server\ ";
+        yield return @"\\Server\\ ";
+
+        // check alt dir seperator character as well
+        yield return @"//";
+        yield return @"// ";
+        yield return @"////////////";
+        yield return @"//S";
+        yield return @"//S ";
+        yield return @"//Server";
+        yield return @"//Server /";
+        yield return @"//Server //";
+        yield return @"//Server/ ";
+        yield return @"//Server// ";
+    }
+
+    public static IEnumerable<string> GetPathsWithReservedDeviceNames()
+    {
+        foreach (string deviceName in GetReservedDeviceNames())
+        {
+            yield return deviceName;
+        }
+
+        foreach (string deviceName in GetReservedDeviceNames())
+        {
+            yield return @"C:\" + deviceName;
+        }
+
+        foreach (string deviceName in GetReservedDeviceNames())
+        {
+            yield return @"C:\Directory\" + deviceName;
+        }
+
+        foreach (string deviceName in GetReservedDeviceNames())
+        {
+            yield return @"\\Server\" + deviceName;
+        }
+    }
+
+    public static IEnumerable<string> GetPathsWithAlternativeDataStreams()
+    {
+        yield return @"AA:";
+        yield return @"AAA:";
+        yield return @"AA:A";
+        yield return @"AAA:A";
+        yield return @"AA:AA";
+        yield return @"AAA:AA";
+        yield return @"AA:AAA";
+        yield return @"AAA:AAA";
+        yield return @"AA:FileName";
+        yield return @"AAA:FileName";
+        yield return @"AA:FileName.txt";
+        yield return @"AAA:FileName.txt";
+        yield return @"A:FileName.txt:";
+        yield return @"AA:FileName.txt:AA";
+        yield return @"AAA:FileName.txt:AAA";
+        yield return @"C:\:";
+        yield return @"C:\:FileName";
+        yield return @"C:\:FileName.txt";
+        yield return @"C:\fileName:";
+        yield return @"C:\fileName:FileName.txt";
+        yield return @"C:\fileName:FileName.txt:";
+        yield return @"C:\fileName:FileName.txt:AA";
+        yield return @"C:\fileName:FileName.txt:AAA";
+        yield return @"ftp://fileName:FileName.txt:AAA";
+    }
+
+    public static IEnumerable<string> GetPathsWithInvalidCharacters()
+    {
+        // NOTE: That I/O treats "file"/http" specially and throws ArgumentException.
+        // Otherwise, it treats all other urls as alternative data streams
+
+        yield return @":";
+        yield return @" :";
+        yield return @"  :";
+        yield return @"C::";
+        yield return @"C::FileName";
+        yield return @"C::FileName.txt";
+        yield return @"C::FileName.txt:";
+        yield return @"C::FileName.txt::";
+        yield return @":f";
+        yield return @":filename";
+        yield return @"file:";
+        yield return @"file:file";
+        yield return @"http:";
+        yield return @"http:/";
+        yield return @"http://";
+        yield return @"http://www";
+        yield return @"http://www.microsoft.com";
+        yield return @"http://www.microsoft.com/index.html";
+        yield return @"http://server";
+        yield return @"http://server/";
+        yield return @"http://server/home";
+        yield return @"file://";
+        yield return @"file:///C|/My Documents/ALetter.html";
+        yield return @"\\?\";
+        yield return @"\\?\UNC\";
+        yield return @"\\?\UNC\Server";
+        yield return @"\\?\UNC\Server\Share";
+        yield return @"\\?\UNC\Server\Share\FileName.txt";
+
+        /* Bug 1011730.  CoreCLR checks : before invalid characters and throws NotSupportedException for these.
+        yield return @"\\?\C:";
+        yield return @"\\?\C:\";
+        yield return @"\\?\C:\Windows";
+        yield return @"\\?\C:\Windows\FileName.txt";
+        */
+
+        foreach (char c in s_invalidFileNameChars)
+        {
+            yield return c.ToString();
+        }
+    }
+
+    public static IEnumerable<string> GetPathsWithComponentLongerThanMaxComponent()
+    {
+        // While paths themselves can be up to and including 32,000 characters, most volumes
+        // limit each component of the path to a total of 255 characters.
+
+        string component = new string('s', MaxComponent + 1);
+
+        yield return String.Format(@"C:\{0}", component);
+        yield return String.Format(@"C:\{0}\Filename.txt", component);
+        yield return String.Format(@"C:\{0}\Filename.txt\", component);
+        yield return String.Format(@"\\{0}\Share", component);
+        yield return String.Format(@"\\Server\{0}", component);
+        yield return String.Format(@"\\Server\{0}\FileName.txt", component);
+        yield return String.Format(@"\\Server\Share\{0}", component);
+    }
+
+    public static IEnumerable<string> GetPathsLongerThanMaxDirectory()
+    {
+        yield return GetLongPath(MaxDirectory + 1);
+        yield return GetLongPath(MaxDirectory + 2);
+        yield return GetLongPath(MaxDirectory + 3);
+    }
+
+    public static IEnumerable<string> GetPathsLongerThanMaxPath()
+    {
+        yield return GetLongPath(MaxPath + 1);
+        yield return GetLongPath(MaxPath + 2);
+        yield return GetLongPath(MaxPath + 3);
+        yield return GetLongPath(Int16.MaxValue);
+        yield return GetLongPath(Int16.MaxValue + 1);
+    }
+
+    private static string GetLongPath(int characterCount)
+    {
+        return IOServices.GetPath(characterCount).FullPath;
+    }
+
+    private static IEnumerable<string> GetReservedDeviceNames()
+    {   // See: http://msdn.microsoft.com/en-us/library/aa365247.aspx
+        yield return "CON";
+        yield return "AUX";
+        yield return "NUL";
+        yield return "PRN";
+        yield return "COM1";
+        yield return "COM2";
+        yield return "COM3";
+        yield return "COM4";
+        yield return "COM5";
+        yield return "COM6";
+        yield return "COM7";
+        yield return "COM8";
+        yield return "COM9";
+        yield return "LPT1";
+        yield return "LPT2";
+        yield return "LPT3";
+        yield return "LPT4";
+        yield return "LPT5";
+        yield return "LPT6";
+        yield return "LPT7";
+        yield return "LPT8";
+        yield return "LPT9";
+    }
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+internal class IOServices
+{
+    public static IEnumerable<string> GetReadyDrives()
+    {
+        foreach (string drive in GetLogicalDrives())
+        {
+            if (IsReady(drive))
+                yield return drive;
+        }
+    }
+
+    public static string GetNotReadyDrive()
+    {
+        string[] drives = GetLogicalDrives();
+        foreach (string drive in drives)
+        {
+            if (!IsReady(drive))
+                return drive;
+        }
+
+        return null;
+    }
+
+    public static string GetNonExistentDrive()
+    {
+        string[] availableDrives = GetLogicalDrives();
+
+        for (char drive = 'A'; drive <= 'Z'; drive++)
+        {
+            if (!availableDrives.Contains(drive + @":\"))
+                return drive + @":\";
+        }
+
+        return null;
+    }
+
+    public static string GetNtfsDriveOtherThanCurrent()
+    {
+        return GetNtfsDriveOtherThan(GetCurrentDrive());
+    }
+
+    public static string GetNtfsDriveOtherThan(string drive)
+    {
+        foreach (string otherDrive in GetLogicalDrives())
+        {
+            if (string.Equals(drive, otherDrive, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!IsFixed(otherDrive))
+                continue;
+
+            if (!IsReady(otherDrive))
+                continue;
+
+            if (IsDriveNTFS(otherDrive))
+                return otherDrive;
+        }
+
+        return null;
+    }
+
+    public static string GetNonNtfsDriveOtherThanCurrent()
+    {
+        return GetNonNtfsDriveOtherThan(GetCurrentDrive());
+    }
+
+    public static string GetNonNtfsDriveOtherThan(string drive)
+    {
+        foreach (string otherDrive in GetLogicalDrives())
+        {
+            if (string.Equals(drive, otherDrive, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!IsReady(otherDrive))
+                continue;
+
+            if (!IsDriveNTFS(otherDrive))
+                return otherDrive;
+        }
+
+        return null;
+    }
+
+
+    public static PathInfo GetPath(int characterCount)
+    {
+        return GetPath("C:", characterCount);
+    }
+
+    public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent = IOInputs.MaxComponent)
+    {
+        List<string> paths = new List<string>();
+        rootPath = rootPath.TrimEnd('\\', '/');
+
+        StringBuilder path = new StringBuilder(characterCount);
+        path.Append(rootPath);
+
+        while (path.Length < characterCount)
+        {
+            path.Append('\\');
+            if (path.Length == characterCount)
+                break;
+
+            // Components need to be in 255 character increments
+            path.Append(new string('A', Math.Min(maxComponent, characterCount - path.Length)));
+            paths.Add(path.ToString());
+        }
+
+        Assert.Equal(path.Length, characterCount);
+
+        return new PathInfo(paths.ToArray());
+    }
+
+    public static IEnumerable<string> CreateDirectories(string rootPath, params string[] names)
+    {
+        List<string> paths = new List<string>();
+
+        foreach (string name in names)
+        {
+            string path = Path.Combine(rootPath, name);
+
+            Directory.CreateDirectory(path);
+
+            paths.Add(path);
+        }
+
+        return paths;
+    }
+
+    public static IEnumerable<string> CreateFiles(string rootPath, params string[] names)
+    {
+        List<string> paths = new List<string>();
+
+        foreach (string name in names)
+        {
+            string path = Path.Combine(rootPath, name);
+
+            FileStream stream = File.Create(path);
+            stream.Dispose();
+
+            paths.Add(path);
+        }
+
+        return paths;
+    }
+
+    public static string AddTrailingSlashIfNeeded(string path)
+    {
+        if (path.Length > 0 && path[path.Length - 1] != Path.DirectorySeparatorChar && path[path.Length - 1] != Path.AltDirectorySeparatorChar)
+        {
+            path = path + Path.DirectorySeparatorChar;
+        }
+
+        return path;
+    }
+
+    public static string RemoveTrailingSlash(string path)
+    {
+        return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static string[] GetLogicalDrives()
+    {   // From .NET Framework's Directory.GetLogicalDrives
+        int drives = DllImports.GetLogicalDrives();
+        if (drives == 0)
+            throw new InvalidOperationException();
+
+        uint d = (uint)drives;
+        int count = 0;
+        while (d != 0)
+        {
+            if (((int)d & 1) != 0) count++;
+            d >>= 1;
+        }
+        string[] result = new string[count];
+        char[] root = new char[] { 'A', ':', '\\' };
+        d = (uint)drives;
+        count = 0;
+        while (d != 0)
+        {
+            if (((int)d & 1) != 0)
+            {
+                result[count++] = new string(root);
+            }
+            d >>= 1;
+            root[0]++;
+        }
+
+        return result;
+    }
+
+    private static string GetDriveFormat(string driveName)
+    {
+        const int volNameLen = 50;
+        StringBuilder volumeName = new StringBuilder(volNameLen);
+        const int fileSystemNameLen = 50;
+        StringBuilder fileSystemName = new StringBuilder(fileSystemNameLen);
+        int serialNumber, maxFileNameLen, fileSystemFlags;
+
+        bool r = DllImports.GetVolumeInformation(driveName, volumeName, volNameLen, out serialNumber, out maxFileNameLen, out fileSystemFlags, fileSystemName, fileSystemNameLen);
+        if (!r)
+        {
+            throw new IOException("DriveName: " + driveName + " ErrorCode:" + Marshal.GetLastWin32Error());
+        }
+
+        return fileSystemName.ToString();
+    }
+
+    public static string GetCurrentDrive()
+    {
+        return Path.GetPathRoot(Directory.GetCurrentDirectory());
+    }
+
+    public static bool IsDriveNTFS(string drive)
+    {
+#if TEST_WINRT
+        // we cannot determine filesystem so assume NTFS
+        return true;
+#else
+        return GetDriveFormat(drive) == "NTFS";
+#endif
+    }
+
+    public static long GetAvailableFreeBytes(string drive)
+    {
+        long ignored;
+        long userBytes;
+        if (!DllImports.GetDiskFreeSpaceEx(drive, out userBytes, out ignored, out ignored))
+        {
+            throw new IOException("DriveName: " + drive + " ErrorCode:" + Marshal.GetLastWin32Error());
+        }
+
+        return userBytes;
+    }
+
+    private static bool IsReady(string drive)
+    {
+        const int ERROR_NOT_READY = 0x00000015;
+
+        long ignored;
+        if (!DllImports.GetDiskFreeSpaceEx(drive, out ignored, out ignored, out ignored))
+        {
+            return Marshal.GetLastWin32Error() != ERROR_NOT_READY;
+        }
+
+        return true;
+    }
+
+    private static bool IsFixed(string drive)
+    {
+        return DllImports.GetDriveType(drive) == 3;
+    }
+}
+

--- a/src/System.IO.FileSystem/tests/PortedCommon/PathInfo.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/PathInfo.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+internal class PathInfo
+{
+    private readonly string[] _paths;
+
+    public PathInfo(string[] paths)
+    {
+        _paths = paths;
+    }
+
+    /// <summary>
+    ///  Gets the sub paths that make up this path. For example, in "C:\Windows\System32", this would return "C:", "C:\Windows", "C:\Windows\System32".
+    /// </summary>
+    public string[] SubPaths
+    {
+        get { return _paths; }
+    }
+
+    public string FullPath
+    {
+        get { return _paths[_paths.Length - 1]; }
+    }
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+This is meant to contain useful utilities for IO related work in ReparsePoints
+ - MountVolume
+ - Encryption
+**/
+#define TRACE
+#define DEBUG
+
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+public static class MountHelper
+{
+    [DllImport("api-ms-win-core-file-l1-2-0.dll", EntryPoint = "GetVolumeNameForVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
+    private static extern bool GetVolumeNameForVolumeMountPoint(String volumeName, StringBuilder uniqueVolumeName, int uniqueNameBufferCapacity);
+    // unique volume name must be "\\?\Volume{GUID}\"
+    [DllImport("api-ms-win-core-kernel32-legacy-l1-1-1.dll", EntryPoint = "SetVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
+    private static extern bool SetVolumeMountPoint(String mountPoint, String uniqueVolumeName);
+    [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
+    private static extern bool DeleteVolumeMountPoint(String mountPoint);
+
+    public static void Mount(String volumeName, String mountPoint)
+    {
+
+        if (volumeName[volumeName.Length - 1] != Path.DirectorySeparatorChar)
+            volumeName += Path.DirectorySeparatorChar;
+        if (mountPoint[mountPoint.Length - 1] != Path.DirectorySeparatorChar)
+            mountPoint += Path.DirectorySeparatorChar;
+
+        Console.WriteLine(String.Format("Mounting volume {0} at {1}", volumeName, mountPoint));
+        bool r;
+        StringBuilder sb = new StringBuilder(1024);
+        r = GetVolumeNameForVolumeMountPoint(volumeName, sb, sb.Capacity);
+        if (!r)
+            throw new Exception(String.Format("Win32 error: {0}", Marshal.GetLastWin32Error()));
+
+        String uniqueName = sb.ToString();
+        Console.WriteLine(String.Format("uniqueName: <{0}>", uniqueName));
+        r = SetVolumeMountPoint(mountPoint, uniqueName);
+        if (!r)
+            throw new Exception(String.Format("Win32 error: {0}", Marshal.GetLastWin32Error()));
+        Task.Delay(100).Wait(); // adding sleep for the file system to settle down so that reparse point mounting works
+    }
+
+    public static void Unmount(String mountPoint)
+    {
+        if (mountPoint[mountPoint.Length - 1] != Path.DirectorySeparatorChar)
+            mountPoint += Path.DirectorySeparatorChar;
+        Console.WriteLine(String.Format("Unmounting the volume at {0}", mountPoint));
+
+        bool r = DeleteVolumeMountPoint(mountPoint);
+        if (!r)
+            throw new Exception(String.Format("Win32 error: {0}", Marshal.GetLastWin32Error()));
+    }
+
+    /// For standalone debugging help. Change Main0 to Main
+     public static void Main0(String[] args)
+    {
+	 	try
+        {
+			if(args[0]=="-m")
+				Mount(args[1], args[2]);
+			if(args[0]=="-u")
+				Unmount(args[1]);
+ 		}
+        catch(Exception ex)
+        {
+	 		Console.WriteLine(ex);
+		}
+    }	
+
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/TemporaryDirectory.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/TemporaryDirectory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using IOPath = System.IO.Path;
+
+internal class TemporaryDirectory : TemporaryFileSystemItem<DirectoryInfo>
+{
+    public TemporaryDirectory()
+        : base(CreateTemporaryDirectoryInfo())
+    {
+    }
+
+    protected override void Delete()
+    {
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, true);
+        }
+    }
+
+    private static DirectoryInfo CreateTemporaryDirectoryInfo()
+    {
+        string path = IOPath.Combine(TestInfo.CurrentDirectory, IOPath.GetRandomFileName());
+
+        return Directory.CreateDirectory(path);
+    }
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/TemporaryFile.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/TemporaryFile.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using IOPath = System.IO.Path;
+
+internal class TemporaryFile : TemporaryFileSystemItem<FileInfo>
+{
+    public TemporaryFile()
+        : base(new FileInfo(IOPath.GetTempFileName()))
+    {
+    }
+
+    protected override void Delete()
+    {
+        File.Delete(Path);
+    }
+}

--- a/src/System.IO.FileSystem/tests/PortedCommon/TemporaryFileSystemItem.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/TemporaryFileSystemItem.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using IOPath = System.IO.Path;
+
+internal abstract class TemporaryFileSystemItem<T> : IDisposable
+    where T : FileSystemInfo
+{
+    private readonly T _info;
+
+    protected TemporaryFileSystemItem(T info)
+    {
+#if !TEST_WINRT  // TODO: reenable once DirectoryInfo adapter is in place
+        Debug.Assert(info.Exists);
+#endif
+
+        _info = info;
+    }
+
+    public string Path
+    {
+        get { return _info.FullName; }
+    }
+
+    public string Drive
+    {
+        get { return IOServices.RemoveTrailingSlash(IOPath.GetPathRoot(_info.FullName)); }
+    }
+
+    public T Info
+    {
+        get { return _info; }
+    }
+
+    public bool IsReadOnly
+    {
+        get { return (_info.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly; }
+        set
+        {
+            if (value)
+            {
+                _info.Attributes |= FileAttributes.ReadOnly;
+            }
+            else
+            {
+                _info.Attributes &= ~FileAttributes.ReadOnly;
+            }
+        }
+    }
+
+    public bool IsHidden
+    {
+        get { return (_info.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden; }
+        set
+        {
+            if (value)
+            {
+                _info.Attributes |= FileAttributes.Hidden;
+            }
+            else
+            {
+                _info.Attributes &= ~FileAttributes.Hidden;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Info.Exists && IsReadOnly)
+        {
+            IsReadOnly = false;
+        }
+
+        Delete();
+    }
+
+    protected abstract void Delete();
+}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -33,6 +33,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <!-- Rewritten -->
+    <Compile Include="DirectoryInfo\Create.cs" />
+    <Compile Include="DirectoryInfo\CreateSubdirectory_str.cs" />
+    <Compile Include="DirectoryInfo\ctor_str.cs" />
+    <Compile Include="DirectoryInfo\Delete.cs" />
+    <Compile Include="DirectoryInfo\Delete_bool.cs" />
     <Compile Include="DirectoryInfo\Exists.cs" />
     <Compile Include="FileStream\Flush.Sharing.cs" />
     <Compile Include="FileStream\Flush_toDisk.cs" />
@@ -72,6 +78,136 @@
     <Compile Include="UnseekableFileStream.cs" />
     <Compile Include="FSAssert.cs" />
     <Compile Include="FileSystemTest.cs" />
+    
+    <!-- Ported -->
+
+    <Compile Include="PortedCommon\CommonUtilities.cs" />
+    <Compile Include="PortedCommon\DllImports.cs" />
+    <Compile Include="PortedCommon\EnumerableUtils.cs" />
+    <Compile Include="PortedCommon\IOInputs.cs" />
+    <Compile Include="PortedCommon\IOServices.cs" />
+    <Compile Include="PortedCommon\PathInfo.cs" />
+    <Compile Include="PortedCommon\ReparsePointUtilities.cs" />
+    <Compile Include="PortedCommon\TemporaryDirectory.cs" />
+    <Compile Include="PortedCommon\TemporaryFile.cs" />
+    <Compile Include="PortedCommon\TemporaryFileSystemItem.cs" />
+    <Compile Include="DirectoryInfo\DirectoryInfo_EnumerableAPIs.cs" />
+    <Compile Include="DirectoryInfo\GetDirectories.cs" />
+    <Compile Include="DirectoryInfo\GetDirectories_str.cs" />
+    <Compile Include="DirectoryInfo\GetDirectories_str_so.cs" />
+    <Compile Include="DirectoryInfo\GetFiles.cs" />
+    <Compile Include="DirectoryInfo\GetFiles_str.cs" />
+    <Compile Include="DirectoryInfo\GetFiles_str_so.cs" />
+    <Compile Include="DirectoryInfo\GetFileSystemInfos.cs" />
+    <Compile Include="DirectoryInfo\GetFileSystemInfos_str.cs" />
+    <Compile Include="DirectoryInfo\Refresh.cs" />
+    <Compile Include="DirectoryInfo\set_Attributes.cs" />
+    <Compile Include="DirectoryInfo\SetCreationTime_dt.cs" />
+    <Compile Include="DirectoryInfo\SetLastAccessTime_dt.cs" />
+    <Compile Include="DirectoryInfo\SetLastWriteTime_dt.cs" />
+    <Compile Include="DirectoryInfo\ToString.cs" />
+    <Compile Include="DirectoryInfo\Extension.cs" />
+    <Compile Include="DirectoryInfo\get_Attributes.cs" />
+    <Compile Include="DirectoryInfo\get_CreationTime.cs" />
+    <Compile Include="DirectoryInfo\get_FullName.cs" />
+    <Compile Include="DirectoryInfo\get_LastAccessTime.cs" />
+    <Compile Include="DirectoryInfo\get_LastWriteTime.cs" />
+    <Compile Include="DirectoryInfo\get_Name.cs" />
+    <Compile Include="DirectoryInfo\get_Parent.cs" />
+    <Compile Include="DirectoryInfo\get_Root.cs" />
+    <Compile Include="DirectoryInfo\GetSetTimes.cs" />
+    <Compile Include="DirectoryInfo\MoveTo_str.cs" />
+    <Compile Include="Directory\GetFiles_str_str_so.cs" />
+    <Compile Include="Directory\GetFileSystemEntries_str.cs" />
+    <Compile Include="Directory\GetFileSystemEntries_str_str.cs" />
+    <Compile Include="Directory\GetLastAccessTime_str.cs" />
+    <Compile Include="Directory\GetLastWriteTime_str.cs" />
+    <Compile Include="Directory\GetSetTimes.cs" />
+    <Compile Include="Directory\IEnumerator_IO_EnumerableAPIs.cs" />
+    <Compile Include="Directory\Modify_FailSafe.cs" />
+    <Compile Include="Directory\Move_str_str.cs" />
+    <Compile Include="Directory\ReparsePoints_MountVolume.cs" />
+    <Compile Include="Directory\SetCreationTime_str_dt.cs" />
+    <Compile Include="Directory\SetCurrentDirectory_dir.cs" />
+    <Compile Include="Directory\SetLastAccessTime_str_dt.cs" />
+    <Compile Include="Directory\SetLastWriteTime_str_dt.cs" />
+    <Compile Include="Directory\Ansichars.cs" />
+    <Compile Include="Directory\CreateDirectory.cs" />
+    <Compile Include="Directory\Delete_MountVolume.cs" />
+    <Compile Include="Directory\Delete_str.cs" />
+    <Compile Include="Directory\Delete_str_bool.cs" />
+    <Compile Include="Directory\Directory_EnumerableAPIs.cs" />
+    <Compile Include="Directory\Exists.cs" />
+    <Compile Include="Directory\GetCreationTime_str.cs" />
+    <Compile Include="Directory\GetCurrentDirectory.cs" />
+    <Compile Include="Directory\GetDirectories_str.cs" />
+    <Compile Include="Directory\GetDirectories_str_str.cs" />
+    <Compile Include="Directory\GetDirectories_str_str_so.cs" />
+    <Compile Include="Directory\GetDirectoryRoot_str.cs" />
+    <Compile Include="Directory\GetFiles_str.cs" />
+    <Compile Include="Directory\GetFiles_str_Str.cs" />
+    <Compile Include="File\Open_str_fm_fa_fs.cs" />
+    <Compile Include="File\OpenRead_str.cs" />
+    <Compile Include="File\OpenText_str.cs" />
+    <Compile Include="File\OpenWrite_str.cs" />
+    <Compile Include="File\ReadAll_all.cs" />
+    <Compile Include="File\ReadAllBytes_Str.cs" />
+    <Compile Include="File\SetAttributes_str_attrs.cs" />
+    <Compile Include="File\SetCreationTime_str_dt.cs" />
+    <Compile Include="File\SetLastAccessTime_str_dt.cs" />
+    <Compile Include="File\SetLastWriteTime_str_dt.cs" />
+    <Compile Include="File\WriteAll_all.cs" />
+    <Compile Include="File\WriteAllBytes_StrBtA.cs" />
+    <Compile Include="File\AppendAll_all.cs" />
+    <Compile Include="File\AppendText_str.cs" />
+    <Compile Include="File\ChangeExtension_str_str.cs" />
+    <Compile Include="File\Copy_str_str.cs" />
+    <Compile Include="File\Copy_str_str_b.cs" />
+    <Compile Include="File\Create_str_i.cs" />
+    <Compile Include="File\CreateText_str.cs" />
+    <Compile Include="File\Delete_str.cs" />
+    <Compile Include="File\Exists_str.cs" />
+    <Compile Include="File\File_EnumerableAPIs.cs" />
+    <Compile Include="File\GetAttributes_str.cs" />
+    <Compile Include="File\GetCreationTime_str.cs" />
+    <Compile Include="File\GetLastAccessTime_str.cs" />
+    <Compile Include="File\GetLastWriteTime_str.cs" />
+    <Compile Include="File\GetSetTimes.cs" />
+    <Compile Include="File\Move_str_str.cs" />
+    <Compile Include="File\Open_str_fm.cs" />
+    <Compile Include="File\Open_str_fm_fa.cs" />
+    <Compile Include="FileInfo\Create.cs" />
+    <Compile Include="FileInfo\Create_str.cs" />
+    <Compile Include="FileInfo\CreateText.cs" />
+    <Compile Include="FileInfo\ctor_str.cs" />
+    <Compile Include="FileInfo\Delete.cs" />
+    <Compile Include="FileInfo\Exists.cs" />
+    <Compile Include="FileInfo\Extension.cs" />
+    <Compile Include="FileInfo\FullName.cs" />
+    <Compile Include="FileInfo\get_Attributes.cs" />
+    <Compile Include="FileInfo\get_CreationTime.cs" />
+    <Compile Include="FileInfo\get_Directory.cs" />
+    <Compile Include="FileInfo\get_DirectoryName.cs" />
+    <Compile Include="FileInfo\get_LastAccessTime.cs" />
+    <Compile Include="FileInfo\get_LastWriteTime.cs" />
+    <Compile Include="FileInfo\get_Length.cs" />
+    <Compile Include="FileInfo\get_Name.cs" />
+    <Compile Include="FileInfo\GetSetTimes.cs" />
+    <Compile Include="FileInfo\MoveTo_str.cs" />
+    <Compile Include="FileInfo\Open_fm.cs" />
+    <Compile Include="FileInfo\Open_fm_fa.cs" />
+    <Compile Include="FileInfo\Open_fm_fa_fs.cs" />
+    <Compile Include="FileInfo\OpenRead.cs" />
+    <Compile Include="FileInfo\OpenText.cs" />
+    <Compile Include="FileInfo\OpenWrite.cs" />
+    <Compile Include="FileInfo\Refresh.cs" />
+    <Compile Include="FileInfo\set_Attributes.cs" />
+    <Compile Include="FileInfo\set_CreationTime_dt.cs" />
+    <Compile Include="FileInfo\ToString.cs" />
+    <Compile Include="FileInfo\AppendText.cs" />
+    <Compile Include="FileInfo\CopyTo_str.cs" />
+    <Compile Include="FileInfo\CopyTo_str_b.cs" />
+    
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Directory\" />
@@ -80,3 +216,4 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
+

--- a/src/System.IO.FileSystem/tests/packages.config
+++ b/src/System.IO.FileSystem/tests/packages.config
@@ -1,18 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.IO" version="4.0.10-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.IO.Pipes" version="4.0.0-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Linq" version="4.0.0-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Runtime" version="4.0.20-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Text.Encoding" version="4.0.10-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Threading.Overlapped" version="4.0.0-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" targetFramework="portable-net45+win+wpa81" />
-  <package id="System.Threading.ThreadPool" version="4.0.10-beta-22703" targetFramework="portable-net45+win+wpa81" />
+  <package id="System.Collections" version="4.0.10-beta-22703" />
+  <package id="System.Console" version="4.0.0-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Globalization" version="4.0.10-beta-22703" />
+  <package id="System.IO" version="4.0.10-beta-22703" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
+  <package id="System.IO.Pipes" version="4.0.0-beta-22703" />
+  <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
+  <package id="System.Threading.Overlapped" version="4.0.0-beta-22703" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
+  <package id="System.Threading.ThreadPool" version="4.0.10-beta-22703" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
Initial commit of ported tests for the System.IO.FileSystem contract.
Includes tests for File, Directory, FileInfo, and DirectoryInfo.

A few tests have been rewritten in the xunit style, but the majority of these tests have been ported from ToF, which were ported from old tree.  When porting, I modified or disabled tests to make sure every test only writes in its working directory.  I verified this with PerfView.  I also replaced hard-coded paths with calls to Path.GetRandomFileName() to prevent multiple runs from interfering with each other, and multiple tests running in parallel from interfering with each other.  Any test that used a delay to wait for the state of the file system to stabilize was marked with OuterLoopAttribute.  On my machine, all of the tests including OuterLoop take between 10s and 15s to run.  Just inner loop tests take between 1s and 2s to run.  Lots of these tests are candidates for rewriting, and Eric introduced a useful base class for tests when he rewrote the FileStream tests.  Checking in these ported assets will give us a good idea of what the coverage is, and act as a baseline to compare the rewritten tests against.