### PR TITLE
Implement System.IO.Pipes for Unix

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.pipe2.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.pipe2.cs
@@ -3,13 +3,11 @@
 
 using System.Runtime.InteropServices;
 
-using size_t  = System.IntPtr;
-
 internal static partial class Interop
 {
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern unsafe size_t write(int fd, byte* buf, size_t count);
+        internal static extern unsafe int pipe2(int* pipefd, int flags);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.mkfifo.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.mkfifo.cs
@@ -3,13 +3,13 @@
 
 using System.Runtime.InteropServices;
 
-using size_t  = System.IntPtr;
+using mode_t = System.Int32;
 
 internal static partial class Interop
 {
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern unsafe size_t write(int fd, byte* buf, size_t count);
+        internal static extern int mkfifo(string pathname, mode_t mode);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.open.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.open.cs
@@ -16,15 +16,16 @@ internal static partial class Interop
         [Flags]
         internal enum OpenFlags
         {
-            O_RDONLY = 0x0,
-            O_WRONLY = 0x1,
-            O_RDWR = 0x2,
-            O_CREAT = 0x40,
-            O_EXCL = 0x80,
-            O_TRUNC = 0x200,
-            O_SYNC = 0x1000,
-            O_ASYNC = 0x2000,
-            O_LARGEFILE = 0x8000
+            O_RDONLY    = 0x0,
+            O_WRONLY    = 0x1,
+            O_RDWR      = 0x2,
+            O_CREAT     = 0x40,
+            O_EXCL      = 0x80,
+            O_TRUNC     = 0x200,
+            O_SYNC      = 0x1000,
+            O_ASYNC     = 0x2000,
+            O_LARGEFILE = 0x8000,
+            O_CLOEXEC   = 0x80000,
         }
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.read.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.read.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 
 using size_t  = System.IntPtr;

--- a/src/Common/src/Interop/Unix/libc/Interop.stat.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.stat.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 
 using dev_t = System.Int64;
@@ -86,7 +85,8 @@ internal static partial class Interop
 
         internal static class FileTypes 
         { 
-            internal const int S_IFMT = 0xF000;
+            internal const int S_IFMT  = 0xF000;
+            internal const int S_IFIFO = 0x1000;
             internal const int S_IFDIR = 0x4000;
             internal const int S_IFREG = 0x8000;
         } 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -267,15 +267,17 @@ namespace System
         /// <param name="buffer">The buffer from which to write data.</param>
         /// <param name="offset">The offset at which the data to write starts in the buffer.</param>
         /// <param name="count">The number of bytes to write.</param>
-        /// <returns>The number of bytes written, or a negative value if there's an error.</returns>
-        private static unsafe int Write(int fd, byte[] buffer, int offset, int count)
+        private static unsafe void Write(int fd, byte[] buffer, int offset, int count)
         {
             fixed (byte* bufPtr = buffer)
             {
-                long result;
-                while (Interop.CheckIo(result = (long)Interop.libc.write(fd, (byte*)bufPtr + offset, (IntPtr)count))) ;
-                Debug.Assert(result == count);
-                return (int)result;
+                while (count > 0)
+                {
+                    int bytesWritten;
+                    while (Interop.CheckIo(bytesWritten = (int)Interop.libc.write(fd, bufPtr + offset, (IntPtr)count))) ;
+                    count -= bytesWritten;
+                    offset += bytesWritten;
+                }
             }
         }
 

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
@@ -63,9 +63,12 @@ namespace System.Diagnostics
                                 }
                             }
 
