### PR TITLE
[WIP] Remove Console.WriteLine from BigInteger tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -21,45 +21,45 @@ namespace System.Numerics.Tests
         {
             String test;
 
-            //Scenario 1: Large BigInteger - positive
+            // Scenario 1: Large BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, s_random);
-                Assert.True(VerifyToString(test, test), " Verification Failed");
+                VerifyToString(test, test);
             }
 
-            //Scenario 2: Small BigInteger - positive
+            // Scenario 2: Small BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, s_random);
-                Assert.True(VerifyToString(test, test), " Verification Failed");
+                VerifyToString(test, test);
             }
 
-            //Scenario 3: Large BigInteger - negative
+            // Scenario 3: Large BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, s_random);
-                Assert.True(VerifyToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test, CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test), " Verification Failed");
+                VerifyToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test, CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test);
             }
 
-            //Scenario 4: Small BigInteger - negative
+            // Scenario 4: Small BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, s_random);
-                Assert.True(VerifyToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test, CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test), " Verification Failed");
+                VerifyToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test, CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + test);
             }
 
-            //Scenario 5: Constant values
-            Assert.True(VerifyToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + "1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + "1"), " Verification Failed");
-            Assert.True(VerifyToString("0", "0"), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MinValue.ToString(), Int16.MinValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MinValue.ToString(), Int32.MinValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MinValue.ToString(), Int64.MinValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Decimal.MinValue.ToString(), Decimal.MinValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MaxValue.ToString(), Int16.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MaxValue.ToString(), Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MaxValue.ToString(), Int64.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyToString(Decimal.MaxValue.ToString(), Decimal.MaxValue.ToString()), " Verification Failed");
+            // Scenario 5: Constant values
+            VerifyToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + "1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + "1");
+            VerifyToString("0", "0");
+            VerifyToString(Int16.MinValue.ToString(), Int16.MinValue.ToString());
+            VerifyToString(Int32.MinValue.ToString(), Int32.MinValue.ToString());
+            VerifyToString(Int64.MinValue.ToString(), Int64.MinValue.ToString());
+            VerifyToString(Decimal.MinValue.ToString(), Decimal.MinValue.ToString());
+            VerifyToString(Int16.MaxValue.ToString(), Int16.MaxValue.ToString());
+            VerifyToString(Int32.MaxValue.ToString(), Int32.MaxValue.ToString());
+            VerifyToString(Int64.MaxValue.ToString(), Int64.MaxValue.ToString());
+            VerifyToString(Decimal.MaxValue.ToString(), Decimal.MaxValue.ToString());
         }
 
         [Fact]
@@ -68,16 +68,16 @@ namespace System.Numerics.Tests
             NumberFormatInfo nfi = new NumberFormatInfo();
             nfi = MarkUp(nfi);
 
-            Assert.True(RunSimpleProviderToStringTests(s_random, "", nfi, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "C", nfi, nfi.CurrencyDecimalDigits, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "D", nfi, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "E", nfi, 6, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "F", nfi, nfi.NumberDecimalDigits, FixedFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "G", nfi, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "N", nfi, nfi.NumberDecimalDigits, NumberFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "P", nfi, nfi.PercentDecimalDigits, PercentFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "X", nfi, 0, HexFormatter), " Verification Failed");
-            Assert.True(RunSimpleProviderToStringTests(s_random, "R", nfi, 0, DecimalFormatter), " Verification Failed");
+            RunSimpleProviderToStringTests(s_random, "", nfi, 0, DecimalFormatter);
+            RunSimpleProviderToStringTests(s_random, "C", nfi, nfi.CurrencyDecimalDigits, CurrencyFormatter);
+            RunSimpleProviderToStringTests(s_random, "D", nfi, 0, DecimalFormatter);
+            RunSimpleProviderToStringTests(s_random, "E", nfi, 6, ExponentialFormatter);
+            RunSimpleProviderToStringTests(s_random, "F", nfi, nfi.NumberDecimalDigits, FixedFormatter);
+            RunSimpleProviderToStringTests(s_random, "G", nfi, 0, DecimalFormatter);
+            RunSimpleProviderToStringTests(s_random, "N", nfi, nfi.NumberDecimalDigits, NumberFormatter);
+            RunSimpleProviderToStringTests(s_random, "P", nfi, nfi.PercentDecimalDigits, PercentFormatter);
+            RunSimpleProviderToStringTests(s_random, "X", nfi, 0, HexFormatter);
+            RunSimpleProviderToStringTests(s_random, "R", nfi, 0, DecimalFormatter);
         }
 
         [Fact]
@@ -86,358 +86,350 @@ namespace System.Numerics.Tests
             String test;
             String format;
 
