### PR TITLE
Enable code coverage for System.Diagnostics.Process

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>System.Diagnostics.Process.Tests</RootNamespace>
     <AssemblyName>System.Diagnostics.Process.Tests</AssemblyName>
     <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
-    <CoverageEnabledForProject>false</CoverageEnabledForProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Code coverage for System.Diagnostics.Process was previously disabled due to tests hanging when coverage was enabled.  The issue appears to stem from the processes launched by the process tests also having profiling enabled, which currently causes problems for the code coverage tool.  This commit works around the problem by removing the relevant environment variables from the launched processes so that profiling isn't enabled for them.

Fixes #655 

Opened https://github.com/OpenCover/opencover/issues/274 for the tooling issue.