-                            if (bufCount != 0)
+                            while (bufCount > 0)
                             {
-                                while (Interop.CheckIo((long)Interop.libc.write((int)fileHandle.DangerousGetHandle(), buf, new IntPtr(bufCount)))) ;
+                                int bytesWritten;
+                                while (Interop.CheckIo(bytesWritten = (int)Interop.libc.write((int)fileHandle.DangerousGetHandle(), buf, new IntPtr(bufCount)))) ;
+                                bufCount -= bytesWritten;
+                                buf += bytesWritten;
                             }
                         }
                     }

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -9,15 +10,45 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafePipeHandle : SafeHandle
     {
+        private const int DefaultInvalidHandle = -1;
+
+        /// <summary>Opens the specified file with the requested flags and mode.</summary>
+        /// <param name="path">The path to the file.</param>
+        /// <param name="flags">The flags with which to open the file.</param>
+        /// <param name="mode">The mode for opening the file.</param>
+        /// <returns>A SafeFileHandle for the opened file.</returns>
+        internal static SafePipeHandle Open(string path, Interop.libc.OpenFlags flags, int mode)
+        {
+            // SafePipeHandle wraps a file descriptor rather than a pointer, and a file descriptor is always 4 bytes
+            // rather than being pointer sized, which means we can't utilize the runtime's ability to marshal safe handles.
+            // Ideally this would be a constrained execution region, but we don't have access to PrepareConstrainedRegions.
+            // We still use a finally block to house the code that opens the file and stores the handle in hopes
+            // of making it as non-interruptable as possible.  The SafePipeHandle is also allocated first to avoid
+            // the allocation after getting the file descriptor but before storing it.
+            SafePipeHandle handle = new SafePipeHandle();
+            try { }
+            finally
+            {
+                int fd;
+                while (Interop.CheckIo(fd = Interop.libc.open(path, flags, mode))) ;
+                Debug.Assert(fd >= 0);
+                handle.SetHandle((IntPtr)fd);
+            }
+            return handle;
+        }
+
         protected override bool ReleaseHandle()
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            // Close the handle. We do not want to throw here nor retry
+            // in the case of an EINTR error, so we simply check whether
+            // the call was successful or not.
+            return Interop.libc.close((int)handle) == 0;
         }
 
         public override bool IsInvalid
         {
             [SecurityCritical]
-            get { throw NotImplemented.ByDesign; } // TODO: Implement this
+            get { return (long)handle < 0; }
         }
     }
 }

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Windows.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Windows.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafePipeHandle : SafeHandle
     {
+        private const int DefaultInvalidHandle = 0;
+
         protected override bool ReleaseHandle()
         {
             return Interop.mincore.CloseHandle(handle);

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Win32.SafeHandles
     [SecurityCritical]
     public sealed partial class SafePipeHandle : SafeHandle
     {
-        private SafePipeHandle() 
-            : base(IntPtr.Zero, true) 
+        private SafePipeHandle()
+            : base(new IntPtr(DefaultInvalidHandle), true) 
         {
         }
 
         public SafePipeHandle(IntPtr preexistingHandle, bool ownsHandle)
-            : base(IntPtr.Zero, ownsHandle)
+            : base(new IntPtr(DefaultInvalidHandle), ownsHandle)
         {
             SetHandle(preexistingHandle);
         }

--- a/src/System.IO.Pipes/src/Resources/SR.cs
+++ b/src/System.IO.Pipes/src/Resources/SR.cs
@@ -176,6 +176,9 @@ namespace System
         internal static string UnknownError_Num {
               get { return SR.GetResourceString("UnknownError_Num", null); }
         }
+        internal static string ArgumentOutOfRange_FileLengthTooBig {
+              get { return SR.GetResourceString("ArgumentOutOfRange_FileLengthTooBig", null); }
+        }
 #else
         internal static string ArgumentOutOfRange_NeedNonNegNum {
               get { return SR.GetResourceString("ArgumentOutOfRange_NeedNonNegNum", @"Non negative number is required."); }
@@ -344,6 +347,9 @@ namespace System
         }
         internal static string UnknownError_Num {
               get { return SR.GetResourceString("UnknownError_Num", @"Unknown error '{0}'."); }
+        }
+        internal static string ArgumentOutOfRange_FileLengthTooBig {
+              get { return SR.GetResourceString("ArgumentOutOfRange_FileLengthTooBig", @"Specified file length was too large for the file system."); }
         }
 
 #endif

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -285,4 +285,7 @@
   <data name="UnknownError_Num" xml:space="preserve">
     <value>Unknown error '{0}'.</value>
   </data>
+  <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
+    <value>Specified file length was too large for the file system.</value>
+  </data>
 </root>

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -66,6 +66,61 @@
     <Compile Include="System\IO\Pipes\NamedPipeClientStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\NamedPipeServerStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.Unix.cs" />
+
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
+      <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.pipe2.cs">
+      <Link>Common\Interop\Unix\Interop.pipe2.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.close.cs">
+      <Link>Common\Interop\Unix\Interop.close.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gethostname.cs">
+      <Link>Common\Interop\Unix\Interop.gethostname.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mkdir.cs">
+      <Link>Common\Interop\Unix\Interop.mkdir.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mkfifo.cs">
+      <Link>Common\Interop\Unix\Interop.mkfifo.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
+      <Link>Common\Interop\Unix\Interop.open.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
+      <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.pipe.cs">
+      <Link>Common\Interop\Unix\Interop.pipe.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.read.cs">
+      <Link>Common\Interop\Unix\Interop.read.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.stat.cs">
+      <Link>Common\Interop\Unix\Interop.stat.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
+      <Link>Common\Interop\Unix\Interop.strerror.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.unlink.cs">
+      <Link>Common\Interop\Unix\Interop.unlink.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.write.cs">
+      <Link>Common\Interop\Unix\Interop.write.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Resource files -->
   <ItemGroup>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Security;
 
 namespace System.IO.Pipes
@@ -18,9 +17,56 @@ namespace System.IO.Pipes
         private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
         {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");
-            Debug.Assert(bufferSize >= 0, "bufferSize is negative");
+            // Ignore bufferSize.  It's optional, and the fcntl F_SETPIPE_SZ for changing it is Linux specific.
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            // Use pipe or pipe2 to create our anonymous pipe
+            int[] fds = new int[2];
+            unsafe
+            {
+                fixed (int* fdsptr = fds)
+                {
+                    bool created = false;
+                    
+                    // If the caller asked for the handle to be non-inheritable, try to use pipe2 to create the pipe.
+                    // Depending on the OS, it may not exist.
+                    if ((inheritability & HandleInheritability.Inheritable) == 0)
+                    {
+                        try
+                        {
+                            while (Interop.CheckIo(Interop.libc.pipe2(fdsptr, (int)Interop.libc.OpenFlags.O_CLOEXEC))) ;
+                            created = true;
+                        }
+                        catch (MissingMethodException) { } // pipe2 is Linux only
+                    }
+
+                    // Fall back to using pipe if either the handle can be inherited or if pipe2 wasn't available to 
+                    // create it as non-inheritable.  We don't just want to fail if we can't make the handle
+                    // non-inheritable as non-inheritance is the default.
+                    if (!created)
+                    {
+                        while (Interop.CheckIo(Interop.libc.pipe(fdsptr))) ;
+                    }
+                }
+            }
+
+            // Create SafePipeHandles for each end of the pipe.  Which ends goes with server and which goes with
+            // client depends on the direction of the pipe.
+            SafePipeHandle serverHandle = new SafePipeHandle(
+                (IntPtr)fds[direction == PipeDirection.In ? Interop.libc.ReadEndOfPipe : Interop.libc.WriteEndOfPipe], 
+                ownsHandle: true);
+            SafePipeHandle clientHandle = new SafePipeHandle(
+                (IntPtr)fds[direction == PipeDirection.In ? Interop.libc.WriteEndOfPipe : Interop.libc.ReadEndOfPipe], 
+                ownsHandle: true);
+
+            // We're connected.  Finish initialization using the newly created handles.
+            InitializeHandle(serverHandle, isExposed: false, isAsync: false);
+            _clientHandle = clientHandle;
+            State = PipeState.Connected;
         }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
@@ -60,5 +60,9 @@ namespace System.IO.Pipes
             State = PipeState.Connected;
         }
 
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Win32.SafeHandles;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security;
 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using System.Security;
-using System.Security.Principal;
 using System.Threading;
 
 namespace System.IO.Pipes
@@ -16,19 +13,29 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeClientStream : PipeStream
     {
-        private static string GetPipePath(string serverName, string pipeName)
-        {
-            throw NotImplemented.ByDesign; // TODO: Implement this
-        }
-
-        // Waits for a pipe instance to become available. This method may return before WaitForConnection is called
-        // on the server end, but WaitForConnection will not return until we have returned.  Any data writen to the
-        // pipe by us after we have connected but before the server has called WaitForConnection will be available
-        // to the server after it calls WaitForConnection. 
         [SecurityCritical]
-        private void ConnectInternal(int timeout, CancellationToken cancellationToken, int startTime)
+        private bool TryConnect(int timeout, CancellationToken cancellationToken)
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            try
+            {
+                // Open the file.  For In or Out, this will block until a client has connected.
+                // Unfortunately for InOut it won't, which is different from the Windows behavior;
+                // on Unix it won't block for InOut until it actually performs a read or write operation.
+                var clientHandle = Microsoft.Win32.SafeHandles.SafePipeHandle.Open(
+                    _normalizedPipePath, 
+                    TranslateFlags(_direction, _pipeOptions, _inheritability),
+                    (int)Interop.libc.Permissions.S_IRWXU);
+
+                // Pipe successfully opened.  Store our client handle.
+                InitializeHandle(clientHandle, isExposed: false, isAsync: (_pipeOptions & PipeOptions.Asynchronous) != 0);
+                State = PipeState.Connected;
+                return true;
+            }
+            catch (FileNotFoundException)
+            {
+                // The FIFO file doesn't yet exist.
+                return false;
+            }
         }
 
         public int NumberOfServerInstances
@@ -38,10 +45,13 @@ namespace System.IO.Pipes
             get
             {
                 CheckPipePropertyOperations();
-
-                throw NotImplemented.ByDesign; // TODO: Implement this
+                throw new PlatformNotSupportedException(); // no way to determine this accurately
             }
         }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
 
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -16,22 +16,12 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeClientStream : PipeStream
     {
-        private static string GetPipePath(string serverName, string pipeName)
-        {
-            string normalizedPipePath = Path.GetFullPath(@"\\" + serverName + @"\pipe\" + pipeName);
-            if (String.Equals(normalizedPipePath, @"\\.\pipe\anonymous", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new ArgumentOutOfRangeException("pipeName", SR.ArgumentOutOfRange_AnonymousReserved);
-            }
-            return normalizedPipePath;
-        }
-
         // Waits for a pipe instance to become available. This method may return before WaitForConnection is called
         // on the server end, but WaitForConnection will not return until we have returned.  Any data writen to the
         // pipe by us after we have connected but before the server has called WaitForConnection will be available
         // to the server after it calls WaitForConnection. 
         [SecurityCritical]
-        private void ConnectInternal(int timeout, CancellationToken cancellationToken, int startTime)
+        private bool TryConnect(int timeout, CancellationToken cancellationToken)
         {
             Interop.SECURITY_ATTRIBUTES secAttrs = PipeStream.GetSecAttrs(_inheritability);
 
@@ -42,100 +32,67 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            // This is the main connection loop. It will loop until the timeout expires.  Most of the 
-            // time, we will be waiting in the WaitNamedPipe win32 blocking function; however, there are
-            // cases when we will need to loop: 1) The server is not created (WaitNamedPipe returns 
-            // straight away in such cases), and 2) when another client connects to our server in between 
-            // our WaitNamedPipe and CreateFile calls.
-            int elapsed = 0;
-            do
+            if (!Interop.mincore.WaitNamedPipe(_normalizedPipePath, timeout))
             {
-                // We want any other exception and and success to have priority over cancellation.
-                cancellationToken.ThrowIfCancellationRequested();
+                int errorCode = Marshal.GetLastWin32Error();
 
-                // Wait for pipe to become free (this will block unless the pipe does not exist).
-                int timeLeft = timeout - elapsed;
-                int waitTime;
-                if (cancellationToken.CanBeCanceled)
+                // Server is not yet created
+                if (errorCode == Interop.ERROR_FILE_NOT_FOUND)
                 {
-                    waitTime = Math.Min(CancellationCheckInterval, timeLeft);
-                }
-                else
-                {
-                    waitTime = timeLeft;
+                    return false;
                 }
 
-                if (!Interop.mincore.WaitNamedPipe(_normalizedPipePath, waitTime))
+                // The timeout has expired.
+                if (errorCode == Interop.ERROR_SUCCESS)
                 {
-                    int errorCode = Marshal.GetLastWin32Error();
-
-                    // Server is not yet created so let's keep looping.
-                    if (errorCode == Interop.ERROR_FILE_NOT_FOUND)
+                    if (cancellationToken.CanBeCanceled)
                     {
-                        continue;
+                        // It may not be real timeout.
+                        return false;
                     }
-
-                    // The timeout has expired.
-                    if (errorCode == Interop.ERROR_SUCCESS)
-                    {
-                        if (cancellationToken.CanBeCanceled)
-                        {
-                            // It may not be real timeout and only checking for cancellation
-                            // let the while condition check it and decide
-                            continue;
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    throw new TimeoutException();
                 }
 
-                // Pipe server should be free.  Let's try to connect to it.
-                int access = 0;
-                if ((PipeDirection.In & _direction) != 0)
-                {
-                    access |= Interop.GENERIC_READ;
-                }
-                if ((PipeDirection.Out & _direction) != 0)
-                {
-                    access |= Interop.GENERIC_WRITE;
-                }
-                SafePipeHandle handle = Interop.mincore.CreateNamedPipeClient(_normalizedPipePath,
-                                            access,           // read and write access
-                                            0,                  // sharing: none
-                                            ref secAttrs,           // security attributes
-                                            FileMode.Open,      // open existing 
-                                            _pipeFlags,         // impersonation flags
-                                            Interop.NULL);  // template file: null
-
-                if (handle.IsInvalid)
-                {
-                    int errorCode = Marshal.GetLastWin32Error();
-
-                    // Handle the possible race condition of someone else connecting to the server 
-                    // between our calls to WaitNamedPipe & CreateFile.
-                    if (errorCode == Interop.ERROR_PIPE_BUSY)
-                    {
-                        continue;
-                    }
-
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
-                }
-
-                // Success! 
-                InitializeHandle(handle, false, (_pipeOptions & PipeOptions.Asynchronous) != 0);
-                State = PipeState.Connected;
-
-                return;
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
             }
-            while (timeout == Timeout.Infinite || (elapsed = unchecked(Environment.TickCount - startTime)) < timeout);
-            // BUGBUG: SerialPort does not use unchecked arithmetic when calculating elapsed times.  This is needed
-            //         because Environment.TickCount can overflow (though only every 49.7 days).
 
-            throw new TimeoutException();
+            // Pipe server should be free.  Let's try to connect to it.
+            int access = 0;
+            if ((PipeDirection.In & _direction) != 0)
+            {
+                access |= Interop.GENERIC_READ;
+            }
+            if ((PipeDirection.Out & _direction) != 0)
+            {
+                access |= Interop.GENERIC_WRITE;
+            }
+            SafePipeHandle handle = Interop.mincore.CreateNamedPipeClient(_normalizedPipePath,
+                                        access,           // read and write access
+                                        0,                  // sharing: none
+                                        ref secAttrs,           // security attributes
+                                        FileMode.Open,      // open existing 
+                                        _pipeFlags,         // impersonation flags
+                                        Interop.NULL);  // template file: null
+
+            if (handle.IsInvalid)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+
+                // Handle the possible race condition of someone else connecting to the server 
+                // between our calls to WaitNamedPipe & CreateFile.
+                if (errorCode == Interop.ERROR_PIPE_BUSY)
+                {
+                    return false;
+                }
+
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+            }
+
+            // Success! 
+            InitializeHandle(handle, false, (_pipeOptions & PipeOptions.Asynchronous) != 0);
+            State = PipeState.Connected;
+
+            return true;
         }
 
         public int NumberOfServerInstances
@@ -161,6 +118,10 @@ namespace System.IO.Pipes
                 return numInstances;
             }
         }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
 
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +15,14 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeServerStream : PipeStream
     {
+        private bool _createdFifo;
+        private string _path;
+        private PipeDirection _direction;
+        private PipeOptions _options;
+        private int _inBufferSize;
+        private int _outBufferSize;
+        private HandleInheritability _inheritability;
+
         [SecurityCritical]
         private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
@@ -29,40 +35,99 @@ namespace System.IO.Pipes
             Debug.Assert((maxNumberOfServerInstances >= 1 && maxNumberOfServerInstances <= 254) || (maxNumberOfServerInstances == MaxAllowedServerInstances), "maxNumberOfServerInstances is invalid");
             Debug.Assert(transmissionMode >= PipeTransmissionMode.Byte && transmissionMode <= PipeTransmissionMode.Message, "transmissionMode is out of range");
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            if (transmissionMode == PipeTransmissionMode.Message)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            // NOTE: We don't have a good way to enforce maxNumberOfServerInstances, and don't currently try.
+            // It's a Windows-specific concept.
+
+            // Make sure the FIFO exists, but don't open it until WaitForConnection is called.
+            _path = GetPipePath(".", pipeName);
+            while (true)
+            {
+                int result = Interop.libc.mkfifo(_path, (int)Interop.libc.Permissions.S_IRWXU);
+                if (result == 0)
+                {
+                    _createdFifo = true;
+                    break;
+                }
+
+                int errno = Marshal.GetLastWin32Error();
+                if (errno == Interop.Errors.EINTR)
+                {
+                    // interrupted; try again
+                    continue;
+                }
+                else if (errno == Interop.Errors.EEXIST)
+                {
+                    // FIFO already exists; nothing more to do
+                    break;
+                }
+                else
+                {
+                    // something else; fail
+                    throw Interop.GetExceptionForIoErrno(errno, _path);
+                }
+            }
+
+            // Store the rest of the creation arguments.  They'll be used when we open the connection
+            // in WaitForConnection.
+            _direction = direction;
+            _options = options;
+            _inBufferSize = inBufferSize;
+            _outBufferSize = outBufferSize;
+            _inheritability = inheritability;
         }
 
-        // This will wait until the client calls Connect().  If we return from this method, we guarantee that
-        // the client has returned from its Connect call.   The client may have done so before this method 
-        // was called (but not before this server is been created, or, if we were servicing another client, 
-        // not before we called Disconnect), in which case, there may be some buffer already in the pipe waiting
-        // for us to read.  See NamedPipeClientStream.Connect for more information.
         [SecurityCritical]
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
         public void WaitForConnection()
         {
             CheckConnectOperationsServer();
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            // Open the file.  For In or Out, this will block until a client has connected.
+            // Unfortunately for InOut it won't, which is different from the Windows behavior;
+            // on Unix it won't block for InOut until it actually performs a read or write operation.
+            var serverHandle = Microsoft.Win32.SafeHandles.SafePipeHandle.Open(
+                _path, 
+                TranslateFlags(_direction, _options, _inheritability), 
+                (int)Interop.libc.Permissions.S_IRWXU);
+
+            // Ignore _inBufferSize and _outBufferSize.  They're optional, and the fcntl F_SETPIPE_SZ for changing 
+            // a pipe's buffer size is Linux specific.
+
+            InitializeHandle(serverHandle, isExposed: false, isAsync: (_options & PipeOptions.Asynchronous) != 0);
+            State = PipeState.Connected;
         }
 
         public Task WaitForConnectionAsync(CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
-
-            return Task.Factory.StartNew(s => ((NamedPipeServerStream)s).WaitForConnection(),
-                this, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                Task.Factory.StartNew(s => ((NamedPipeServerStream)s).WaitForConnection(),
+                    this, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         [SecurityCritical]
         public void Disconnect()
         {
             CheckDisconnectOperations();
+            State = PipeState.Disconnected;
+            InternalHandle.Dispose();
+            InitializeHandle(null, false, false);
+        }
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+        protected override void Dispose(bool disposing)
+        {
+            // If we created the FIFO object, be a good citizen and clean it up.
+            // If this doesn't happen, worst case is we leave a temp file around.
+            if (_createdFifo && _path != null)
+            {
+                Interop.libc.unlink(_path); // ignore any errors
+            }
+            base.Dispose(disposing);
         }
 
         // Gets the username of the connected client.  Not that we will not have access to the client's 
@@ -72,8 +137,12 @@ namespace System.IO.Pipes
         public String GetImpersonationUserName()
         {
             CheckWriteOperations();
-
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            throw new PlatformNotSupportedException();
         }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -18,10 +18,6 @@ namespace System.IO.Pipes
     public sealed partial class NamedPipeServerStream : PipeStream
     {
         [SecurityCritical]
-        private unsafe static readonly IOCompletionCallback s_WaitForConnectionCallback =
-            new IOCompletionCallback(NamedPipeServerStream.AsyncWaitForConnectionCallback);
-
-        [SecurityCritical]
         private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 HandleInheritability inheritability)
@@ -76,7 +72,7 @@ namespace System.IO.Pipes
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
         public void WaitForConnection()
         {
-            CheckConnectOperationsServer();
+            CheckConnectOperationsServerWithHandle();
 
             if (IsAsync)
             {
@@ -126,153 +122,6 @@ namespace System.IO.Pipes
                 cancellationToken.CanBeCanceled ? new IOCancellationHelper(cancellationToken) : null);
         }
 
-        // Async version of WaitForConnection.  See the comments above for more info.
-        [SecurityCritical]
-        private unsafe IAsyncResult BeginWaitForConnection(AsyncCallback callback, Object state)
-        {
-            CheckConnectOperationsServer();
-
-            if (!IsAsync)
-            {
-                throw new InvalidOperationException(SR.InvalidOperation_PipeNotAsync);
-            }
-
-            // Create and store async stream class library specific data in the 
-            // async result
-            PipeAsyncResult asyncResult = new PipeAsyncResult();
-            asyncResult._handle = InternalHandle;
-            asyncResult._userCallback = callback;
-            asyncResult._userStateObject = state;
-
-            IOCancellationHelper cancellationHelper = state as IOCancellationHelper;
-
-            // Create wait handle and store in async result
-            ManualResetEvent waitHandle = new ManualResetEvent(false);
-            asyncResult._waitHandle = waitHandle;
-
-            // Create a managed overlapped class
-            // We will set the file offsets later
-            Overlapped overlapped = new Overlapped();
-            overlapped.OffsetLow = 0;
-            overlapped.OffsetHigh = 0;
-            overlapped.AsyncResult = asyncResult;
-
-            // Pack the Overlapped class, and store it in the async result
-            NativeOverlapped* intOverlapped = overlapped.Pack(s_WaitForConnectionCallback, null);
-            asyncResult._overlapped = intOverlapped;
-            if (!Interop.mincore.ConnectNamedPipe(InternalHandle, intOverlapped))
-            {
-                int errorCode = Marshal.GetLastWin32Error();
-
-                if (errorCode == Interop.ERROR_IO_PENDING)
-                {
-                    if (cancellationHelper != null)
-                    {
-                        cancellationHelper.AllowCancellation(InternalHandle, intOverlapped);
-                    }
-                    return asyncResult;
-                }
-
-                // WaitForConnectionCallback will not be called because we completed synchronously.
-                // Either the pipe is already connected, or there was an error. Unpin and free the overlapped again.
-                Overlapped.Free(intOverlapped);
-                asyncResult._overlapped = null;
-
-                // Did the client already connect to us?
-                if (errorCode == Interop.ERROR_PIPE_CONNECTED)
-                {
-                    if (State == PipeState.Connected)
-                    {
-                        throw new InvalidOperationException(SR.InvalidOperation_PipeAlreadyConnected);
-                    }
-                    asyncResult.CallUserCallback();
-                    return asyncResult;
-                }
-
-                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
-            }
-            // will set state to Connected when EndWait is called
-            if (cancellationHelper != null)
-            {
-                cancellationHelper.AllowCancellation(InternalHandle, intOverlapped);
-            }
-
-            return asyncResult;
-        }
-
-        // Async version of WaitForConnection.  See comments for WaitForConnection for more info.
-        [SecurityCritical]
-        private unsafe void EndWaitForConnection(IAsyncResult asyncResult)
-        {
-            CheckConnectOperationsServer();
-
-            if (asyncResult == null)
-            {
-                throw new ArgumentNullException("asyncResult");
-            }
-            if (!IsAsync)
-            {
-                throw new InvalidOperationException(SR.InvalidOperation_PipeNotAsync);
-            }
-
-            PipeAsyncResult afsar = asyncResult as PipeAsyncResult;
-            if (afsar == null)
-            {
-                throw __Error.GetWrongAsyncResult();
-            }
-
-            // Ensure we can't get into any races by doing an interlocked
-            // CompareExchange here.  Avoids corrupting memory via freeing the
-            // NativeOverlapped class or GCHandle twice.  -- 
-            if (1 == Interlocked.CompareExchange(ref afsar._EndXxxCalled, 1, 0))
-            {
-                throw __Error.GetEndWaitForConnectionCalledTwice();
-            }
-
-            IOCancellationHelper cancellationHelper = afsar.AsyncState as IOCancellationHelper;
-            if (cancellationHelper != null)
-            {
-                cancellationHelper.SetOperationCompleted();
-            }
-
-            // Obtain the WaitHandle, but don't use public property in case we
-            // delay initialize the manual reset event in the future.
-            WaitHandle wh = afsar._waitHandle;
-            if (wh != null)
-            {
-                // We must block to ensure that ConnectionIOCallback has completed,
-                // and we should close the WaitHandle in here.  AsyncFSCallback
-                // and the hand-ported imitation version in COMThreadPool.cpp 
-                // are the only places that set this event.
-                using (wh)
-                {
-                    wh.WaitOne();
-                    Debug.Assert(afsar._isComplete == true, "NamedPipeServerStream::EndWaitForConnection - AsyncFSCallback didn't set _isComplete to true!");
-                }
-            }
-
-            // We should have freed the overlapped and set it to null either in the Begin
-            // method (if ConnectNamedPipe completed synchronously) or in AsyncWaitForConnectionCallback.
-            // If it is not nulled out, we should not be past the above wait:
-            Debug.Assert(afsar._overlapped == null);
-
-            // Now check for any error during the read.
-            if (afsar._errorCode != 0)
-            {
-                if (afsar._errorCode == Interop.ERROR_OPERATION_ABORTED)
-                {
-                    if (cancellationHelper != null)
-                    {
-                        cancellationHelper.ThrowIOOperationAborted();
-                    }
-                }
-                throw Win32Marshal.GetExceptionForWin32Error(afsar._errorCode);
-            }
-
-            // Success
-            State = PipeState.Connected;
-        }
-
         [SecurityCritical]
         public void Disconnect()
         {
@@ -286,6 +135,33 @@ namespace System.IO.Pipes
 
             State = PipeState.Disconnected;
         }
+
+        // Gets the username of the connected client.  Not that we will not have access to the client's 
+        // username until it has written at least once to the pipe (and has set its impersonationLevel 
+        // argument appropriately). 
+        [SecurityCritical]
+        public String GetImpersonationUserName()
+        {
+            CheckWriteOperations();
+
+            StringBuilder userName = new StringBuilder(Interop.CREDUI_MAX_USERNAME_LENGTH + 1);
+
+            if (!Interop.mincore.GetNamedPipeHandleState(InternalHandle, Interop.NULL, Interop.NULL,
+                Interop.NULL, Interop.NULL, userName, userName.Capacity))
+            {
+                WinIOError(Marshal.GetLastWin32Error());
+            }
+
+            return userName.ToString();
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+        [SecurityCritical]
+        private unsafe static readonly IOCompletionCallback s_WaitForConnectionCallback =
+            new IOCompletionCallback(NamedPipeServerStream.AsyncWaitForConnectionCallback);
 
 #if RunAs
         // This method calls a delegate while impersonating the client. Note that we will not have
@@ -373,23 +249,151 @@ namespace System.IO.Pipes
         }
 #endif
 
-        // Gets the username of the connected client.  Not that we will not have access to the client's 
-        // username until it has written at least once to the pipe (and has set its impersonationLevel 
-        // argument appropriately). 
+        // Async version of WaitForConnection.  See the comments above for more info.
         [SecurityCritical]
-        public String GetImpersonationUserName()
+        private unsafe IAsyncResult BeginWaitForConnection(AsyncCallback callback, Object state)
         {
-            CheckWriteOperations();
+            CheckConnectOperationsServerWithHandle();
 
-            StringBuilder userName = new StringBuilder(Interop.CREDUI_MAX_USERNAME_LENGTH + 1);
-
-            if (!Interop.mincore.GetNamedPipeHandleState(InternalHandle, Interop.NULL, Interop.NULL,
-                Interop.NULL, Interop.NULL, userName, userName.Capacity))
+            if (!IsAsync)
             {
-                WinIOError(Marshal.GetLastWin32Error());
+                throw new InvalidOperationException(SR.InvalidOperation_PipeNotAsync);
             }
 
-            return userName.ToString();
+            // Create and store async stream class library specific data in the 
+            // async result
+            PipeAsyncResult asyncResult = new PipeAsyncResult();
+            asyncResult._handle = InternalHandle;
+            asyncResult._userCallback = callback;
+            asyncResult._userStateObject = state;
+
+            IOCancellationHelper cancellationHelper = state as IOCancellationHelper;
+
+            // Create wait handle and store in async result
+            ManualResetEvent waitHandle = new ManualResetEvent(false);
+            asyncResult._waitHandle = waitHandle;
+
+            // Create a managed overlapped class
+            // We will set the file offsets later
+            Overlapped overlapped = new Overlapped();
+            overlapped.OffsetLow = 0;
+            overlapped.OffsetHigh = 0;
+            overlapped.AsyncResult = asyncResult;
+
+            // Pack the Overlapped class, and store it in the async result
+            NativeOverlapped* intOverlapped = overlapped.Pack(s_WaitForConnectionCallback, null);
+            asyncResult._overlapped = intOverlapped;
+            if (!Interop.mincore.ConnectNamedPipe(InternalHandle, intOverlapped))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (errorCode == Interop.ERROR_IO_PENDING)
+                {
+                    if (cancellationHelper != null)
+                    {
+                        cancellationHelper.AllowCancellation(InternalHandle, intOverlapped);
+                    }
+                    return asyncResult;
+                }
+
+                // WaitForConnectionCallback will not be called because we completed synchronously.
+                // Either the pipe is already connected, or there was an error. Unpin and free the overlapped again.
+                Overlapped.Free(intOverlapped);
+                asyncResult._overlapped = null;
+
+                // Did the client already connect to us?
+                if (errorCode == Interop.ERROR_PIPE_CONNECTED)
+                {
+                    if (State == PipeState.Connected)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_PipeAlreadyConnected);
+                    }
+                    asyncResult.CallUserCallback();
+                    return asyncResult;
+                }
+
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+            }
+            // will set state to Connected when EndWait is called
+            if (cancellationHelper != null)
+            {
+                cancellationHelper.AllowCancellation(InternalHandle, intOverlapped);
+            }
+
+            return asyncResult;
+        }
+
+        // Async version of WaitForConnection.  See comments for WaitForConnection for more info.
+        [SecurityCritical]
+        private unsafe void EndWaitForConnection(IAsyncResult asyncResult)
+        {
+            CheckConnectOperationsServerWithHandle();
+
+            if (asyncResult == null)
+            {
+                throw new ArgumentNullException("asyncResult");
+            }
+            if (!IsAsync)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_PipeNotAsync);
+            }
+
+            PipeAsyncResult afsar = asyncResult as PipeAsyncResult;
+            if (afsar == null)
+            {
+                throw __Error.GetWrongAsyncResult();
+            }
+
+            // Ensure we can't get into any races by doing an interlocked
+            // CompareExchange here.  Avoids corrupting memory via freeing the
+            // NativeOverlapped class or GCHandle twice.  -- 
+            if (1 == Interlocked.CompareExchange(ref afsar._EndXxxCalled, 1, 0))
+            {
+                throw __Error.GetEndWaitForConnectionCalledTwice();
+            }
+
+            IOCancellationHelper cancellationHelper = afsar.AsyncState as IOCancellationHelper;
+            if (cancellationHelper != null)
+            {
+                cancellationHelper.SetOperationCompleted();
+            }
+
+            // Obtain the WaitHandle, but don't use public property in case we
+            // delay initialize the manual reset event in the future.
+            WaitHandle wh = afsar._waitHandle;
+            if (wh != null)
+            {
+                // We must block to ensure that ConnectionIOCallback has completed,
+                // and we should close the WaitHandle in here.  AsyncFSCallback
+                // and the hand-ported imitation version in COMThreadPool.cpp 
+                // are the only places that set this event.
+                using (wh)
+                {
+                    wh.WaitOne();
+                    Debug.Assert(afsar._isComplete == true, "NamedPipeServerStream::EndWaitForConnection - AsyncFSCallback didn't set _isComplete to true!");
+                }
+            }
+
+            // We should have freed the overlapped and set it to null either in the Begin
+            // method (if ConnectNamedPipe completed synchronously) or in AsyncWaitForConnectionCallback.
+            // If it is not nulled out, we should not be past the above wait:
+            Debug.Assert(afsar._overlapped == null);
+
+            // Now check for any error during the read.
+            if (afsar._errorCode != 0)
+            {
+                if (afsar._errorCode == Interop.ERROR_OPERATION_ABORTED)
+                {
+                    if (cancellationHelper != null)
+                    {
+                        cancellationHelper.ThrowIOOperationAborted();
+                    }
+                }
+                throw Win32Marshal.GetExceptionForWin32Error(afsar._errorCode);
+            }
+
+            // Success
+            State = PipeState.Connected;
         }
 
         // Callback to be called by the OS when completing the async WaitForConnection operation.
@@ -442,6 +446,15 @@ namespace System.IO.Pipes
             {
                 userCallback(asyncResult);
             }
+        }
+
+        private void CheckConnectOperationsServerWithHandle()
+        {
+            if (InternalHandle == null)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_PipeHandleNotSet);
+            }
+            CheckConnectOperationsServer();
         }
     }
 }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -159,15 +159,11 @@ namespace System.IO.Pipes
             // "pipe is being closed" if other side is closing (as does win32) or no-op if
             // already connected
 
