### PR TITLE
Improve code coverage for System.IO.UnmanagedMemoryStream

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/tests/ArrayHelpers.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/ArrayHelpers.cs
@@ -26,10 +26,7 @@ namespace System.IO.Tests
         {
             var random = new Random(100);
             var data = new byte[length];
-            for (int index = 0; index < length; index++)
-            {
-                data[index] = (byte)random.Next();
-            }
+            random.NextBytes(data);
             return data;
         }
 
@@ -50,7 +47,7 @@ namespace System.IO.Tests
 
         private sealed class ArrayComparer<T> : IEqualityComparer<T[]>
         {
-            public static ArrayComparer<T> Instance = new ArrayComparer<T>();
+            public static readonly ArrayComparer<T> Instance = new ArrayComparer<T>();
 
             private ArrayComparer() // use the static Instance singleton
             {

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmaCtorTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmaCtorTests.cs
@@ -29,6 +29,8 @@ namespace System.IO.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryAccessor(fakeBuffer, 2, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryAccessor(fakeBuffer, -1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryAccessor(fakeBuffer, 1, 2, (FileAccess)(-1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryAccessor(fakeBuffer, 1, 2, (FileAccess)42));
 
             Assert.Throws<ArgumentException>(() => new UnmanagedMemoryAccessor(fakeBuffer, 2, 999));
             Assert.Throws<ArgumentException>(() => new UnmanagedMemoryAccessor(fakeBuffer, 999, 9));

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmaTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmaTests.cs
@@ -42,93 +42,214 @@ namespace System.IO.Tests
         [Fact]
         public static void UmaReadWrite()
         {
-            var capacity = 99;
+            var capacity = 199;
 
-            Boolean v1 = true; // 1
-            Byte v2 = (Byte)123; // 1
-            Char v3 = (Char)255; // 1
-            Int16 v4 = Int16.MaxValue - 1; // 2
-            Int32 v5 = Int32.MinValue; // 4
-            Int64 v6 = 12345; // 8
-            Decimal v7 = 1.1m; //123.456m; // 16
-            Single v8 = 0.000123f; // 4
-            Double v9 = 1234567.890; // 8
-            SByte v10 = (SByte)(-128); // 1
-            UInt16 v11 = UInt16.MinValue; // 2
-            UInt32 v12 = 67890; // 4
-            UInt64 v13 = UInt32.MaxValue - 12345; // 8
+            const bool expectedBool = true; // 1
+            const byte expectedByte = 123; // 1
+            const sbyte expectedSByte = -128; // 1
+            const char expectedChar = (char)255; // 2
+            const ushort expectedUInt16 = ushort.MinValue; // 2
+            const short expectedInt16 = short.MaxValue - 1; // 2
+            const uint expectedUInt32 = 67890; // 4
+            const int expectedInt32 = int.MinValue; // 4
+            const float expectedSingle = 0.000123f; // 4
+            const ulong expectedUInt64 = ulong.MaxValue - 12345; // 8
+            const long expectedInt64 = 12345; // 8
+            const double expectedDouble = 1234567.890; // 8
+            const decimal expectedDecimal = 1.1m; //123.456m; // 16
 
             using (var buffer = new TestSafeBuffer(capacity))
             using (var uma = new UnmanagedMemoryAccessor(buffer, 0, capacity, FileAccess.ReadWrite))
             {
                 long pos = 0;
-                uma.Write(pos, v1);
-                pos += sizeof(Boolean);
-                uma.Write(pos, v2);
-                pos += sizeof(Byte);
-                uma.Write(pos, v3);
-                pos += sizeof(Char);
-                uma.Write(pos, v4);
-                pos += sizeof(Int16);
-                uma.Write(pos, v5);
-                pos += sizeof(Int32);
-                uma.Write(pos, v6);
-                pos += sizeof(Int64);
-                long pp = pos;
-                uma.Write(pos, v7);
-                pos += sizeof(Decimal);
-                uma.Write(pos, v8);
-                pos += sizeof(Single);
-                uma.Write(pos, v9);
-                pos += sizeof(Double);
-                uma.Write(pos, v10);
-                pos += sizeof(SByte);
-                uma.Write(pos, v11);
-                pos += sizeof(UInt16);
-                uma.Write(pos, v12);
-                pos += sizeof(UInt32);
-                uma.Write(pos, v13);
+
+                uma.Write(pos, expectedBool);
+                pos += sizeof(bool);
+
+                uma.Write(pos, expectedByte);
+                pos += sizeof(byte);
+
+                uma.Write(pos, expectedSByte);
+                pos += sizeof(sbyte);
+
+                pos = EnsureAligned(pos, sizeof(char));
+                uma.Write(pos, expectedChar);
+                pos += sizeof(char);
+
+                pos = EnsureNotAligned(pos, sizeof(char));
+                uma.Write(pos, expectedChar);
+                pos += sizeof(char);
+
+                pos = EnsureAligned(pos, sizeof(ushort));
+                uma.Write(pos, expectedUInt16);
+                pos += sizeof(ushort);
+
+                pos = EnsureNotAligned(pos, sizeof(ushort));
+                uma.Write(pos, expectedUInt16);
+                pos += sizeof(ushort);
+
+                pos = EnsureAligned(pos, sizeof(short));
+                uma.Write(pos, expectedInt16);
+                pos += sizeof(short);
+
+                pos = EnsureNotAligned(pos, sizeof(short));
+                uma.Write(pos, expectedInt16);
+                pos += sizeof(short);
+
+                pos = EnsureAligned(pos, sizeof(uint));
+                uma.Write(pos, expectedUInt32);
+                pos += sizeof(uint);
+
+                pos = EnsureNotAligned(pos, sizeof(uint));
+                uma.Write(pos, expectedUInt32);
+                pos += sizeof(uint);
+
+                pos = EnsureAligned(pos, sizeof(int));
+                uma.Write(pos, expectedInt32);
+                pos += sizeof(int);
+
+                pos = EnsureNotAligned(pos, sizeof(int));
+                uma.Write(pos, expectedInt32);
+                pos += sizeof(int);
+
+                pos = EnsureAligned(pos, sizeof(float));
+                uma.Write(pos, expectedSingle);
+                pos += sizeof(float);
+
+                pos = EnsureNotAligned(pos, sizeof(float));
+                uma.Write(pos, expectedSingle);
+                pos += sizeof(float);
+
+                pos = EnsureAligned(pos, sizeof(ulong));
+                uma.Write(pos, expectedUInt64);
+                pos += sizeof(ulong);
+
+                pos = EnsureNotAligned(pos, sizeof(ulong));
+                uma.Write(pos, expectedUInt64);
+                pos += sizeof(ulong);
+
+                pos = EnsureAligned(pos, sizeof(long));
+                uma.Write(pos, expectedInt64);
+                pos += sizeof(long);
+
+                pos = EnsureNotAligned(pos, sizeof(long));
+                uma.Write(pos, expectedInt64);
+                pos += sizeof(long);
+
+                pos = EnsureAligned(pos, sizeof(double));
+                uma.Write(pos, expectedDouble);
+                pos += sizeof(double);
+
+                pos = EnsureNotAligned(pos, sizeof(double));
+                uma.Write(pos, expectedDouble);
+                pos += sizeof(double);
+
+                pos = EnsureAligned(pos, sizeof(decimal));
+                uma.Write(pos, expectedDecimal);
+                pos += sizeof(decimal);
+
+                pos = EnsureNotAligned(pos, sizeof(decimal));
+                uma.Write(pos, expectedDecimal);
 
                 pos = 0;
-                var v01 = uma.ReadBoolean(pos);
-                Assert.Equal(v1, v01);
-                pos += sizeof(Boolean);
-                var v02 = uma.ReadByte(pos);
-                Assert.Equal(v2, v02);
-                pos += sizeof(Byte);
-                var v03 = uma.ReadChar(pos);
-                Assert.Equal(v3, v03);
-                pos += sizeof(Char);
-                var v04 = uma.ReadInt16(pos);
-                Assert.Equal(v4, v04);
-                pos += sizeof(Int16);
-                var v05 = uma.ReadInt32(pos);
-                Assert.Equal(v5, v05);
-                pos += sizeof(Int32);
-                var v06 = uma.ReadInt64(pos);
-                Assert.Equal(v6, v06);
-                pos += sizeof(Int64);
-                var v07 = uma.ReadDecimal(pos);
-                Assert.Equal(v7, v07);
-                pos += sizeof(Decimal);
-                var v08 = uma.ReadSingle(pos);
-                Assert.Equal(v8, v08);
-                pos += sizeof(Single);
-                var v09 = uma.ReadDouble(pos);
-                Assert.Equal(v9, v09);
-                pos += sizeof(Double);
-                var v010 = uma.ReadSByte(pos);
-                Assert.Equal(v10, v010);
-                pos += sizeof(SByte);
-                var v011 = uma.ReadUInt16(pos);
-                Assert.Equal(v11, v011);
-                pos += sizeof(UInt16);
-                var v012 = uma.ReadUInt32(pos);
-                Assert.Equal(v12, v012);
-                pos += sizeof(UInt32);
-                var v013 = uma.ReadUInt64(pos);
-                Assert.Equal(v13, v013);
+                Assert.Equal(expectedBool, uma.ReadBoolean(pos));
+                pos += sizeof(bool);
+
+                Assert.Equal(expectedByte, uma.ReadByte(pos));
+                pos += sizeof(byte);
+
+                Assert.Equal(expectedSByte, uma.ReadSByte(pos));
+                pos += sizeof(sbyte);
+
+                pos = EnsureAligned(pos, sizeof(char));
+                Assert.Equal(expectedChar, uma.ReadChar(pos));
+                pos += sizeof(char);
+
+                pos = EnsureNotAligned(pos, sizeof(char));
+                Assert.Equal(expectedChar, uma.ReadChar(pos));
+                pos += sizeof(char);
+
+                pos = EnsureAligned(pos, sizeof(ushort));
+                Assert.Equal(expectedUInt16, uma.ReadUInt16(pos));
+                pos += sizeof(ushort);
+
+                pos = EnsureNotAligned(pos, sizeof(ushort));
+                Assert.Equal(expectedUInt16, uma.ReadUInt16(pos));
+                pos += sizeof(ushort);
+
+                pos = EnsureAligned(pos, sizeof(short));
+                Assert.Equal(expectedInt16, uma.ReadInt16(pos));
+                pos += sizeof(short);
+
+                pos = EnsureNotAligned(pos, sizeof(short));
+                Assert.Equal(expectedInt16, uma.ReadInt16(pos));
+                pos += sizeof(short);
+
+                pos = EnsureAligned(pos, sizeof(uint));
+                Assert.Equal(expectedUInt32, uma.ReadUInt32(pos));
+                pos += sizeof(uint);
+
+                pos = EnsureNotAligned(pos, sizeof(uint));
+                Assert.Equal(expectedUInt32, uma.ReadUInt32(pos));
+                pos += sizeof(uint);
+
+                pos = EnsureAligned(pos, sizeof(int));
+                Assert.Equal(expectedInt32, uma.ReadInt32(pos));
+                pos += sizeof(int);
+
+                pos = EnsureNotAligned(pos, sizeof(int));
+                Assert.Equal(expectedInt32, uma.ReadInt32(pos));
+                pos += sizeof(int);
+
+                pos = EnsureAligned(pos, sizeof(float));
+                Assert.Equal(expectedSingle, uma.ReadSingle(pos));
+                pos += sizeof(float);
+
+                pos = EnsureNotAligned(pos, sizeof(float));
+                Assert.Equal(expectedSingle, uma.ReadSingle(pos));
+                pos += sizeof(float);
+
+                pos = EnsureAligned(pos, sizeof(ulong));
+                Assert.Equal(expectedUInt64, uma.ReadUInt64(pos));
+                pos += sizeof(ulong);
+
+                pos = EnsureNotAligned(pos, sizeof(ulong));
+                Assert.Equal(expectedUInt64, uma.ReadUInt64(pos));
+                pos += sizeof(ulong);
+
+                pos = EnsureAligned(pos, sizeof(long));
+                Assert.Equal(expectedInt64, uma.ReadInt64(pos));
+                pos += sizeof(long);
+
+                pos = EnsureNotAligned(pos, sizeof(long));
+                Assert.Equal(expectedInt64, uma.ReadInt64(pos));
+                pos += sizeof(long);
+
+                pos = EnsureAligned(pos, sizeof(double));
+                Assert.Equal(expectedDouble, uma.ReadDouble(pos));
+                pos += sizeof(double);
+
+                pos = EnsureNotAligned(pos, sizeof(double));
+                Assert.Equal(expectedDouble, uma.ReadDouble(pos));
+                pos += sizeof(double);
+
+                pos = EnsureAligned(pos, sizeof(decimal));
+                Assert.Equal(expectedDecimal, uma.ReadDecimal(pos));
+                pos += sizeof(decimal);
+
+                pos = EnsureNotAligned(pos, sizeof(decimal));
+                Assert.Equal(expectedDecimal, uma.ReadDecimal(pos));
             }
+        }
+
+        private static long EnsureAligned(long position, int n)
+        {
+            return ((position & (n - 1)) == 0) ? position : (position / n + 1) * n;
+        }
+
+        private static long EnsureNotAligned(long position, int n)
+        {
+            return ((position & (n - 1)) != 0) ? position : ++position;
         }
     }
 }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmaTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmaTests.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
         [Fact]
         public static void UmaInvalidReadWrite()
         {
-            var capacity = 99;
+            const int capacity = 99;
             FakeSafeBuffer sbuf = new FakeSafeBuffer((ulong)capacity);
 
             using (var uma = new UnmanagedMemoryAccessor(sbuf, 0, capacity, FileAccess.ReadWrite))
@@ -42,7 +42,7 @@ namespace System.IO.Tests
         [Fact]
         public static void UmaReadWrite()
         {
-            var capacity = 199;
+            const int capacity = 199;
 
             const bool expectedBool = true; // 1
             const byte expectedByte = 123; // 1

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsCtorTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsCtorTests.cs
@@ -20,6 +20,8 @@ namespace System.IO.Tests
 
                 Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 2, -1));
                 Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, -1, 1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 2, (FileAccess)(-1)));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 2, (FileAccess)42));
 
                 Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 2, 999));
                 Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 999, 9));

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsCtorTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsCtorTests.cs
@@ -8,52 +8,43 @@ namespace System.IO.Tests
     public class UmsCtorTests
     {
         [Fact]
-        public static void CtorsThatFail()
+        public static unsafe void CtorsThatFail()
         {
-            unsafe
-            {
-                Assert.Throws<ArgumentNullException>(() => { var ums = new UnmanagedMemoryStream(null, 0); });
+            Assert.Throws<ArgumentNullException>(() => { var ums = new UnmanagedMemoryStream(null, 0); });
 
-                TestSafeBuffer nullBuffer = null;
-                FakeSafeBuffer fakeBuffer = new FakeSafeBuffer(99);
-                Assert.Throws<ArgumentNullException>(() => new UnmanagedMemoryStream(nullBuffer, 0, 1));
+            TestSafeBuffer nullBuffer = null;
+            FakeSafeBuffer fakeBuffer = new FakeSafeBuffer(99);
+            Assert.Throws<ArgumentNullException>(() => new UnmanagedMemoryStream(nullBuffer, 0, 1));
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 2, -1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, -1, 1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 2, (FileAccess)(-1)));
-                Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 2, (FileAccess)42));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 2, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, -1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 2, (FileAccess)(-1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 2, (FileAccess)42));
 
