### PR TITLE
Update the System.Diagnostics.Process tests

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
@@ -13,13 +13,13 @@ namespace ProcessTest_ConsoleApp
                 if (args[0].Equals("infinite"))
                 {
                     // To avoid potential issues with orphaned processes (say, the test exits before
-                    // exiting the process), we'll say "infinite" is actually 30 seconds.
-                    Thread.Sleep(30 * 1000);
+                    // exiting the process), we'll say "infinite" is actually 100 seconds.
+                    Sleep(100 * 1000);
                 }
                 else if (args[0].Equals("error"))
                 {
                     Console.Error.WriteLine("ProcessTest_ConsoleApp.exe error stream");
-                    DelayTask();
+                    Sleep();
                 }
                 else if (args[0].Equals("input"))
                 {
@@ -29,7 +29,7 @@ namespace ProcessTest_ConsoleApp
                 {
                     Console.WriteLine("ProcessTest_ConsoleApp.exe started");
                     Console.WriteLine("ProcessTest_ConsoleApp.exe closed");
-                    DelayTask();
+                    Sleep();
                 }
                 else
                 {
@@ -39,9 +39,14 @@ namespace ProcessTest_ConsoleApp
             return 100;
         }
 
-        public static void DelayTask()
+        private static void Sleep()
         {
-            Task.Delay(TimeSpan.FromMilliseconds(100)).Wait();
+            Sleep(100d);
+        }
+
+        private static void Sleep(double timeinMs)
+        {
+            Task.Delay(TimeSpan.FromMilliseconds(timeinMs)).Wait();
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTest_ConsoleApp/ProcessTest_ConsoleApp.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ProcessTest_ConsoleApp
 {
@@ -7,45 +8,40 @@ namespace ProcessTest_ConsoleApp
     {
         static int Main(string[] args)
         {
-            try
+            if (args.Length > 0)
             {
-                if (args.Length > 0)
+                if (args[0].Equals("infinite"))
                 {
-                    if (args[0].Equals("infinite"))
-                    {
-                        // To avoid potential issues with orphaned processes (say, the test exits before
-                        // exiting the process), we'll say "infinite" is actually 30 seconds.
-                        
-                        Console.WriteLine("ProcessTest_ConsoleApp.exe started with an endless loop");
-                        Thread.Sleep(30 * 1000);
-                    }
-                    if (args[0].Equals("error"))
-                    {
-                        Exception ex = new Exception("Intentional Exception thrown");
-                        throw ex;
-                    }
-                    if (args[0].Equals("input"))
-                    {
-                        string str = Console.ReadLine();
-                    }
+                    // To avoid potential issues with orphaned processes (say, the test exits before
+                    // exiting the process), we'll say "infinite" is actually 30 seconds.
+                    Thread.Sleep(30 * 1000);
                 }
-                else
+                else if (args[0].Equals("error"))
+                {
+                    Console.Error.WriteLine("ProcessTest_ConsoleApp.exe error stream");
+                    DelayTask();
+                }
+                else if (args[0].Equals("input"))
+                {
+                    string str = Console.ReadLine();
+                }
+                else if (args[0].Equals("stream"))
                 {
                     Console.WriteLine("ProcessTest_ConsoleApp.exe started");
                     Console.WriteLine("ProcessTest_ConsoleApp.exe closed");
+                    DelayTask();
                 }
-
-                return 100;
+                else
+                {
+                    Console.WriteLine(string.Join(" ", args));
+                }
             }
-            catch (Exception toLog)
-            {
-                // We're testing STDERR streams, not the JIT debugger. 
-                // This makes the process behave just like a crashing .NET app, but without the WER invocation
-                // nor the blocking dialog that comes with it, or the need to suppress that.
-                Console.Error.WriteLine(string.Format("Unhandled Exception: {0}", toLog.Message));
-                return 1;
-            }
+            return 100;
+        }
 
+        public static void DelayTask()
+        {
+            Task.Delay(TimeSpan.FromMilliseconds(100)).Wait();
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -155,10 +155,10 @@ namespace System.Diagnostics.ProcessTests
         [Fact]
         public void Process_ExitTime()
         {
-            DateTime timeBeforeProcessStart = DateTime.Now;
+            DateTime timeBeforeProcessStart = DateTime.UtcNow;
             Process p = CreateProcessInfinite();
             StartAndKillProcessWithDelay(p);
-            Assert.True(p.ExitTime > timeBeforeProcessStart, "Process_ExitTime is incorrect.");
+            Assert.True(p.ExitTime.ToUniversalTime() > timeBeforeProcessStart, "Process_ExitTime is incorrect.");
         }
 
 

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
@@ -47,7 +47,7 @@ namespace System.Diagnostics.ProcessTests
                     Assert.Equal(p.StandardError.CurrentEncoding.CodePage, Encoding.UTF8.CodePage);
 
                     p.Kill();
-                    p.WaitForExit();
+                    p.WaitForExit(WaitInMS);
                 }
 
                 {
@@ -67,7 +67,7 @@ namespace System.Diagnostics.ProcessTests
                     Assert.Equal(p.StandardError.CurrentEncoding.CodePage, s_ConsoleEncoding);
 
                     p.Kill();
-                    p.WaitForExit();
+                    p.WaitForExit(WaitInMS);
                 }
             }
             finally

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
@@ -24,69 +24,56 @@ namespace System.Diagnostics.ProcessTests
         private const int s_ConsoleEncoding = 437;
 
         [Fact]
-        [ActiveIssue(335)]
-        public static void Process_EncodingBeforeProvider()
+        public void Process_EncodingBeforeProvider()
         {
-            SetConsoleCP(s_ConsoleEncoding);
-            SetConsoleOutputCP(s_ConsoleEncoding);
 
             int inputEncoding = GetConsoleCP();
             int outputEncoding = GetConsoleOutputCP();
 
             try
             {
-                Process p = CreateProcessInfinite();
-                p.StartInfo.RedirectStandardInput = true;
-                p.Start();
-                Assert.Equal(p.StandardInput.Encoding.CodePage, Encoding.UTF8.CodePage);
-                p.Kill();
-                p.WaitForExit();
-
-                p = CreateProcessInfinite();
-                p.StartInfo.RedirectStandardOutput = true;
-                p.Start();
-                Assert.Equal(p.StandardOutput.CurrentEncoding.CodePage,  Encoding.UTF8.CodePage);
-                p.Kill();
-                p.WaitForExit();
-
-                p = CreateProcessInfinite();
-                p.StartInfo.RedirectStandardError = true;
-                p.Start();
-                Assert.Equal(p.StandardError.CurrentEncoding.CodePage, Encoding.UTF8.CodePage);
-                p.Kill();
-                p.WaitForExit();
-
-
-                // Register the codeprovider which will ensure 437 is enabled.
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                p = CreateProcessInfinite();
-                p.StartInfo.RedirectStandardInput = true;
-                p.Start();
-                Assert.Equal(p.StandardInput.Encoding.CodePage, inputEncoding);
-                p.Kill();
-                p.WaitForExit();
-
-                p = CreateProcessInfinite();
-                p.StartInfo.RedirectStandardOutput = true;
-                p.Start();
-                Assert.Equal(p.StandardOutput.CurrentEncoding.CodePage, outputEncoding);
-                p.Kill();
-                p.WaitForExit();
-
-                p = CreateProcessInfinite();
-                p.StartInfo.RedirectStandardError = true;
-                p.Start();
-                Assert.Equal(p.StandardError.CurrentEncoding.CodePage, outputEncoding);
-                p.Kill();
-                p.WaitForExit();
-            }
-            finally
-            {
-                foreach (Process p in Process.GetProcessesByName(s_ProcessName))
                 {
+                    SetConsoleCP(s_ConsoleEncoding);
+                    SetConsoleOutputCP(s_ConsoleEncoding);
+
+                    Process p = CreateProcessInfinite();
+                    p.StartInfo.RedirectStandardInput = true;
+                    p.StartInfo.RedirectStandardOutput = true;
+                    p.StartInfo.RedirectStandardError = true;
+                    p.Start();
+
+                    Assert.Equal(p.StandardInput.Encoding.CodePage, Encoding.UTF8.CodePage);
+                    Assert.Equal(p.StandardOutput.CurrentEncoding.CodePage, Encoding.UTF8.CodePage);
+                    Assert.Equal(p.StandardError.CurrentEncoding.CodePage, Encoding.UTF8.CodePage);
+
                     p.Kill();
                     p.WaitForExit();
                 }
+
+                {
+                    SetConsoleCP(s_ConsoleEncoding);
+                    SetConsoleOutputCP(s_ConsoleEncoding);
+
+                    // Register the codeprovider which will ensure 437 is enabled.
+                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                    Process p = CreateProcessInfinite();
+                    p.StartInfo.RedirectStandardInput = true;
+                    p.StartInfo.RedirectStandardOutput = true;
+                    p.StartInfo.RedirectStandardError = true;
+                    p.Start();
+
+                    Assert.Equal(p.StandardInput.Encoding.CodePage, s_ConsoleEncoding);
+                    Assert.Equal(p.StandardOutput.CurrentEncoding.CodePage, s_ConsoleEncoding);
+                    Assert.Equal(p.StandardError.CurrentEncoding.CodePage, s_ConsoleEncoding);
+
+                    p.Kill();
+                    p.WaitForExit();
+                }
+            }
+            finally
+            {
+                SetConsoleCP(inputEncoding);
+                SetConsoleOutputCP(outputEncoding);
             }
         }
     }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -12,26 +12,17 @@ namespace System.Diagnostics.ProcessTests
 
         Process CreateProcessError()
         {
-            Process p = new Process();
-            p.StartInfo.FileName = _processName;
-            p.StartInfo.Arguments = "error";
-            return p;
+            return CreateProcess("error");
         }
 
         Process CreateProcessInput()
         {
-            Process p = new Process();
-            p.StartInfo.FileName = _processName;
-            p.StartInfo.Arguments = "input";
-            return p;
+            return CreateProcess("input");
         }
 
         Process CreateProcessStream()
         {
-            Process p = new Process();
-            p.StartInfo.FileName = _processName;
-            p.StartInfo.Arguments = "stream";
-            return p;
+            return CreateProcess("stream");
         }
 
         [Fact]
@@ -41,27 +32,20 @@ namespace System.Diagnostics.ProcessTests
             p.StartInfo.RedirectStandardError = true;
             p.Start();
             Assert.Equal(p.StandardError.ReadToEnd(), "ProcessTest_ConsoleApp.exe error stream\r\n");
-            p.WaitForExit();
+            p.WaitForExit(WaitInMS);
         }
-
-        private StringBuilder process_AsyncErrorStream_sb = new StringBuilder();
 
         [Fact]
         public void Process_AsyncErrorStream()
         {
-            process_AsyncErrorStream_sb.Clear();
+            StringBuilder sb = new StringBuilder();
             Process p = CreateProcessError();
             p.StartInfo.RedirectStandardError = true;
-            p.ErrorDataReceived += process_AsyncErrorStream_ErrorDataReceived;
+            p.ErrorDataReceived += (s, e) => { sb.Append(e.Data); };
             p.Start();
             p.BeginErrorReadLine();
-            p.WaitForExit();
-            Assert.Equal("ProcessTest_ConsoleApp.exe error stream", process_AsyncErrorStream_sb.ToString());
-        }
-
-        public void process_AsyncErrorStream_ErrorDataReceived(object sender, DataReceivedEventArgs e)
-        {
-            process_AsyncErrorStream_sb.Append(e.Data);
+            p.WaitForExit(WaitInMS);
+            Assert.Equal("ProcessTest_ConsoleApp.exe error stream", sb.ToString());
         }
 
         [Fact]
@@ -71,71 +55,49 @@ namespace System.Diagnostics.ProcessTests
             p.StartInfo.RedirectStandardOutput = true;
             p.Start();
             string s = p.StandardOutput.ReadToEnd();
-            p.WaitForExit();
+            p.WaitForExit(WaitInMS);
             Assert.Equal(s, "ProcessTest_ConsoleApp.exe started\r\nProcessTest_ConsoleApp.exe closed\r\n");
         }