-            if (InternalHandle == null)
-            {
-                throw new InvalidOperationException(SR.InvalidOperation_PipeHandleNotSet);
-            }
             if (State == PipeState.Closed)
             {
                 throw __Error.GetPipeNotOpen();
             }
-            if (InternalHandle.IsClosed)
+            if (InternalHandle != null && InternalHandle.IsClosed) // only check IsClosed if we have a handle
             {
                 throw __Error.GetPipeNotOpen();
             }

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -4,21 +4,79 @@
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.IO.Pipes
 {
     public abstract partial class PipeStream : Stream
     {
+        private const string PipeDirectoryPath = "/tmp/corefxnamedpipes/";
+
+        internal static string GetPipePath(string serverName, string pipeName)
+        {
+            if (serverName != "." && serverName != Interop.libc.gethostname())
+            {
+                // Cross-machine pipes are not supported.
+                throw new PlatformNotSupportedException();
+            }
+
+            if (pipeName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                // Since pipes are stored as files in the file system, we don't support
+                // pipe names that are actually paths or that otherwise have invalid
+                // filename characters in them.
+                throw new PlatformNotSupportedException();
+            }
+
+            // Make sure we have the directory in which to put the pipe paths
+            while (true)
+            {
+                int result = Interop.libc.mkdir(PipeDirectoryPath, (int)Interop.libc.Permissions.S_IRWXU);
+                if (result >= 0)
+                {
+                    // directory created
+                    break;
+                }
+
+                int errno = Marshal.GetLastWin32Error();
+                if (errno == Interop.Errors.EINTR)
+                {
+                    // I/O was interrupted, try again
+                    continue;
+                }
+                else if (errno == Interop.Errors.EEXIST)
+                {
+                    // directory already exists
+                    break;
+                }
+                else
+                {
+                    throw Interop.GetExceptionForIoErrno(errno, PipeDirectoryPath, isDirectory: true);
+                }
+            }
+
+            // Return the pipe path
+            return PipeDirectoryPath + pipeName;
+        }
+
         /// <summary>Throws an exception if the supplied handle does not represent a valid pipe.</summary>
         /// <param name="safePipeHandle">The handle to validate.</param>
         internal static void ValidateHandleIsPipe(SafePipeHandle safePipeHandle)
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            SysCall(safePipeHandle, (fd, _, __) =>
+            {
+                Interop.libc.structStat buf;
+                int result = Interop.libc.fstat(fd, out buf);
+                if (result == 0)
+                {
+                    if ((buf.st_mode & Interop.libc.FileTypes.S_IFMT) != Interop.libc.FileTypes.S_IFIFO)
+                    {
+                        throw new IOException(SR.IO_InvalidPipeHandle);
+                    }
+                }
+                return result;
+            });
         }
 
         /// <summary>Initializes the handle to be used asynchronously.</summary>
@@ -39,7 +97,15 @@ namespace System.IO.Pipes
             Debug.Assert(offset >= 0, "offset is negative");
             Debug.Assert(count >= 0, "count is negative");
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            fixed (byte* bufPtr = buffer)
+            {
+                return (int)SysCall(_handle, (fd, ptr, len) =>
+                {
+                    long result = (long)Interop.libc.read(fd, (byte*)ptr, (IntPtr)len);
+                    Debug.Assert(result <= len);
+                    return result;
+                }, (IntPtr)(bufPtr + offset), count);
+            }
         }
 
         [SecurityCritical]