-                Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 2, 999));
-                Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 999, 9));
-                Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 100));
+            Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 2, 999));
+            Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 999, 9));
+            Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, 1, 100));
 
-                Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, Int32.MaxValue, 1));
-            }
+            Assert.Throws<ArgumentException>(() => new UnmanagedMemoryStream(fakeBuffer, Int32.MaxValue, 1));
         }
 
         [Fact]
-        public static void PointerCtor()
+        public static unsafe void PointerCtor()
         {
             int someInt32 = 42;
-            unsafe
+            int* pInt32 = &someInt32;
+            byte* pByte = (byte*)pInt32;
+            using (var stream = new UnmanagedMemoryStream(pByte, 0))
             {
-                int* pInt32 = &someInt32;
-                byte* pByte = (byte*)pInt32;
-                using (var stream = new UnmanagedMemoryStream(pByte, 0))
-                {
-                    Assert.True(stream.CanRead);
-                    Assert.True(stream.CanSeek);
-                    Assert.False(stream.CanWrite);
+                Assert.True(stream.CanRead);
+                Assert.True(stream.CanSeek);
+                Assert.False(stream.CanWrite);
 
-                    Assert.Equal(0, stream.Length);
-                    Assert.Equal(0, stream.Capacity);
-                    Assert.Equal(0, stream.Position);
+                Assert.Equal(0, stream.Length);
+                Assert.Equal(0, stream.Capacity);
+                Assert.Equal(0, stream.Position);
 
-                    if (stream.PositionPointer != pByte)
-                    {
-                        Assert.True(false);
-                    }
-                }
+                Assert.False(stream.PositionPointer != pByte);
             }
         }
     }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsManager.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsManager.cs