-
-        private StringBuilder process_AsyncOutputStream_sb = new StringBuilder();
 
         [Fact]
         public void Process_AsyncOutputStream()
         {
-            process_AsyncOutputStream_sb.Clear();
-            Process p = CreateProcessStream();
-            p.StartInfo.RedirectStandardOutput = true;
-            p.OutputDataReceived += process_AsyncOutputStream_OutputDataReceived;
-            p.Start();
-            p.BeginOutputReadLine();
-            p.WaitForExit();
-            Assert.Equal(process_AsyncOutputStream_sb.ToString(), "ProcessTest_ConsoleApp.exe startedProcessTest_ConsoleApp.exe closed");
+            {
+                StringBuilder sb = new StringBuilder();
+                Process p = CreateProcessStream();
+                p.StartInfo.RedirectStandardOutput = true;
+                p.OutputDataReceived += (s, e) => sb.Append(e.Data);
+                p.Start();
+                p.BeginOutputReadLine();
+                p.WaitForExit(WaitInMS);
+                Assert.Equal(sb.ToString(), "ProcessTest_ConsoleApp.exe startedProcessTest_ConsoleApp.exe closed");
+            }
 
-
-            // Now add the CancelAsyncAPI as well.
-            process_AsyncOutputStream_sb.Clear();
-            p = CreateProcessStream();
-            p.StartInfo.RedirectStandardOutput = true;
-            p.OutputDataReceived += process_AsyncOutputStream_OutputDataReceived2;
-            p.Start();
-            p.BeginOutputReadLine();
-            p.WaitForExit();
-            Assert.Equal(process_AsyncOutputStream_sb.ToString(), "ProcessTest_ConsoleApp.exe started");
-        }
-
-        void process_AsyncOutputStream_OutputDataReceived(object sender, DataReceivedEventArgs e)
-        {
-            process_AsyncOutputStream_sb.Append(e.Data);
-        }
-
-        void process_AsyncOutputStream_OutputDataReceived2(object sender, DataReceivedEventArgs e)
-        {
-            process_AsyncOutputStream_sb.Append(e.Data);
-            Process p = sender as Process;
-            p.CancelOutputRead();
+            {
+                // Now add the CancelAsyncAPI as well.
+                StringBuilder sb = new StringBuilder();
+                Process p = CreateProcessStream();
+                p.StartInfo.RedirectStandardOutput = true;
+                p.OutputDataReceived += (s, e) => { sb.Append(e.Data); ((Process)s).CancelOutputRead(); };
+                p.Start();
+                p.BeginOutputReadLine();
+                p.WaitForExit(WaitInMS);
+                Assert.Equal(sb.ToString(), "ProcessTest_ConsoleApp.exe started");
+            }
         }
 
         [Fact]
         public void Process_SyncStreams()
         {
-            // Check whether the input streams works correctly.
-
-            //1. Check with RedirectStandardInput
             Process p = CreateProcessInput();
             p.StartInfo.RedirectStandardInput = true;
             p.StartInfo.RedirectStandardOutput = true;
-            p.OutputDataReceived += process_SyncStreams_OutputDataReceived;
+            p.OutputDataReceived += (s, e) => { Assert.Equal(e.Data, "This string should come as output"); };
             p.Start();
             using (StreamWriter writer = p.StandardInput)
             {
                 string str = "This string should come as output";
                 writer.WriteLine(str);
-            }
-        }
-
-        public void process_SyncStreams_OutputDataReceived(object sender, DataReceivedEventArgs e)
-        {
-            if (e.Data != null)
-            {
-                Assert.Equal(e.Data, "This string should come as output");
             }
         }
     }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -9,105 +9,112 @@ namespace System.Diagnostics.ProcessTests
 {
     public partial class ProcessTest
     {
+
+        Process CreateProcessError()
+        {
+            Process p = new Process();
+            p.StartInfo.FileName = _processName;
+            p.StartInfo.Arguments = "error";
+            return p;
+        }
+
+        Process CreateProcessInput()
+        {
+            Process p = new Process();
+            p.StartInfo.FileName = _processName;
+            p.StartInfo.Arguments = "input";
+            return p;
+        }
+
+        Process CreateProcessStream()
+        {
+            Process p = new Process();
+            p.StartInfo.FileName = _processName;
+            p.StartInfo.Arguments = "stream";
+            return p;
+        }
+
         [Fact]
-        public static void Process_SyncErrorStream()
+        public void Process_SyncErrorStream()
         {
             Process p = CreateProcessError();
             p.StartInfo.RedirectStandardError = true;
             p.Start();
-            if (!p.HasExited)
-            {
-                string s = p.StandardError.ReadToEnd();
-                p.WaitForExit();
-
-                s = s.Replace("\r", "").Replace("\n", "");
-
-                Assert.Equal("Unhandled Exception: Intentional Exception thrown", s);
-            }
+            Assert.Equal(p.StandardError.ReadToEnd(), "ProcessTest_ConsoleApp.exe error stream\r\n");
+            p.WaitForExit();
         }
 
-        private static StringBuilder s_process_AsyncErrorStream_sb = new StringBuilder();
+        private StringBuilder process_AsyncErrorStream_sb = new StringBuilder();
 
         [Fact]
-        public static void Process_AsyncErrorStream()
+        public void Process_AsyncErrorStream()
         {
-            s_process_AsyncErrorStream_sb.Clear();
+            process_AsyncErrorStream_sb.Clear();
             Process p = CreateProcessError();
             p.StartInfo.RedirectStandardError = true;
             p.ErrorDataReceived += process_AsyncErrorStream_ErrorDataReceived;
             p.Start();
-            if (!p.HasExited)
-            {
-                p.BeginErrorReadLine();
-                p.WaitForExit();
-                Assert.Equal("Unhandled Exception: Intentional Exception thrown", s_process_AsyncErrorStream_sb.ToString());
-            }
+            p.BeginErrorReadLine();
+            p.WaitForExit();
+            Assert.Equal("ProcessTest_ConsoleApp.exe error stream", process_AsyncErrorStream_sb.ToString());
         }
 
-        public static void process_AsyncErrorStream_ErrorDataReceived(object sender, DataReceivedEventArgs e)
+        public void process_AsyncErrorStream_ErrorDataReceived(object sender, DataReceivedEventArgs e)
         {
-            s_process_AsyncErrorStream_sb.Append(e.Data);
+            process_AsyncErrorStream_sb.Append(e.Data);
         }
 
         [Fact]
-        public static void Process_SyncOutputStream()
+        public void Process_SyncOutputStream()
         {
-            Process p = CreateProcess();
+            Process p = CreateProcessStream();
             p.StartInfo.RedirectStandardOutput = true;
             p.Start();
-            if (!p.HasExited)
-            {
-                string s = p.StandardOutput.ReadToEnd();
-                p.WaitForExit();
-                Assert.Equal(s, "ProcessTest_ConsoleApp.exe started\r\nProcessTest_ConsoleApp.exe closed\r\n");
-            }
+            string s = p.StandardOutput.ReadToEnd();
+            p.WaitForExit();
+            Assert.Equal(s, "ProcessTest_ConsoleApp.exe started\r\nProcessTest_ConsoleApp.exe closed\r\n");
         }
 
-        private static StringBuilder s_process_AsyncOutputStream_sb = new StringBuilder();
+        private StringBuilder process_AsyncOutputStream_sb = new StringBuilder();
 
         [Fact]
-        public static void Process_AsyncOutputStream()
+        public void Process_AsyncOutputStream()
         {
-            s_process_AsyncOutputStream_sb.Clear();
-            Process p = CreateProcess();
+            process_AsyncOutputStream_sb.Clear();
+            Process p = CreateProcessStream();
             p.StartInfo.RedirectStandardOutput = true;
             p.OutputDataReceived += process_AsyncOutputStream_OutputDataReceived;
             p.Start();
-            if (!p.HasExited)
-            {
-                p.BeginOutputReadLine();
-                p.WaitForExit();
-                Assert.Equal(s_process_AsyncOutputStream_sb.ToString(), "ProcessTest_ConsoleApp.exe startedProcessTest_ConsoleApp.exe closed");
-            }
+            p.BeginOutputReadLine();
+            p.WaitForExit();
+            Assert.Equal(process_AsyncOutputStream_sb.ToString(), "ProcessTest_ConsoleApp.exe startedProcessTest_ConsoleApp.exe closed");
+
 
             // Now add the CancelAsyncAPI as well.
-            s_process_AsyncOutputStream_sb.Clear();
-            p = CreateProcess();
+            process_AsyncOutputStream_sb.Clear();
+            p = CreateProcessStream();
             p.StartInfo.RedirectStandardOutput = true;
             p.OutputDataReceived += process_AsyncOutputStream_OutputDataReceived2;
             p.Start();
-            if (!p.HasExited)
-            {
-                p.BeginOutputReadLine();
-                p.WaitForExit();
-                Assert.Equal(s_process_AsyncOutputStream_sb.ToString(), "ProcessTest_ConsoleApp.exe started");
-            }
+            p.BeginOutputReadLine();
+            p.WaitForExit();
+            Assert.Equal(process_AsyncOutputStream_sb.ToString(), "ProcessTest_ConsoleApp.exe started");
         }
 
-        static void process_AsyncOutputStream_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        void process_AsyncOutputStream_OutputDataReceived(object sender, DataReceivedEventArgs e)
         {
-            s_process_AsyncOutputStream_sb.Append(e.Data);
+            process_AsyncOutputStream_sb.Append(e.Data);
         }
 
-        static void process_AsyncOutputStream_OutputDataReceived2(object sender, DataReceivedEventArgs e)
+        void process_AsyncOutputStream_OutputDataReceived2(object sender, DataReceivedEventArgs e)
         {
-            s_process_AsyncOutputStream_sb.Append(e.Data);
+            process_AsyncOutputStream_sb.Append(e.Data);
             Process p = sender as Process;
             p.CancelOutputRead();
         }
 
         [Fact]
-        public static void Process_SyncStreams()
+        public void Process_SyncStreams()
         {
             // Check whether the input streams works correctly.
 
@@ -117,18 +124,14 @@ namespace System.Diagnostics.ProcessTests
             p.StartInfo.RedirectStandardOutput = true;
             p.OutputDataReceived += process_SyncStreams_OutputDataReceived;
             p.Start();
-            if (!p.HasExited)
+            using (StreamWriter writer = p.StandardInput)
             {
-                using (StreamWriter writer = p.StandardInput)
-                {
-                    string str = "This string should come as output";
-                    writer.WriteLine(str);
-                }
-                // Check that we get this as output
+                string str = "This string should come as output";
+                writer.WriteLine(str);
             }
         }
 
-        public static void process_SyncStreams_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        public void process_SyncStreams_OutputDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (e.Data != null)
             {

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_UseShellExecute.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_UseShellExecute.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.ProcessTests
     public partial class ProcessTest
     {
         [Fact]
-        public static void ProcessStartInfo_UseShellExecute()
+        public void ProcessStartInfo_UseShellExecute()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
 

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
@@ -4,8 +4,6 @@
   <package id="System.Console" version="4.0.0-beta-22703" />
   <package id="System.IO" version="4.0.10-beta-22703" />
   <package id="System.Linq" version="4.0.0-beta-22703" />
-  <package id="System.Linq.Expressions" version="4.0.10-beta-22703 "/>
-  <package id="System.Linq.Queryable" version="4.0.0-beta-22703" />
   <package id="System.Runtime" version="4.0.20-beta-22703" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
   <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
@@ -3,6 +3,9 @@
   <package id="Microsoft.Win32.Primitives" version="4.0.0-beta-22703" />
   <package id="System.Console" version="4.0.0-beta-22703" />
   <package id="System.IO" version="4.0.10-beta-22703" />
+  <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Linq.Expressions" version="4.0.10-beta-22703 "/>
+  <package id="System.Linq.Queryable" version="4.0.0-beta-22703" />
   <package id="System.Runtime" version="4.0.20-beta-22703" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
   <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
@@ -14,7 +17,7 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
   <package id="System.Threading.Thread" version="4.0.0-beta-22703" />
   <package id="System.Threading.ThreadPool" version="4.0.10-beta-22703" />
-
+  
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
[x] Isolate each test to ensure multiple tests can run in parallel.
[x] Add the Dispose pattern to kill any orphaned processes.
[x] Prevent the tests from changing the current process state.
[x] Fix and enable tests that were disabled.