@@ -52,7 +118,20 @@ namespace System.IO.Pipes
             Debug.Assert(offset >= 0, "offset is negative");
             Debug.Assert(count >= 0, "count is negative");
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            fixed (byte* bufPtr = buffer)
+            {
+                while (count > 0)
+                {
+                    int bytesWritten = (int)SysCall(_handle, (fd, ptr, len) =>
+                    {
+                        long result = (long)Interop.libc.write(fd, (byte*)ptr, (IntPtr)len);
+                        Debug.Assert(result <= len);
+                        return result;
+                    }, (IntPtr)(bufPtr + offset), count);
+                    count -= bytesWritten;
+                    offset += bytesWritten;
+                }
+            }
         }
 
         // Blocks until the other end of the pipe has read in all written buffer.
@@ -65,10 +144,8 @@ namespace System.IO.Pipes
                 throw __Error.GetWriteNotSupported();
             }
 
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            throw new PlatformNotSupportedException(); // no mechanism for this on Unix
         }
-
-        // ********************** Public Properties *********************** //
 
         // Gets the transmission mode for the pipe.  This is virtual so that subclassing types can 
         // override this in cases where only one mode is legal (such as anonymous pipes)
@@ -79,15 +156,7 @@ namespace System.IO.Pipes
             get
             {
                 CheckPipePropertyOperations();
-
-                if (_isFromExistingHandle)
-                {
-                    throw NotImplemented.ByDesign; // TODO: Implement this
-                }
-                else
-                {
-                    return _transmissionMode;
-                }
+                return PipeTransmissionMode.Byte; // Unix pipes are only byte-based, not message-based
             }
         }
 