@@ -9,42 +9,34 @@ namespace System.IO.Tests
     // this class holds managed native memory used by UnmanagedMemoryStream
     internal class UmsManager : IDisposable
     {
-        private UnmanagedMemoryStream _stream;
+        private readonly UnmanagedMemoryStream _stream;
         private IntPtr _memory;
-        private int _memorySizeInBytes;
         private bool _isDisposed;
 
         public unsafe UmsManager(FileAccess access, int capacity)
         {
-            _memorySizeInBytes = capacity;
-            unsafe
+            int memorySizeInBytes = capacity;
+            _memory = Marshal.AllocHGlobal(memorySizeInBytes);
+            byte* bytes = (byte*)_memory.ToPointer();
+            byte* currentByte = bytes;
+            for (int index = 0; index < memorySizeInBytes; index++)
             {
-                _memory = Marshal.AllocHGlobal(_memorySizeInBytes);
-                byte* bytes = (byte*)_memory.ToPointer();
-                byte* currentByte = bytes;
-                for (int index = 0; index < _memorySizeInBytes; index++)
-                {
-                    *currentByte = 0;
-                    currentByte++;
-                }
-                _stream = new UnmanagedMemoryStream(bytes, _memorySizeInBytes, _memorySizeInBytes, access);
+                *currentByte = 0;
+                currentByte++;
             }
+            _stream = new UnmanagedMemoryStream(bytes, memorySizeInBytes, memorySizeInBytes, access);
         }
 
         public unsafe UmsManager(FileAccess access, byte[] seedData)
         {
-            _memorySizeInBytes = seedData.Length;
-            unsafe
+            int memorySizeInBytes = seedData.Length;
+            _memory = Marshal.AllocHGlobal(memorySizeInBytes);
+            byte* destination = (byte*)_memory.ToPointer();
+            fixed (byte* source = seedData)
             {
-                _memory = Marshal.AllocHGlobal(_memorySizeInBytes);
-                byte* bytes = (byte*)_memory.ToPointer();
-                byte* currentByte = bytes;
-                for (int index = 0; index < _memorySizeInBytes; index++)
-                {
-                    *currentByte = seedData[index];
-                }
-                _stream = new UnmanagedMemoryStream(bytes, _memorySizeInBytes, _memorySizeInBytes, access);
+                Buffer.MemoryCopy(source, destination, memorySizeInBytes, memorySizeInBytes);
             }
+            _stream = new UnmanagedMemoryStream(destination, memorySizeInBytes, memorySizeInBytes, access);
         }
 
         public UnmanagedMemoryStream Stream
@@ -61,16 +53,10 @@ namespace System.IO.Tests
             var array = new byte[count];
             unsafe
             {
-                fixed (byte* parray = array)
+                byte* source = (byte*)_memory.ToPointer();
+                fixed (byte* destination = array)
                 {
-                    byte* source = (byte*)_memory.ToPointer();
-                    byte* destination = parray;
-                    for (int i = 0; i < count; i++)
-                    {
-                        *destination = *source;
-                        destination++;
-                        source++;
-                    }
+                    Buffer.MemoryCopy(source, destination, array.Length, count);
                 }
             }
 

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsRead.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsRead.cs
@@ -57,7 +57,7 @@ namespace System.IO.Tests
             {
                 byte[] read = ReadAllBytes(stream);
                 Assert.Equal(stream.Position, read.Length);
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(read, manager.ToArray()));
+                Assert.Equal(manager.ToArray(), read, ArrayHelpers.Comparer<byte>());
             }
             else
             {
@@ -68,7 +68,7 @@ namespace System.IO.Tests
         [Fact]
         public static void InvalidReadWrite()
         {
-            var length = 1000;
+            const int length = 1000;
             using (var manager = new UmsManager(FileAccess.Read, length))
             {
                 UnmanagedMemoryStream stream = manager.Stream;

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsRead.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsRead.cs
@@ -75,19 +75,27 @@ namespace System.IO.Tests
 
                 //case#3: call Read with null, ArgumentNullException should be thrown.
                 Assert.Throws<ArgumentNullException>(() => stream.Read(null, 0, 3));
+                Assert.Throws<ArgumentNullException>(() => stream.ReadAsync(null, 0, 3).GetAwaiter().GetResult());
                 Assert.Throws<ArgumentNullException>(() => stream.Write(null, 0, 7));
+                Assert.Throws<ArgumentNullException>(() => stream.WriteAsync(null, 0, 7).GetAwaiter().GetResult());
 
                 //case#4: call Read with start<0, ArgumentOutOfRangeException should be thrown.
                 Assert.Throws<ArgumentOutOfRangeException>(() => stream.Read(new byte[] { }, SByte.MinValue, 9));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.ReadAsync(new byte[] { }, SByte.MinValue, 9).GetAwaiter().GetResult());
                 Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(new byte[] { }, -1, 6));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.WriteAsync(new byte[] { }, -1, 6).GetAwaiter().GetResult());
 
                 //case#5: call Read with count<0, ArgumentOutOfRangeException should be thrown.
                 Assert.Throws<ArgumentOutOfRangeException>(() => stream.Read(new byte[] { }, 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.ReadAsync(new byte[] { }, 0, -1).GetAwaiter().GetResult());
                 Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(new byte[] { }, 1, -2));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.WriteAsync(new byte[] { }, 1, -2).GetAwaiter().GetResult());
 
                 //case#6: call Read with count > ums.Length-startIndex, ArgumentOutOfRangeException should be thrown.
                 Assert.Throws<ArgumentException>(() => stream.Read(new byte[10], 0, 11)); // "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection."
