### PR TITLE
Make (THandle)(Handle)default(THandle) round-trip for all handles

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
@@ -118,17 +118,17 @@ namespace System.Reflection.Metadata.Ecma335
         DeletedMarks = 0x80,    // Indicates metadata might contain items marked deleted
     }
 
-    internal enum StringKind : byte
+    internal enum StringKind
     {
-        Plain = 0,
-        WinRTPrefixed = 1,
-        DotTerminated = 2,
+        Plain = 0 << TokenTypeIds.RowIdBitCount,
+        WinRTPrefixed = 1 << TokenTypeIds.RowIdBitCount,
+        DotTerminated = 2 << TokenTypeIds.RowIdBitCount,
     }
 
-    internal enum NamespaceKind : byte
+    internal enum NamespaceKind
     {
-        Plain = 0,
-        Synthetic = 1,
+        Plain = 0 << TokenTypeIds.RowIdBitCount,
+        Synthetic = 1 << TokenTypeIds.RowIdBitCount,
     }
 
     internal static class TokenTypeIds
@@ -185,6 +185,7 @@ namespace System.Reflection.Metadata.Ecma335
         internal const uint MaxNamespace = SyntheticNamespace;
 
         internal const uint StringOrNamespaceKindMask = 0x03000000;
+        internal const uint StringOrNamespaceValueMask = VirtualBitAndRowIdMask | StringOrNamespaceKindMask;
 
         internal const uint HeapMask = 0x70000000;
         internal const uint RIDMask = 0x00FFFFFF;

--- a/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
@@ -16,7 +16,6 @@ namespace System.Reflection.Metadata.Tests
 
             Action<Handle, HandleKind> assert = (handle, expectedKind) =>
             {
-                Assert.False(expectedKinds.Count == 0, "Repeat handle in tests below.");
                 Assert.Equal(expectedKind, handle.Kind);
                 expectedKinds.Remove(expectedKind);
             };
@@ -50,30 +49,18 @@ namespace System.Reflection.Metadata.Tests
             assert(default(ConstantHandle), HandleKind.Constant);
             assert(default(ManifestResourceHandle), HandleKind.ManifestResource);
             assert(default(AssemblyFileHandle), HandleKind.AssemblyFile);
-
             assert(default(MethodImplementationHandle), HandleKind.MethodImplementation);
             assert(default(AssemblyFileHandle), HandleKind.AssemblyFile);
-
-            // Bug #: DevDiv: Bug 1048345: [System.Reflection.Metadata] For select handles, default(THandle) does not preserve type.
-            // Not changing this immediately, because it has been this way for a long time so need to check Roslyn compat.
-            // 
-            //assertEqual(default(StringHandle), HandleKind.String);
-            //assertEqual(default(AssemblyReferenceHandle), HandleKind.AssemblyReference);
-            //assertEqual(default(UserStringHandle), HandleKind.UserString);
-            //assertEqual(default(GuidHandle), HandleKind.Guid);
-            //assertEqual(default(BlobHandle), HandleKind.Blob);
-            //assertEqual(default(NamespaceDefinitionHandle), HandleKind.NamespaceDefinition);
-
-            // In the meantime, check using initialized handles behave as expected
-            assert(MetadataTokens.StringHandle(1), HandleKind.String);
-            assert(MetadataTokens.AssemblyReferenceHandle(1), HandleKind.AssemblyReference);
-            assert(MetadataTokens.UserStringHandle(1), HandleKind.UserString);
-            assert(MetadataTokens.GuidHandle(1), HandleKind.Guid);
-            assert(MetadataTokens.BlobHandle(1), HandleKind.Blob);
-            assert(NamespaceDefinitionHandle.FromIndexOfFullName(1), HandleKind.NamespaceDefinition);
+            assert(default(StringHandle), HandleKind.String);
+            assert(default(AssemblyReferenceHandle), HandleKind.AssemblyReference);
+            assert(default(UserStringHandle), HandleKind.UserString);
+            assert(default(GuidHandle), HandleKind.Guid);
+            assert(default(BlobHandle), HandleKind.Blob);
+            assert(default(NamespaceDefinitionHandle), HandleKind.NamespaceDefinition);
 
             Assert.True(expectedKinds.Count == 0, "Some handles are missing from this test: " + String.Join(",\r\n", expectedKinds));
         }
+
         [Fact]
         public void HandleKindHidesSpecialStringAndNamespaces()
         {
@@ -98,7 +85,7 @@ namespace System.Reflection.Metadata.Tests
                         case (uint)HandleKind.String + 3:
                             Assert.Equal(HandleKind.String, handle.Kind);
 
-                            StringKind stringType = (StringKind)(i - (int)HandleKind.String);
+                            StringKind stringType = (StringKind)((i - (int)HandleKind.String) << TokenTypeIds.RowIdBitCount);
                             StringHandle stringHandle;
                             try
                             {
@@ -119,7 +106,7 @@ namespace System.Reflection.Metadata.Tests
                         case (uint)HandleKind.NamespaceDefinition + 3:
                             Assert.Equal(HandleKind.NamespaceDefinition, handle.Kind);
 
-                            NamespaceKind namespaceType = (NamespaceKind)(i - (int)HandleKind.NamespaceDefinition);
+                            NamespaceKind namespaceType = (NamespaceKind)((i - (int)HandleKind.NamespaceDefinition) << TokenTypeIds.RowIdBitCount);
                             NamespaceDefinitionHandle namespaceHandle;
                             try
                             {


### PR DESCRIPTION
For most handles, default(THandle) was the canonical nil handle.

This makes the behaviour consistent for all handles by ensuring
that a strongly-typed handle never carries the type bits that
are redundant once you know the strong type. These bits are now
added and removed for all handles when converted to the weak
Handle and back. To be clear, we already did this in the easy
case (handle is just a row id), but now we do it in all cases.