### PR TITLE
Remove link to a document that no longer exists

### DIFF
--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XHashtable.cs
@@ -113,8 +113,7 @@ namespace System.Xml.Linq
 #if !SILVERLIGHT 
                     Thread.MemoryBarrier();
 #else // SILVERLIGHT
-                    // According to this document "http://my/sites/juddhall/ThreadingFeatureCrew/Shared Documents/System.Threading - FX Audit Proposal.docx"
-                    // The MemoryBarrier method usage is busted (mostly - don't know about ours) and should be removed.
+                    // The MemoryBarrier method usage is probably incorrect and should be removed.
 
                     // Replacing with Interlocked.CompareExchange for now (with no effect)
                     //   which will do a very similar thing to MemoryBarrier (it's just slower)
@@ -305,8 +304,7 @@ namespace System.Xml.Linq
 #if !SILVERLIGHT
                 Thread.MemoryBarrier();
 #else // SILVERLIGHT
-                // According to this document "http://my/sites/juddhall/ThreadingFeatureCrew/Shared Documents/System.Threading - FX Audit Proposal.docx"
-                // The MemoryBarrier method usage is busted (mostly - don't know about ours) and should be removed.
+                // The MemoryBarrier method usage is probably incorrect and should be removed.
 
                 // Replacing with Interlocked.CompareExchange for now (with no effect)
                 //   which will do a very similar thing to MemoryBarrier (it's just slower)


### PR DESCRIPTION
There is a link to an internal SharePoint site that no longer exits, so it's unclear what the content was but the gist seems to be contained in the code comment.