### PR TITLE
Fix CustomAttributeNamedArgument to return the correct value

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeNamedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeNamedArgument.cs
@@ -41,7 +41,7 @@ namespace System.Reflection.Metadata
 
         public object Value
         {
-            get { return _type; }
+            get { return _value; }
         }
     }
 }


### PR DESCRIPTION
There is a bug where `CustomAttributeNamedArgument` returns the type instead of the value. Strong typing can't help with `object`, can it?

@nguerrera 