@@ -105,7 +174,9 @@ namespace System.IO.Pipes
                     throw new NotSupportedException(SR.NotSupported_UnreadableStream);
                 }
 
-                throw NotImplemented.ByDesign; // TODO: Implement this
+                // On Linux this could be retrieved using F_GETPIPE_SZ with fcntl, but that's non-conforming
+                // and works only on recent versions of Linux.  For now, we'll leave this as unsupported.
+                throw new PlatformNotSupportedException();
             }
         }
 
@@ -125,19 +196,8 @@ namespace System.IO.Pipes
                     throw new NotSupportedException(SR.NotSupported_UnwritableStream);
                 }
 
-                int outBufferSize;
-
-                // Use cached value if direction is out; otherwise get fresh version
-                if (_pipeDirection == PipeDirection.Out)
-                {
-                    outBufferSize = _outBufferSize;
-                }
-                else
-                {
-                    throw NotImplemented.ByDesign; // TODO: Implement this
-                }
-
-                return outBufferSize;
+                // See comments in inBufferSize
+                throw new PlatformNotSupportedException();
             }
         }
 
@@ -147,13 +207,7 @@ namespace System.IO.Pipes
             get
             {
                 CheckPipePropertyOperations();
-
-                // get fresh value if it could be stale
-                if (_isFromExistingHandle || IsHandleExposed)
-                {
-                    throw NotImplemented.ByDesign;
-                }
-                return _readMode;
+                return PipeTransmissionMode.Byte; // Unix pipes are only byte-based, not message-based
             }
             [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
@@ -165,11 +219,101 @@ namespace System.IO.Pipes
                     throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_TransmissionModeByteOrMsg);
                 }
 
