### PR TITLE
Improve code coverage for System.Diagnostics.Debug

### DIFF
--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/DebuggerDisplayAttribute.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/DebuggerDisplayAttribute.cs
@@ -48,6 +48,7 @@ namespace System.Diagnostics
 
         public Type Target
         {
+            get { return _target; }
             set
             {
                 if (value == null)
@@ -59,7 +60,6 @@ namespace System.Diagnostics
                 _targetName = value.AssemblyQualifiedName;
                 _target = value;
             }
-            get { return _target; }
         }
 
         public string TargetTypeName

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/DebuggerTypeProxyAttribute.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/DebuggerTypeProxyAttribute.cs
@@ -53,7 +53,6 @@ namespace System.Diagnostics
         {
             get { return _targetName; }
             set { _targetName = value; }
-
         }
     }
 }

--- a/src/System.Diagnostics.Debug/tests/AttributeTests.cs
+++ b/src/System.Diagnostics.Debug/tests/AttributeTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    class AttributeTests
+    public class AttributeTests
     {
         [Fact]
         void DebuggerBrowsableAttributeOnlyAllowsKnownModes()
@@ -18,14 +18,8 @@ namespace System.Diagnostics.Tests
             // it is not part of the enum.
             new DebuggerBrowsableAttribute((DebuggerBrowsableState)1);
 
-
-            // All other values are invalid.
-            for(int i = int.MinValue; i < 0; i++)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => new DebuggerBrowsableAttribute((DebuggerBrowsableState)i));
-            }
-
-            for(int i = 4; i <= int.MaxValue; i++)
+            // All other values are invalid.  Test a few...
+            foreach (int i in new[] { int.MinValue, -10, -1, 4, 5, 10, int.MaxValue })
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => new DebuggerBrowsableAttribute((DebuggerBrowsableState)i));
             }
@@ -54,9 +48,9 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        void NullIsInvalidForDebuggerDisplayType()
+        void NullIsInvalidForDebuggerDisplayTarget()
         {
-            Assert.Throws<ArgumentNullException>(() => (new DebuggerDisplayAttribute("myValue")).Type = null);
+            Assert.Throws<ArgumentNullException>(() => (new DebuggerDisplayAttribute("myValue")).Target = null);
         }
 
         [Fact]
@@ -73,6 +67,35 @@ namespace System.Diagnostics.Tests
 
             d.TargetTypeName = typeof(DebugTests).AssemblyQualifiedName;
             Assert.Equal(typeof(DebugTests).AssemblyQualifiedName, d.TargetTypeName);
+
+            d.Type = "typeName";
+            Assert.Equal("typeName", d.Type);
+        }
+
+        [Fact]
+        void DebuggerTypeProxyAttributeConstruction()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DebuggerTypeProxyAttribute((Type)null));
+
+            Assert.Null(new DebuggerTypeProxyAttribute((string)null).TargetTypeName);
+            Assert.Equal(typeof(DebugTests).AssemblyQualifiedName, new DebuggerTypeProxyAttribute(typeof(DebugTests)).ProxyTypeName);
+            Assert.Equal(typeof(DebugTests).AssemblyQualifiedName, new DebuggerTypeProxyAttribute(typeof(DebugTests).AssemblyQualifiedName).ProxyTypeName);
+        }
+
+        [Fact]
+        void DebuggerTypeProxyAttributePropertiesRoundTrip()
+        {
+            DebuggerTypeProxyAttribute d = new DebuggerTypeProxyAttribute(typeof(DebugTests));
+
+            d.Target = typeof(AttributeTests);
+            Assert.Equal(typeof(AttributeTests), d.Target);
+            Assert.Equal(typeof(AttributeTests).AssemblyQualifiedName, d.TargetTypeName);
+
+            Assert.Throws<ArgumentNullException>(() => d.Target = null);
+
+            d.TargetTypeName = typeof(DebugTests).AssemblyQualifiedName;
+            Assert.Equal(typeof(DebugTests).AssemblyQualifiedName, d.TargetTypeName);
+            Assert.Equal(typeof(AttributeTests), d.Target);
         }
     }
 }

