### PR TITLE
Fix "new Process().StartInfo.Environment" to initialize the collection

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -482,7 +482,7 @@ namespace System.Diagnostics
             {
                 if (_startInfo == null)
                 {
-                    _startInfo = new ProcessStartInfo(this);
+                    _startInfo = new ProcessStartInfo();
                 }
                 return _startInfo;
             }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -25,7 +25,6 @@ namespace System.Diagnostics
         private Encoding _standardErrorEncoding;
 
         private bool _createNoWindow = false;
-        private WeakReference _weakParentProcess;
         internal Dictionary<string, string> _environmentVariables;
 
         /// <devdoc>
@@ -34,11 +33,6 @@ namespace System.Diagnostics
         /// </devdoc>
         public ProcessStartInfo()
         {
-        }
-
-        internal ProcessStartInfo(Process parent)
-        {
-            _weakParentProcess = new WeakReference(parent);
         }
 
         /// <devdoc>
@@ -90,14 +84,11 @@ namespace System.Diagnostics
             {
                 if (_environmentVariables == null)
                 {
-                    _environmentVariables = new Dictionary<string, string>();
-
-                    // if not in design mode, initialize the child environment block with all the parent variables
-                    if (!(_weakParentProcess != null &&
-                          _weakParentProcess.IsAlive))
+                    IDictionary envVars = System.Environment.GetEnvironmentVariables();
+                    _environmentVariables = new Dictionary<string, string>(envVars.Count);
+                    foreach (DictionaryEntry entry in envVars)
                     {
-                        foreach (DictionaryEntry entry in System.Environment.GetEnvironmentVariables())
-                            _environmentVariables.Add((string)entry.Key, (string)entry.Value);
+                        _environmentVariables.Add((string)entry.Key, (string)entry.Value);
                     }
                 }
                 return _environmentVariables;

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -625,14 +625,12 @@ namespace System.Diagnostics.ProcessTests
         [Fact]
         public static void Process_Environment()
         {
+            Assert.NotEqual(0, new Process().StartInfo.Environment.Count);
+
             ProcessStartInfo psi = new ProcessStartInfo();
 
             // Creating a detached ProcessStartInfo will pre-populate the environment
-            // with current environmental variables. 
-
-            // When used with an existing Process.ProcessStartInfo the following behavior
-            //  * Desktop - Populates with current EnvironmentVariable
-            //  * Project K - Does NOT pre-populate environment.
+            // with current environmental variables.
 
             var Environment2 = psi.Environment;
 


### PR DESCRIPTION
The original desktop code for ProcessStartInfo.Environment had this:

http://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/ProcessStartInfo.cs,178
```
if (!(this.weakParentProcess != null &&
      this.weakParentProcess.IsAlive &&
      ((Component)this.weakParentProcess.Target).Site != null &&
      ((Component)this.weakParentProcess.Target).Site.DesignMode)) {
        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
            environmentVariables.Add((string)entry.Key, (string)entry.Value);
        }
}
```

Ignoring the race condition present here where ```weakParentProcess.Target``` could change to be ```null``` after ```IsAlive``` is checked, this is only not initializing the environment variables dictionary if the Process object is sited in design mode.  If it's not in design-mode, Site will be null or DesignMode will be false, the whole condition will be true, and the environment variables will be initialized.

When this was brought over to .NET Core, it appears the condition was just trimmed to remove the Component-related checks, since Process doesn't derive from Component in .NET Core:

```
if (!(_weakParentProcess != null &&
      _weakParentProcess.IsAlive))
{
    foreach (DictionaryEntry entry in System.Environment.GetEnvironmentVariables())
        _environmentVariables.Add((string)entry.Key, (string)entry.Value);
}
```

But that changes the polarity of the condition; now regardless of whether we're in design-mode or not, the environment variables are only ever configured if the WeakReference doesn't exist or is no longer active, which will very rarely be the case when the ProcessStartInfo is constructed via "new Process().StartInfo" (and causes a race condition in the behavior of ProcessStartInfo.Environment).  From a comment in the test, it looks like the test actually broke based on this change, but then the test was just updated with a comment to say that this is the expected behavior... I don't know why that would be the case, but I think we should fix it.

This commit removes those faulty checks so that the environment variables are always initialized.  And since this was the only use for the WeakReference, that's removed, too.