-                throw NotImplemented.ByDesign; // TODO: Implement this
+                if (value != PipeTransmissionMode.Byte) // Unix pipes are only byte-based, not message-based
+                {
+                    throw new PlatformNotSupportedException();
+                }
+
+                // nop, since it's already the only valid value
+            }
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+        internal static Interop.libc.OpenFlags TranslateFlags(PipeDirection direction, PipeOptions options, HandleInheritability inheritability)
+        {
+            // Translate direction
+            Interop.libc.OpenFlags flags =
+                direction == PipeDirection.InOut ? Interop.libc.OpenFlags.O_RDWR :
+                direction == PipeDirection.Out ? Interop.libc.OpenFlags.O_WRONLY :
+                Interop.libc.OpenFlags.O_RDONLY;
+
+            // Translate options
+            if ((options & PipeOptions.WriteThrough) != 0)
+            {
+                flags |= Interop.libc.OpenFlags.O_SYNC;
+            }
+
+            // Translate inheritability.
+            if ((inheritability & HandleInheritability.Inheritable) == 0)
+            {
+                flags |= Interop.libc.OpenFlags.O_CLOEXEC;
+            }
+            
+            // PipeOptions.Asynchronous is ignored, at least for now.  Asynchronous processing
+            // is handling just by queueing a work item to do the work synchronously on a pool thread.
+
+            return flags;
+        }
+
+        /// <summary>
+        /// Helper for making system calls that involve the stream's file descriptor.
+        /// System calls are expected to return greather than or equal to zero on success,
+        /// and less than zero on failure.  In the case of failure, errno is expected to
+        /// be set to the relevant error code.
+        /// </summary>
+        /// <param name="sysCall">A delegate that invokes the system call.</param>
+        /// <param name="arg1">The first argument to be passed to the system call, after the file descriptor.</param>
+        /// <param name="arg2">The second argument to be passed to the system call.</param>
+        /// <returns>The return value of the system call.</returns>
+        /// <remarks>
+        /// Arguments are expected to be passed via <paramref name="arg1"/> and <paramref name="arg2"/>
+        /// so as to avoid delegate and closure allocations at the call sites.
+        /// </remarks>
+        private static long SysCall(
+            SafePipeHandle handle,
+            Func<int, IntPtr, int, long> sysCall,
+            IntPtr arg1 = default(IntPtr), int arg2 = default(int))
+        {
+            bool gotRefOnHandle = false;
+            try
+            {
+                // Get the file descriptor from the handle.  We increment the ref count to help
+                // ensure it's not closed out from under us.
+                handle.DangerousAddRef(ref gotRefOnHandle);
+                Debug.Assert(gotRefOnHandle);
+                int fd = (int)handle.DangerousGetHandle();
+                Debug.Assert(fd >= 0);
+
+                // System calls may fail due to EINTR (signal interruption).  We need to retry in those cases.
+                while (true)
+                {
+                    long result = sysCall(fd, arg1, arg2);
+                    if (result < 0)
+                    {
+                        int errno = Marshal.GetLastWin32Error();
+                        if (errno == Interop.Errors.EINTR)
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            throw Interop.GetExceptionForIoErrno(errno);
+                        }
+                    }
+                    return result;
+                }
+            }
+            finally
+            {
+                if (gotRefOnHandle)
+                {
+                    handle.DangerousRelease();
+                }
             }
         }
 
     }
 }