--- a/src/System.Diagnostics.Debug/tests/DebugTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
 
@@ -39,6 +39,10 @@ namespace System.Diagnostics.Tests
             VerifyLogged(() => { Debug.Write((object)null, "category"); }, "category:");
             VerifyLogged(() => { Debug.Write("logged"); }, "logged");
             VerifyLogged(() => { Debug.Write("logged", "category"); }, "category:logged");
+            VerifyLogged(() => { Debug.Write("logged", (string)null); }, "logged");
+
+            string longString = new string('d', 8192);
+            VerifyLogged(() => { Debug.Write(longString); }, longString);
         }
 
         [Fact]
@@ -50,6 +54,7 @@ namespace System.Diagnostics.Tests
             VerifyLogged(() => { Debug.WriteLine((object)null, "category"); }, "category:" + Environment.NewLine);
             VerifyLogged(() => { Debug.WriteLine("logged"); }, "logged" + Environment.NewLine);         
             VerifyLogged(() => { Debug.WriteLine("logged", "category"); }, "category:logged" + Environment.NewLine);
+            VerifyLogged(() => { Debug.WriteLine("logged", (string)null); }, "logged" + Environment.NewLine);
             VerifyLogged(() => { Debug.WriteLine("{0} {1}", 'a', 'b'); }, "a b" + Environment.NewLine);
         }
 
@@ -88,6 +93,7 @@ namespace System.Diagnostics.Tests
 
         static void VerifyLogged(Action test, string expectedOutput)
         {
+            // First use our test logger to verify the output
             Debug.IDebugLogger oldLogger = Debug.s_logger;
             Debug.s_logger = WriteLogger.Instance;
 
@@ -105,6 +111,10 @@ namespace System.Diagnostics.Tests
             {
                 Debug.s_logger = oldLogger;
             }
+
+            // Then also use the actual logger for this platform, just to verify
+            // that nothing fails.
+            test();
         }
 
         static void VerifyAssert(Action test, params string[] expectedOutputStrings)

--- a/src/System.Diagnostics.Debug/tests/DebuggerTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebuggerTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public class DebuggerTests
+    {
+        [Fact]
+        public void IsAttached()
+        {
+            // TODO: Implement this when Debugger is properly implemented
+            Assert.False(Debugger.IsAttached);
+        }
+
+        [Fact]
+        public void Launch()
+        {
+            // TODO: Implement this when Debugger is properly implemented
+            Assert.Throws<NotImplementedException>(() => Debugger.Launch());
+        }
+
+        [Fact]
+        public void Break()
+        {
+            // TODO: Implement this when Debugger is properly implemented
+            Assert.Throws<NotImplementedException>(() => Debugger.Break());
+        }
+    }
+}

--- a/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttributeTests.cs" />
+    <Compile Include="DebuggerTests.cs" />
     <Compile Include="DebugTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>


### PR DESCRIPTION
Primary changes:
- The AttributeTests class wasn't public, and thus none of its tests were being run.  Fixed it to be public, and fixed one of its tests that was throwing ~4 billion exceptions and thus taking a very long time to run :)
- Added coverage for DebuggerTypeProxyAttribute, which was left out of the tests
- (Potentially controversial) The current testing is done against a test mock.  This means that while the Debug API is being exercised, the actual underlying implementation is not.  I added a call to exercise that underlying implementation as well, just to ensure it's not failing, but no verification is done on its output.
- Added stubbed out tests for Debugger, which is currently not implemented.  This will help ensure we go back and add tests when the real implementation is available.
- Added tests for a few other corner cases

This boosts the code coverage of the tests from ~40% to ~67%.  We are unlikely to get much higher than this: the remaining missed code paths are either related to resources or to popping up assert modal dialogs, which we don't want to do in tests.