+                Assert.Throws<ArgumentException>(() => stream.ReadAsync(new byte[10], 0, 11).GetAwaiter().GetResult());
                 Assert.Throws<ArgumentException>(() => stream.Write(new byte[3], 0, 4));
+                Assert.Throws<ArgumentException>(() => stream.WriteAsync(new byte[3], 0, 4).GetAwaiter().GetResult());
 
                 //case#10: Call Read on a n length stream, (Capacity is implicitly n), position is set to end, call it,  should throw ArgumentException.
                 Assert.Throws<ArgumentException>(() => stream.Read(new byte[] { }, 0, 1));

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsReadWrite.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsReadWrite.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
         [Fact]
         public static void ReadWrite()
         {
-            var length = 1000;
+            const int length = 1000;
             using (var manager = new UmsManager(FileAccess.ReadWrite, length))
             {
                 UnmanagedMemoryStream stream = manager.Stream;
@@ -23,15 +23,15 @@ namespace System.IO.Tests
                 stream.Write(copy, 0, length);
 
                 var memory = manager.ToArray();
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(bytes, memory));
+                Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
 
                 stream.Seek(0, SeekOrigin.Begin);
                 byte[] read = UmsReadTests.ReadAllBytes(stream);
                 Assert.Equal(stream.Position, read.Length);
 
                 byte[] current = manager.ToArray();
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(read, current));
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(read, bytes));
+                Assert.Equal(current, read, ArrayHelpers.Comparer<byte>());
+                Assert.Equal(bytes, read, ArrayHelpers.Comparer<byte>());
 
                 stream.Write(new byte[0], 0, 0);
             }