-            //Currency
-            Assert.True(RunStandardFormatToStringTests(s_random, "C", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.CurrencyDecimalDigits, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "c0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "C1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "c2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "C5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "c33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, CurrencyFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "C99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, CurrencyFormatter), " Verification Failed");
+            // Currency
+            RunStandardFormatToStringTests(s_random, "C", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.CurrencyDecimalDigits, CurrencyFormatter);
+            RunStandardFormatToStringTests(s_random, "c0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, CurrencyFormatter);
+            RunStandardFormatToStringTests(s_random, "C1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, CurrencyFormatter);
+            RunStandardFormatToStringTests(s_random, "c2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CurrencyFormatter);
+            RunStandardFormatToStringTests(s_random, "C5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, CurrencyFormatter);
+            RunStandardFormatToStringTests(s_random, "c33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, CurrencyFormatter);
+            RunStandardFormatToStringTests(s_random, "C99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, CurrencyFormatter);
 
-            //Decimal
-            Assert.True(RunStandardFormatToStringTests(s_random, "D", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "d0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "D1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "d2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "D5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "d33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "D99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, DecimalFormatter), " Verification Failed");
+            // Decimal
+            RunStandardFormatToStringTests(s_random, "D", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "d0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "D1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "d2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "D5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "d33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "D99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
-            //Exponential (note: negative percision means lower case e)
-            Assert.True(RunStandardFormatToStringTests(s_random, "E", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "E0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "E1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "e2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -2, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "E5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "e33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -33, ExponentialFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "E99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, ExponentialFormatter), " Verification Failed");
-            //test exponent of 4 digits
+            // Exponential (note: negative percision means lower case e)
+            RunStandardFormatToStringTests(s_random, "E", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ExponentialFormatter);
+            RunStandardFormatToStringTests(s_random, "E0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ExponentialFormatter);
+            RunStandardFormatToStringTests(s_random, "E1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExponentialFormatter);
+            RunStandardFormatToStringTests(s_random, "e2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -2, ExponentialFormatter);
+            RunStandardFormatToStringTests(s_random, "E5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, ExponentialFormatter);
+            RunStandardFormatToStringTests(s_random, "e33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -33, ExponentialFormatter);
+            RunStandardFormatToStringTests(s_random, "E99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, ExponentialFormatter);
+            // Test exponent of 4 digits
             test = GetDigitSequence(2000, 2000, s_random);
-            Assert.True(VerifyToString(test, "E", ExponentialFormatter(test, 6, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+            VerifyToString(test, "E", ExponentialFormatter(test, 6, CultureInfo.CurrentUICulture.NumberFormat));
 
-            //Fixed-Point
-            Assert.True(RunStandardFormatToStringTests(s_random, "f", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalDigits, FixedFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "F0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, FixedFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "f1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, FixedFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "F2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, FixedFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "f5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, FixedFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "F33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, FixedFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "f99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, FixedFormatter), " Verification Failed");
+            // Fixed-Point
+            RunStandardFormatToStringTests(s_random, "f", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalDigits, FixedFormatter);
+            RunStandardFormatToStringTests(s_random, "F0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, FixedFormatter);
+            RunStandardFormatToStringTests(s_random, "f1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, FixedFormatter);
+            RunStandardFormatToStringTests(s_random, "F2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, FixedFormatter);
+            RunStandardFormatToStringTests(s_random, "f5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, FixedFormatter);
+            RunStandardFormatToStringTests(s_random, "F33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, FixedFormatter);
+            RunStandardFormatToStringTests(s_random, "f99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, FixedFormatter);
 
-            //General
-            Assert.True(RunStandardFormatToStringTests(s_random, "g", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "G0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "G1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "G2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "g5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "G33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "g99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, DecimalFormatter), " Verification Failed");
+            // General
+            RunStandardFormatToStringTests(s_random, "g", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "G0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "G1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "G2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "g5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "G33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "g99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
-            //Number
-            Assert.True(RunStandardFormatToStringTests(s_random, "n", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalDigits, NumberFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "N0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, NumberFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "N1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, NumberFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "N2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, NumberFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "n5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, NumberFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "N33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, NumberFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "n99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, NumberFormatter), " Verification Failed");
+            // Number
+            RunStandardFormatToStringTests(s_random, "n", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalDigits, NumberFormatter);
+            RunStandardFormatToStringTests(s_random, "N0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, NumberFormatter);
+            RunStandardFormatToStringTests(s_random, "N1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, NumberFormatter);
+            RunStandardFormatToStringTests(s_random, "N2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, NumberFormatter);
+            RunStandardFormatToStringTests(s_random, "n5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, NumberFormatter);
+            RunStandardFormatToStringTests(s_random, "N33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, NumberFormatter);
+            RunStandardFormatToStringTests(s_random, "n99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, NumberFormatter);
 
-            //Percent
-            Assert.True(RunStandardFormatToStringTests(s_random, "p", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.PercentDecimalDigits, PercentFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "P0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, PercentFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "P1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, PercentFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "P2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, PercentFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "p5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, PercentFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "P33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, PercentFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "p99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, PercentFormatter), " Verification Failed");
+            // Percent
+            RunStandardFormatToStringTests(s_random, "p", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, CultureInfo.CurrentUICulture.NumberFormat.PercentDecimalDigits, PercentFormatter);
+            RunStandardFormatToStringTests(s_random, "P0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, PercentFormatter);
+            RunStandardFormatToStringTests(s_random, "P1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, PercentFormatter);
+            RunStandardFormatToStringTests(s_random, "P2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, PercentFormatter);
+            RunStandardFormatToStringTests(s_random, "p5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, PercentFormatter);
+            RunStandardFormatToStringTests(s_random, "P33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, PercentFormatter);
+            RunStandardFormatToStringTests(s_random, "p99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, PercentFormatter);
 
-            //Hex
-            Assert.True(RunStandardFormatToStringTests(s_random, "X", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, HexFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "X0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, HexFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "x1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -1, HexFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "X2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, HexFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "x5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -5, HexFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "X33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, HexFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "x99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -99, HexFormatter), " Verification Failed");
+            // Hex
+            RunStandardFormatToStringTests(s_random, "X", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, HexFormatter);
+            RunStandardFormatToStringTests(s_random, "X0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, HexFormatter);
+            RunStandardFormatToStringTests(s_random, "x1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -1, HexFormatter);
+            RunStandardFormatToStringTests(s_random, "X2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, HexFormatter);
+            RunStandardFormatToStringTests(s_random, "x5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -5, HexFormatter);
+            RunStandardFormatToStringTests(s_random, "X33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, HexFormatter);
+            RunStandardFormatToStringTests(s_random, "x99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -99, HexFormatter);
 
-            //RoundTrip
-            Assert.True(RunStandardFormatToStringTests(s_random, "R", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "R0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "r1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "R2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "r5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "R33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, DecimalFormatter), " Verification Failed");
-            Assert.True(RunStandardFormatToStringTests(s_random, "r99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, DecimalFormatter), " Verification Failed");
+            // RoundTrip
+            RunStandardFormatToStringTests(s_random, "R", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "R0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "r1", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "R2", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "r5", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "R33", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+            RunStandardFormatToStringTests(s_random, "r99", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
-            //other - invalid format characters
+            // Other - invalid format characters
             for (int i = 0; i < s_samples; i++)
             {
                 format = GetRandomInvalidFormatChar(s_random);
                 test = GetDigitSequence(10, 100, s_random);
-                Assert.True(VerifyToString(test, true, format, false, null, true, null), " Verification Failed");
+                VerifyToString(test, format, null, true, null);
             }
         }
 
         [Fact]
         public static void RunCustomFormatZeroPlaceholder()
         {
-            //Zero Placeholder
-            Assert.True(RunCustomFormatToStringTests(s_random, "0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ZeroFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 4, ZeroFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, new String('0', 500), CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 500, ZeroFormatter), " Verification Failed");
+            // Zero Placeholder
+            RunCustomFormatToStringTests(s_random, "0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ZeroFormatter);
+            RunCustomFormatToStringTests(s_random, "0000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 4, ZeroFormatter);
+            RunCustomFormatToStringTests(s_random, new String('0', 500), CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 500, ZeroFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatDigitPlaceholder()
         {
-            //Digit Placeholder
-            Assert.True(RunCustomFormatToStringTests(s_random, "#", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ZeroFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "####", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ZeroFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, new String('#', 500), CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ZeroFormatter), " Verification Failed");
+            // Digit Placeholder
+            RunCustomFormatToStringTests(s_random, "#", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ZeroFormatter);
+            RunCustomFormatToStringTests(s_random, "####", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ZeroFormatter);
+            RunCustomFormatToStringTests(s_random, new String('#', 500), CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ZeroFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatDecimalPoint()
         {
-            //Decimal Point (match required digits before and after point with percision)
-            Assert.True(RunCustomFormatToStringTests(s_random, "#.#", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalPointFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "00.00", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalPointFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0000.0.00.0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 4, DecimalPointFormatter), " Verification Failed");
+            // Decimal Point (match required digits before and after point with percision)
+            RunCustomFormatToStringTests(s_random, "#.#", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, DecimalPointFormatter);
+            RunCustomFormatToStringTests(s_random, "00.00", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, DecimalPointFormatter);
+            RunCustomFormatToStringTests(s_random, "0000.0.00.0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 4, DecimalPointFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatThousandsSeparator()
         {
-            //Thousands Seperator
-            Assert.True(RunCustomFormatToStringTests(s_random, "#,#", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ThousandsFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "00,00", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 4, ThousandsFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0000,0,00,0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 8, ThousandsFormatter), " Verification Failed");
+            // Thousands Seperator
+            RunCustomFormatToStringTests(s_random, "#,#", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ThousandsFormatter);
+            RunCustomFormatToStringTests(s_random, "00,00", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 4, ThousandsFormatter);
+            RunCustomFormatToStringTests(s_random, "0000,0,00,0", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 8, ThousandsFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatNumberScaling()
         {
-            //Number Scaling (match scale factor to decimal places+3
-            Assert.True(RunCustomFormatToStringTests(s_random, "#,", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, ScalingFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#,,.000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ScalingFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#,,,.000000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 9, ScalingFormatter), " Verification Failed");
+            // Number Scaling (match scale factor to decimal places+3
+            RunCustomFormatToStringTests(s_random, "#,", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, ScalingFormatter);
+            RunCustomFormatToStringTests(s_random, "#,,.000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ScalingFormatter);
+            RunCustomFormatToStringTests(s_random, "#,,,.000000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 9, ScalingFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatPercentSign()
         {
-            //Percent Sign
-            Assert.True(RunCustomFormatToStringTests(s_random, "#%", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, PercentSymbolFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#%000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, PercentSymbolFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#%000000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, PercentSymbolFormatter), " Verification Failed");
+            // Percent Sign
+            RunCustomFormatToStringTests(s_random, "#%", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, PercentSymbolFormatter);
+            RunCustomFormatToStringTests(s_random, "#%000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, PercentSymbolFormatter);
+            RunCustomFormatToStringTests(s_random, "#%000000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, PercentSymbolFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatScientificNotation()
         {
-            //Scientific Notation
-            Assert.True(RunCustomFormatToStringTests(s_random, "0.000000E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ScientificFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0.000000E-000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ScientificFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0.000000E+000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, SignedScientificFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0.000000e000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -6, ScientificFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0.000000e-000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -6, ScientificFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0.000000e+000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -6, SignedScientificFormatter), " Verification Failed");
+            // Scientific Notation
+            RunCustomFormatToStringTests(s_random, "0.000000E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ScientificFormatter);
+            RunCustomFormatToStringTests(s_random, "0.000000E-000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, ScientificFormatter);
+            RunCustomFormatToStringTests(s_random, "0.000000E+000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, SignedScientificFormatter);
+            RunCustomFormatToStringTests(s_random, "0.000000e000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -6, ScientificFormatter);
+            RunCustomFormatToStringTests(s_random, "0.000000e-000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -6, ScientificFormatter);
+            RunCustomFormatToStringTests(s_random, "0.000000e+000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, -6, SignedScientificFormatter);
         }
 
         [Fact]
         public static void RunCustomFormatEscapeChar()
         {
-            //Escape Character
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\\\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\'")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\\\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\"")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\\%", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "%")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\n", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\n")), " Verification Failed");
+            // Escape Character
+            RunCustomFormatToStringTests(s_random, "0\\\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\'"));
+            RunCustomFormatToStringTests(s_random, "0\\\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\""));
+            RunCustomFormatToStringTests(s_random, "0\\%", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "%"));
+            RunCustomFormatToStringTests(s_random, "0\n", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\n"));
         }
 
         [Fact]
         public static void RunCustomFormatLiterals()
         {
-            //Literals
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\'.0\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ".0")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\".0\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ".0")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\',0\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ",0")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\",0\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ",0")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\',\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ",")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\",\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ",")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\'%\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "%")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\"%\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "%")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\'E+0\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "E+0")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\"E+0\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "E+0")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\'\\\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\\")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "0\"\\\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\\")), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#\',\'%", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ExtraFormatter(PercentSymbolFormatter, ",", CultureInfo.CurrentUICulture.NumberFormat.PercentSymbol.Length)), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "000\",\".000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, ExtraFormatter(DecimalPointFormatter, ",", CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator.Length + 3)), " Verification Failed");
+            // Literals
+            RunCustomFormatToStringTests(s_random, "0\'.0\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ".0"));
+            RunCustomFormatToStringTests(s_random, "0\".0\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ".0"));
+            RunCustomFormatToStringTests(s_random, "0\',0\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ",0"));
+            RunCustomFormatToStringTests(s_random, "0\",0\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ",0"));
+            RunCustomFormatToStringTests(s_random, "0\',\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ","));
+            RunCustomFormatToStringTests(s_random, "0\",\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, ","));
+            RunCustomFormatToStringTests(s_random, "0\'%\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "%"));
+            RunCustomFormatToStringTests(s_random, "0\"%\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "%"));
+            RunCustomFormatToStringTests(s_random, "0\'E+0\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "E+0"));
+            RunCustomFormatToStringTests(s_random, "0\"E+0\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "E+0"));
+            RunCustomFormatToStringTests(s_random, "0\'\\\'", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\\"));
+            RunCustomFormatToStringTests(s_random, "0\"\\\"", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 1, ExtraFormatter(ZeroFormatter, "\\"));
+            RunCustomFormatToStringTests(s_random, "#\',\'%", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, ExtraFormatter(PercentSymbolFormatter, ",", CultureInfo.CurrentUICulture.NumberFormat.PercentSymbol.Length));
+            RunCustomFormatToStringTests(s_random, "000\",\".000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, ExtraFormatter(DecimalPointFormatter, ",", CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator.Length + 3));
         }
 
         [Fact]
         public static void RunCustomFormatSeparator()
         {
-            //Seperator
-            Assert.True(RunCustomFormatToStringTests(s_random, "00.00;0.00E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(DecimalPointFormatter, ScientificFormatter)), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "00.00;;0.00E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(DecimalPointFormatter, DecimalPointFormatter, ScientificFormatter, true)), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "00.00;#%00;0.00E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(DecimalPointFormatter, PercentSymbolFormatter, ScientificFormatter)), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "00000000000000000000000000000.00000000000000000000000000000;", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 29, DecimalPointFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "00000000000000000000000000000.00000000000000000000000000000;;", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 29, DecimalPointFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, ";", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(EmptyFormatter, EmptyFormatter, EmptyFormatter, true)), " Verification Failed");
+            // Seperator
+            RunCustomFormatToStringTests(s_random, "00.00;0.00E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(DecimalPointFormatter, ScientificFormatter));
+            RunCustomFormatToStringTests(s_random, "00.00;;0.00E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(DecimalPointFormatter, DecimalPointFormatter, ScientificFormatter, true));
+            RunCustomFormatToStringTests(s_random, "00.00;#%00;0.00E000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(DecimalPointFormatter, PercentSymbolFormatter, ScientificFormatter));
+            RunCustomFormatToStringTests(s_random, "00000000000000000000000000000.00000000000000000000000000000;", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 29, DecimalPointFormatter);
+            RunCustomFormatToStringTests(s_random, "00000000000000000000000000000.00000000000000000000000000000;;", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 29, DecimalPointFormatter);
+            RunCustomFormatToStringTests(s_random, ";", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 2, CombinedFormatter(EmptyFormatter, EmptyFormatter, EmptyFormatter, true));
         }
 
         [Fact]
         public static void CustomFormatPerMille()
         {
-            //PerMillie Symbol
-            Assert.True(RunCustomFormatToStringTests(s_random, "#\u2030", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, PerMilleSymbolFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#\u2030000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, PerMilleSymbolFormatter), " Verification Failed");
-            Assert.True(RunCustomFormatToStringTests(s_random, "#\u2030000000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, PerMilleSymbolFormatter), " Verification Failed");
+            // PerMillie Symbol
+            RunCustomFormatToStringTests(s_random, "#\u2030", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 0, PerMilleSymbolFormatter);
+            RunCustomFormatToStringTests(s_random, "#\u2030000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 3, PerMilleSymbolFormatter);
+            RunCustomFormatToStringTests(s_random, "#\u2030000000", CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, 6, PerMilleSymbolFormatter);
         }
 
-        private static bool RunSimpleProviderToStringTests(Random random, String format, NumberFormatInfo provider, int percision, StringFormatter formatter)
+        private static void RunSimpleProviderToStringTests(Random random, String format, NumberFormatInfo provider, int percision, StringFormatter formatter)
         {
-            bool ret = true;
             String test;
-            bool hasFormat = (format != String.Empty);
 
-            //Scenario 1: Large BigInteger - positive
+            // Scenario 1: Large BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, random);
-                Assert.True(VerifyToString(test, hasFormat, format, true, provider, false, formatter(test, percision, provider)), " Verification Failed");
+                VerifyToString(test, format, provider, false, formatter(test, percision, provider));
             }
 
-            //Scenario 2: Small BigInteger - positive
+            // Scenario 2: Small BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, random);
-                Assert.True(VerifyToString(test, hasFormat, format, true, provider, false, formatter(test, percision, provider)), " Verification Failed");
+                VerifyToString(test, format, provider, false, formatter(test, percision, provider));
             }
 
-            //Scenario 3: Large BigInteger - negative
+            // Scenario 3: Large BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, random);
-                Assert.True(VerifyToString(provider.NegativeSign + test, hasFormat, format, true, provider, false, formatter(provider.NegativeSign + test, percision, provider)), " Verification Failed");
+                VerifyToString(provider.NegativeSign + test, format, provider, false, formatter(provider.NegativeSign + test, percision, provider));
             }
 
-            //Scenario 4: Small BigInteger - negative
+            // Scenario 4: Small BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, random);
-                Assert.True(VerifyToString(provider.NegativeSign + test, hasFormat, format, true, provider, false, formatter(provider.NegativeSign + test, percision, provider)), " Verification Failed");
+                VerifyToString(provider.NegativeSign + test, format, provider, false, formatter(provider.NegativeSign + test, percision, provider));
             }
 
-            //Scenario 5: Constant values
-            Assert.True(VerifyToString(provider.NegativeSign + "1", hasFormat, format, true, provider, false, formatter(provider.NegativeSign + "1", percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(provider.NegativeSign + "0", hasFormat, format, true, provider, false, formatter("0", percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString("0", hasFormat, format, true, provider, false, formatter("0", percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MinValue.ToString("d", provider), hasFormat, format, true, provider, false, formatter(Int16.MinValue.ToString("d", provider), percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MinValue.ToString("d", provider), hasFormat, format, true, provider, false, formatter(Int32.MinValue.ToString("d", provider), percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MinValue.ToString("d", provider), hasFormat, format, true, provider, false, formatter(Int64.MinValue.ToString("d", provider), percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MaxValue.ToString("d", provider), hasFormat, format, true, provider, false, formatter(Int16.MaxValue.ToString("d", provider), percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MaxValue.ToString("d", provider), hasFormat, format, true, provider, false, formatter(Int32.MaxValue.ToString("d", provider), percision, provider)), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MaxValue.ToString("d", provider), hasFormat, format, true, provider, false, formatter(Int64.MaxValue.ToString("d", provider), percision, provider)), " Verification Failed");
-
-            return ret;
+            // Scenario 5: Constant values
+            VerifyToString(provider.NegativeSign + "1", format, provider, false, formatter(provider.NegativeSign + "1", percision, provider));
+            VerifyToString(provider.NegativeSign + "0", format, provider, false, formatter("0", percision, provider));
+            VerifyToString("0", format, provider, false, formatter("0", percision, provider));
+            VerifyToString(Int16.MinValue.ToString("d", provider), format, provider, false, formatter(Int16.MinValue.ToString("d", provider), percision, provider));
+            VerifyToString(Int32.MinValue.ToString("d", provider), format, provider, false, formatter(Int32.MinValue.ToString("d", provider), percision, provider));
+            VerifyToString(Int64.MinValue.ToString("d", provider), format, provider, false, formatter(Int64.MinValue.ToString("d", provider), percision, provider));
+            VerifyToString(Int16.MaxValue.ToString("d", provider), format, provider, false, formatter(Int16.MaxValue.ToString("d", provider), percision, provider));
+            VerifyToString(Int32.MaxValue.ToString("d", provider), format, provider, false, formatter(Int32.MaxValue.ToString("d", provider), percision, provider));
+            VerifyToString(Int64.MaxValue.ToString("d", provider), format, provider, false, formatter(Int64.MaxValue.ToString("d", provider), percision, provider));
         }
-        private static bool RunStandardFormatToStringTests(Random random, String format, String negativeSign, int percision, StringFormatter formatter)
+
+        private static void RunStandardFormatToStringTests(Random random, String format, String negativeSign, int percision, StringFormatter formatter)
         {
-            bool ret = true;
             String test;
 
-            //Scenario 1: Large BigInteger - positive
+            // Scenario 1: Large BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, random);
-                Assert.True(VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 2: Small BigInteger - positive
+            // Scenario 2: Small BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, random);
-                Assert.True(VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 3: Large BigInteger - negative
+            // Scenario 3: Large BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, random);
-                Assert.True(VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 4: Small BigInteger - negative
+            // Scenario 4: Small BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, random);
-                Assert.True(VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 5: Constant values
-            Assert.True(VerifyToString(negativeSign + "1", format, formatter(negativeSign + "1", percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(negativeSign + "0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString("0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MinValue.ToString(), format, formatter(Int16.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MinValue.ToString(), format, formatter(Int32.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MinValue.ToString(), format, formatter(Int64.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Decimal.MinValue.ToString(), format, formatter(Decimal.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MaxValue.ToString(), format, formatter(Int16.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MaxValue.ToString(), format, formatter(Int32.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MaxValue.ToString(), format, formatter(Int64.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Decimal.MaxValue.ToString(), format, formatter(Decimal.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-
-            return ret;
+            // Scenario 5: Constant values
+            VerifyToString(negativeSign + "1", format, formatter(negativeSign + "1", percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(negativeSign + "0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString("0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int16.MinValue.ToString(), format, formatter(Int16.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int32.MinValue.ToString(), format, formatter(Int32.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int64.MinValue.ToString(), format, formatter(Int64.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Decimal.MinValue.ToString(), format, formatter(Decimal.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int16.MaxValue.ToString(), format, formatter(Int16.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int32.MaxValue.ToString(), format, formatter(Int32.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int64.MaxValue.ToString(), format, formatter(Int64.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Decimal.MaxValue.ToString(), format, formatter(Decimal.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
         }
-        private static bool RunCustomFormatToStringTests(Random random, String format, String negativeSign, int percision, StringFormatter formatter)
+
+        private static void RunCustomFormatToStringTests(Random random, String format, String negativeSign, int percision, StringFormatter formatter)
         {
-            bool ret = true;
             String test;
 
-            //Scenario 1: Large BigInteger - positive
+            // Scenario 1: Large BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, random);
-                Assert.True(VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 2: Small BigInteger - positive
+            // Scenario 2: Small BigInteger - positive
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, random);
-                Assert.True(VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(test, format, formatter(test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 3: Large BigInteger - negative
+            // Scenario 3: Large BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(100, 1000, random);
-                Assert.True(VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 4: Small BigInteger - negative
+            // Scenario 4: Small BigInteger - negative
             for (int i = 0; i < s_samples; i++)
             {
                 test = GetDigitSequence(1, 20, random);
-                Assert.True(VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
+                VerifyToString(negativeSign + test, format, formatter(negativeSign + test, percision, CultureInfo.CurrentUICulture.NumberFormat));
             }
 
-            //Scenario 5: Constant values
-            Assert.True(VerifyToString(negativeSign + "1", format, formatter(negativeSign + "1", percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(negativeSign + "0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString("0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MinValue.ToString(), format, formatter(Int16.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MinValue.ToString(), format, formatter(Int32.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MinValue.ToString(), format, formatter(Int64.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Decimal.MinValue.ToString(), format, formatter(Decimal.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int16.MaxValue.ToString(), format, formatter(Int16.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int32.MaxValue.ToString(), format, formatter(Int32.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Int64.MaxValue.ToString(), format, formatter(Int64.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-            Assert.True(VerifyToString(Decimal.MaxValue.ToString(), format, formatter(Decimal.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat)), " Verification Failed");
-
-            return ret;
+            // Scenario 5: Constant values
+            VerifyToString(negativeSign + "1", format, formatter(negativeSign + "1", percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(negativeSign + "0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString("0", format, formatter("0", percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int16.MinValue.ToString(), format, formatter(Int16.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int32.MinValue.ToString(), format, formatter(Int32.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int64.MinValue.ToString(), format, formatter(Int64.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Decimal.MinValue.ToString(), format, formatter(Decimal.MinValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int16.MaxValue.ToString(), format, formatter(Int16.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int32.MaxValue.ToString(), format, formatter(Int32.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Int64.MaxValue.ToString(), format, formatter(Int64.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
+            VerifyToString(Decimal.MaxValue.ToString(), format, formatter(Decimal.MaxValue.ToString(), percision, CultureInfo.CurrentUICulture.NumberFormat));
         }
 
         private static String CurrencyFormatter(String input, int percision, NumberFormatInfo nfi)
@@ -530,6 +522,7 @@ namespace System.Numerics.Tests
 
             return pre + GroupFormatDigits(input, nfi.CurrencyGroupSeparator, nfi.CurrencyGroupSizes, nfi.CurrencyDecimalSeparator, percision) + post;
         }
+
         private static String DecimalFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -550,6 +543,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ExponentialFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -624,6 +618,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String FixedFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -647,6 +642,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String GeneralFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             String output = input;
@@ -695,6 +691,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String NumberFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             String pre = String.Empty;
@@ -727,6 +724,7 @@ namespace System.Numerics.Tests
 
             return pre + GroupFormatDigits(input, nfi.NumberGroupSeparator, nfi.NumberGroupSizes, nfi.NumberDecimalSeparator, percision) + post;
         }
+
         private static String PercentFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             String pre = String.Empty;
@@ -805,6 +803,7 @@ namespace System.Numerics.Tests
             }
             return pre + GroupFormatDigits(input, nfi.PercentGroupSeparator, nfi.PercentGroupSizes, nfi.PercentDecimalSeparator, percision) + post;
         }
+
         private static String HexFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool upper = true;
@@ -827,6 +826,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ZeroFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -857,6 +857,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String DecimalPointFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -892,6 +893,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ThousandsFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             String pre = String.Empty;
@@ -909,6 +911,7 @@ namespace System.Numerics.Tests
 
             return pre + GroupFormatDigits(input, nfi.NumberGroupSeparator, nfi.NumberGroupSizes, String.Empty, 0);
         }
+
         private static String ScalingFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -992,6 +995,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String PercentSymbolFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -1028,6 +1032,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String PerMilleSymbolFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -1064,6 +1069,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ScientificFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -1138,6 +1144,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String SignedScientificFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             bool IsNeg = false;
@@ -1212,6 +1219,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String EmptyFormatter(String input, int percision, NumberFormatInfo nfi)
         {
             String temp = String.Empty;
@@ -1228,6 +1236,7 @@ namespace System.Numerics.Tests
         {
             return ExtraFormatter(formatter, added, 0);
         }
+
         private static StringFormatter ExtraFormatter(StringFormatter formatter, String added, int placesAfter)
         {
             StringFormatter sf = delegate (String input, int percision, NumberFormatInfo nfi)
@@ -1242,14 +1251,17 @@ namespace System.Numerics.Tests
             };
             return sf;
         }
+
         private static StringFormatter CombinedFormatter(StringFormatter posFormatter, StringFormatter negFormatter)
         {
             return CombinedFormatter(posFormatter, negFormatter, posFormatter);
         }
+
         private static StringFormatter CombinedFormatter(StringFormatter posFormatter, StringFormatter negFormatter, StringFormatter zeroFormatter)
         {
             return CombinedFormatter(posFormatter, negFormatter, zeroFormatter, false);
         }
+
         private static StringFormatter CombinedFormatter(StringFormatter posFormatter, StringFormatter negFormatter, StringFormatter zeroFormatter, bool negInherited)
         {
             StringFormatter sf = delegate (String input, int percision, NumberFormatInfo nfi)
@@ -1279,106 +1291,66 @@ namespace System.Numerics.Tests
             return sf;
         }
 
-        private static bool VerifyToString(String test, String expectedResult)
+        private static void VerifyToString(String test, String expectedResult)
         {
-            return VerifyToString(test, false, null, false, null, false, expectedResult);
+            VerifyToString(test, format: null, provider: null, expectError: false, expectedResult: expectedResult);
         }
-        private static bool VerifyToString(String test, String format, String expectedResult)
-        {
-            return VerifyToString(test, true, format, false, null, false, expectedResult);
-        }
-        private static bool VerifyToString(String test, bool hasFormat, String format, bool hasProvider, IFormatProvider provider, bool expectError, String expectedResult)
-        {
-            bool ret = true;
-            string result = null;
 
+        private static void VerifyToString(String test, String format, String expectedResult)
+        {
+            VerifyToString(test, format: format, provider: null, expectError: false, expectedResult: expectedResult);
+        }
+
+        private static void VerifyToString(String test, String format, IFormatProvider provider, bool expectError, String expectedResult)
+        {
+            bool hasFormat = !String.IsNullOrEmpty(format);
+            bool hasProvider = provider != null;
+            string result = null;
+            
             try
             {
                 if (hasFormat)
                 {
-                    if (hasProvider)
-                    {
-                        result = BigInteger.Parse(test, provider).ToString(format, provider);
-                    }
-                    else
-                    {
-                        result = BigInteger.Parse(test).ToString(format);
-                    }
+                    result = hasProvider ? BigInteger.Parse(test, provider).ToString(format, provider) :
+                                           BigInteger.Parse(test).ToString(format);
                 }
                 else
                 {
-                    if (hasProvider)
-                    {
-                        result = BigInteger.Parse(test, provider).ToString(provider);
-                    }
-                    else
-                    {
-                        result = BigInteger.Parse(test).ToString();
-                    }
+                    result = hasProvider ? BigInteger.Parse(test, provider).ToString(provider) :
+                                           BigInteger.Parse(test).ToString();
                 }
 
-                if (expectError)
+                Assert.False(expectError, "Expected exception not encountered.");
+
+                if (expectedResult != result)
                 {
-                    Console.WriteLine("Expected Exception not encountered.");
-                    ret = false;
+                    Assert.Equal(expectedResult.Length, result.Length);
+
+                    int index = expectedResult.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
+                    Assert.False(index == 0, "'E' found at beginning of expectedResult");
+
+                    bool equal = false;
+                    if (index > 0)
+                    {
+                        var dig1 = (byte)expectedResult[index - 1];
+                        var dig2 = (byte)result[index - 1];
+
+                        equal |= (dig2 == dig1 - 1 || dig2 == dig1 + 1);
+                        equal |= (dig1 == '9' && dig2 == '0' || dig2 == '9' && dig1 == '0');
+                        equal |= (index == 1 && (dig1 == '9' && dig2 == '1' || dig2 == '9' && dig1 == '1'));
+                    }
+
+                    Assert.True(equal);
                 }
                 else
                 {
-                    if (expectedResult != result)
-                    {
-                        ret = false;
-                        if (expectedResult.Length != result.Length)
-                        {
-                            Console.WriteLine("ToString values did not match: Expected:\r\n{0}.\r\nActual:\r\n{1}", expectedResult, result);
-                        }
-                        else
-                        {
-                            int index = expectedResult.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
-                            if (index == 0)
-                                throw new ArgumentException("E found at beginning of String: {0}", expectedResult);
-                            if (index > 0)
-                            {
-                                var dig1 = (byte)expectedResult[index - 1];
-                                var dig2 = (byte)result[index - 1];
-
-                                if (dig2 == dig1 - 1 || dig2 == dig1 + 1)
-                                    ret = true;
-                                if (dig1 == '9' && dig2 == '0' || dig2 == '9' && dig1 == '0')
-                                    ret = true;
-                                if (index == 1 && (dig1 == '9' && dig2 == '1' || dig2 == '9' && dig1 == '1'))
-                                    ret = true;
-                            }
-                        }
-                    }
-
-                    if (ret == false)
-                    {
-                        Console.WriteLine("ToString values did not match: Expected:\r\n{0}.\r\nActual:\r\n{1}", expectedResult, result);
-                    }
+                    Assert.Equal(expectedResult, result);
                 }
             }
             catch (Exception e)
             {
-                if (e.GetType() == typeof(FormatException))
-                {
-                    if (expectError)
-                    {
-                        //Intentionally left blank.
-                    }
-                    else
-                    {
-                        Console.WriteLine("Unexpected Exception:" + e);
-                        ret = false;
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("Unexpected Exception:" + e);
-                    ret = false;
-                }
+                Assert.True(expectError && e.GetType() == typeof(FormatException), "Unexpected Exception:" + e);
             }
-
-            return ret;
         }
 
         private static String GetDigitSequence(int min, int max, Random random)
@@ -1431,13 +1403,14 @@ namespace System.Numerics.Tests
                         result = 'C';
                 }
             }
-            String res = new String(result, 1);
-            return res;
+            return new String(result, 1);
         }
+
         private static String Fix(String input)
         {
             return Fix(input, false);
         }
+
         private static String Fix(String input, bool isHex)
         {
             String output = input;
@@ -1462,6 +1435,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ConvertHexToDecimal(string input)
         {
             char[] inArr = input.ToCharArray();
@@ -1509,6 +1483,7 @@ namespace System.Numerics.Tests
             String y2 = new String(number.ToArray());
             return y2;
         }
+
         private static String ConvertDecimalToHex(string input, bool upper, NumberFormatInfo nfi)
         {
             String output = string.Empty;
@@ -1541,6 +1516,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ConvertToExp(string input, int places)
         {
             Char[] temp = input.Substring(0, places + 2).ToCharArray();
@@ -1582,6 +1558,7 @@ namespace System.Numerics.Tests
 
             return ret;
         }
+
         private static String GenerateGroups(int[] sizes, string seperator, Random random)
         {
             List<int> total_sizes = new List<int>();
@@ -1617,7 +1594,9 @@ namespace System.Numerics.Tests
             for (int j = total_sizes.Count - 1; j > 0; j--)
             {
                 if ((first) && (total_sizes[j] >= num_digits))
+                {
                     continue;
+                }
                 int group_size = num_digits - total_sizes[j - 1];
                 if (first)
                 {
@@ -1707,15 +1686,12 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ZeroString(int size)
         {
-            String ret = String.Empty;
-            if (size >= 1)
-            {
-                ret = new String('0', size);
-            }
-            return ret;
+            return size >= 1 ? new String('0', size) : String.Empty;
         }
+
         private static String FString(int size, bool upper)
         {
             String ret = String.Empty;
@@ -1762,66 +1738,6 @@ namespace System.Numerics.Tests
             nfi.PositiveSign = ">>";
 
             return nfi;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-            return Eval(retValue, errorMsg + " Expected:" + (null == expected ? "<null>" : expected.ToString()) + " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            //if (!retValue)
-            //{
-            //    Eval(retValue, errorMsg + " Expected:" + (null == expected ? "<null>" : expected.ToString()) + " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-            //    throw new ApplicationException();
-            //}
-
-
-            //return true;
-        }
-        public static bool Eval(BigInteger x, String y, String errorMsg)
-        {
-            bool IsPos = (x >= 0);
-            bool ret = true;
-            String y2 = null;
-
-            if (!IsPos)
-            {
-                x = -x;
-            }
-
-            if (x == 0)
-            {
-                Assert.True(y.Equals("0"), " Verification Failed");
-            }
-            else
-            {
-                List<char> number = new List<char>();
-                while (x > 0)
-                {
-                    number.Add((x % 10).ToString().ToCharArray()[0]);
-                    x = x / 10;
-                }
-                number.Reverse();
-                y2 = new String(number.ToArray());
-                Assert.True(y2.Equals(y, StringComparison.OrdinalIgnoreCase), " Verification Failed");
-            }
-
-            if (!ret)
-            {
-                Console.WriteLine("Error: " + errorMsg);
-                Console.WriteLine("got:      " + y2);
-                Console.WriteLine("expected: " + y);
-            }
-            return ret;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/absolutevalue.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/absolutevalue.cs
@@ -16,108 +16,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunAbsoluteValueTests()
         {
-            long temp;
-            byte[] tempByteArray1 = new byte[0];
+            byte[] byteArray = new byte[0];
 
             // AbsoluteValue Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAbsoluteValueString(Print(tempByteArray1) + "uAbs"), " Verification Failed");
+                byteArray = GetRandomByteArray(s_random);
+                VerifyAbsoluteValueString(Print(byteArray) + "uAbs");
             }
 
             // AbsoluteValue Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAbsoluteValueString(Print(tempByteArray1) + "uAbs"), " Verification Failed");
+                byteArray = GetRandomByteArray(s_random, 2);
+                VerifyAbsoluteValueString(Print(byteArray) + "uAbs");
             }
 
             // AbsoluteValue Method - zero
-            Assert.True(VerifyAbsoluteValueString("0 uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString("0 uAbs");
 
             // AbsoluteValue Method - -1
-            Assert.True(VerifyAbsoluteValueString("-1 uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString("-1 uAbs");
 
             // AbsoluteValue Method - 1
-            Assert.True(VerifyAbsoluteValueString("1 uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString("1 uAbs");
 
-            temp = Int32.MinValue;
             // AbsoluteValue Method - Int32.MinValue
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int32.MinValue.ToString() + " uAbs");
 
             // AbsoluteValue Method - Int32.MinValue-1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " -1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int32.MinValue.ToString() + " -1 b+ uAbs");
 
             // AbsoluteValue Method - Int32.MinValue+1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " 1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int32.MinValue.ToString() + " 1 b+ uAbs");
 
-            temp = Int32.MaxValue;
             // AbsoluteValue Method - Int32.MaxValue
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int32.MaxValue.ToString() + " uAbs");
 
             // AbsoluteValue Method - Int32.MaxValue-1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " -1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int32.MaxValue.ToString() + " -1 b+ uAbs");
 
             // AbsoluteValue Method - Int32.MaxValue+1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " 1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int32.MaxValue.ToString() + " 1 b+ uAbs");
 
-            temp = Int64.MinValue;
             // AbsoluteValue Method - Int64.MinValue
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int64.MinValue.ToString() + " uAbs");
 
             // AbsoluteValue Method - Int64.MinValue-1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " -1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int64.MinValue.ToString() + " -1 b+ uAbs");
 
             // AbsoluteValue Method - Int64.MinValue+1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " 1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int64.MinValue.ToString() + " 1 b+ uAbs");
 
-            temp = Int64.MaxValue;
             // AbsoluteValue Method - Int64.MaxValue
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int64.MaxValue.ToString() + " uAbs");
 
             // AbsoluteValue Method - Int64.MaxValue-1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " -1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int64.MaxValue.ToString() + " -1 b+ uAbs");
 
             // AbsoluteValue Method - Int64.MaxValue+1
-            Assert.True(VerifyAbsoluteValueString(temp.ToString() + " 1 b+ uAbs"), " Verification Failed");
+            VerifyAbsoluteValueString(Int64.MaxValue.ToString() + " 1 b+ uAbs");
         }
 
-        private static bool VerifyAbsoluteValueString(string opstring)
+        private static void VerifyAbsoluteValueString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -141,27 +115,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/add.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/add.cs
@@ -16,145 +16,139 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunAddTests()
         {
-            byte[] tempByteArray1 = new byte[0];
-            byte[] tempByteArray2 = new byte[0];
+            byte[] byteArray1 = new byte[0];
+            byte[] byteArray2 = new byte[0];
 
             // Add Method - Two Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(s_random);
-                tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                byteArray1 = GetRandomByteArray(s_random);
+                byteArray2 = GetRandomByteArray(s_random);
+                VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
             }
 
             // Add Method - Two Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(s_random, 2);
-                tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                byteArray1 = GetRandomByteArray(s_random, 2);
+                byteArray2 = GetRandomByteArray(s_random, 2);
+                VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
             }
 
-            // Add Method - One large and one small BigIntegers
+            // Add Method - One large and one small BigInteger
             for (int i = 0; i < s_samples; i++)
             {
                 try
                 {
-                    tempByteArray1 = GetRandomByteArray(s_random);
-                    tempByteArray2 = GetRandomByteArray(s_random, 2);
-                    Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                    byteArray1 = GetRandomByteArray(s_random);
+                    byteArray2 = GetRandomByteArray(s_random, 2);
+                    VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
 
-                    tempByteArray1 = GetRandomByteArray(s_random, 2);
-                    tempByteArray2 = GetRandomByteArray(s_random);
-                    Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                    byteArray1 = GetRandomByteArray(s_random, 2);
+                    byteArray2 = GetRandomByteArray(s_random);
+                    VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    Console.WriteLine("Array1: " + Print(tempByteArray1));
-                    Console.WriteLine("Array2: " + Print(tempByteArray2));
+                    Console.WriteLine("Array1: " + Print(byteArray1));
+                    Console.WriteLine("Array2: " + Print(byteArray2));
                     throw;
                 }
             }
 
-            // Add Method - One large BigIntegers and zero
+            // Add Method - One large BigInteger and zero
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(s_random);
-                tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                byteArray1 = GetRandomByteArray(s_random);
+                byteArray2 = new byte[] { 0 };
+                VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
 
-                tempByteArray1 = new byte[] { 0 };
-                tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                byteArray1 = new byte[] { 0 };
+                byteArray2 = GetRandomByteArray(s_random);
+                VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
             }
 
-            // Add Method - One small BigIntegers and zero
+            // Add Method - One small BigInteger and zero
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(s_random, 2);
-                tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                byteArray1 = GetRandomByteArray(s_random, 2);
+                byteArray2 = new byte[] { 0 };
+                VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
 
-                tempByteArray1 = new byte[] { 0 };
-                tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "bAdd"), " Verification Failed");
+                byteArray1 = new byte[] { 0 };
+                byteArray2 = GetRandomByteArray(s_random, 2);
+                VerifyAdditionString(Print(byteArray1) + Print(byteArray2) + "bAdd");
             }
 
             // 32 bit boundary n1=0 n2=0 c=0
-            Assert.True(VerifyAdditionString("0 0 bAdd"), " Verification Failed");
+            VerifyAdditionString("0 0 bAdd");
 
             // 32 bit boundary n1=0 n2=0 c=1
-            Assert.True(VerifyAdditionString((Math.Pow(2, 31) + Math.Pow(2, 30)) + " " + (Math.Pow(2, 31) + Math.Pow(2, 30)) + " bAdd"), " Verification Failed");
+            VerifyAdditionString((Math.Pow(2, 31) + Math.Pow(2, 30)) + " " + (Math.Pow(2, 31) + Math.Pow(2, 30)) + " bAdd");
 
             // 32 bit boundary n1=0 n2=1 c=0
-            Assert.True(VerifyAdditionString("0" + " " + Math.Pow(2, 32) + " bAdd"), " Verification Failed");
+            VerifyAdditionString("0" + " " + Math.Pow(2, 32) + " bAdd");
 
             // 32 bit boundary n1=0 n2=1 c=1
-            Assert.True(VerifyAdditionString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " bAdd"), " Verification Failed");
+            VerifyAdditionString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " bAdd");
 
             // 32 bit boundary n1=1 n2=0 c=0
-            Assert.True(VerifyAdditionString(Math.Pow(2, 32) + " " + "0" + " bAdd"), " Verification Failed");
+            VerifyAdditionString(Math.Pow(2, 32) + " " + "0" + " bAdd");
 
             // 32 bit boundary n1=1 n2=0 c=1
-            Assert.True(VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + Math.Pow(2, 31) + " bAdd"), " Verification Failed");
+            VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + Math.Pow(2, 31) + " bAdd");
 
             // 32 bit boundary n1=0 n2=1 c=0
-            Assert.True(VerifyAdditionString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " bAdd"), " Verification Failed");
+            VerifyAdditionString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " bAdd");
 
             // 32 bit boundary n1=0 n2=1 c=1
-            Assert.True(VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " bAdd"), " Verification Failed");
+            VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " bAdd");
 
             // Identity (x+y)+z == (y+z)+x
-            //Check some identities
-            // (x+y)+z = (y+z)+x
-
-            Assert.True(VerifyIdentityString(
+            VerifyIdentityString(
                     Int64.MaxValue.ToString() + " " + Int32.MaxValue.ToString() + " bAdd " + Int16.MaxValue.ToString() + " bAdd",
                     Int32.MaxValue.ToString() + " " + Int16.MaxValue.ToString() + " bAdd " + Int64.MaxValue.ToString() + " bAdd"
-            ), "Test failed");
+            );
 
             byte[] x = GetRandomByteArray(s_random);
             byte[] y = GetRandomByteArray(s_random);
             byte[] z = GetRandomByteArray(s_random);
 
-            Assert.True(VerifyIdentityString(Print(x) + Print(y) + Print(z) + "bAdd bAdd", Print(y) + Print(z) + Print(x) + "bAdd bAdd"), " Verification Failed");
+            VerifyIdentityString(Print(x) + Print(y) + Print(z) + "bAdd bAdd", Print(y) + Print(z) + Print(x) + "bAdd bAdd");
         }
 
-        private static bool VerifyAdditionString(string opstring)
+        private static void VerifyAdditionString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
+        private static void VerifyIdentityString(string opstring1, string opstring2)
         {
-            bool ret = true;
-
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -178,27 +172,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -22,39 +22,39 @@ namespace System.Numerics.Tests
             // Byte Explicit Cast from BigInteger: Random value < Byte.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(Byte.MinValue, s_random);
             value = bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger));
 
             // Byte Explicit Cast from BigInteger: Byte.MinValue - 1
             bigInteger = new BigInteger(Byte.MinValue);
             bigInteger -= BigInteger.One;
             value = bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger));
 
             // Byte Explicit Cast from BigInteger: Byte.MinValue
-            Assert.True(VerifyByteExplicitCastFromBigInteger(Byte.MinValue), " Verification Failed");
+            VerifyByteExplicitCastFromBigInteger(Byte.MinValue);
 
             // Byte Explicit Cast from BigInteger: 0
-            Assert.True(VerifyByteExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyByteExplicitCastFromBigInteger(0);
 
             // Byte Explicit Cast from BigInteger: 1
-            Assert.True(VerifyByteExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyByteExplicitCastFromBigInteger(1);
 
             // Byte Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyByteExplicitCastFromBigInteger((Byte)s_random.Next(1, Byte.MaxValue)), " Verification Failed");
+                VerifyByteExplicitCastFromBigInteger((Byte)s_random.Next(1, Byte.MaxValue));
             }
 
             // Byte Explicit Cast from BigInteger: Byte.MaxValue + 1
             bigInteger = new BigInteger(Byte.MaxValue);
             bigInteger += BigInteger.One;
             value = bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger));
 
             // Byte Explicit Cast from BigInteger: Random value > Byte.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(Byte.MaxValue, s_random);
             value = bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyByteExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -66,13 +66,13 @@ namespace System.Numerics.Tests
             // SByte Explicit Cast from BigInteger: Random value < SByte.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(SByte.MinValue, s_random);
             value = (SByte)bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger));
 
             // SByte Explicit Cast from BigInteger: SByte.MinValue - 1
             bigInteger = new BigInteger(SByte.MinValue);
             bigInteger -= BigInteger.One;
             value = (SByte)bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger));
 
             // SByte Explicit Cast from BigInteger: SByte.MinValue
             VerifySByteExplicitCastFromBigInteger(SByte.MinValue);
@@ -80,22 +80,22 @@ namespace System.Numerics.Tests
             // SByte Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySByteExplicitCastFromBigInteger((SByte)s_random.Next(SByte.MinValue, 0)), " Verification Failed");
+                VerifySByteExplicitCastFromBigInteger((SByte)s_random.Next(SByte.MinValue, 0));
             }
 
             // SByte Explicit Cast from BigInteger: -1
-            Assert.True(VerifySByteExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifySByteExplicitCastFromBigInteger(-1);
 
             // SByte Explicit Cast from BigInteger: 0
-            Assert.True(VerifySByteExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifySByteExplicitCastFromBigInteger(0);
 
             // SByte Explicit Cast from BigInteger: 1
-            Assert.True(VerifySByteExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifySByteExplicitCastFromBigInteger(1);
 
             // SByte Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySByteExplicitCastFromBigInteger((SByte)s_random.Next(1, SByte.MaxValue)), " Verification Failed");
+                VerifySByteExplicitCastFromBigInteger((SByte)s_random.Next(1, SByte.MaxValue));
             }
 
             // SByte Explicit Cast from BigInteger: SByte.MaxValue
@@ -105,12 +105,12 @@ namespace System.Numerics.Tests
             bigInteger = new BigInteger(SByte.MaxValue);
             bigInteger += BigInteger.One;
             value = (SByte)bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger));
 
             // SByte Explicit Cast from BigInteger: Random value > SByte.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan((UInt64)SByte.MaxValue, s_random);
             value = (SByte)bigInteger.ToByteArray()[0];
-            Assert.True(VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifySByteExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -122,42 +122,42 @@ namespace System.Numerics.Tests
             // UInt16 Explicit Cast from BigInteger: Random value < UInt16.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(UInt16.MinValue, s_random);
             value = BitConverter.ToUInt16(ByteArrayMakeMinSize(bigInteger.ToByteArray(), 2), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt16 Explicit Cast from BigInteger: UInt16.MinValue - 1
             bigInteger = new BigInteger(UInt16.MinValue);
             bigInteger -= BigInteger.One;
             value = BitConverter.ToUInt16(new byte[] { 0xff, 0xff }, 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt16 Explicit Cast from BigInteger: UInt16.MinValue
-            Assert.True(VerifyUInt16ExplicitCastFromBigInteger(UInt16.MinValue), " Verification Failed");
+            VerifyUInt16ExplicitCastFromBigInteger(UInt16.MinValue);
 
             // UInt16 Explicit Cast from BigInteger: 0
-            Assert.True(VerifyUInt16ExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyUInt16ExplicitCastFromBigInteger(0);
 
             // UInt16 Explicit Cast from BigInteger: 1
-            Assert.True(VerifyUInt16ExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyUInt16ExplicitCastFromBigInteger(1);
 
             // UInt16 Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyUInt16ExplicitCastFromBigInteger((UInt16)s_random.Next(1, UInt16.MaxValue)), " Verification Failed");
+                VerifyUInt16ExplicitCastFromBigInteger((UInt16)s_random.Next(1, UInt16.MaxValue));
             }
 
             // UInt16 Explicit Cast from BigInteger: UInt16.MaxValue
-            Assert.True(VerifyUInt16ExplicitCastFromBigInteger(UInt16.MaxValue), " Verification Failed");
+            VerifyUInt16ExplicitCastFromBigInteger(UInt16.MaxValue);
 
             // UInt16 Explicit Cast from BigInteger: UInt16.MaxValue + 1
             bigInteger = new BigInteger(UInt16.MaxValue);
             bigInteger += BigInteger.One;
             value = BitConverter.ToUInt16(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt16 Explicit Cast from BigInteger: Random value > UInt16.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(UInt16.MaxValue, s_random);
             value = BitConverter.ToUInt16(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -169,51 +169,51 @@ namespace System.Numerics.Tests
             // Int16 Explicit Cast from BigInteger: Random value < Int16.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(Int16.MinValue, s_random);
             value = BitConverter.ToInt16(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int16 Explicit Cast from BigInteger: Int16.MinValue - 1
             bigInteger = new BigInteger(Int16.MinValue);
             bigInteger -= BigInteger.One;
             value = BitConverter.ToInt16(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int16 Explicit Cast from BigInteger: Int16.MinValue
-            Assert.True(VerifyInt16ExplicitCastFromBigInteger(Int16.MinValue), " Verification Failed");
+            VerifyInt16ExplicitCastFromBigInteger(Int16.MinValue);
 
             // Int16 Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt16ExplicitCastFromBigInteger((Int16)s_random.Next(Int16.MinValue, 0)), " Verification Failed");
+                VerifyInt16ExplicitCastFromBigInteger((Int16)s_random.Next(Int16.MinValue, 0));
             }
 
             // Int16 Explicit Cast from BigInteger: -1
-            Assert.True(VerifyInt16ExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifyInt16ExplicitCastFromBigInteger(-1);
 
             // Int16 Explicit Cast from BigInteger: 0
-            Assert.True(VerifyInt16ExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyInt16ExplicitCastFromBigInteger(0);
 
             // Int16 Explicit Cast from BigInteger: 1
-            Assert.True(VerifyInt16ExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyInt16ExplicitCastFromBigInteger(1);
 
             // Int16 Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt16ExplicitCastFromBigInteger((Int16)s_random.Next(1, Int16.MaxValue)), " Verification Failed");
+                VerifyInt16ExplicitCastFromBigInteger((Int16)s_random.Next(1, Int16.MaxValue));
             }
 
             // Int16 Explicit Cast from BigInteger: Int16.MaxValue
-            Assert.True(VerifyInt16ExplicitCastFromBigInteger(Int16.MaxValue), " Verification Failed");
+            VerifyInt16ExplicitCastFromBigInteger(Int16.MaxValue);
 
             // Int16 Explicit Cast from BigInteger: Int16.MaxValue + 1
             bigInteger = new BigInteger(Int16.MaxValue);
             bigInteger += BigInteger.One;
             value = BitConverter.ToInt16(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int16 Explicit Cast from BigInteger: Random value > Int16.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan((UInt64)Int16.MaxValue, s_random);
             value = BitConverter.ToInt16(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt16ExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -225,42 +225,42 @@ namespace System.Numerics.Tests
             // UInt32 Explicit Cast from BigInteger: Random value < UInt32.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(UInt32.MinValue, s_random);
             value = BitConverter.ToUInt32(ByteArrayMakeMinSize(bigInteger.ToByteArray(), 4), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt32 Explicit Cast from BigInteger: UInt32.MinValue - 1
             bigInteger = new BigInteger(UInt32.MinValue);
             bigInteger -= BigInteger.One;
             value = BitConverter.ToUInt32(new byte[] { 0xff, 0xff, 0xff, 0xff }, 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt32 Explicit Cast from BigInteger: UInt32.MinValue
-            Assert.True(VerifyUInt32ExplicitCastFromBigInteger(UInt32.MinValue), " Verification Failed");
+            VerifyUInt32ExplicitCastFromBigInteger(UInt32.MinValue);
 
             // UInt32 Explicit Cast from BigInteger: 0
-            Assert.True(VerifyUInt32ExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyUInt32ExplicitCastFromBigInteger(0);
 
             // UInt32 Explicit Cast from BigInteger: 1
-            Assert.True(VerifyUInt32ExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyUInt32ExplicitCastFromBigInteger(1);
 
             // UInt32 Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyUInt32ExplicitCastFromBigInteger((UInt32)(UInt32.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyUInt32ExplicitCastFromBigInteger((UInt32)(UInt32.MaxValue * s_random.NextDouble()));
             }
 
             // UInt32 Explicit Cast from BigInteger: UInt32.MaxValue
-            Assert.True(VerifyUInt32ExplicitCastFromBigInteger(UInt32.MaxValue), " Verification Failed");
+            VerifyUInt32ExplicitCastFromBigInteger(UInt32.MaxValue);
 
             // UInt32 Explicit Cast from BigInteger: UInt32.MaxValue + 1
             bigInteger = new BigInteger(UInt32.MaxValue);
             bigInteger += BigInteger.One;
             value = BitConverter.ToUInt32(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt32 Explicit Cast from BigInteger: Random value > UInt32.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(UInt32.MaxValue, s_random);
             value = BitConverter.ToUInt32(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -272,51 +272,51 @@ namespace System.Numerics.Tests
             // Int32 Explicit Cast from BigInteger: Random value < Int32.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(Int32.MinValue, s_random);
             value = BitConverter.ToInt32(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int32 Explicit Cast from BigInteger: Int32.MinValue - 1
             bigInteger = new BigInteger(Int32.MinValue);
             bigInteger -= BigInteger.One;
             value = BitConverter.ToInt32(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int32 Explicit Cast from BigInteger: Int32.MinValue
-            Assert.True(VerifyInt32ExplicitCastFromBigInteger(Int32.MinValue), " Verification Failed");
+            VerifyInt32ExplicitCastFromBigInteger(Int32.MinValue);
 
             // Int32 Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt32ExplicitCastFromBigInteger((Int32)s_random.Next(Int32.MinValue, 0)), " Verification Failed");
+                VerifyInt32ExplicitCastFromBigInteger((Int32)s_random.Next(Int32.MinValue, 0));
             }
 
             // Int32 Explicit Cast from BigInteger: -1
-            Assert.True(VerifyInt32ExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifyInt32ExplicitCastFromBigInteger(-1);
 
             // Int32 Explicit Cast from BigInteger: 0
-            Assert.True(VerifyInt32ExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyInt32ExplicitCastFromBigInteger(0);
 
             // Int32 Explicit Cast from BigInteger: 1
-            Assert.True(VerifyInt32ExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyInt32ExplicitCastFromBigInteger(1);
 
             // Int32 Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt32ExplicitCastFromBigInteger((Int32)s_random.Next(1, Int32.MaxValue)), " Verification Failed");
+                VerifyInt32ExplicitCastFromBigInteger((Int32)s_random.Next(1, Int32.MaxValue));
             }
 
             // Int32 Explicit Cast from BigInteger: Int32.MaxValue
-            Assert.True(VerifyInt32ExplicitCastFromBigInteger(Int32.MaxValue), " Verification Failed");
+            VerifyInt32ExplicitCastFromBigInteger(Int32.MaxValue);
 
             // Int32 Explicit Cast from BigInteger: Int32.MaxValue + 1
             bigInteger = new BigInteger(Int32.MaxValue);
             bigInteger += BigInteger.One;
             value = BitConverter.ToInt32(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int32 Explicit Cast from BigInteger: Random value > Int32.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(Int32.MaxValue, s_random);
             value = BitConverter.ToInt32(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt32ExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -328,42 +328,42 @@ namespace System.Numerics.Tests
             // UInt64 Explicit Cast from BigInteger: Random value < UInt64.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(0, s_random);
             value = BitConverter.ToUInt64(ByteArrayMakeMinSize(bigInteger.ToByteArray(), 8), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt64 Explicit Cast from BigInteger: UInt64.MinValue - 1
             bigInteger = new BigInteger(UInt64.MinValue);
             bigInteger -= BigInteger.One;
             value = BitConverter.ToUInt64(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt64 Explicit Cast from BigInteger: UInt64.MinValue
-            Assert.True(VerifyUInt64ExplicitCastFromBigInteger(UInt64.MinValue), " Verification Failed");
+            VerifyUInt64ExplicitCastFromBigInteger(UInt64.MinValue);
 
             // UInt64 Explicit Cast from BigInteger: 0
-            Assert.True(VerifyUInt64ExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyUInt64ExplicitCastFromBigInteger(0);
 
             // UInt64 Explicit Cast from BigInteger: 1
-            Assert.True(VerifyUInt64ExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyUInt64ExplicitCastFromBigInteger(1);
 
             // UInt64 Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyUInt64ExplicitCastFromBigInteger((UInt64)(UInt64.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyUInt64ExplicitCastFromBigInteger((UInt64)(UInt64.MaxValue * s_random.NextDouble()));
             }
 
             // UInt64 Explicit Cast from BigInteger: UInt64.MaxValue
-            Assert.True(VerifyUInt64ExplicitCastFromBigInteger(UInt64.MaxValue), " Verification Failed");
+            VerifyUInt64ExplicitCastFromBigInteger(UInt64.MaxValue);
 
             // UInt64 Explicit Cast from BigInteger: UInt64.MaxValue + 1
             bigInteger = new BigInteger(UInt64.MaxValue);
             bigInteger += BigInteger.One;
             value = BitConverter.ToUInt64(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger));
 
             // UInt64 Explicit Cast from BigInteger: Random value > UInt64.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(UInt64.MaxValue, s_random);
             value = BitConverter.ToUInt64(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -375,51 +375,51 @@ namespace System.Numerics.Tests
             // Int64 Explicit Cast from BigInteger: Random value < Int64.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(Int64.MinValue, s_random);
             value = BitConverter.ToInt64(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int64 Explicit Cast from BigInteger: Int64.MinValue - 1
             bigInteger = new BigInteger(Int64.MinValue);
             bigInteger -= BigInteger.One;
             value = BitConverter.ToInt64(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int64 Explicit Cast from BigInteger: Int64.MinValue
-            Assert.True(VerifyInt64ExplicitCastFromBigInteger(Int64.MinValue), " Verification Failed");
+            VerifyInt64ExplicitCastFromBigInteger(Int64.MinValue);
 
             // Int64 Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt64ExplicitCastFromBigInteger(((Int64)(Int64.MaxValue * s_random.NextDouble())) - Int64.MaxValue), " Verification Failed");
+                VerifyInt64ExplicitCastFromBigInteger(((Int64)(Int64.MaxValue * s_random.NextDouble())) - Int64.MaxValue);
             }
 
             // Int64 Explicit Cast from BigInteger: -1
-            Assert.True(VerifyInt64ExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifyInt64ExplicitCastFromBigInteger(-1);
 
             // Int64 Explicit Cast from BigInteger: 0
-            Assert.True(VerifyInt64ExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyInt64ExplicitCastFromBigInteger(0);
 
             // Int64 Explicit Cast from BigInteger: 1
-            Assert.True(VerifyInt64ExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyInt64ExplicitCastFromBigInteger(1);
 
             // Int64 Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt64ExplicitCastFromBigInteger((Int64)(Int64.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyInt64ExplicitCastFromBigInteger((Int64)(Int64.MaxValue * s_random.NextDouble()));
             }
 
             // Int64 Explicit Cast from BigInteger: Int64.MaxValue
-            Assert.True(VerifyInt64ExplicitCastFromBigInteger(Int64.MaxValue), " Verification Failed");
+            VerifyInt64ExplicitCastFromBigInteger(Int64.MaxValue);
 
             // Int64 Explicit Cast from BigInteger: Int64.MaxValue + 1
             bigInteger = new BigInteger(Int64.MaxValue);
             bigInteger += BigInteger.One;
             value = BitConverter.ToInt64(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger));
 
             // Int64 Explicit Cast from BigInteger: Random value > Int64.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(Int64.MaxValue, s_random);
             value = BitConverter.ToInt64(bigInteger.ToByteArray(), 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyInt64ExplicitCastFromBigInteger(value, bigInteger));
         }
 
         [Fact]
@@ -429,65 +429,65 @@ namespace System.Numerics.Tests
 
             // Single Explicit Cast from BigInteger: Random value < Single.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(Single.MinValue * 2.0, s_random);
-            Assert.True(VerifySingleExplicitCastFromBigInteger(Single.NegativeInfinity, bigInteger), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(Single.NegativeInfinity, bigInteger);
 
             // Single Explicit Cast from BigInteger: Single.MinValue - 1
             bigInteger = new BigInteger(Single.MinValue);
             bigInteger -= BigInteger.One;
-            Assert.True(VerifySingleExplicitCastFromBigInteger(Single.MinValue, bigInteger), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(Single.MinValue, bigInteger);
 
             // Single Explicit Cast from BigInteger: Single.MinValue
-            Assert.True(VerifySingleExplicitCastFromBigInteger(Single.MinValue), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(Single.MinValue);
 
             // Single Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastFromBigInteger(((Single)(Single.MaxValue * s_random.NextDouble())) - Single.MaxValue), " Verification Failed");
+                VerifySingleExplicitCastFromBigInteger(((Single)(Single.MaxValue * s_random.NextDouble())) - Single.MaxValue);
             }
 
             // Single Explicit Cast from BigInteger: Random Negative Non-integral > -100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastFromBigInteger(((Single)(100 * s_random.NextDouble())) - 100), " Verification Failed");
+                VerifySingleExplicitCastFromBigInteger(((Single)(100 * s_random.NextDouble())) - 100);
             }
 
             // Single Explicit Cast from BigInteger: -1
-            Assert.True(VerifySingleExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(-1);
 
             // Single Explicit Cast from BigInteger: 0
-            Assert.True(VerifySingleExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(0);
 
             // Single Explicit Cast from BigInteger: 1
-            Assert.True(VerifySingleExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(1);
 
             // Single Explicit Cast from BigInteger: Random Positive Non-integral < 100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastFromBigInteger((Single)(100 * s_random.NextDouble())), " Verification Failed");
+                VerifySingleExplicitCastFromBigInteger((Single)(100 * s_random.NextDouble()));
             }
 
             // Single Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastFromBigInteger((Single)(Single.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifySingleExplicitCastFromBigInteger((Single)(Single.MaxValue * s_random.NextDouble()));
             }
 
             // Single Explicit Cast from BigInteger: Single.MaxValue + 1
             bigInteger = new BigInteger(Single.MaxValue);
             bigInteger += BigInteger.One;
-            Assert.True(VerifySingleExplicitCastFromBigInteger(Single.MaxValue, bigInteger), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(Single.MaxValue, bigInteger);
 
             // Single Explicit Cast from BigInteger: Random value > Single.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(Single.MaxValue * 2, s_random);
-            Assert.True(VerifySingleExplicitCastFromBigInteger(Single.PositiveInfinity, bigInteger), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(Single.PositiveInfinity, bigInteger);
 
             // Single Explicit Cast from BigInteger: value < Single.MaxValue but can not be accurately represented in a Single
             bigInteger = new BigInteger(16777217);
-            Assert.True(VerifySingleExplicitCastFromBigInteger(16777216f, bigInteger), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(16777216f, bigInteger);
 
             // Single Explicit Cast from BigInteger: Single.MinValue < value but can not be accurately represented in a Single
             bigInteger = new BigInteger(-16777217);
-            Assert.True(VerifySingleExplicitCastFromBigInteger(-16777216f, bigInteger), " Verification Failed");
+            VerifySingleExplicitCastFromBigInteger(-16777216f, bigInteger);
         }
 
         [Fact]
@@ -498,69 +498,69 @@ namespace System.Numerics.Tests
             // Double Explicit Cast from BigInteger: Random value < Double.MinValue
             bigInteger = GenerateRandomBigIntegerLessThan(Double.MinValue, s_random);
             bigInteger *= 2;
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(Double.NegativeInfinity, bigInteger), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(Double.NegativeInfinity, bigInteger);
 
             // Double Explicit Cast from BigInteger: Double.MinValue - 1
             bigInteger = new BigInteger(Double.MinValue);
             bigInteger -= BigInteger.One;
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(Double.MinValue, bigInteger), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(Double.MinValue, bigInteger);
 
             // Double Explicit Cast from BigInteger: Double.MinValue
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(Double.MinValue), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(Double.MinValue);
 
             // Double Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastFromBigInteger(((Double)(Double.MaxValue * s_random.NextDouble())) - Double.MaxValue), " Verification Failed");
+                VerifyDoubleExplicitCastFromBigInteger(((Double)(Double.MaxValue * s_random.NextDouble())) - Double.MaxValue);
             }
 
             // Double Explicit Cast from BigInteger: Random Negative Non-integral > -100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastFromBigInteger(((Double)(100 * s_random.NextDouble())) - 100), " Verification Failed");
+                VerifyDoubleExplicitCastFromBigInteger(((Double)(100 * s_random.NextDouble())) - 100);
             }
 
             // Double Explicit Cast from BigInteger: -1
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(-1);
 
             // Double Explicit Cast from BigInteger: 0
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(0);
 
             // Double Explicit Cast from BigInteger: 1
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(1);
 
             // Double Explicit Cast from BigInteger: Random Positive Non-integral < 100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastFromBigInteger((Double)(100 * s_random.NextDouble())), " Verification Failed");
+                VerifyDoubleExplicitCastFromBigInteger((Double)(100 * s_random.NextDouble()));
             }
 
             // Double Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastFromBigInteger((Double)(Double.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyDoubleExplicitCastFromBigInteger((Double)(Double.MaxValue * s_random.NextDouble()));
             }
 
             // Double Explicit Cast from BigInteger: Double.MaxValue
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(Double.MaxValue), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(Double.MaxValue);
 
             // Double Explicit Cast from BigInteger: Double.MaxValue + 1
             bigInteger = new BigInteger(Double.MaxValue);
             bigInteger += BigInteger.One;
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(Double.MaxValue, bigInteger), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(Double.MaxValue, bigInteger);
 
             // Double Explicit Cast from BigInteger: Random value > Double.MaxValue
             bigInteger = GenerateRandomBigIntegerGreaterThan(Double.MaxValue, s_random);
             bigInteger *= 2;
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(Double.PositiveInfinity, bigInteger), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(Double.PositiveInfinity, bigInteger);
 
             // Double Explicit Cast from BigInteger: value < Double.MaxValue but can not be accurately represented in a Double
             bigInteger = new BigInteger(9007199254740993);
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(9007199254740992, bigInteger), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(9007199254740992, bigInteger);
 
             // Double Explicit Cast from BigInteger: Double.MinValue < value but can not be accurately represented in a Double
             bigInteger = new BigInteger(-9007199254740993);
-            Assert.True(VerifyDoubleExplicitCastFromBigInteger(-9007199254740992, bigInteger), " Verification Failed");
+            VerifyDoubleExplicitCastFromBigInteger(-9007199254740992, bigInteger);
         }
 
         [Fact]
@@ -595,7 +595,7 @@ namespace System.Numerics.Tests
                     bits[j] = (int)temp2;
                 }
                 value = new Decimal(bits[0], bits[1], bits[2], true, 0);
-                Assert.True(VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+                VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger));
             }
 
             // Decimal Explicit Cast from BigInteger: Decimal.MinValue - 1
@@ -619,48 +619,48 @@ namespace System.Numerics.Tests
                 bits[j] = (int)temp2;
             }
             value = new Decimal(bits[0], bits[1], bits[2], true, 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger));
 
             // Decimal Explicit Cast from BigInteger: Decimal.MinValue
-            Assert.True(VerifyDecimalExplicitCastFromBigInteger(Decimal.MinValue), " Verification Failed");
+            VerifyDecimalExplicitCastFromBigInteger(Decimal.MinValue);
 
             // Decimal Explicit Cast from BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDecimalExplicitCastFromBigInteger(((Decimal)((Double)Decimal.MaxValue * s_random.NextDouble())) - Decimal.MaxValue), " Verification Failed");
+                VerifyDecimalExplicitCastFromBigInteger(((Decimal)((Double)Decimal.MaxValue * s_random.NextDouble())) - Decimal.MaxValue);
             }
 
             // Decimal Explicit Cast from BigInteger: Random Negative Non-Integral > -100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
                 value = (Decimal)(100 * s_random.NextDouble() - 100);
-                Assert.True(VerifyDecimalExplicitCastFromBigInteger(Decimal.Truncate(value), new BigInteger(value)), " Verification Failed");
+                VerifyDecimalExplicitCastFromBigInteger(Decimal.Truncate(value), new BigInteger(value));
             }
 
             // Decimal Explicit Cast from BigInteger: -1
-            Assert.True(VerifyDecimalExplicitCastFromBigInteger(-1), " Verification Failed");
+            VerifyDecimalExplicitCastFromBigInteger(-1);
 
             // Decimal Explicit Cast from BigInteger: 0
-            Assert.True(VerifyDecimalExplicitCastFromBigInteger(0), " Verification Failed");
+            VerifyDecimalExplicitCastFromBigInteger(0);
 
             // Decimal Explicit Cast from BigInteger: 1
-            Assert.True(VerifyDecimalExplicitCastFromBigInteger(1), " Verification Failed");
+            VerifyDecimalExplicitCastFromBigInteger(1);
 
             // Decimal Explicit Cast from BigInteger: Random Positive Non-Integral < 100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
                 value = (Decimal)(100 * s_random.NextDouble());
-                Assert.True(VerifyDecimalExplicitCastFromBigInteger(Decimal.Truncate(value), new BigInteger(value)), " Verification Failed");
+                VerifyDecimalExplicitCastFromBigInteger(Decimal.Truncate(value), new BigInteger(value));
             }
 
             // Decimal Explicit Cast from BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDecimalExplicitCastFromBigInteger((Decimal)((Double)Decimal.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyDecimalExplicitCastFromBigInteger((Decimal)((Double)Decimal.MaxValue * s_random.NextDouble()));
             }
 
             // Decimal Explicit Cast from BigInteger: Decimal.MaxValue
-            Assert.True(VerifyDecimalExplicitCastFromBigInteger(Decimal.MaxValue), " Verification Failed");
+            VerifyDecimalExplicitCastFromBigInteger(Decimal.MaxValue);
 
             // Decimal Explicit Cast from BigInteger: Decimal.MaxValue + 1
             bigInteger = new BigInteger(Decimal.MaxValue);
@@ -671,7 +671,7 @@ namespace System.Numerics.Tests
                 bits[j] = BitConverter.ToInt32(temp, 4 * j);
             }
             value = new Decimal(bits[0], bits[1], bits[2], false, 0);
-            Assert.True(VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+            VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger));
 
             // Decimal Explicit Cast from BigInteger: Random value > Decimal.MaxValue
             for (int i = 0; i < NumberOfRandomIterations; ++i)
@@ -683,11 +683,10 @@ namespace System.Numerics.Tests
                     bits[j] = BitConverter.ToInt32(temp, 4 * j);
                 }
                 value = new Decimal(bits[0], bits[1], bits[2], false, 0);
-                Assert.True(VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger)), " Verification Failed");
+                VerifyException<OverflowException>(() => VerifyDecimalExplicitCastFromBigInteger(value, bigInteger));
             }
         }
-
-
+        
         private static BigInteger GenerateRandomNegativeBigInteger(Random random)
         {
             BigInteger bigInteger;
@@ -752,180 +751,141 @@ namespace System.Numerics.Tests
             return (GenerateRandomPositiveBigInteger(random) + (BigInteger)value) + 1;
         }
 
-        private static bool VerifyByteExplicitCastFromBigInteger(Byte value)
+        private static void VerifyByteExplicitCastFromBigInteger(Byte value)
         {
             BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (Byte)bigInteger, "Value after cast");
+            VerifyByteExplicitCastFromBigInteger(value, bigInteger);
         }
-        private static bool VerifyByteExplicitCastFromBigInteger(Byte value, BigInteger bigInteger)
+
+        private static void VerifyByteExplicitCastFromBigInteger(Byte value, BigInteger bigInteger)
         {
-            return Eval(value, (Byte)bigInteger, "Value after cast");
+            Assert.Equal(value, (Byte)bigInteger);
         }
 
-        private static bool VerifySByteExplicitCastFromBigInteger(SByte value)
-        {
-            BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (SByte)bigInteger, "Value after cast");
-        }
-        private static bool VerifySByteExplicitCastFromBigInteger(SByte value, BigInteger bigInteger)
-        {
-            return Eval(value, (SByte)bigInteger, "Value after cast");
-        }
-
-        private static bool VerifyUInt16ExplicitCastFromBigInteger(UInt16 value)
+        private static void VerifySByteExplicitCastFromBigInteger(SByte value)
         {
             BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (UInt16)bigInteger, "Value after cast");
+            VerifySByteExplicitCastFromBigInteger(value, bigInteger);
         }
-        private static bool VerifyUInt16ExplicitCastFromBigInteger(UInt16 value, BigInteger bigInteger)
+        private static void VerifySByteExplicitCastFromBigInteger(SByte value, BigInteger bigInteger)
         {
-            return Eval(value, (UInt16)bigInteger, "Value after cast");
+            Assert.Equal(value, (SByte)bigInteger);
         }
 
-        private static bool VerifyInt16ExplicitCastFromBigInteger(Int16 value)
-        {
-            BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (Int16)bigInteger, "Value after cast");
-        }
-        private static bool VerifyInt16ExplicitCastFromBigInteger(Int16 value, BigInteger bigInteger)
-        {
-            return Eval(value, (Int16)bigInteger, "Value after cast");
-        }
-
-        private static bool VerifyUInt32ExplicitCastFromBigInteger(UInt32 value)
+        private static void VerifyUInt16ExplicitCastFromBigInteger(UInt16 value)
         {
             BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (UInt32)bigInteger, "Value after cast");
+            VerifyUInt16ExplicitCastFromBigInteger(value, bigInteger);
         }
-        private static bool VerifyUInt32ExplicitCastFromBigInteger(UInt32 value, BigInteger bigInteger)
+        private static void VerifyUInt16ExplicitCastFromBigInteger(UInt16 value, BigInteger bigInteger)
         {
-            return Eval(value, (UInt32)bigInteger, "Value after cast");
+            Assert.Equal(value, (UInt16)bigInteger);
         }
 
-        private static bool VerifyInt32ExplicitCastFromBigInteger(Int32 value)
-        {
-            BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (Int32)bigInteger, "Value after cast");
-        }
-        private static bool VerifyInt32ExplicitCastFromBigInteger(Int32 value, BigInteger bigInteger)
-        {
-            return Eval(value, (Int32)bigInteger, "Value after cast");
-        }
-
-        private static bool VerifyUInt64ExplicitCastFromBigInteger(UInt64 value)
+        private static void VerifyInt16ExplicitCastFromBigInteger(Int16 value)
         {
             BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (UInt64)bigInteger, "Value after cast");
+            VerifyInt16ExplicitCastFromBigInteger(value, bigInteger);
         }
-        private static bool VerifyUInt64ExplicitCastFromBigInteger(UInt64 value, BigInteger bigInteger)
+        private static void VerifyInt16ExplicitCastFromBigInteger(Int16 value, BigInteger bigInteger)
         {
-            return Eval(value, (UInt64)bigInteger, "Value after cast");
+            Assert.Equal(value, (Int16)bigInteger);
         }
 
-        private static bool VerifyInt64ExplicitCastFromBigInteger(Int64 value)
-        {
-            BigInteger bigInteger = new BigInteger(value);
-
-            return Eval(value, (Int64)bigInteger, "Value after cast");
-        }
-        private static bool VerifyInt64ExplicitCastFromBigInteger(Int64 value, BigInteger bigInteger)
-        {
-            return Eval(value, (Int64)bigInteger, "Value after cast");
-        }
-
-        private static bool VerifySingleExplicitCastFromBigInteger(Single value)
+        private static void VerifyUInt32ExplicitCastFromBigInteger(UInt32 value)
         {
             BigInteger bigInteger = new BigInteger(value);
-
-            return VerifySingleExplicitCastFromBigInteger(value, bigInteger);
+            VerifyUInt32ExplicitCastFromBigInteger(value, bigInteger);
         }
-        private static bool VerifySingleExplicitCastFromBigInteger(Single value, BigInteger bigInteger)
+        private static void VerifyUInt32ExplicitCastFromBigInteger(UInt32 value, BigInteger bigInteger)
         {
-            return Eval((Single)Math.Truncate(value), (Single)bigInteger, "Value after cast");
+            Assert.Equal(value, (UInt32)bigInteger);
         }
 
-        private static bool VerifyDoubleExplicitCastFromBigInteger(Double value)
-        {
-            BigInteger bigInteger = new BigInteger(value);
-
-            return VerifyDoubleExplicitCastFromBigInteger(value, bigInteger);
-        }
-        private static bool VerifyDoubleExplicitCastFromBigInteger(Double value, BigInteger bigInteger)
-        {
-            return Eval(Math.Truncate(value), (Double)bigInteger, "Value after cast");
-        }
-
-        private static bool VerifyDecimalExplicitCastFromBigInteger(Decimal value)
+        private static void VerifyInt32ExplicitCastFromBigInteger(Int32 value)
         {
             BigInteger bigInteger = new BigInteger(value);
-
-            return VerifyDecimalExplicitCastFromBigInteger(value, bigInteger);
+            VerifyInt32ExplicitCastFromBigInteger(value, bigInteger);
         }
-        private static bool VerifyDecimalExplicitCastFromBigInteger(Decimal value, BigInteger bigInteger)
+        private static void VerifyInt32ExplicitCastFromBigInteger(Int32 value, BigInteger bigInteger)
         {
-            return Eval(value, (Decimal)bigInteger, "Value after cast");
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
+            Assert.Equal(value, (Int32)bigInteger);
         }
 
-        public static bool VerifyException<T>(ExceptionGenerator exceptionGenerator) where T : Exception
+        private static void VerifyUInt64ExplicitCastFromBigInteger(UInt64 value)
         {
-            return VerifyException(typeof(T), exceptionGenerator);
+            BigInteger bigInteger = new BigInteger(value);
+            VerifyUInt64ExplicitCastFromBigInteger(value, bigInteger);
         }
-        public static bool VerifyException(Type expectedExceptionType, ExceptionGenerator exceptionGenerator)
+        private static void VerifyUInt64ExplicitCastFromBigInteger(UInt64 value, BigInteger bigInteger)
         {
-            return VerifyException(expectedExceptionType, exceptionGenerator, String.Empty);
+            Assert.Equal(value, (UInt64)bigInteger);
         }
-        public static bool VerifyException(Type expectedExceptionType, ExceptionGenerator exceptionGenerator, string message)
-        {
-            bool retValue = true;
 
+        private static void VerifyInt64ExplicitCastFromBigInteger(Int64 value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+            VerifyInt64ExplicitCastFromBigInteger(value, bigInteger);
+        }
+        private static void VerifyInt64ExplicitCastFromBigInteger(Int64 value, BigInteger bigInteger)
+        {
+            Assert.Equal(value, (Int64)bigInteger);
+        }
+
+        private static void VerifySingleExplicitCastFromBigInteger(Single value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+            VerifySingleExplicitCastFromBigInteger(value, bigInteger);
+        }
+        private static void VerifySingleExplicitCastFromBigInteger(Single value, BigInteger bigInteger)
+        {
+            Assert.Equal((Single)Math.Truncate(value), (Single)bigInteger);
+        }
+
+        private static void VerifyDoubleExplicitCastFromBigInteger(Double value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+            VerifyDoubleExplicitCastFromBigInteger(value, bigInteger);
+        }
+        private static void VerifyDoubleExplicitCastFromBigInteger(Double value, BigInteger bigInteger)
+        {
+            Assert.Equal(Math.Truncate(value), (Double)bigInteger);
+        }
+
+        private static void VerifyDecimalExplicitCastFromBigInteger(Decimal value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+            VerifyDecimalExplicitCastFromBigInteger(value, bigInteger);
+        }
+        private static void VerifyDecimalExplicitCastFromBigInteger(Decimal value, BigInteger bigInteger)
+        {
+            Assert.Equal(value, (Decimal)bigInteger);
+        }
+        
+        public static void VerifyException<T>(ExceptionGenerator exceptionGenerator) where T : Exception
+        {
+             VerifyException(typeof(T), exceptionGenerator);
+        }
+
+        public static void VerifyException(Type expectedExceptionType, ExceptionGenerator exceptionGenerator)
+        {
             try
             {
                 exceptionGenerator();
-                retValue &= Eval(false, (String.IsNullOrEmpty(message) ? String.Empty : (message + Environment.NewLine)) +
-                    String.Format("Err_05940iedz Expected exception of the type {0} to be thrown and nothing was thrown", expectedExceptionType));
+                Assert.True(false, String.Format("Err_05940iedz Expected exception of the type {0} to be thrown and nothing was thrown", expectedExceptionType));
             }
             catch (Exception exception)
             {
-                retValue &= Eval<Type>(expectedExceptionType, exception.GetType(),
-                    (String.IsNullOrEmpty(message) ? String.Empty : (message + Environment.NewLine)) +
-                    String.Format("Err_38223oipwj Expected exception and actual exception differ.  Expected {0}, got \n{1}", expectedExceptionType, exception));
+                Assert.Equal(expectedExceptionType, exception.GetType());
             }
-
-            return retValue;
         }
 
         public static byte[] ByteArrayMakeMinSize(Byte[] input, int minSize)
         {
             if (input.Length >= minSize)
+            {
                 return input;
+            }
 
             Byte[] output = new byte[minSize];
             Byte filler = 0;
@@ -937,10 +897,7 @@ namespace System.Numerics.Tests
 
             for (int i = 0; i < output.Length; i++)
             {
-                if (i < input.Length)
-                    output[i] = input[i];
-                if (i >= input.Length)
-                    output[i] = filler;
+                output[i] = (i < input.Length) ? input[i] : filler;
             }
 
             return output;

--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_to.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_to.cs
@@ -12,219 +12,217 @@ namespace System.Numerics.Tests
 
         private const int NumberOfRandomIterations = 10;
         private static Random s_random = new Random(100);
-
-
-
+        
         [Fact]
         public static void RunByteImplicitCastToBigIntegerTests()
         {
             // Byte Implicit Cast to BigInteger: Byte.MinValue
-            Assert.True(VerifyByteImplicitCastToBigInteger(Byte.MinValue), " Verification Failed");
+            VerifyByteImplicitCastToBigInteger(Byte.MinValue);
 
             // Byte Implicit Cast to BigInteger: 0
-            Assert.True(VerifyByteImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyByteImplicitCastToBigInteger(0);
 
             // Byte Implicit Cast to BigInteger: 1
-            Assert.True(VerifyByteImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyByteImplicitCastToBigInteger(1);
 
             // Byte Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyByteImplicitCastToBigInteger((Byte)s_random.Next(1, Byte.MaxValue)), " Verification Failed");
+                VerifyByteImplicitCastToBigInteger((Byte)s_random.Next(1, Byte.MaxValue));
             }
 
             // Byte Implicit Cast to BigInteger: Byte.MaxValue
-            Assert.True(VerifyByteImplicitCastToBigInteger(Byte.MaxValue), " Verification Failed");
+            VerifyByteImplicitCastToBigInteger(Byte.MaxValue);
         }
 
         [Fact]
         public static void RunSByteImplicitCastToBigIntegerTests()
         {
             // SByte Implicit Cast to BigInteger: SByte.MinValue
-            Assert.True(VerifySByteImplicitCastToBigInteger(SByte.MinValue), " Verification Failed");
+            VerifySByteImplicitCastToBigInteger(SByte.MinValue);
 
             // SByte Implicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySByteImplicitCastToBigInteger((SByte)s_random.Next(SByte.MinValue, 0)), " Verification Failed");
+                VerifySByteImplicitCastToBigInteger((SByte)s_random.Next(SByte.MinValue, 0));
             }
 
             // SByte Implicit Cast to BigInteger: -1
-            Assert.True(VerifySByteImplicitCastToBigInteger(-1), " Verification Failed");
+            VerifySByteImplicitCastToBigInteger(-1);
 
             // SByte Implicit Cast to BigInteger: 0
-            Assert.True(VerifySByteImplicitCastToBigInteger(0), " Verification Failed");
+            VerifySByteImplicitCastToBigInteger(0);
 
             // SByte Implicit Cast to BigInteger: 1
-            Assert.True(VerifySByteImplicitCastToBigInteger(1), " Verification Failed");
+            VerifySByteImplicitCastToBigInteger(1);
 
             // SByte Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySByteImplicitCastToBigInteger((SByte)s_random.Next(1, SByte.MaxValue)), " Verification Failed");
+                VerifySByteImplicitCastToBigInteger((SByte)s_random.Next(1, SByte.MaxValue));
             }
 
             // SByte Implicit Cast to BigInteger: SByte.MaxValue
-            Assert.True(VerifySByteImplicitCastToBigInteger(SByte.MaxValue), " Verification Failed");
+            VerifySByteImplicitCastToBigInteger(SByte.MaxValue);
         }
 
         [Fact]
         public static void RunUInt16ImplicitCastToBigIntegerTests()
         {
             // UInt16 Implicit Cast to BigInteger: UInt16.MinValue
-            Assert.True(VerifyUInt16ImplicitCastToBigInteger(UInt16.MinValue), " Verification Failed");
+            VerifyUInt16ImplicitCastToBigInteger(UInt16.MinValue);
 
             // UInt16 Implicit Cast to BigInteger: 0
-            Assert.True(VerifyUInt16ImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyUInt16ImplicitCastToBigInteger(0);
 
             // UInt16 Implicit Cast to BigInteger: 1
-            Assert.True(VerifyUInt16ImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyUInt16ImplicitCastToBigInteger(1);
 
             // UInt16 Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyUInt16ImplicitCastToBigInteger((UInt16)s_random.Next(1, UInt16.MaxValue)), " Verification Failed");
+                VerifyUInt16ImplicitCastToBigInteger((UInt16)s_random.Next(1, UInt16.MaxValue));
             }
 
             // UInt16 Implicit Cast to BigInteger: UInt16.MaxValue
-            Assert.True(VerifyUInt16ImplicitCastToBigInteger(UInt16.MaxValue), " Verification Failed");
+            VerifyUInt16ImplicitCastToBigInteger(UInt16.MaxValue);
         }
 
         [Fact]
         public static void RunInt16ImplicitCastToBigIntegerTests()
         {
             // Int16 Implicit Cast to BigInteger: Int16.MinValue
-            Assert.True(VerifyInt16ImplicitCastToBigInteger(Int16.MinValue), " Verification Failed");
+            VerifyInt16ImplicitCastToBigInteger(Int16.MinValue);
 
             // Int16 Implicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt16ImplicitCastToBigInteger((Int16)s_random.Next(Int16.MinValue, 0)), " Verification Failed");
+                VerifyInt16ImplicitCastToBigInteger((Int16)s_random.Next(Int16.MinValue, 0));
             }
 
             // Int16 Implicit Cast to BigInteger: -1
-            Assert.True(VerifyInt16ImplicitCastToBigInteger(-1), " Verification Failed");
+            VerifyInt16ImplicitCastToBigInteger(-1);
 
             // Int16 Implicit Cast to BigInteger: 0
-            Assert.True(VerifyInt16ImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyInt16ImplicitCastToBigInteger(0);
 
             // Int16 Implicit Cast to BigInteger: 1
-            Assert.True(VerifyInt16ImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyInt16ImplicitCastToBigInteger(1);
 
             // Int16 Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt16ImplicitCastToBigInteger((Int16)s_random.Next(1, Int16.MaxValue)), " Verification Failed");
+                VerifyInt16ImplicitCastToBigInteger((Int16)s_random.Next(1, Int16.MaxValue));
             }
 
             // Int16 Implicit Cast to BigInteger: Int16.MaxValue
-            Assert.True(VerifyInt16ImplicitCastToBigInteger(Int16.MaxValue), " Verification Failed");
+            VerifyInt16ImplicitCastToBigInteger(Int16.MaxValue);
         }
 
         [Fact]
         public static void RunUInt32ImplicitCastToBigIntegerTests()
         {
             // UInt32 Implicit Cast to BigInteger: UInt32.MinValue
-            Assert.True(VerifyUInt32ImplicitCastToBigInteger(UInt32.MinValue), " Verification Failed");
+            VerifyUInt32ImplicitCastToBigInteger(UInt32.MinValue);
 
             // UInt32 Implicit Cast to BigInteger: 0
-            Assert.True(VerifyUInt32ImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyUInt32ImplicitCastToBigInteger(0);
 
             // UInt32 Implicit Cast to BigInteger: 1
-            Assert.True(VerifyUInt32ImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyUInt32ImplicitCastToBigInteger(1);
 
             // UInt32 Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyUInt32ImplicitCastToBigInteger((UInt32)(UInt32.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyUInt32ImplicitCastToBigInteger((UInt32)(UInt32.MaxValue * s_random.NextDouble()));
             }
 
             // UInt32 Implicit Cast to BigInteger: UInt32.MaxValue
-            Assert.True(VerifyUInt32ImplicitCastToBigInteger(UInt32.MaxValue), " Verification Failed");
+            VerifyUInt32ImplicitCastToBigInteger(UInt32.MaxValue);
         }
 
         [Fact]
         public static void RunInt32ImplicitCastToBigIntegerTests()
         {
             // Int32 Implicit Cast to BigInteger: Int32.MinValue
-            Assert.True(VerifyInt32ImplicitCastToBigInteger(Int32.MinValue), " Verification Failed");
+            VerifyInt32ImplicitCastToBigInteger(Int32.MinValue);
 
             // Int32 Implicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt32ImplicitCastToBigInteger((Int32)s_random.Next(Int32.MinValue, 0)), " Verification Failed");
+                VerifyInt32ImplicitCastToBigInteger((Int32)s_random.Next(Int32.MinValue, 0));
             }
 
             // Int32 Implicit Cast to BigInteger: -1
-            Assert.True(VerifyInt32ImplicitCastToBigInteger(-1), " Verification Failed");
+            VerifyInt32ImplicitCastToBigInteger(-1);
 
             // Int32 Implicit Cast to BigInteger: 0
-            Assert.True(VerifyInt32ImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyInt32ImplicitCastToBigInteger(0);
 
             // Int32 Implicit Cast to BigInteger: 1
-            Assert.True(VerifyInt32ImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyInt32ImplicitCastToBigInteger(1);
 
             // Int32 Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt32ImplicitCastToBigInteger((Int32)s_random.Next(1, Int32.MaxValue)), " Verification Failed");
+                VerifyInt32ImplicitCastToBigInteger((Int32)s_random.Next(1, Int32.MaxValue));
             }
 
             // Int32 Implicit Cast to BigInteger: Int32.MaxValue
-            Assert.True(VerifyInt32ImplicitCastToBigInteger(Int32.MaxValue), " Verification Failed");
+            VerifyInt32ImplicitCastToBigInteger(Int32.MaxValue);
         }
 
         [Fact]
         public static void RunUInt64ImplicitCastToBigIntegerTests()
         {
             // UInt64 Implicit Cast to BigInteger: UInt64.MinValue
-            Assert.True(VerifyUInt64ImplicitCastToBigInteger(UInt64.MinValue), " Verification Failed");
+            VerifyUInt64ImplicitCastToBigInteger(UInt64.MinValue);
 
             // UInt64 Implicit Cast to BigInteger: 0
-            Assert.True(VerifyUInt64ImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyUInt64ImplicitCastToBigInteger(0);
 
             // UInt64 Implicit Cast to BigInteger: 1
-            Assert.True(VerifyUInt64ImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyUInt64ImplicitCastToBigInteger(1);
 
             // UInt64 Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyUInt64ImplicitCastToBigInteger((UInt64)(UInt64.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyUInt64ImplicitCastToBigInteger((UInt64)(UInt64.MaxValue * s_random.NextDouble()));
             }
 
             // UInt64 Implicit Cast to BigInteger: UInt64.MaxValue
-            Assert.True(VerifyUInt64ImplicitCastToBigInteger(UInt64.MaxValue), " Verification Failed");
+            VerifyUInt64ImplicitCastToBigInteger(UInt64.MaxValue);
         }
 
         [Fact]
         public static void RunInt64ImplicitCastToBigIntegerTests()
         {
             // Int64 Implicit Cast to BigInteger: Int64.MinValue
-            Assert.True(VerifyInt64ImplicitCastToBigInteger(Int64.MinValue), " Verification Failed");
+            VerifyInt64ImplicitCastToBigInteger(Int64.MinValue);
 
             // Int64 Implicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt64ImplicitCastToBigInteger(((Int64)(Int64.MaxValue * s_random.NextDouble())) - Int64.MaxValue), " Verification Failed");
+                VerifyInt64ImplicitCastToBigInteger(((Int64)(Int64.MaxValue * s_random.NextDouble())) - Int64.MaxValue);
             }
 
             // Int64 Implicit Cast to BigInteger: -1
-            Assert.True(VerifyInt64ImplicitCastToBigInteger(-1), " Verification Failed");
+            VerifyInt64ImplicitCastToBigInteger(-1);
 
             // Int64 Implicit Cast to BigInteger: 0
-            Assert.True(VerifyInt64ImplicitCastToBigInteger(0), " Verification Failed");
+            VerifyInt64ImplicitCastToBigInteger(0);
 
             // Int64 Implicit Cast to BigInteger: 1
-            Assert.True(VerifyInt64ImplicitCastToBigInteger(1), " Verification Failed");
+            VerifyInt64ImplicitCastToBigInteger(1);
 
             // Int64 Implicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyInt64ImplicitCastToBigInteger((Int64)(Int64.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyInt64ImplicitCastToBigInteger((Int64)(Int64.MaxValue * s_random.NextDouble()));
             }
 
             // Int64 Implicit Cast to BigInteger: Int64.MaxValue
-            Assert.True(VerifyInt64ImplicitCastToBigInteger(Int64.MaxValue), " Verification Failed");
+            VerifyInt64ImplicitCastToBigInteger(Int64.MaxValue);
         }
 
         [Fact]
@@ -233,65 +231,65 @@ namespace System.Numerics.Tests
             Single value;
 
             // Single Explicit Cast to BigInteger: Single.NegativeInfinity
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Single.NegativeInfinity; }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Single.NegativeInfinity; });
 
             // Single Explicit Cast to BigInteger: Single.MinValue
-            Assert.True(VerifySingleExplicitCastToBigInteger(Single.MinValue), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(Single.MinValue);
 
             // Single Explicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastToBigInteger(((Single)(Single.MaxValue * s_random.NextDouble())) - Single.MaxValue), " Verification Failed");
+                VerifySingleExplicitCastToBigInteger(((Single)(Single.MaxValue * s_random.NextDouble())) - Single.MaxValue);
             }
 
             // Single Explicit Cast to BigInteger: Random Non-Integral Negative > -100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastToBigInteger((Single)(-100 * s_random.NextDouble())), " Verification Failed");
+                VerifySingleExplicitCastToBigInteger((Single)(-100 * s_random.NextDouble()));
             }
 
             // Single Explicit Cast to BigInteger: -1
-            Assert.True(VerifySingleExplicitCastToBigInteger(-1), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(-1);
 
             // Single Explicit Cast to BigInteger: 0
-            Assert.True(VerifySingleExplicitCastToBigInteger(0), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(0);
 
             // Single Explicit Cast to BigInteger: 1
-            Assert.True(VerifySingleExplicitCastToBigInteger(1), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(1);
 
             // Single Explicit Cast to BigInteger: Random Non-Integral Positive < 100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastToBigInteger((Single)(100 * s_random.NextDouble())), " Verification Failed");
+                VerifySingleExplicitCastToBigInteger((Single)(100 * s_random.NextDouble()));
             }
 
             // Single Explicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifySingleExplicitCastToBigInteger((Single)(Single.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifySingleExplicitCastToBigInteger((Single)(Single.MaxValue * s_random.NextDouble()));
             }
 
             // Single Explicit Cast to BigInteger: Single.MaxValue
-            Assert.True(VerifySingleExplicitCastToBigInteger(Single.MaxValue), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(Single.MaxValue);
 
             // Single Explicit Cast to BigInteger: Single.PositiveInfinity
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Single.PositiveInfinity; }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Single.PositiveInfinity; });
 
             // Single Explicit Cast to BigInteger: Single.Epsilon
-            Assert.True(VerifySingleExplicitCastToBigInteger(Single.Epsilon), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(Single.Epsilon);
 
             // Single Explicit Cast to BigInteger: Single.NaN
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Single.NaN; }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Single.NaN; });
 
             //There are multiple ways to represent a NaN just try another one
             // Single Explicit Cast to BigInteger: Single.NaN 2
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)ConvertInt32ToSingle(0x7FC00000); }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)ConvertInt32ToSingle(0x7FC00000); });
 
             // Single Explicit Cast to BigInteger: Smallest Exponent
-            Assert.True(VerifySingleExplicitCastToBigInteger((Single)Math.Pow(2, -126)), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger((Single)Math.Pow(2, -126));
 
             // Single Explicit Cast to BigInteger: Largest Exponent
-            Assert.True(VerifySingleExplicitCastToBigInteger((Single)Math.Pow(2, 127)), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger((Single)Math.Pow(2, 127));
 
             // Single Explicit Cast to BigInteger: Largest number less then 1
             value = 0;
@@ -299,11 +297,11 @@ namespace System.Numerics.Tests
             {
                 value += (Single)(Math.Pow(2, -i));
             }
-            Assert.True(VerifySingleExplicitCastToBigInteger(value), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(value);
 
             // Single Explicit Cast to BigInteger: Smallest number greater then 1
             value = (Single)(1 + Math.Pow(2, -23));
-            Assert.True(VerifySingleExplicitCastToBigInteger(value), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(value);
 
             // Single Explicit Cast to BigInteger: Largest number less then 2
             value = 0;
@@ -312,7 +310,7 @@ namespace System.Numerics.Tests
                 value += (Single)(Math.Pow(2, -i));
             }
             value += 1;
-            Assert.True(VerifySingleExplicitCastToBigInteger(value), " Verification Failed");
+            VerifySingleExplicitCastToBigInteger(value);
         }
 
         [Fact]
@@ -321,65 +319,65 @@ namespace System.Numerics.Tests
             Double value;
 
             // Double Explicit Cast to BigInteger: Double.NegativeInfinity
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Double.NegativeInfinity; }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Double.NegativeInfinity; });
 
             // Double Explicit Cast to BigInteger: Double.MinValue
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(Double.MinValue), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(Double.MinValue);
 
             // Double Explicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastToBigInteger(((Double)(Double.MaxValue * s_random.NextDouble())) - Double.MaxValue), " Verification Failed");
+                VerifyDoubleExplicitCastToBigInteger(((Double)(Double.MaxValue * s_random.NextDouble())) - Double.MaxValue);
             }
 
             // Double Explicit Cast to BigInteger: Random Non-Integral Negative > -100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastToBigInteger((Double)(-100 * s_random.NextDouble())), " Verification Failed");
+                VerifyDoubleExplicitCastToBigInteger((Double)(-100 * s_random.NextDouble()));
             }
 
             // Double Explicit Cast to BigInteger: -1
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(-1), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(-1);
 
             // Double Explicit Cast to BigInteger: 0
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(0), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(0);
 
             // Double Explicit Cast to BigInteger: 1
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(1), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(1);
 
             // Double Explicit Cast to BigInteger: Random Non-Integral Positive < 100
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastToBigInteger((Double)(100 * s_random.NextDouble())), " Verification Failed");
+                VerifyDoubleExplicitCastToBigInteger((Double)(100 * s_random.NextDouble()));
             }
 
             // Double Explicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
             {
-                Assert.True(VerifyDoubleExplicitCastToBigInteger((Double)(Double.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyDoubleExplicitCastToBigInteger((Double)(Double.MaxValue * s_random.NextDouble()));
             }
 
             // Double Explicit Cast to BigInteger: Double.MaxValue
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(Double.MaxValue), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(Double.MaxValue);
 
             // Double Explicit Cast to BigInteger: Double.PositiveInfinity
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Double.PositiveInfinity; }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Double.PositiveInfinity; });
 
             // Double Explicit Cast to BigInteger: Double.Epsilon
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(Double.Epsilon), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(Double.Epsilon);
 
             // Double Explicit Cast to BigInteger: Double.NaN
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Double.NaN; }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)Double.NaN; });
 
             //There are multiple ways to represent a NaN just try another one
             // Double Explicit Cast to BigInteger: Double.NaN 2
-            Assert.True(VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)ConvertInt64ToDouble(0x7FF8000000000000); }), " Verification Failed");
+            VerifyException<OverflowException>(delegate () { BigInteger temp = (BigInteger)ConvertInt64ToDouble(0x7FF8000000000000); });
 
             // Double Explicit Cast to BigInteger: Smallest Exponent
-            Assert.True(VerifyDoubleExplicitCastToBigInteger((Double)Math.Pow(2, -1022)), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger((Double)Math.Pow(2, -1022));
 
             // Double Explicit Cast to BigInteger: Largest Exponent
-            Assert.True(VerifyDoubleExplicitCastToBigInteger((Double)Math.Pow(2, 1023)), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger((Double)Math.Pow(2, 1023));
 
             // Double Explicit Cast to BigInteger: Largest number less then 1
             value = 0;
@@ -387,11 +385,11 @@ namespace System.Numerics.Tests
             {
                 value += (Double)(Math.Pow(2, -i));
             }
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(value);
 
             // Double Explicit Cast to BigInteger: Smallest number greater then 1
             value = (Double)(1 + Math.Pow(2, -52));
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(value);
 
             // Double Explicit Cast to BigInteger: Largest number less then 2
             value = 0;
@@ -400,7 +398,7 @@ namespace System.Numerics.Tests
                 value += (Double)(Math.Pow(2, -i));
             }
             value += 1;
-            Assert.True(VerifyDoubleExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDoubleExplicitCastToBigInteger(value);
         }
 
         [Fact]
@@ -409,7 +407,7 @@ namespace System.Numerics.Tests
             Decimal value;
 
             // Decimal Explicit Cast to BigInteger: Decimal.MinValue
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(Decimal.MinValue), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(Decimal.MinValue);
 
             // Decimal Explicit Cast to BigInteger: Random Negative
             for (int i = 0; i < NumberOfRandomIterations; ++i)
@@ -420,17 +418,17 @@ namespace System.Numerics.Tests
                     s_random.Next(Int32.MinValue, Int32.MaxValue),
                     true,
                     (byte)s_random.Next(0, 29));
-                Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+                VerifyDecimalExplicitCastToBigInteger(value);
             }
 
             // Decimal Explicit Cast to BigInteger: -1
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(-1), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(-1);
 
             // Decimal Explicit Cast to BigInteger: 0
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(0), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(0);
 
             // Decimal Explicit Cast to BigInteger: 1
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(1), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(1);
 
             // Decimal Explicit Cast to BigInteger: Random Positive
             for (int i = 0; i < NumberOfRandomIterations; ++i)
@@ -441,44 +439,44 @@ namespace System.Numerics.Tests
                     s_random.Next(Int32.MinValue, Int32.MaxValue),
                     false,
                     (byte)s_random.Next(0, 29));
-                Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+                VerifyDecimalExplicitCastToBigInteger(value);
             }
 
             // Decimal Explicit Cast to BigInteger: Decimal.MaxValue
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(Decimal.MaxValue), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(Decimal.MaxValue);
 
             // Decimal Explicit Cast to BigInteger: Smallest Exponent
             unchecked
             {
                 value = new Decimal(1, 0, 0, false, 0);
             }
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(value);
 
             // Decimal Explicit Cast to BigInteger: Largest Exponent and zero integer
             unchecked
             {
                 value = new Decimal(0, 0, 0, false, 28);
             }
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(value);
 
             // Decimal Explicit Cast to BigInteger: Largest Exponent and non zero integer
             unchecked
             {
                 value = new Decimal(1, 0, 0, false, 28);
             }
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(value);
 
             // Decimal Explicit Cast to BigInteger: Largest number less then 1
             value = 1 - new Decimal(1, 0, 0, false, 28);
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(value);
 
             // Decimal Explicit Cast to BigInteger: Smallest number greater then 1
             value = 1 + new Decimal(1, 0, 0, false, 28);
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(value);
 
             // Decimal Explicit Cast to BigInteger: Largest number less then 2
             value = 2 - new Decimal(1, 0, 0, false, 28);
-            Assert.True(VerifyDecimalExplicitCastToBigInteger(value), " Verification Failed");
+            VerifyDecimalExplicitCastToBigInteger(value);
         }
 
         private static Single ConvertInt32ToSingle(Int32 value)
@@ -491,217 +489,176 @@ namespace System.Numerics.Tests
             return BitConverter.ToDouble(BitConverter.GetBytes(value), 0);
         }
 
-        private static bool VerifyByteImplicitCastToBigInteger(Byte value)
+        private static void VerifyByteImplicitCastToBigInteger(Byte value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to Byte {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "Byte.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (Byte)bigInteger, "Round tripped Byte");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (Byte)bigInteger);
 
             if (value != Byte.MaxValue)
             {
-                ret &= Eval((Byte)(value + 1), (Byte)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((Byte)(value + 1), (Byte)(bigInteger + 1));
             }
 
             if (value != Byte.MinValue)
             {
-                ret &= Eval((Byte)(value - 1), (Byte)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((Byte)(value - 1), (Byte)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifySByteImplicitCastToBigInteger(SByte value)
+        private static void VerifySByteImplicitCastToBigInteger(SByte value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to SByte {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "SByte.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (SByte)bigInteger, "Round tripped SByte");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (SByte)bigInteger);
 
             if (value != SByte.MaxValue)
             {
-                ret &= Eval((SByte)(value + 1), (SByte)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((SByte)(value + 1), (SByte)(bigInteger + 1));
             }
 
             if (value != SByte.MinValue)
             {
-                ret &= Eval((SByte)(value - 1), (SByte)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((SByte)(value - 1), (SByte)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifyUInt16ImplicitCastToBigInteger(UInt16 value)
+        private static void VerifyUInt16ImplicitCastToBigInteger(UInt16 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to UInt16 {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "UInt16.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (UInt16)bigInteger, "Round tripped UInt16");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (UInt16)bigInteger);
 
             if (value != UInt16.MaxValue)
             {
-                ret &= Eval((UInt16)(value + 1), (UInt16)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((UInt16)(value + 1), (UInt16)(bigInteger + 1));
             }
 
             if (value != UInt16.MinValue)
             {
-                ret &= Eval((UInt16)(value - 1), (UInt16)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((UInt16)(value - 1), (UInt16)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifyInt16ImplicitCastToBigInteger(Int16 value)
+        private static void VerifyInt16ImplicitCastToBigInteger(Int16 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to Int16 {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "Int16.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (Int16)bigInteger, "Round tripped Int16");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (Int16)bigInteger);
 
             if (value != Int16.MaxValue)
             {
-                ret &= Eval((Int16)(value + 1), (Int16)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((Int16)(value + 1), (Int16)(bigInteger + 1));
             }
 
             if (value != Int16.MinValue)
             {
-                ret &= Eval((Int16)(value - 1), (Int16)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((Int16)(value - 1), (Int16)(bigInteger - 1));
             }
-
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+    
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifyUInt32ImplicitCastToBigInteger(UInt32 value)
+        private static void VerifyUInt32ImplicitCastToBigInteger(UInt32 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to UInt32 {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "UInt32.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (UInt32)bigInteger, "Round tripped UInt32");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (UInt32)bigInteger);
 
             if (value != UInt32.MaxValue)
             {
-                ret &= Eval((UInt32)(value + 1), (UInt32)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((UInt32)(value + 1), (UInt32)(bigInteger + 1));
             }
 
             if (value != UInt32.MinValue)
             {
-                ret &= Eval((UInt32)(value - 1), (UInt32)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((UInt32)(value - 1), (UInt32)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifyInt32ImplicitCastToBigInteger(Int32 value)
+        private static void VerifyInt32ImplicitCastToBigInteger(Int32 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to Int32 {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "Int32.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (Int32)bigInteger, "Round tripped Int32");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (Int32)bigInteger);
 
             if (value != Int32.MaxValue)
             {
-                ret &= Eval((Int32)(value + 1), (Int32)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((Int32)(value + 1), (Int32)(bigInteger + 1));
             }
 
             if (value != Int32.MinValue)
             {
-                ret &= Eval((Int32)(value - 1), (Int32)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((Int32)(value - 1), (Int32)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifyUInt64ImplicitCastToBigInteger(UInt64 value)
+        private static void VerifyUInt64ImplicitCastToBigInteger(UInt64 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to UInt64 {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "UInt64.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (UInt64)bigInteger, "Round tripped UInt64");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (UInt64)bigInteger);
 
             if (value != UInt64.MaxValue)
             {
-                ret &= Eval((UInt64)(value + 1), (UInt64)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((UInt64)(value + 1), (UInt64)(bigInteger + 1));
             }
 
             if (value != UInt64.MinValue)
             {
-                ret &= Eval((UInt64)(value - 1), (UInt64)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((UInt64)(value - 1), (UInt64)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifyInt64ImplicitCastToBigInteger(Int64 value)
+        private static void VerifyInt64ImplicitCastToBigInteger(Int64 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = value;
 
-            bigInteger = value;
-
-            ret &= Eval(bigInteger.Equals(value), String.Format("Expected BigInteger {0} to be equal to Int64 {1}", bigInteger, value));
-            ret &= Eval(value.ToString(), bigInteger.ToString(), "Int64.ToString() and BigInteger.ToString()");
-            ret &= Eval(value, (Int64)bigInteger, "Round tripped Int64");
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(value.ToString(), bigInteger.ToString());
+            Assert.Equal(value, (Int64)bigInteger);
 
             if (value != Int64.MaxValue)
             {
-                ret &= Eval((Int64)(value + 1), (Int64)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((Int64)(value + 1), (Int64)(bigInteger + 1));
             }
 
             if (value != Int64.MinValue)
             {
-                ret &= Eval((Int64)(value - 1), (Int64)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((Int64)(value - 1), (Int64)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == value);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
-        private static bool VerifySingleExplicitCastToBigInteger(Single value)
+        private static void VerifySingleExplicitCastToBigInteger(Single value)
         {
-            bool ret = true;
             Single expectedValue;
             BigInteger bigInteger;
 
@@ -716,33 +673,30 @@ namespace System.Numerics.Tests
 
             bigInteger = (BigInteger)value;
 
-            ret &= Eval(expectedValue, (Single)bigInteger, "Round tripped Single");
+            Assert.Equal(expectedValue, (Single)bigInteger);
 
             // Single can only accurately represent integers between -16777216 and 16777216 exclusive.
             // ToString starts to become inaccurate at this point.
             if (expectedValue < 16777216 && -16777216 < expectedValue)
             {
-                ret &= Eval(expectedValue.ToString("G9"), bigInteger.ToString(), "Single.ToString() and BigInteger.ToString()");
+                Assert.Equal(expectedValue.ToString("G9"), bigInteger.ToString());
             }
 
             if (expectedValue != Math.Floor(Single.MaxValue))
             {
-                ret &= Eval((Single)(expectedValue + 1), (Single)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((Single)(expectedValue + 1), (Single)(bigInteger + 1));
             }
 
             if (expectedValue != Math.Ceiling(Single.MinValue))
             {
-                ret &= Eval((Single)(expectedValue - 1), (Single)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((Single)(expectedValue - 1), (Single)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == expectedValue);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
         }
 
-        private static bool VerifyDoubleExplicitCastToBigInteger(Double value)
+        private static void VerifyDoubleExplicitCastToBigInteger(Double value)
         {
-            bool ret = true;
             Double expectedValue;
             BigInteger bigInteger;
 
@@ -757,29 +711,26 @@ namespace System.Numerics.Tests
 
             bigInteger = (BigInteger)value;
 
-            ret &= Eval(expectedValue, (Double)bigInteger, "Round tripped Double");
+            Assert.Equal(expectedValue, (Double)bigInteger);
 
             // Double can only accurately represent integers between -9007199254740992 and 9007199254740992 exclusive.
             // ToString starts to become inaccurate at this point.
             if (expectedValue < 9007199254740992 && -9007199254740992 < expectedValue)
             {
-                ret &= Eval(expectedValue.ToString(), bigInteger.ToString(), "Single.ToString() and BigInteger.ToString()");
+                Assert.Equal(expectedValue.ToString(), bigInteger.ToString());
             }
 
             if (!Single.IsInfinity((Single)expectedValue))
             {
-                ret &= Eval((Double)(expectedValue + 1), (Double)(bigInteger + 1), "Adding 1");
-                ret &= Eval((Double)(expectedValue - 1), (Double)(bigInteger - 1), "Subtracting 1");
+                Assert.Equal((Double)(expectedValue + 1), (Double)(bigInteger + 1));
+                Assert.Equal((Double)(expectedValue - 1), (Double)(bigInteger - 1));
             }
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == expectedValue);
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
         }
 
-        private static bool VerifyDecimalExplicitCastToBigInteger(Decimal value)
+        private static void VerifyDecimalExplicitCastToBigInteger(Decimal value)
         {
-            bool ret = true;
             Decimal expectedValue;
             BigInteger bigInteger;
 
@@ -794,131 +745,75 @@ namespace System.Numerics.Tests
 
             bigInteger = (BigInteger)value;
 
-            ret &= Eval(expectedValue.ToString(), bigInteger.ToString(), "Decimal.ToString() and BigInteger.ToString()");
-            ret &= Eval(expectedValue, (Decimal)bigInteger, "Round tripped Decimal");
+            Assert.Equal(expectedValue.ToString(), bigInteger.ToString());
+            Assert.Equal(expectedValue, (Decimal)bigInteger);
 
-            ret &= VerifyBigintegerUsingIdentities(bigInteger, 0 == expectedValue);
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
 
             if (expectedValue != Math.Floor(Decimal.MaxValue))
             {
-                ret &= Eval((Decimal)(expectedValue + 1), (Decimal)(bigInteger + 1), "BigInteger added to 1");
+                Assert.Equal((Decimal)(expectedValue + 1), (Decimal)(bigInteger + 1));
             }
 
             if (expectedValue != Math.Ceiling(Decimal.MinValue))
             {
-                ret &= Eval((Decimal)(expectedValue - 1), (Decimal)(bigInteger - 1), "BigInteger subtracted by 1");
+                Assert.Equal((Decimal)(expectedValue - 1), (Decimal)(bigInteger - 1));
             }
-
-            return ret;
         }
 
-        private static bool VerifyBigintegerUsingIdentities(BigInteger bigInteger, bool isZero)
+        private static void VerifyBigIntegerUsingIdentities(BigInteger bigInteger, bool isZero)
         {
-            bool ret = true;
-            BigInteger tempBigInteger;
+            BigInteger tempBigInteger = new BigInteger(bigInteger.ToByteArray());
 
-            tempBigInteger = new BigInteger(bigInteger.ToByteArray());
-
-            ret &= Eval(bigInteger, tempBigInteger, "BigInteger coppied using ctor(byte[], bool)");
+            Assert.Equal(bigInteger, tempBigInteger);
 
             if (isZero)
             {
-                ret &= Eval(BigInteger.Zero, bigInteger, "Comparing constructed BigInteger with BigInteger.Zero");
+               Assert.Equal(BigInteger.Zero, bigInteger);
             }
             else
             {
-                ret &= Eval(BigInteger.Zero != bigInteger, String.Format("Expected BigInteger to not be equal to zero {0}", bigInteger));
+               Assert.NotEqual(BigInteger.Zero, bigInteger);
 
                 // x/x = 1
-                ret &= Eval(BigInteger.One, bigInteger / bigInteger, "BigInteger divided by itself");
+               Assert.Equal(BigInteger.One, bigInteger / bigInteger);
             }
 
             // (x + 1) - 1 = x
-            ret &= Eval(bigInteger, (bigInteger + BigInteger.One) - BigInteger.One, "Add 1 to the BigInteger then subtract 1");
+            Assert.Equal(bigInteger, (bigInteger + BigInteger.One) - BigInteger.One);
 
             // (x + 1) - x = 1
-            ret &= Eval(BigInteger.One, (bigInteger + BigInteger.One) - bigInteger, "Add 1 to the BigInteger then subtract the BigInteger");
+            Assert.Equal(BigInteger.One, (bigInteger + BigInteger.One) - bigInteger);
 
             // x - x = 0
-            ret &= Eval(BigInteger.Zero, bigInteger - bigInteger, "Subtract the BigInteger form itself");
+            Assert.Equal(BigInteger.Zero, bigInteger - bigInteger);
 
             // x + x = 2x
-            ret &= Eval(2 * bigInteger, bigInteger + bigInteger, "Expected Adding the BigInteger to istself to be equal to 2 times the BigInteger");
+            Assert.Equal(2 * bigInteger, bigInteger + bigInteger);
 
             // x/1 = x
-            ret &= Eval(bigInteger, bigInteger / BigInteger.One, "BigInteger divided by 1");
+            Assert.Equal(bigInteger, bigInteger / BigInteger.One);
 
             // 1 * x = x
-            ret &= Eval(bigInteger, BigInteger.One * bigInteger, "BigInteger multiplied by 1");
-
-            return ret;
+            Assert.Equal(bigInteger, BigInteger.One * bigInteger);
         }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
+        
+        public static void VerifyException<T>(ExceptionGenerator exceptionGenerator) where T : Exception
         {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
+            VerifyException(typeof(T), exceptionGenerator);
 
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
         }
-        public static bool Eval(bool expression, string message)
+        public static void VerifyException(Type expectedExceptionType, ExceptionGenerator exceptionGenerator)
         {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
-        }
-
-        public static bool VerifyException<T>(ExceptionGenerator exceptionGenerator) where T : Exception
-        {
-            return VerifyException(typeof(T), exceptionGenerator);
-        }
-        public static bool VerifyException(Type expectedExceptionType, ExceptionGenerator exceptionGenerator)
-        {
-            return VerifyException(expectedExceptionType, exceptionGenerator, String.Empty);
-        }
-        public static bool VerifyException(Type expectedExceptionType, ExceptionGenerator exceptionGenerator, string message)
-        {
-            bool retValue = true;
-
             try
             {
                 exceptionGenerator();
-                retValue &= Eval(false, (String.IsNullOrEmpty(message) ? String.Empty : (message + Environment.NewLine)) +
-                    String.Format("Err_05940iedz Expected exception of the type {0} to be thrown and nothing was thrown", expectedExceptionType));
+                Assert.True(false, String.Format("Err_05940iedz Expected exception of the type {0} to be thrown and nothing was thrown", expectedExceptionType));
             }
             catch (Exception exception)
             {
-                retValue &= Eval<Type>(expectedExceptionType, exception.GetType(),
-                    (String.IsNullOrEmpty(message) ? String.Empty : (message + Environment.NewLine)) +
-                    String.Format("Err_38223oipwj Expected exception and actual exception differ.  Expected {0}, got \n{1}", expectedExceptionType, exception));
+                Assert.Equal(expectedExceptionType, exception.GetType());
             }
-
-            return retValue;
-        }
-
-        private static bool ApproxEqual(double value1, double value2)
-        {
-            //Special case values;
-            if (Double.IsNaN(value1))
-                return Double.IsNaN(value2);
-            if (Double.IsNegativeInfinity(value1))
-                return Double.IsNegativeInfinity(value2);
-            if (Double.IsPositiveInfinity(value1))
-                return Double.IsPositiveInfinity(value2);
-
-            double result = Math.Abs((value1 / value2) - 1);
-
-            if (result <= Double.Parse("1e-16"))
-                Console.WriteLine("Values not approximately equal");
-
-            return (result <= Double.Parse("1e-16"));
         }
     }
 }


### PR DESCRIPTION
Remove Console.WriteLine() invocations from:
* absolutevalue.cs
* add.cs
* BigIntegerToStringTests.cs
* cast_from.cs
* cast_to.cs

Refactor tests to better use Xunit.Assert

All tests pass:
```
RunTestsForProject:
  corerun.exe xunit.console.netcore.exe System.Runtime.Numerics.Tests.dll  -not
  rait category=outerloop -xml .\testResults.xml -notrait category=failing
  xUnit.net console test runner (64-bit .NET Core)
  Copyright (C) 2014 Outercurve Foundation.

  Discovering: System.Runtime.Numerics.Tests
  Discovered:  System.Runtime.Numerics.Tests
  Starting:    System.Runtime.Numerics.Tests
  Finished:    System.Runtime.Numerics.Tests

  === TEST EXECUTION SUMMARY ===
     System.Runtime.Numerics.Tests  Total: 248, Errors: 0, Failed: 0, Skipped:
  0, Time: 2.129s
Done Building Project "C:\Users\hpshelton\Documents\Projects\corefx\src\System.
Runtime.Numerics\tests\System.Runtime.Numerics.Tests.csproj" (BuildAndTest targ
et(s)).


Build succeeded.
```
Begins progress against [#915 (Remove uses of Console.WriteLine in the Unit Tests?)](https://github.com/dotnet/corefx/issues/915).

This PR removes the use of a centralized function that returns a `bool` in favor of direct invocation of `Assert` inline. This has the advantage of (imho) improved readability and removes the usages of Console.WriteLine() not picked up by Xunit at the possible expense of ease of debugging with breakpoints in the editor. 

Is this style something that the team would be interested in merging or should I focus solely on removing the Console usages with minimal impact to the structure of the remaining test code?