### PR TITLE
Fix input data format in unit tests depending on culture

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/DecimalConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DecimalConverterTests.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Tests
         {
             ConvertFrom_WithContext(new object[2, 3]
                 {
-                    { "1.1  ", (Decimal)1.1, null },
+                    { 1.1m + " ", (Decimal)1.1, null },
                     { "+7", (Decimal)7, CultureInfo.InvariantCulture }
                 },
                 DecimalConverterTests.s_converter);
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Tests
         {
             ConvertTo_WithContext(new object[3, 3]
                 {
-                    {(Decimal)1.1, "1.1", null},
+                    {(Decimal)1.1, 1.1m.ToString(), null},
                     {(Decimal)1.1, (Byte)1, CultureInfo.InvariantCulture},
                     {(Decimal)1.1, (Single)1.1, null}
                 },

--- a/src/System.ComponentModel.TypeConverter/tests/DoubleConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DoubleConverterTests.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Tests
         {
             ConvertFrom_WithContext(new object[2, 3]
                 {
-                    { "1.1  ", (Double)1.1, null },
+                    { 1.1 + " ", (Double)1.1, null },
                     { "+7", (Double)7, CultureInfo.InvariantCulture }
                 },
                 DoubleConverterTests.s_converter);
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Tests
         {
             ConvertTo_WithContext(new object[3, 3]
                 {
-                    { (Double)1.1, "1.1", null },
+                    { (Double)1.1, 1.1.ToString(), null },
                     { (Double)1.1, (Single)1.1, CultureInfo.InvariantCulture },
                     { (Double)1.1, (Single)1.1, null }
                 },

--- a/src/System.ComponentModel.TypeConverter/tests/SingleConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SingleConverterTests.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Tests
         {
             ConvertFrom_WithContext(new object[2, 3]
                 {
-                    { "1.1  ", (Single)1.1, null },
+                    { 1.1f + " ", (Single)1.1, null },
                     { "+7", (Single)7, CultureInfo.InvariantCulture }
                 },
                 SingleConverterTests.s_converter);
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Tests
         {
             ConvertTo_WithContext(new object[2, 3]
                 {
-                    { (Single)1.1, "1.1", null },
+                    { (Single)1.1, 1.1f.ToString(), null },
                     { (Single)1.1, 1, CultureInfo.InvariantCulture }
                 },
                 SingleConverterTests.s_converter);


### PR DESCRIPTION
This commit fixes tests that fails on machine where decimal symbol different from "." (dot).

    System.ComponentModel.Tests.SingleConverterTests.ConvertFrom_WithContext [FAIL]
        System.Exception : 1.1 is not a valid value for Single.
        ---- System.FormatException : Input string was not in a correct format.
        Stack Trace:
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\BaseNumberConverter.cs(109,0): at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\ConverterTestBase.cs(53,0): at System.ComponentModel.Tests.ConverterTestBase.ConvertFrom_WithContext(Object[,] data, TypeConverter converter)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\SingleConverterTests.cs(16,0): at System.ComponentModel.Tests.SingleConverterTests.ConvertFrom_WithContext()
           ----- Inner Stack Trace -----
              at System.Number.ParseSingle(String value, NumberStyles options, NumberFormatInfo numfmt)
              at System.Single.Parse(String s, NumberStyles style, IFormatProvider provider)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\SingleConverter.cs(50,0): at System.ComponentModel.SingleConverter.FromString(String value, NumberFormatInfo formatInfo)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\BaseNumberConverter.cs(104,0): at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
     System.ComponentModel.Tests.SingleConverterTests.ConvertTo_WithContext [FAIL]
        Assert.Equal() Failure
        Expected: 1.1
        Actual:   1,1
        Stack Trace:
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\ConverterTestBase.cs(32,0): at System.ComponentModel.Tests.ConverterTestBase.ConvertTo_WithContext(Object[,] data, TypeConverter converter)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\SingleConverterTests.cs(34,0): at System.ComponentModel.Tests.SingleConverterTests.ConvertTo_WithContext()
     System.ComponentModel.Tests.DoubleConverterTests.ConvertFrom_WithContext [FAIL]
        System.Exception : 1.1 is not a valid value for Double.
        ---- System.FormatException : Input string was not in a correct format.
        Stack Trace:
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\BaseNumberConverter.cs(109,0): at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\ConverterTestBase.cs(53,0): at System.ComponentModel.Tests.ConverterTestBase.ConvertFrom_WithContext(Object[,] data, TypeConverter converter)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\DoubleConverterTests.cs(16,0): at System.ComponentModel.Tests.DoubleConverterTests.ConvertFrom_WithContext()
           ----- Inner Stack Trace -----
              at System.Number.ParseDouble(String value, NumberStyles options, NumberFormatInfo numfmt)
              at System.Double.Parse(String s, NumberStyles style, IFormatProvider provider)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\DoubleConverter.cs(50,0): at System.ComponentModel.DoubleConverter.FromString(String value, NumberFormatInfo formatInfo)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\BaseNumberConverter.cs(104,0): at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
     System.ComponentModel.Tests.DecimalConverterTests.ConvertFrom_WithContext [FAIL]
        System.Exception : 1.1 is not a valid value for Decimal.
        ---- System.FormatException : Input string was not in a correct format.
        Stack Trace:
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\BaseNumberConverter.cs(109,0): at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\ConverterTestBase.cs(53,0): at System.ComponentModel.Tests.ConverterTestBase.ConvertFrom_WithContext(Object[,] data, TypeConverter converter)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\DecimalConverterTests.cs(16,0): at System.ComponentModel.Tests.DecimalConverterTests.ConvertFrom_WithContext()
           ----- Inner Stack Trace -----
              at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
              at System.Number.ParseDecimal(String value, NumberStyles options, NumberFormatInfo numfmt)
              at System.Decimal.Parse(String s, NumberStyles style, IFormatProvider provider)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\DecimalConverter.cs(50,0): at System.ComponentModel.DecimalConverter.FromString(String value, NumberFormatInfo formatInfo)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\BaseNumberConverter.cs(104,0): at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
     System.ComponentModel.Tests.DecimalConverterTests.ConvertTo_WithContext [FAIL]
        Assert.Equal() Failure
        Expected: 1.1
        Actual:   1,1
        Stack Trace:
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\ConverterTestBase.cs(32,0): at System.ComponentModel.Tests.ConverterTestBase.ConvertTo_WithContext(Object[,] data, TypeConverter converter)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\DecimalConverterTests.cs(34,0): at System.ComponentModel.Tests.DecimalConverterTests.ConvertTo_WithContext()
     System.ComponentModel.Tests.DoubleConverterTests.ConvertTo_WithContext [FAIL]
        Assert.Equal() Failure
        Expected: 1.1
        Actual:   1,1
        Stack Trace:
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\ConverterTestBase.cs(32,0): at System.ComponentModel.Tests.ConverterTestBase.ConvertTo_WithContext(Object[,] data, TypeConverter converter)
           D:\Workspace\corefx\src\System.ComponentModel.TypeConverter\tests\DoubleConverterTests.cs(34,0): at System.ComponentModel.Tests.DoubleConverterTests.ConvertTo_WithContext()
    Finished:    System.ComponentModel.TypeConverter.Tests
    === TEST EXECUTION SUMMARY ===
     System.ComponentModel.TypeConverter.Tests  Total: 100, Errors: 0, Failed: 6, Skipped: 0, Time: 0,858s`