### PR TITLE
Allow strerror to work with either strerror_r signature

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.gnu_get_libc_version.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.gnu_get_libc_version.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        internal static bool IsGnu { get { return s_isGnu.Value; } }
+
+        internal static string gnu_get_libc_version()
+        {
+            return Marshal.PtrToStringAnsi(gnu_get_libc_version_native());
+        }
+
+        [DllImport(Libraries.Libc, EntryPoint = "gnu_get_libc_version")]
+        private static extern IntPtr gnu_get_libc_version_native();
+
+        private static readonly Lazy<bool> s_isGnu = new Lazy<bool>(() =>
+        {
+            try
+            {
+                // Just try to call the P/Invoke.  If it succeeds, this is GNU libc.
+                gnu_get_libc_version_native();
+                return true;
+            }
+            catch
+            {
+                // Otherwise, it's not.
+                return false;
+            }
+        });
+    }
+}

--- a/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
@@ -10,15 +10,70 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        internal unsafe static string strerror(int errno) // thread-safe version of strerror that internally uses strerror_r, which is thread-safe
+        internal static string strerror(int errno)
         {
-            const int bufferLength = 1024; // length long enough for most any Unix error messages
-            byte* buffer = stackalloc byte[bufferLength];
-            IntPtr errorPtr = (IntPtr)strerror_r(errno, buffer, (IntPtr)bufferLength);
-            return Marshal.PtrToStringAnsi(errorPtr); // TODO: Use the proper Encoding
+            string result = s_isGnu.Value ? strerror_gnu(errno) : strerror_xsi(errno);
+            // System.Diagnostics.Debug.WriteLine("strerror: " + result + "\n" + System.Environment.StackTrace); // uncomment to aid debugging
+            return result;
         }
 
+        // strerror is not thread-safe; instead, there is the strerror_r function, which is thread-safe.
+        // However, there are two versions of strerror_r:
+        // - GNU: char* strerror_r(int, char*, size_t);
+        // - XSI: int   strerror_r(int, char*, size_T);
+        // The former may or may not use the supplied buffer, and returns the error message string.
+        // The latter stores the error message string into the supplied buffer.
+        // Due to the different return values, we don't want to just choose one signature
+        // and try to use a heuristic to deduce which version we're dealing with, as that
+        // could result in a stack imbalance due to the varied return result size on 64-bit.  Instead,
+        // we detect whether we're compiled against GNU's libc by trying to invoke its
+        // version-getting method, and invoke the right signature based on that.
+
+        private static Lazy<bool> s_isGnu = new Lazy<bool>(() =>
+        {
+            try
+            {
+                // Just try to call the P/Invoke.  If it succeeds, this is GNU libc.
+                gnu_get_libc_version();
+                return true;
+            }
+            catch
+            {
+                // Otherwise, it's not.
+                return false;
+            }
+        });
+
+        private const int MaxErrorMessageLength = 1024; // length long enough for most any Unix error messages
+
+        private static unsafe string strerror_gnu(int errno)
+        {
+            byte* buffer = stackalloc byte[MaxErrorMessageLength];
+            return strerror_r_gnu(errno, buffer, (IntPtr)MaxErrorMessageLength);
+        }
+
+        private static unsafe string strerror_xsi(int errno)
+        {
+            byte* buffer = stackalloc byte[MaxErrorMessageLength];
+            int ignored = strerror_r_xsi(errno, buffer, (size_t)MaxErrorMessageLength);
+
+            // We ignore the return value of strerror_r.  The only three valid return values are 0
+            // for success, EINVAL for an unknown errno value, and ERANGE if there's not enough
+            // buffer space provided.  For EINVAL, it'll still fill the buffer with a reasonable error
+            // string (e.g. "Unknown error: 0x123"), and for ERANGE, it'll fill the buffer with as much 
+            // of the error as can it, null-terminated.  For now we don't grow the buffer, we could
+            // in the future if desired.
+
+            return Marshal.PtrToStringAnsi((IntPtr)buffer);
+        }
+
+        [DllImport(Libraries.Libc, EntryPoint = "strerror_r")]
+        private static extern unsafe string strerror_r_gnu(int errnum, byte* buf, size_t buflen);
+
+        [DllImport(Libraries.Libc, EntryPoint = "strerror_r")]
+        private static extern unsafe int    strerror_r_xsi(int errnum, byte* buf, size_t buflen);
+
         [DllImport(Libraries.Libc)]
-        private static extern unsafe byte* strerror_r(int errnum, byte* buf, size_t buflen); // GNU-specific
+        private static extern string gnu_get_libc_version();
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         internal static string strerror(int errno)
         {
-            string result = s_isGnu.Value ? strerror_gnu(errno) : strerror_xsi(errno);
+            string result = IsGnu ? strerror_gnu(errno) : strerror_xsi(errno);
             // System.Diagnostics.Debug.WriteLine("strerror: " + result + "\n" + System.Environment.StackTrace); // uncomment to aid debugging
             return result;
         }