@@ -40,7 +40,7 @@ namespace System.IO.Tests
         [Fact]
         public static void ReadWriteByte()
         {
-            var length = 1000;
+            const int length = 1000;
             using (var manager = new UmsManager(FileAccess.ReadWrite, length))
             {
                 UnmanagedMemoryStream stream = manager.Stream;
@@ -59,7 +59,7 @@ namespace System.IO.Tests
 
                 var memory = manager.ToArray();
 
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(bytes, memory));
+                Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
             }
         }
     }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsSecurityTest.cs
@@ -54,10 +54,9 @@ public class UmsSecurityTests
         stream.Position = 0;
         Byte[] streamData = new Byte[originalData.Length];
         int value = stream.Read(streamData, 0, streamData.Length);
-        Assert.Equal(originalData.Length, value);
 
-        for (int i = 0; i < originalData.Length; i++)
-            Assert.Equal(originalData[i], streamData[i]);
+        Assert.Equal(originalData.Length, value);
+        Assert.Equal(originalData, streamData, ArrayHelpers.Comparer<byte>());
 
         stream.Position = 0;
     }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsTests.cs
@@ -85,7 +85,7 @@ namespace System.IO.Tests
         [Fact]
         public static void SeekTests()
         {
-            int length = 1000;
+            const int length = 1000;
             using (var manager = new UmsManager(FileAccess.ReadWrite, length))
             {
                 UnmanagedMemoryStream stream = manager.Stream;

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
+using System.Threading;
 
 // TODO: add WriteAsync, Timeout, Flush, CopyTo tests
 
@@ -70,9 +71,14 @@ namespace System.IO.Tests
             {
                 UnmanagedMemoryStream stream = manager.Stream;
                 UmsTests.ReadWriteUmsInvariants(stream);
-                // TODO: uncomment once we run againts core CLR; currently type load issues with IOException
-                // Assert.Throws<IOException>(() => stream.SetLength(1001)); 
+                Assert.Throws<IOException>(() => stream.SetLength(1001)); 
                 Assert.Throws<ArgumentOutOfRangeException>(() => stream.SetLength(SByte.MinValue));
+
+                const long expectedLength = 500;
+                stream.Position = 501;
+                stream.SetLength(expectedLength);
+                Assert.Equal(expectedLength, stream.Length);
+                Assert.Equal(expectedLength, stream.Position);
             }
         }
 
@@ -85,15 +91,13 @@ namespace System.IO.Tests
                 UnmanagedMemoryStream stream = manager.Stream;
                 UmsTests.ReadWriteUmsInvariants(stream);
 
-                // TODO: uncomment once we run againts core CLR; currently type load issues with IOException
-                //Assert.Throws<IOException>(() => stream.Seek(unchecked(Int32.MaxValue + 1), SeekOrigin.Begin)); 
-                //Assert.Throws<IOException>(() => stream.Seek(Int64.MinValue, SeekOrigin.End));
-                Assert.Throws<ArgumentException>(() => stream.Seek(0, (SeekOrigin)7)); // Invalid seek origin          
+                Assert.Throws<IOException>(() => stream.Seek(unchecked(Int32.MaxValue + 1), SeekOrigin.Begin));
+                Assert.Throws<IOException>(() => stream.Seek(Int64.MinValue, SeekOrigin.End));
+                Assert.Throws<ArgumentException>(() => stream.Seek(0, (SeekOrigin)7)); // Invalid seek origin
 
                 stream.Seek(10, SeekOrigin.Begin);
                 Assert.Equal(10, stream.Position);
 
-                /* TODO: uncomment once we run againts core CLR; currently type load issues with IOException
                 Assert.Throws<IOException>(() => stream.Seek(-1, SeekOrigin.Begin)); // An attempt was made to move the position before the beginning of the stream 
                 Assert.Equal(10, stream.Position);
 
@@ -102,7 +106,6 @@ namespace System.IO.Tests
 
                 Assert.Throws<IOException>(() => stream.Seek(-(stream.Length + 1), SeekOrigin.End)); //  "An attempt was made to move the position before the beginning of the stream."
                 Assert.Equal(10, stream.Position);
-                */
 
                 // Seek from SeekOrigin.Begin
                 stream.Seek(0, SeekOrigin.Begin);
@@ -173,12 +176,17 @@ namespace System.IO.Tests
                 Assert.Throws<ObjectDisposedException>(() => stream.Seek(0, SeekOrigin.Current));
                 Assert.Throws<ObjectDisposedException>(() => stream.Seek(0, SeekOrigin.End));
 
+                Assert.Throws<ObjectDisposedException>(() => stream.Flush());
+                Assert.Throws<ObjectDisposedException>(() => stream.FlushAsync(CancellationToken.None).GetAwaiter().GetResult());
+
                 byte[] buffer = ArrayHelpers.CreateByteArray(10);
                 Assert.Throws<ObjectDisposedException>(() => stream.Read(buffer, 0, buffer.Length));
+                Assert.Throws<ObjectDisposedException>(() => stream.ReadAsync(buffer, 0, buffer.Length).GetAwaiter().GetResult());
                 Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
 
                 Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(0));
                 Assert.Throws<ObjectDisposedException>(() => stream.Write(buffer, 0, buffer.Length));