-
-

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -90,12 +90,11 @@ namespace System.IO.Pipes
 
         // Once a PipeStream has a handle ready, it should call this method to set up the PipeStream.  If
         // the pipe is in a connected state already, it should also set the IsConnected (protected) property.
+        // This method may also be called to uninitialize a handle, setting it to null.
         [SecuritySafeCritical]
         internal void InitializeHandle(SafePipeHandle handle, bool isExposed, bool isAsync)
         {
-            Debug.Assert(handle != null, "handle is null");
-
-            if (isAsync)
+            if (isAsync && handle != null)
             {
                 InitializeAsyncHandle(handle);
             }


### PR DESCRIPTION
This PR provides an initial implementation of the System.IO.Pipes library on Unix.

A few notes:
- Ignore almost all of the changes in the *.Windows.cs files... I just moved some code around to put code above or below a "PAL Layer" comment, as we've done in other places in CoreFX.  The only interesting change in the Windows code was that in the named pipe client, I refactored out the retry/cancellation/timing loop so that it could be used by the Unix code as well, and in doing so I added some slightly smarter spinning support.  There were also one or two places where some validation logic in shared code was overly aggressive in what it was checking for when it came to Unix, so I refactored those checks into a core piece and a Windows-specific additional check.
- The .NET APIs map fairly closely to the Windows APIs, and thus there will be some rough edges here on the Unix side, e.g. calling WaitForConnection with named pipes and an InOut direction won't block as it does on Windows.
- I use a bit of "light up" to make some things work on Linux that probably won't as-is on Mac, e.g. in anonymous pipes, I mapped non-inheritability to using O_CLOEXEC, but pipe2 which accepts a flags argument that allows O_CLOEXEC to be specified is Linux-specific (as is dup3 that would allow for reopening a handle with O_CLOEXEC).  This doesn't seem particularly problematic, though, since the primary use case for anonymous pipes is having them be inherited... just another of the rough edges.
- As part of this, I also realized that in the various places in CoreFX we were making libc write calls we might have been losing data, as write doesn't guarantee it'll write out all of the supplied data. I fixed those call sites.