@@ -27,21 +27,6 @@ internal static partial class Interop
         // and try to use a heuristic to deduce which version we're dealing with.  Instead,
         // we detect whether we're compiled against GNU's libc by trying to invoke its
         // version-getting method, and invoke the right signature based on that.
-
-        private static Lazy<bool> s_isGnu = new Lazy<bool>(() =>
-        {
-            try
-            {
-                // Just try to call the P/Invoke.  If it succeeds, this is GNU libc.
-                gnu_get_libc_version();
-                return true;
-            }
-            catch
-            {
-                // Otherwise, it's not.
-                return false;
-            }
-        });
 
         private const int MaxErrorMessageLength = 1024; // length long enough for most any Unix error messages
 
@@ -72,8 +57,5 @@ internal static partial class Interop
 
         [DllImport(Libraries.Libc, EntryPoint = "strerror_r")]
         private static extern unsafe int    strerror_r_xsi(int errnum, byte* buf, size_t buflen);
-
-        [DllImport(Libraries.Libc)]
-        private static extern IntPtr gnu_get_libc_version();
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
@@ -49,7 +49,8 @@ internal static partial class Interop
         private static unsafe string strerror_gnu(int errno)
         {
             byte* buffer = stackalloc byte[MaxErrorMessageLength];
-            return strerror_r_gnu(errno, buffer, (IntPtr)MaxErrorMessageLength);
+            IntPtr result = strerror_r_gnu(errno, buffer, (IntPtr)MaxErrorMessageLength);
+            return Marshal.PtrToStringAnsi(result);
         }
 
         private static unsafe string strerror_xsi(int errno)
@@ -68,12 +69,12 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.Libc, EntryPoint = "strerror_r")]
-        private static extern unsafe string strerror_r_gnu(int errnum, byte* buf, size_t buflen);
+        private static extern unsafe IntPtr strerror_r_gnu(int errnum, byte* buf, size_t buflen);
 
         [DllImport(Libraries.Libc, EntryPoint = "strerror_r")]
         private static extern unsafe int    strerror_r_xsi(int errnum, byte* buf, size_t buflen);
 
         [DllImport(Libraries.Libc)]
-        private static extern string gnu_get_libc_version();
+        private static extern IntPtr gnu_get_libc_version();
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.strerror.cs
@@ -23,9 +23,8 @@ internal static partial class Interop
         // - XSI: int   strerror_r(int, char*, size_T);
         // The former may or may not use the supplied buffer, and returns the error message string.
         // The latter stores the error message string into the supplied buffer.
-        // Due to the different return values, we don't want to just choose one signature
-        // and try to use a heuristic to deduce which version we're dealing with, as that
-        // could result in a stack imbalance due to the varied return result size on 64-bit.  Instead,
+        // Due to the varied behaviors, we don't want to just choose one signature
+        // and try to use a heuristic to deduce which version we're dealing with.  Instead,
         // we detect whether we're compiled against GNU's libc by trying to invoke its
         // version-getting method, and invoke the right signature based on that.
 

--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -37,6 +37,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
       <Link>Common\Interop\Unix\Interop.strerror.cs</Link>
     </Compile>

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -64,6 +64,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getenv.cs">
       <Link>Common\Interop\Unix\Interop.getenv.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek.cs">
       <Link>Common\Interop\Unix\Interop.lseek64.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -68,6 +68,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.close.cs">
       <Link>Common\Interop\Unix\libc\Interop.close.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
       <Link>Common\Interop\Unix\libc\Interop.open.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -30,6 +30,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.statvfs.cs">
       <Link>Common\Interop\Unix\Interop.statvfs.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -149,6 +149,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.geteuid.cs">
       <Link>Common\Interop\Unix\Interop.geteuid.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getcwd.cs">
       <Link>Common\Interop\Unix\Interop.getcwd.cs</Link>
     </Compile>

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -58,6 +58,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.madvise.cs">
       <Link>Common\Interop\Unix\Interop.madvise.cs</Link>
     </Compile>


### PR DESCRIPTION
There are two versions of strerror_r, GNU and XSI, with almost the same signature, but with different return types and varying behavior.  The current code is faulty in that it always assume the GNU version, and in doing so will usually fail with null dereferences if the XSI version is used. This change attempts to detect which version is being used by sniffing for the GNU libc version. (If gnu_get_libc_version is an inappropriate function to use for this purpose, I'm happy to switch to something else; I've not yet tested this on Mac.)