+                Assert.Throws<ObjectDisposedException>(() => stream.WriteAsync(buffer, 0, buffer.Length).GetAwaiter().GetResult());
             }
         }
     }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
@@ -58,7 +58,25 @@ namespace System.IO.Tests
             {
                 UnmanagedMemoryStream stream = manager.Stream;
                 UmsTests.ReadUmsInvariants(stream);
+
+                var bytes = new byte[3];
+                Assert.Throws<NotSupportedException>(() => stream.Write(bytes, 0, bytes.Length));
                 Assert.Throws<NotSupportedException>(() => stream.WriteByte(1));
+            }
+        }
+
+        [Fact]
+        public static void CannotWriteWithOverflow()
+        {
+            using (var manager = new UmsManager(FileAccess.Write, 1000))
+            {
+                UnmanagedMemoryStream stream = manager.Stream;
+                UmsTests.WriteUmsInvariants(stream);
+                stream.Position = long.MaxValue;
+
+                var bytes = new byte[3];
+                Assert.Throws<IOException>(() => stream.Write(bytes, 0, bytes.Length));
+                Assert.Throws<IOException>(() => stream.WriteByte(1));
             }
         }
     }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
         [Fact]
         public static void Write()
         {
-            var length = 1000;
+            const int length = 1000;
             using (var manager = new UmsManager(FileAccess.Write, length))
             {
                 UnmanagedMemoryStream stream = manager.Stream;
@@ -23,7 +23,7 @@ namespace System.IO.Tests
 
                 var memory = manager.ToArray();
 
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(bytes, memory));
+                Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
 
                 stream.Write(new byte[0], 0, 0);
             }
@@ -32,7 +32,7 @@ namespace System.IO.Tests
         [Fact]
         public static void WriteByte()
         {
-            var length = 1000;
+            const int length = 1000;
             using (var manager = new UmsManager(FileAccess.Write, length))
             {
                 UnmanagedMemoryStream stream = manager.Stream;
@@ -47,7 +47,7 @@ namespace System.IO.Tests
 
                 var memory = manager.ToArray();
 
-                Assert.True(ArrayHelpers.Comparer<byte>().Equals(bytes, memory));
+                Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
             }
         }
 


### PR DESCRIPTION
Improved code coverage for `System.IO.UnmanagedMemoryStream`
Before: 79%
After: 89%
Fixes  #929