### PR TITLE
Further BigInteger test refactoring

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/BigIntTools.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/BigIntTools.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text;
-using Xunit;
 
 namespace BigIntTools
 {
@@ -12,12 +11,13 @@ namespace BigIntTools
         public static string BuildRandomNumber(int maxdigits, int seed)
         {
             Random random = new Random(seed);
-            //Ensure that we have at least 1 digit
+
+            // Ensure that we have at least 1 digit
             int numDigits = random.Next() % maxdigits + 1;
-
-
+            
             StringBuilder randNum = new StringBuilder();
-            //We'll make some numbers negative
+            
+            // We'll make some numbers negative
             while (randNum.Length < numDigits)
             {
                 randNum.Append(random.Next().ToString());
@@ -27,7 +27,9 @@ namespace BigIntTools
                 return "-" + randNum.ToString().Substring(0, numDigits);
             }
             else
+            {
                 return randNum.ToString().Substring(0, numDigits);
+            }
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -17,6 +15,7 @@ namespace System.Numerics.Tests
             int seed = 100;
             RunTests(seed);
         }
+
         public static void RunTests(int seed)
         {
             Random random = new Random(seed);
@@ -218,8 +217,7 @@ namespace System.Numerics.Tests
 
             // One Larger (BigInteger), Int64.MaxValue
             VerifyComparison((BigInteger)Int64.MaxValue + 1, Int64.MaxValue, 1);
-
-
+            
 
             //1 Random Inputs
             // Random BigInteger only differs by sign
@@ -399,6 +397,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
+
         private static void VerifyComparison(BigInteger x, Int32 y, int expectedResult)
         {
             bool expectedEquals = 0 == expectedResult;
@@ -437,6 +436,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
+
         private static void VerifyComparison(BigInteger x, UInt32 y, int expectedResult)
         {
             bool expectedEquals = 0 == expectedResult;
@@ -475,6 +475,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
+
         private static void VerifyComparison(BigInteger x, Int64 y, int expectedResult)
         {
             bool expectedEquals = 0 == expectedResult;
@@ -512,6 +513,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
+
         private static void VerifyComparison(BigInteger x, UInt64 y, int expectedResult)
         {
             bool expectedEquals = 0 == expectedResult;
@@ -549,6 +551,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
+
         private static void VerifyComparison(BigInteger x, bool IsXNegative, BigInteger y, bool IsYNegative, int expectedResult)
         {
             bool expectedEquals = 0 == expectedResult;
@@ -600,9 +603,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
-
-
-
+        
         private static void VerifyCompareResult(int expected, int actual, string message)
         {
             if (0 == expected)

--- a/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -227,7 +228,8 @@ namespace System.Numerics.Tests
                 do
                 {
                     byteArray = GetRandomByteArray(random);
-                } while (IsZero(byteArray));
+                } 
+                while (MyBigIntImp.IsZero(byteArray));
 
                 BigInteger b2 = new BigInteger(byteArray);
                 if (b2 > (BigInteger)0)
@@ -290,7 +292,9 @@ namespace System.Numerics.Tests
             do
             {
                 byteArray = GetRandomByteArray(random);
-            } while (IsZero(byteArray));
+            } 
+            while (MyBigIntImp.IsZero(byteArray));
+
             isNegative = 0 == random.Next(0, 2);
             VerifyComparison(BigInteger.Zero, false, 0 / new BigInteger(byteArray), isNegative, 0);
 
@@ -335,7 +339,9 @@ namespace System.Numerics.Tests
             do
             {
                 byteArray = GetRandomByteArray(random);
-            } while (IsZero(byteArray));
+            } 
+            while (MyBigIntImp.IsZero(byteArray));
+
             BigInteger b1 = new BigInteger(byteArray);
             VerifyComparison(BigInteger.One, false, b1 / b1, false, 0);
         }
@@ -419,8 +425,7 @@ namespace System.Numerics.Tests
                 Assert.Equal(x.GetHashCode(), ((BigInteger)y).GetHashCode());
                 Assert.Equal(x.ToString(), ((BigInteger)y).ToString());
             }
-
-
+            
             Assert.Equal(x.GetHashCode(), x.GetHashCode());
             Assert.Equal(((BigInteger)y).GetHashCode(), ((BigInteger)y).GetHashCode());
 
@@ -716,34 +721,14 @@ namespace System.Numerics.Tests
             return 0;
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
-        }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; ++i)
-            {
-                if (0 != value[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/IsEven.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/IsEven.cs
@@ -78,8 +78,7 @@ namespace System.Numerics.Tests
             // Negative One
             VerifyIsEven(BigInteger.MinusOne, false);
         }
-
-
+        
         private static void VerifyIsEven(BigInteger bigInt, bool expectedAnswer)
         {
             Assert.Equal(expectedAnswer, bigInt.IsEven);

--- a/src/System.Runtime.Numerics/tests/BigInteger/IsEven.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/IsEven.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using BigIntTools;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -18,7 +16,7 @@ namespace System.Numerics.Tests
         {
             Random random = new Random(s_seed);
 
-            //Just basic tests
+            // Just basic tests
             // Large Even Number
             VerifyIsEven((BigInteger)Int64.MaxValue + 1, true);
 
@@ -54,13 +52,12 @@ namespace System.Numerics.Tests
 
             // Large Negative Odd Number
             VerifyIsEven(((BigInteger)Int64.MaxValue + 2) * -1, false);
-
+            
 
             // Large Negative Random Even Number
             for (int i = 0; i < Reps; i++)
             {
                 string bigInt2 = BigIntTools.Utils.BuildRandomNumber(random.Next() % MaxDigits + 1, random.Next());
-
                 VerifyIsEven(BigInteger.Parse(bigInt2) * -2, true);
             }
 
@@ -83,9 +80,9 @@ namespace System.Numerics.Tests
         }
 
 
-        private static bool VerifyIsEven(BigInteger bigInt, bool expectedAnswer)
+        private static void VerifyIsEven(BigInteger bigInt, bool expectedAnswer)
         {
-            return expectedAnswer == bigInt.IsEven;
+            Assert.Equal(expectedAnswer, bigInt.IsEven);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/IsOne.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/IsOne.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using BigIntTools;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -12,7 +10,7 @@ namespace System.Numerics.Tests
         private static int s_seed = 0;
 
         [Fact]
-        public static void RunInOneTests()
+        public static void RunIsOneTests()
         {
             Random random = new Random(s_seed);
 
@@ -41,9 +39,10 @@ namespace System.Numerics.Tests
             // Uint32.MaxValue + 1
             VerifyIsOne((BigInteger)UInt32.MaxValue + 1, false);
         }
-        private static bool VerifyIsOne(BigInteger bigInt, bool expectedAnswer)
+
+        private static void VerifyIsOne(BigInteger bigInt, bool expectedAnswer)
         {
-            return expectedAnswer == bigInt.IsOne;
+            Assert.Equal(expectedAnswer, bigInt.IsOne);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/IsPowerOfTwo.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/IsPowerOfTwo.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using BigIntTools;
-using System;
 using System.Collections;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -39,38 +36,38 @@ namespace System.Numerics.Tests
             bigIntegerLarge = new BigInteger(byteArray2);
             bigIntegerPowerOfTwo = new BigInteger(byteArray3);
 
-            //Just basic tests
+            // Just basic tests
             // Large Power Of Two
-            Assert.True(VerifyIsPowerOfTwo((BigInteger)Int32.MaxValue + 1, true), " Verification Failed");
+            VerifyIsPowerOfTwo((BigInteger)Int32.MaxValue + 1, true);
 
             // Large Non Power Of Two
-            Assert.True(VerifyIsPowerOfTwo((BigInteger)Int32.MaxValue + 2, false), " Verification Failed");
+            VerifyIsPowerOfTwo((BigInteger)Int32.MaxValue + 2, false);
 
 
             // Small Power Of Two
-            Assert.True(VerifyIsPowerOfTwo((BigInteger)Int16.MaxValue + 1, true), " Verification Failed");
+            VerifyIsPowerOfTwo((BigInteger)Int16.MaxValue + 1, true);
 
             // Small Non Power Of Two
-            Assert.True(VerifyIsPowerOfTwo((BigInteger)Int32.MaxValue - 2, false), " Verification Failed");
+            VerifyIsPowerOfTwo((BigInteger)Int32.MaxValue - 2, false);
 
-            //Zero Case, 1, -1
+            // Zero Case, 1, -1
             // Zero
-            Assert.True(VerifyIsPowerOfTwo(BigInteger.Zero, false), " Verification Failed");
+            VerifyIsPowerOfTwo(BigInteger.Zero, false);
 
             // One
-            Assert.True(VerifyIsPowerOfTwo(BigInteger.One, true), " Verification Failed");
+            VerifyIsPowerOfTwo(BigInteger.One, true);
 
             // Negative One
-            Assert.True(VerifyIsPowerOfTwo(BigInteger.MinusOne, false), " Verification Failed");
+            VerifyIsPowerOfTwo(BigInteger.MinusOne, false);
 
             // Random Small BigInteger
-            Assert.True(VerifyIsPowerOfTwo(bigIntegerSmall, CheckExpected(byteArray1)), " Verification Failed");
+            VerifyIsPowerOfTwo(bigIntegerSmall, CheckExpected(byteArray1));
 
             // Random Large BigInteger
-            Assert.True(VerifyIsPowerOfTwo(bigIntegerLarge, CheckExpected(byteArray2)), " Verification Failed");
+            VerifyIsPowerOfTwo(bigIntegerLarge, CheckExpected(byteArray2));
 
             // Random BigInteger Power of Two
-            Assert.True(VerifyIsPowerOfTwo(bigIntegerPowerOfTwo, true), " Verification Failed");
+            VerifyIsPowerOfTwo(bigIntegerPowerOfTwo, true);
         }
 
         private static bool CheckExpected(byte[] value)
@@ -79,7 +76,7 @@ namespace System.Numerics.Tests
             bool expected = false;
             BitArray value2 = new BitArray(value);
 
-            //count the number or 1's in the value
+            // Count the number of 1's in the value
             for (int i = 0; i < value2.Length; i++)
             {
                 if (value2[i])
@@ -88,7 +85,7 @@ namespace System.Numerics.Tests
                 }
             }
 
-            //if only one 1 and value is positive. 
+            // If only one 1 and value is positive. 
             if ((1 == valueOne) && (!value2[value2.Length - 1]))
             {
                 expected = true;
@@ -122,7 +119,7 @@ namespace System.Numerics.Tests
             return value;
         }
 
-        private static Byte[] GetPowerOfTwoByteArray(Random random)
+        private static byte[] GetPowerOfTwoByteArray(Random random)
         {
             double exactOnePosition;
 
@@ -143,13 +140,10 @@ namespace System.Numerics.Tests
 
             return value;
         }
-
-
-
-
-        private static bool VerifyIsPowerOfTwo(BigInteger bigInt, bool expectedAnswer)
+        
+        private static void VerifyIsPowerOfTwo(BigInteger bigInt, bool expectedAnswer)
         {
-            return expectedAnswer == bigInt.IsPowerOfTwo;
+            Assert.Equal(expectedAnswer, bigInt.IsPowerOfTwo);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/IsZero.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/IsZero.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using BigIntTools;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -10,8 +8,7 @@ namespace System.Numerics.Tests
     public class IsZeroTest
     {
         private static int s_seed = 0;
-
-
+        
         [Fact]
         public static void RunIsZeroTests()
         {
@@ -42,6 +39,7 @@ namespace System.Numerics.Tests
             // Uint32.MaxValue + 1
             VerifyIsZero((BigInteger)UInt32.MaxValue + 1, false);
         }
+
         private static void VerifyIsZero(BigInteger bigInt, bool expectedAnswer)
         {
             Assert.Equal(expectedAnswer, bigInt.IsZero);

--- a/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
 using Xunit;
 
@@ -13,6 +12,7 @@ namespace Tools
     public static class MyBigIntImp
     {
         public static BigInteger outParam = 0;
+
         public static BigInteger DoUnaryOperatorMine(BigInteger num1, string op)
         {
             List<byte> bytes1 = new List<byte>(num1.ToByteArray());
@@ -22,8 +22,14 @@ namespace Tools
             switch (op)
             {
                 case "uSign":
-                    if (IsZero(bytes1)) return new BigInteger(0);
-                    if (IsZero(Max(bytes1, new List<byte>(new byte[] { 0 })))) return new BigInteger(-1);
+                    if (IsZero(bytes1))
+                    {
+                        return new BigInteger(0);
+                    }
+                    if (IsZero(Max(bytes1, new List<byte>(new byte[] { 0 }))))
+                    {
+                        return new BigInteger(-1);
+                    }
                     return new BigInteger(1);
                 case "u~":
                     return new BigInteger(Not(bytes1).ToArray());
@@ -64,7 +70,10 @@ namespace Tools
                     }
                     return ApproximateBigInteger(result);
                 case "uAbs":
-                    if ((bytes1[bytes1.Count - 1] & 0x80) != 0) bytes1 = Negate(bytes1);
+                    if ((bytes1[bytes1.Count - 1] & 0x80) != 0)
+                    {
+                        bytes1 = Negate(bytes1);
+                    }
                     return new BigInteger(bytes1.ToArray());
                 case "u--":
                     return new BigInteger(Add(bytes1, new List<byte>(new byte[] { 0xff })).ToArray());
@@ -76,11 +85,12 @@ namespace Tools
                 case "u+":
                     return num1;
                 default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
+                    Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;
             }
             return new BigInteger();
         }
+
         public static BigInteger DoBinaryOperatorMine(BigInteger num1, BigInteger num2, string op)
         {
             List<byte> bytes1 = new List<byte>(num1.ToByteArray());
@@ -133,11 +143,12 @@ namespace Tools
                 case "b+":
                     return new BigInteger(Add(bytes1, bytes2).ToArray());
                 default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
+                    Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;
             }
             return new BigInteger();
         }
+
         public static BigInteger DoTertanaryOperatorMine(BigInteger num1, BigInteger num2, BigInteger num3, string op)
         {
             List<byte> bytes1 = new List<byte>(num1.ToByteArray());
@@ -149,7 +160,7 @@ namespace Tools
                 case "tModPow":
                     return new BigInteger(ModPow(bytes1, bytes2, bytes3).ToArray());
                 default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
+                    Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;
             }
             return new BigInteger();
@@ -171,7 +182,10 @@ namespace Tools
             {
                 int temp = bytes1[i] + bytes2[i];
 
-                if (carry) temp++;
+                if (carry)
+                {
+                    temp++;
+                }
                 carry = false;
 
                 if (temp > byte.MaxValue)
@@ -186,12 +200,16 @@ namespace Tools
 
             if ((num1neg == num2neg) & (num1neg != bnewneg))
             {
-                if (num1neg) extender = 0xff;
+                if (num1neg)
+                {
+                    extender = 0xff;
+                }
                 bnew.Add(extender);
             }
 
             return bnew;
         }
+
         private static List<byte> Negate(List<byte> bytes)
         {
             bool carry;
@@ -206,7 +224,10 @@ namespace Tools
             for (int i = 0; i < bytes.Count; i++)
             {
                 int temp = (i == 0 ? 0x01 : 0x00) + bytes[i];
-                if (carry) temp++;
+                if (carry)
+                {
+                    temp++;
+                }
                 carry = false;
 
                 if (temp > byte.MaxValue)
@@ -231,6 +252,7 @@ namespace Tools
 
             return bnew;
         }
+
         private static List<byte> Multiply(List<byte> bytes1, List<byte> bytes2)
         {
             NormalizeLengths(bytes1, bytes2);
@@ -261,13 +283,20 @@ namespace Tools
 
             return bresult;
         }
+
         private static List<byte> Divide(List<byte> bytes1, List<byte> bytes2)
         {
             bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
             bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
 
-            if (!numPos) bytes1 = Negate(bytes1);
-            if (!denPos) bytes2 = Negate(bytes2);
+            if (!numPos)
+            {
+                bytes1 = Negate(bytes1);
+            }
+            if (!denPos)
+            {
+                bytes2 = Negate(bytes2);
+            }
 
             bool qPos = (numPos == denPos);
 
@@ -296,7 +325,10 @@ namespace Tools
                 }
             }
             int shift = ba11loc - ba21loc;
-            if (shift < 0) return new List<byte>(new byte[] { (byte)0 });
+            if (shift < 0) 
+            {
+                return new List<byte>(new byte[] { (byte)0 });
+            }
             BitArray br = new BitArray(shift + 1, false);
 
             for (int i = 0; i < shift; i++)
@@ -329,13 +361,20 @@ namespace Tools
 
             return result;
         }
+
         private static List<byte> Remainder(List<byte> bytes1, List<byte> bytes2)
         {
             bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
             bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
 
-            if (!numPos) bytes1 = Negate(bytes1);
-            if (!denPos) bytes2 = Negate(bytes2);
+            if (!numPos)
+            {
+                bytes1 = Negate(bytes1); 
+            }
+            if (!denPos)
+            {
+                bytes2 = Negate(bytes2);
+            }
 
             Trim(bytes1);
             Trim(bytes2);
@@ -400,9 +439,13 @@ namespace Tools
             }
             return bytes1;
         }
+
         private static List<byte> Pow(List<byte> bytes1, List<byte> bytes2)
         {
-            if (IsZero(bytes2)) return new List<byte>(new byte[] { 1 });
+            if (IsZero(bytes2))
+            {
+                return new List<byte>(new byte[] { 1 });
+            }
 
             BitArray ba2 = new BitArray(bytes2.ToArray());
             int last1 = 0;
@@ -440,6 +483,7 @@ namespace Tools
             }
             return (result == null) ? new List<byte>(new byte[] { 1 }) : result;
         }
+
         private static List<byte> ModPow(List<byte> bytes1, List<byte> bytes2, List<byte> bytes3)
         {
             if (IsZero(bytes2))
@@ -486,6 +530,7 @@ namespace Tools
             }
             return (result == null) ? Remainder(new List<byte>(new byte[] { 1 }), bytes3) : result;
         }
+
         private static List<byte> GCD(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> temp;
@@ -493,8 +538,14 @@ namespace Tools
             bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
             bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
 
-            if (!numPos) bytes1 = Negate(bytes1);
-            if (!denPos) bytes2 = Negate(bytes2);
+            if (!numPos)
+            {
+                bytes1 = Negate(bytes1);
+            }
+            if (!denPos)
+            {
+                bytes2 = Negate(bytes2);
+            }
 
             Trim(bytes1);
             Trim(bytes2);
@@ -507,6 +558,7 @@ namespace Tools
             }
             return bytes1;
         }
+
         private static List<byte> Max(List<byte> bytes1, List<byte> bytes2)
         {
             bool b1Pos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
@@ -514,8 +566,14 @@ namespace Tools
 
             if (b1Pos != b2Pos)
             {
-                if (b1Pos) return bytes1;
-                if (b2Pos) return bytes2;
+                if (b1Pos)
+                {
+                    return bytes1;
+                }
+                if (b2Pos)
+                {
+                    return bytes2;
+                }
             }
 
             List<byte> sum = Add(bytes1, Negate(Copy(bytes2)));
@@ -527,6 +585,7 @@ namespace Tools
 
             return bytes1;
         }
+
         private static List<byte> And(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
@@ -539,6 +598,7 @@ namespace Tools
 
             return bnew;
         }
+
         private static List<byte> Or(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
@@ -551,6 +611,7 @@ namespace Tools
 
             return bnew;
         }
+
         private static List<byte> Xor(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
@@ -562,6 +623,7 @@ namespace Tools
             }
             return bnew;
         }
+
         private static List<byte> Not(List<byte> bytes)
         {
             List<byte> bnew = new List<byte>();
@@ -573,6 +635,7 @@ namespace Tools
 
             return bnew;
         }
+
         private static List<byte> ShiftLeft(List<byte> bytes1, List<byte> bytes2)
         {
             int byteShift = (int)new BigInteger(Divide(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
@@ -630,6 +693,7 @@ namespace Tools
 
             return bytes1;
         }
+
         private static List<byte> ShiftLeftGrow(List<byte> bytes)
         {
             List<byte> bresult = new List<byte>();
@@ -638,9 +702,15 @@ namespace Tools
             {
                 byte newbyte = bytes[i];
 
-                if (newbyte > 127) newbyte -= 128;
+                if (newbyte > 127) 
+                {
+                    newbyte -= 128; 
+                }
                 newbyte = (byte)(newbyte * 2);
-                if ((i != 0) && (bytes[i - 1] >= 128)) newbyte++;
+                if ((i != 0) && (bytes[i - 1] >= 128))
+                {
+                    newbyte++;
+                }
 
                 bresult.Add(newbyte);
             }
@@ -655,6 +725,7 @@ namespace Tools
 
             return bresult;
         }
+
         private static List<byte> ShiftLeftDrop(List<byte> bytes)
         {
             List<byte> bresult = new List<byte>();
@@ -663,15 +734,22 @@ namespace Tools
             {
                 byte newbyte = bytes[i];
 
-                if (newbyte > 127) newbyte -= 128;
+                if (newbyte > 127)
+                {
+                    newbyte -= 128;
+                }
                 newbyte = (byte)(newbyte * 2);
-                if ((i != 0) && (bytes[i - 1] >= 128)) newbyte++;
+                if ((i != 0) && (bytes[i - 1] >= 128))
+                {
+                    newbyte++;
+                }
 
                 bresult.Add(newbyte);
             }
 
             return bresult;
         }
+
         private static List<byte> ShiftRight(List<byte> bytes)
         {
             List<byte> bresult = new List<byte>();
@@ -694,6 +772,7 @@ namespace Tools
 
             return bresult;
         }
+
         private static List<byte> SetLength(List<byte> bytes, int size)
         {
             List<byte> bresult = new List<byte>();
@@ -705,6 +784,7 @@ namespace Tools
 
             return bresult;
         }
+
         private static List<byte> Copy(List<byte> bytes)
         {
             List<byte> ret = new List<byte>();
@@ -714,6 +794,7 @@ namespace Tools
             }
             return ret;
         }
+
         private static void NormalizeLengths(List<byte> bytes1, List<byte> bytes2)
         {
             bool num1neg = (bytes1[bytes1.Count - 1] & 0x80) != 0;
@@ -743,6 +824,7 @@ namespace Tools
                 }
             }
         }
+
         private static void Trim(List<byte> bytes)
         {
             while (bytes.Count > 1)
@@ -771,6 +853,7 @@ namespace Tools
                 }
             }
         }
+
         private static List<byte> GetBytes(BitArray ba)
         {
             int length = ((ba.Length) / 8) + 1;
@@ -791,6 +874,7 @@ namespace Tools
 
             return mask;
         }
+
         private static String Print(byte[] bytes)
         {
             string ret = String.Empty;
@@ -800,12 +884,16 @@ namespace Tools
             }
             return ret;
         }
+
         private static bool IsZero(List<byte> list)
         {
             byte[] value = list.ToArray();
             for (int i = 0; i < value.Length; i++)
             {
-                if (value[i] != 0) return false;
+                if (value[i] != 0)
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -813,16 +901,28 @@ namespace Tools
         public static BigInteger ApproximateBigInteger(double value)
         {
             //Special case values;
-            if (Double.IsNaN(value)) return new BigInteger(-101);
-            if (Double.IsNegativeInfinity(value)) return new BigInteger(-102);
-            if (Double.IsPositiveInfinity(value)) return new BigInteger(-103);
+            if (Double.IsNaN(value))
+            {
+                return new BigInteger(-101);
+            }
+            if (Double.IsNegativeInfinity(value))
+            {
+                return new BigInteger(-102);
+            }
+            if (Double.IsPositiveInfinity(value))
+            {
+                return new BigInteger(-103);
+            }
 
             BigInteger result = new BigInteger(Math.Round(value, 0));
 
             if (result != 0)
             {
                 bool pos = (value > 0);
-                if (!pos) value = -value;
+                if (!pos)
+                {
+                    value = -value;
+                }
 
                 int size = (int)Math.Floor(Math.Log10(value));
 
@@ -832,7 +932,10 @@ namespace Tools
                     result = result - (result % BigInteger.Pow(10, size - 17));
                 }
 
-                if (!pos) value = -value;
+                if (!pos)
+                {
+                    value = -value;
+                }
             }
 
             return result;

--- a/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -166,7 +166,7 @@ namespace Tools
             return new BigInteger();
         }
 
-        private static List<byte> Add(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Add(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
             bool num1neg = (bytes1[bytes1.Count - 1] & 0x80) != 0;
@@ -210,7 +210,7 @@ namespace Tools
             return bnew;
         }
 
-        private static List<byte> Negate(List<byte> bytes)
+        public static List<byte> Negate(List<byte> bytes)
         {
             bool carry;
             List<byte> bnew = new List<byte>();
@@ -253,7 +253,7 @@ namespace Tools
             return bnew;
         }
 
-        private static List<byte> Multiply(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Multiply(List<byte> bytes1, List<byte> bytes2)
         {
             NormalizeLengths(bytes1, bytes2);
             List<byte> bresult = new List<byte>();
@@ -284,7 +284,7 @@ namespace Tools
             return bresult;
         }
 
-        private static List<byte> Divide(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Divide(List<byte> bytes1, List<byte> bytes2)
         {
             bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
             bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
@@ -362,7 +362,7 @@ namespace Tools
             return result;
         }
 
-        private static List<byte> Remainder(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Remainder(List<byte> bytes1, List<byte> bytes2)
         {
             bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
             bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
@@ -440,7 +440,7 @@ namespace Tools
             return bytes1;
         }
 
-        private static List<byte> Pow(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Pow(List<byte> bytes1, List<byte> bytes2)
         {
             if (IsZero(bytes2))
             {
@@ -484,7 +484,7 @@ namespace Tools
             return (result == null) ? new List<byte>(new byte[] { 1 }) : result;
         }
 
-        private static List<byte> ModPow(List<byte> bytes1, List<byte> bytes2, List<byte> bytes3)
+        public static List<byte> ModPow(List<byte> bytes1, List<byte> bytes2, List<byte> bytes3)
         {
             if (IsZero(bytes2))
             {
@@ -531,7 +531,7 @@ namespace Tools
             return (result == null) ? Remainder(new List<byte>(new byte[] { 1 }), bytes3) : result;
         }
 
-        private static List<byte> GCD(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> GCD(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> temp;
 
@@ -559,7 +559,7 @@ namespace Tools
             return bytes1;
         }
 
-        private static List<byte> Max(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Max(List<byte> bytes1, List<byte> bytes2)
         {
             bool b1Pos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
             bool b2Pos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
@@ -586,7 +586,7 @@ namespace Tools
             return bytes1;
         }
 
-        private static List<byte> And(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> And(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
             NormalizeLengths(bytes1, bytes2);
@@ -599,7 +599,7 @@ namespace Tools
             return bnew;
         }
 
-        private static List<byte> Or(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Or(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
             NormalizeLengths(bytes1, bytes2);
@@ -612,7 +612,7 @@ namespace Tools
             return bnew;
         }
 
-        private static List<byte> Xor(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> Xor(List<byte> bytes1, List<byte> bytes2)
         {
             List<byte> bnew = new List<byte>();
             NormalizeLengths(bytes1, bytes2);
@@ -624,7 +624,7 @@ namespace Tools
             return bnew;
         }
 
-        private static List<byte> Not(List<byte> bytes)
+        public static List<byte> Not(List<byte> bytes)
         {
             List<byte> bnew = new List<byte>();
 
@@ -636,7 +636,7 @@ namespace Tools
             return bnew;
         }
 
-        private static List<byte> ShiftLeft(List<byte> bytes1, List<byte> bytes2)
+        public static List<byte> ShiftLeft(List<byte> bytes1, List<byte> bytes2)
         {
             int byteShift = (int)new BigInteger(Divide(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
             sbyte bitShift = (sbyte)new BigInteger(Remainder(bytes2, new List<byte>(new byte[] { 8 })).ToArray());
@@ -694,7 +694,7 @@ namespace Tools
             return bytes1;
         }
 
-        private static List<byte> ShiftLeftGrow(List<byte> bytes)
+        public static List<byte> ShiftLeftGrow(List<byte> bytes)
         {
             List<byte> bresult = new List<byte>();
 
@@ -726,7 +726,7 @@ namespace Tools
             return bresult;
         }
 
-        private static List<byte> ShiftLeftDrop(List<byte> bytes)
+        public static List<byte> ShiftLeftDrop(List<byte> bytes)
         {
             List<byte> bresult = new List<byte>();
 
@@ -750,7 +750,7 @@ namespace Tools
             return bresult;
         }
 
-        private static List<byte> ShiftRight(List<byte> bytes)
+        public static List<byte> ShiftRight(List<byte> bytes)
         {
             List<byte> bresult = new List<byte>();
 
@@ -773,7 +773,7 @@ namespace Tools
             return bresult;
         }
 
-        private static List<byte> SetLength(List<byte> bytes, int size)
+        public static List<byte> SetLength(List<byte> bytes, int size)
         {
             List<byte> bresult = new List<byte>();
 
@@ -785,7 +785,7 @@ namespace Tools
             return bresult;
         }
 
-        private static List<byte> Copy(List<byte> bytes)
+        public static List<byte> Copy(List<byte> bytes)
         {
             List<byte> ret = new List<byte>();
             for (int i = 0; i < bytes.Count; i++)
@@ -795,7 +795,7 @@ namespace Tools
             return ret;
         }
 
-        private static void NormalizeLengths(List<byte> bytes1, List<byte> bytes2)
+        public static void NormalizeLengths(List<byte> bytes1, List<byte> bytes2)
         {
             bool num1neg = (bytes1[bytes1.Count - 1] & 0x80) != 0;
             bool num2neg = (bytes2[bytes2.Count - 1] & 0x80) != 0;
@@ -825,7 +825,7 @@ namespace Tools
             }
         }
 
-        private static void Trim(List<byte> bytes)
+        public static void Trim(List<byte> bytes)
         {
             while (bytes.Count > 1)
             {
@@ -854,7 +854,7 @@ namespace Tools
             }
         }
 
-        private static List<byte> GetBytes(BitArray ba)
+        public static List<byte> GetBytes(BitArray ba)
         {
             int length = ((ba.Length) / 8) + 1;
 
@@ -875,7 +875,30 @@ namespace Tools
             return mask;
         }
 
-        private static String Print(byte[] bytes)
+        public static String Print(byte[] bytes)
+        {
+            String ret = "make ";
+
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                ret += bytes[i] + " ";
+            }
+
+            ret += "endmake ";
+            return ret;
+        }
+        
+        public static String PrintFormatX(byte[] bytes)
+        {
+            string ret = String.Empty;
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                ret += bytes[i].ToString("x");
+            }
+            return ret;
+        }
+
+        public static String PrintFormatX2(byte[] bytes)
         {
             string ret = String.Empty;
             for (int i = 0; i < bytes.Length; i++)
@@ -885,9 +908,13 @@ namespace Tools
             return ret;
         }
 
-        private static bool IsZero(List<byte> list)
+        public static bool IsZero(List<byte> list)
         {
-            byte[] value = list.ToArray();
+            return IsZero(list.ToArray());
+        }
+
+        public static bool IsZero(byte[] value)
+        {
             for (int i = 0; i < value.Length; i++)
             {
                 if (value[i] != 0)
@@ -897,7 +924,24 @@ namespace Tools
             }
             return true;
         }
-
+        
+        public static byte[] GetNonZeroRandomByteArray(Random random, int size)
+        {
+            byte[] value = new byte[size];
+            while (IsZero(value))
+            {
+                random.NextBytes(value);
+            }
+            return value;
+        }
+        
+        public static byte[] GetRandomByteArray(Random random, int size)
+        {
+            byte[] value = new byte[size];
+            random.NextBytes(value);
+            return value;
+        }
+        
         public static BigInteger ApproximateBigInteger(double value)
         {
             //Special case values;

--- a/src/System.Runtime.Numerics/tests/BigInteger/absolutevalue.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/absolutevalue.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tests
             // AbsoluteValue Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                byteArray = GetRandomByteArray(s_random, 2);
+                byteArray = MyBigIntImp.GetRandomByteArray(s_random, 2);
                 VerifyAbsoluteValueString(Print(byteArray) + "uAbs");
             }
 
@@ -89,32 +89,12 @@ namespace System.Numerics.Tests
 
         private static Byte[] GetRandomByteArray(Random random)
         {
-            return GetRandomByteArray(random, random.Next(0, 1024));
-        }
-
-        private static Byte[] GetRandomByteArray(Random random, int size)
-        {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, random.Next(0, 1024));
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/add.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/add.cs
@@ -144,34 +144,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -957,7 +958,7 @@ namespace System.Numerics.Tests
         {
             BigInteger bigInteger;
             byte[] roundTrippedByteArray;
-            bool isZero = IsZero(value);
+            bool isZero = MyBigIntImp.IsZero(value);
 
             bigInteger = new BigInteger(value);
 
@@ -1154,20 +1155,7 @@ namespace System.Numerics.Tests
             // 1 * x = x
             Assert.Equal(bigInteger, (BigInteger.One * bigInteger));
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; ++i)
-            {
-                if (0 != value[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
+        
         private static bool IsOutOfRangeUInt64(byte[] value)
         {
             if (value.Length == 0)

--- a/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -11,390 +10,294 @@ namespace System.Numerics.Tests
         private static int s_samples = 10;
         private static Random s_random = new Random(100);
 
-
         [Fact]
         public static void RunCtorInt32Tests()
         {
             // ctor(Int32): Int32.MinValue
-            Assert.True(VerifyCtorInt32(Int32.MinValue), " Verification Failed");
+            VerifyCtorInt32(Int32.MinValue);
 
             // ctor(Int32): -1
-            Assert.True(VerifyCtorInt32((Int32)(-1)), " Verification Failed");
+            VerifyCtorInt32((Int32)(-1));
 
             // ctor(Int32): 0
-            Assert.True(VerifyCtorInt32((Int32)0), " Verification Failed");
+            VerifyCtorInt32((Int32)0);
 
             // ctor(Int32): 1
-            Assert.True(VerifyCtorInt32((Int32)1), " Verification Failed");
+            VerifyCtorInt32((Int32)1);
 
             // ctor(Int32): Int32.MaxValue
-            Assert.True(VerifyCtorInt32(Int32.MaxValue), " Verification Failed");
+            VerifyCtorInt32(Int32.MaxValue);
 
             // ctor(Int32): Random Positive
             for (int i = 0; i < s_samples; ++i)
             {
-                Assert.True(VerifyCtorInt32((Int32)s_random.Next(1, Int32.MaxValue)), " Verification Failed");
+                VerifyCtorInt32((Int32)s_random.Next(1, Int32.MaxValue));
             }
 
             // ctor(Int32): Random Negative
             for (int i = 0; i < s_samples; ++i)
             {
-                Assert.True(VerifyCtorInt32((Int32)s_random.Next(Int32.MinValue, 0)), " Verification Failed");
+                VerifyCtorInt32((Int32)s_random.Next(Int32.MinValue, 0));
             }
         }
-        private static bool VerifyCtorInt32(Int32 value)
+
+        private static void VerifyCtorInt32(Int32 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = new BigInteger(value);
 
-            bigInteger = new BigInteger(value);
-
-            if (!bigInteger.Equals(value))
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to Int32 {1}", bigInteger, value);
-                ret = false;
-            }
-            if (String.CompareOrdinal(value.ToString(), bigInteger.ToString()) != 0)
-            {
-                Console.WriteLine("Int32.ToString() and BigInteger.ToString() on {0} and {1} should be equal", value, bigInteger);
-                ret = false;
-            }
-            if (value != (Int32)bigInteger)
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to Int32 {1}", bigInteger, value);
-                ret = false;
-            }
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(0, String.CompareOrdinal(value.ToString(), bigInteger.ToString()));
+            Assert.Equal(value, (Int32)bigInteger);
 
             if (value != Int32.MaxValue)
             {
-                if ((Int32)(value + 1) != (Int32)(bigInteger + 1))
-                {
-                    Console.WriteLine("Adding 1 to both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((Int32)(value + 1), (Int32)(bigInteger + 1));
             }
 
             if (value != Int32.MinValue)
             {
-                if ((Int32)(value - 1) != (Int32)(bigInteger - 1))
-                {
-                    Console.WriteLine("Subtracting 1 from both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((Int32)(value - 1), (Int32)(bigInteger - 1));
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == value), " Verification Failed");
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
         [Fact]
         public static void RunCtorInt64Tests()
         {
             // ctor(Int64): Int64.MinValue
-            Assert.True(VerifyCtorInt64(Int64.MinValue), " Verification Failed");
+            VerifyCtorInt64(Int64.MinValue);
 
             // ctor(Int64): Int32.MinValue-1
-            Assert.True(VerifyCtorInt64(((Int64)Int32.MinValue) - 1), " Verification Failed");
+            VerifyCtorInt64(((Int64)Int32.MinValue) - 1);
 
             // ctor(Int64): Int32.MinValue
-            Assert.True(VerifyCtorInt64((Int64)Int32.MinValue), " Verification Failed");
+            VerifyCtorInt64((Int64)Int32.MinValue);
 
             // ctor(Int64): -1
-            Assert.True(VerifyCtorInt64((Int64)(-1)), " Verification Failed");
+            VerifyCtorInt64((Int64)(-1));
 
             // ctor(Int64): 0
-            Assert.True(VerifyCtorInt64((Int64)0), " Verification Failed");
+            VerifyCtorInt64((Int64)0);
 
             // ctor(Int64): 1
-            Assert.True(VerifyCtorInt64((Int64)1), " Verification Failed");
+            VerifyCtorInt64((Int64)1);
 
             // ctor(Int64): Int32.MaxValue
-            Assert.True(VerifyCtorInt64((Int64)Int32.MaxValue), " Verification Failed");
+            VerifyCtorInt64((Int64)Int32.MaxValue);
 
             // ctor(Int64): Int32.MaxValue+1
-            Assert.True(VerifyCtorInt64(((Int64)Int32.MaxValue) + 1), " Verification Failed");
+            VerifyCtorInt64(((Int64)Int32.MaxValue) + 1);
 
             // ctor(Int64): Int64.MaxValue
-            Assert.True(VerifyCtorInt64(Int64.MaxValue), " Verification Failed");
+            VerifyCtorInt64(Int64.MaxValue);
 
             // ctor(Int64): Random Positive
             for (int i = 0; i < s_samples; ++i)
             {
-                Assert.True(VerifyCtorInt64((Int64)(Int64.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyCtorInt64((Int64)(Int64.MaxValue * s_random.NextDouble()));
             }
 
             // ctor(Int64): Random Negative
             for (int i = 0; i < s_samples; ++i)
             {
-                Assert.True(VerifyCtorInt64((Int64)(Int64.MaxValue * s_random.NextDouble()) - Int64.MaxValue), " Verification Failed");
+                VerifyCtorInt64((Int64)(Int64.MaxValue * s_random.NextDouble()) - Int64.MaxValue);
             }
         }
-        private static bool VerifyCtorInt64(Int64 value)
+
+        private static void VerifyCtorInt64(Int64 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = new BigInteger(value);
 
-            bigInteger = new BigInteger(value);
-
-            if (!bigInteger.Equals(value))
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to Int64 {1}", bigInteger, value);
-                ret = false;
-            }
-            if (String.CompareOrdinal(value.ToString(), bigInteger.ToString()) != 0)
-            {
-                Console.WriteLine("Int64.ToString() and BigInteger.ToString() on {0} and {1} should be equal", value, bigInteger);
-                ret = false;
-            }
-            if (value != (Int64)bigInteger)
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to Int64 {1}", bigInteger, value);
-                ret = false;
-            }
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(0, String.CompareOrdinal(value.ToString(), bigInteger.ToString()));
+            Assert.Equal(value, (Int64)bigInteger);
 
             if (value != Int64.MaxValue)
             {
-                if ((Int64)(value + 1) != (Int64)(bigInteger + 1))
-                {
-                    Console.WriteLine("Adding 1 to both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((Int64)(value + 1), (Int64)(bigInteger + 1));
             }
 
             if (value != Int64.MinValue)
             {
-                if ((Int64)(value - 1) != (Int64)(bigInteger - 1))
-                {
-                    Console.WriteLine("Subtracting 1 from both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((Int64)(value - 1), (Int64)(bigInteger - 1));
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == value), " Verification Failed");
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
         [Fact]
         public static void RunCtorUInt32Tests()
         {
             // ctor(UInt32): UInt32.MinValue
-            Assert.True(VerifyCtorUInt32(UInt32.MinValue), " Verification Failed");
+            VerifyCtorUInt32(UInt32.MinValue);
 
             // ctor(UInt32): 0
-            Assert.True(VerifyCtorUInt32((UInt32)0), " Verification Failed");
+            VerifyCtorUInt32((UInt32)0);
 
             // ctor(UInt32): 1
-            Assert.True(VerifyCtorUInt32((UInt32)1), " Verification Failed");
+            VerifyCtorUInt32((UInt32)1);
 
             // ctor(UInt32): Int32.MaxValue
-            Assert.True(VerifyCtorUInt32((UInt32)Int32.MaxValue), " Verification Failed");
+            VerifyCtorUInt32((UInt32)Int32.MaxValue);
 
             // ctor(UInt32): Int32.MaxValue+1
-            Assert.True(VerifyCtorUInt32(((UInt32)Int32.MaxValue) + 1), " Verification Failed");
+            VerifyCtorUInt32(((UInt32)Int32.MaxValue) + 1);
 
             // ctor(UInt32): UInt32.MaxValue
-            Assert.True(VerifyCtorUInt32(UInt32.MaxValue), " Verification Failed");
+            VerifyCtorUInt32(UInt32.MaxValue);
 
             // ctor(UInt32): Random Positive
             for (int i = 0; i < s_samples; ++i)
             {
-                Assert.True(VerifyCtorUInt32((UInt32)(UInt32.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyCtorUInt32((UInt32)(UInt32.MaxValue * s_random.NextDouble()));
             }
         }
-        private static bool VerifyCtorUInt32(UInt32 value)
+
+        private static void VerifyCtorUInt32(UInt32 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = new BigInteger(value);
 
-            bigInteger = new BigInteger(value);
-
-            if (!bigInteger.Equals(value))
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to UInt32 {1}", bigInteger, value);
-                ret = false;
-            }
-            if (String.CompareOrdinal(value.ToString(), bigInteger.ToString()) != 0)
-            {
-                Console.WriteLine("UInt32.ToString() and BigInteger.ToString() on {0} and {1} should be equal", value, bigInteger);
-                ret = false;
-            }
-            if (value != (UInt32)bigInteger)
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to UInt32 {1}", bigInteger, value);
-                ret = false;
-            }
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(0, String.CompareOrdinal(value.ToString(), bigInteger.ToString()));
+            Assert.Equal(value, (UInt32)bigInteger);
 
             if (value != UInt32.MaxValue)
             {
-                if ((UInt32)(value + 1) != (UInt32)(bigInteger + 1))
-                {
-                    Console.WriteLine("Adding 1 to both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((UInt32)(value + 1), (UInt32)(bigInteger + 1));
             }
 
             if (value != UInt32.MinValue)
             {
-                if ((UInt32)(value - 1) != (UInt32)(bigInteger - 1))
-                {
-                    Console.WriteLine("Subtracting 1 from both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((UInt32)(value - 1), (UInt32)(bigInteger - 1));
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == value), " Verification Failed");
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
         [Fact]
         public static void RunCtorUInt64Tests()
         {
             // ctor(UInt64): UInt64.MinValue
-            Assert.True(VerifyCtorUInt64(UInt64.MinValue), " Verification Failed");
+            VerifyCtorUInt64(UInt64.MinValue);
 
             // ctor(UInt64): 0
-            Assert.True(VerifyCtorUInt64((UInt64)0), " Verification Failed");
+            VerifyCtorUInt64((UInt64)0);
 
             // ctor(UInt64): 1
-            Assert.True(VerifyCtorUInt64((UInt64)1), " Verification Failed");
+            VerifyCtorUInt64((UInt64)1);
 
             // ctor(UInt64): Int32.MaxValue
-            Assert.True(VerifyCtorUInt64((UInt64)Int32.MaxValue), " Verification Failed");
+            VerifyCtorUInt64((UInt64)Int32.MaxValue);
 
             // ctor(UInt64): Int32.MaxValue+1
-            Assert.True(VerifyCtorUInt64(((UInt64)Int32.MaxValue) + 1), " Verification Failed");
+            VerifyCtorUInt64(((UInt64)Int32.MaxValue) + 1);
 
             // ctor(UInt64): UInt64.MaxValue
-            Assert.True(VerifyCtorUInt64(UInt64.MaxValue), " Verification Failed");
+            VerifyCtorUInt64(UInt64.MaxValue);
 
             // ctor(UInt64): Random Positive
             for (int i = 0; i < s_samples; ++i)
             {
-                Assert.True(VerifyCtorUInt64((UInt64)(UInt64.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyCtorUInt64((UInt64)(UInt64.MaxValue * s_random.NextDouble()));
             }
         }
-        private static bool VerifyCtorUInt64(UInt64 value)
+
+        private static void VerifyCtorUInt64(UInt64 value)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = new BigInteger(value);
 
-            bigInteger = new BigInteger(value);
-
-            if (!bigInteger.Equals(value))
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to UInt64 {1}", bigInteger, value);
-                ret = false;
-            }
-            if (String.CompareOrdinal(value.ToString(), bigInteger.ToString()) != 0)
-            {
-                Console.WriteLine("UInt64.ToString() and BigInteger.ToString() on {0} and {1} should be equal", value, bigInteger);
-                ret = false;
-            }
-            if (value != (UInt64)bigInteger)
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to UInt64 {1}", bigInteger, value);
-                ret = false;
-            }
+            Assert.Equal(value, bigInteger);
+            Assert.Equal(0, String.CompareOrdinal(value.ToString(), bigInteger.ToString()));
+            Assert.Equal(value, (UInt64)bigInteger);
 
             if (value != UInt64.MaxValue)
             {
-                if ((UInt64)(value + 1) != (UInt64)(bigInteger + 1))
-                {
-                    Console.WriteLine("Adding 1 to both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((UInt64)(value + 1), (UInt64)(bigInteger + 1));
             }
 
             if (value != UInt64.MinValue)
             {
-                if ((UInt64)(value - 1) != (UInt64)(bigInteger - 1))
-                {
-                    Console.WriteLine("Subtracting 1 from both {0} and {1} should remain equal", value, bigInteger);
-                    ret = false;
-                }
+                Assert.Equal((UInt64)(value - 1), (UInt64)(bigInteger - 1));
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == value), " Verification Failed");
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == value);
         }
 
         [Fact]
         public static void RunCtorSingleTests()
         {
-            Single value;
-
             // ctor(Single): Single.Minvalue
-            Assert.True(VerifyCtorSingle(Single.MinValue), " Verification Failed");
+            VerifyCtorSingle(Single.MinValue);
 
             // ctor(Single): Int32.MinValue-1
-            Assert.True(VerifyCtorSingle(((Single)Int32.MinValue) - 1), " Verification Failed");
+            VerifyCtorSingle(((Single)Int32.MinValue) - 1);
 
             // ctor(Single): Int32.MinValue
-            Assert.True(VerifyCtorSingle(((Single)Int32.MinValue)), " Verification Failed");
+            VerifyCtorSingle(((Single)Int32.MinValue));
 
             // ctor(Single): Int32.MinValue+1
-            Assert.True(VerifyCtorSingle(((Single)Int32.MinValue) + 1), " Verification Failed");
+            VerifyCtorSingle(((Single)Int32.MinValue) + 1);
 
             // ctor(Single): -1
-            Assert.True(VerifyCtorSingle((Single)(-1)), " Verification Failed");
+            VerifyCtorSingle((Single)(-1));
 
             // ctor(Single): 0
-            Assert.True(VerifyCtorSingle((Single)0), " Verification Failed");
+            VerifyCtorSingle((Single)0);
 
             // ctor(Single): 1
-            Assert.True(VerifyCtorSingle((Single)1), " Verification Failed");
+            VerifyCtorSingle((Single)1);
 
             // ctor(Single): Int32.MaxValue-1
-            Assert.True(VerifyCtorSingle(((Single)Int32.MaxValue) - 1), " Verification Failed");
+            VerifyCtorSingle(((Single)Int32.MaxValue) - 1);
 
             // ctor(Single): Int32.MaxValue
-            Assert.True(VerifyCtorSingle(((Single)Int32.MaxValue)), " Verification Failed");
+            VerifyCtorSingle(((Single)Int32.MaxValue));
 
             // ctor(Single): Int32.MaxValue+1
-            Assert.True(VerifyCtorSingle(((Single)Int32.MaxValue) + 1), " Verification Failed");
+            VerifyCtorSingle(((Single)Int32.MaxValue) + 1);
 
             // ctor(Single): Single.MaxValue
-            Assert.True(VerifyCtorSingle(Single.MaxValue), " Verification Failed");
+            VerifyCtorSingle(Single.MaxValue);
 
             // ctor(Single): Random Positive
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorSingle((Single)(Single.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyCtorSingle((Single)(Single.MaxValue * s_random.NextDouble()));
             }
 
             // ctor(Single): Random Negative
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorSingle(((Single)(Single.MaxValue * s_random.NextDouble())) - Single.MaxValue), " Verification Failed");
+                VerifyCtorSingle(((Single)(Single.MaxValue * s_random.NextDouble())) - Single.MaxValue);
             }
 
             // ctor(Single): Small Random Positive with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorSingle((Single)(s_random.Next(0, 100) + s_random.NextDouble())), " Verification Failed");
+                VerifyCtorSingle((Single)(s_random.Next(0, 100) + s_random.NextDouble()));
             }
 
             // ctor(Single): Small Random Negative with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorSingle(((Single)(s_random.Next(-100, 0) - s_random.NextDouble()))), " Verification Failed");
+                VerifyCtorSingle(((Single)(s_random.Next(-100, 0) - s_random.NextDouble())));
             }
 
             // ctor(Single): Large Random Positive with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorSingle((Single)((Single.MaxValue * s_random.NextDouble()) + s_random.NextDouble())), " Verification Failed");
+                VerifyCtorSingle((Single)((Single.MaxValue * s_random.NextDouble()) + s_random.NextDouble()));
             }
 
             // ctor(Single): Large Random Negative with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorSingle(((Single)((-(Single.MaxValue - 1) * s_random.NextDouble()) - s_random.NextDouble()))), " Verification Failed");
+                VerifyCtorSingle(((Single)((-(Single.MaxValue - 1) * s_random.NextDouble()) - s_random.NextDouble())));
             }
 
             // ctor(Single): Single.Epsilon
-            Assert.True(VerifyCtorSingle(Single.Epsilon), " Verification Failed");
+            VerifyCtorSingle(Single.Epsilon);
 
             // ctor(Single): Single.NegativeInfinity
             Assert.Throws<OverflowException>(() => new BigInteger(Single.NegativeInfinity));
@@ -418,38 +321,38 @@ namespace System.Numerics.Tests
             });
 
             // ctor(Single): Smallest Exponent
-            Assert.True(VerifyCtorSingle((Single)Math.Pow(2, -126)), " Verification Failed");
+            VerifyCtorSingle((Single)Math.Pow(2, -126));
 
             // ctor(Single): Largest Exponent
-            Assert.True(VerifyCtorSingle((Single)Math.Pow(2, 127)), " Verification Failed");
+            VerifyCtorSingle((Single)Math.Pow(2, 127));
 
-            // ctor(Single): Largest number less then 1
-            value = 0;
+            // ctor(Single): Largest number less than 1
+            Single value = 0;
             for (int i = 1; i <= 24; ++i)
             {
                 value += (Single)(Math.Pow(2, -i));
             }
-            Assert.True(VerifyCtorSingle(value), " Verification Failed");
+            VerifyCtorSingle(value);
 
-            // ctor(Single): Smallest number greater then 1
+            // ctor(Single): Smallest number greater than 1
             value = (Single)(1 + Math.Pow(2, -23));
-            Assert.True(VerifyCtorSingle(value), " Verification Failed");
+            VerifyCtorSingle(value);
 
-            // ctor(Single): Largest number less then 2
+            // ctor(Single): Largest number less than 2
             value = 0;
             for (int i = 1; i <= 23; ++i)
             {
                 value += (Single)(Math.Pow(2, -i));
             }
             value += 1;
-            Assert.True(VerifyCtorSingle(value), " Verification Failed");
+            VerifyCtorSingle(value);
         }
-        private static bool VerifyCtorSingle(Single value)
-        {
-            bool ret = true;
-            BigInteger bigInteger;
-            Single expectedValue;
 
+        private static void VerifyCtorSingle(Single value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+
+            Single expectedValue;
             if (value < 0)
             {
                 expectedValue = (Single)Math.Ceiling(value);
@@ -459,128 +362,116 @@ namespace System.Numerics.Tests
                 expectedValue = (Single)Math.Floor(value);
             }
 
-            bigInteger = new BigInteger(value);
-
-            if (expectedValue != (Single)bigInteger)
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to Single {1}", bigInteger, expectedValue);
-                ret = false;
-            }
+            Assert.Equal(expectedValue, (Single)bigInteger);
 
             // Single can only accurately represent integers between -16777216 and 16777216 exclusive.
             // ToString starts to become inaccurate at this point.
             if (expectedValue < 16777216 && -16777216 < expectedValue)
             {
-                if (!expectedValue.ToString("G9").Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase))
-                {
-                    ret = false;
-                }
+                Assert.True(expectedValue.ToString("G9").Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase), "Single.ToString() and BigInteger.ToString() not equal");
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == expectedValue), " Verification Failed");
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
         }
 
         [Fact]
         public static void RunCtorDoubleTests()
         {
-            Double value;
-
             // ctor(Double): Double.Minvalue
-            Assert.True(VerifyCtorDouble(Double.MinValue), " Verification Failed");
+            VerifyCtorDouble(Double.MinValue);
 
             // ctor(Double): Single.Minvalue
-            Assert.True(VerifyCtorDouble((Double)Single.MinValue), " Verification Failed");
+            VerifyCtorDouble((Double)Single.MinValue);
 
             // ctor(Double): Int64.MinValue-1
-            Assert.True(VerifyCtorDouble(((Double)Int64.MinValue) - 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int64.MinValue) - 1);
 
             // ctor(Double): Int64.MinValue
-            Assert.True(VerifyCtorDouble(((Double)Int64.MinValue)), " Verification Failed");
+            VerifyCtorDouble(((Double)Int64.MinValue));
 
             // ctor(Double): Int64.MinValue+1
-            Assert.True(VerifyCtorDouble(((Double)Int64.MinValue) + 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int64.MinValue) + 1);
 
             // ctor(Double): Int32.MinValue-1
-            Assert.True(VerifyCtorDouble(((Double)Int32.MinValue) - 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int32.MinValue) - 1);
 
             // ctor(Double): Int32.MinValue
-            Assert.True(VerifyCtorDouble(((Double)Int32.MinValue)), " Verification Failed");
+            VerifyCtorDouble(((Double)Int32.MinValue));
 
             // ctor(Double): Int32.MinValue+1
-            Assert.True(VerifyCtorDouble(((Double)Int32.MinValue) + 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int32.MinValue) + 1);
 
             // ctor(Double): -1
-            Assert.True(VerifyCtorDouble((Double)(-1)), " Verification Failed");
+            VerifyCtorDouble((Double)(-1));
 
             // ctor(Double): 0
-            Assert.True(VerifyCtorDouble((Double)0), " Verification Failed");
+            VerifyCtorDouble((Double)0);
 
             // ctor(Double): 1
-            Assert.True(VerifyCtorDouble((Double)1), " Verification Failed");
+            VerifyCtorDouble((Double)1);
 
             // ctor(Double): Int32.MaxValue-1
-            Assert.True(VerifyCtorDouble(((Double)Int32.MaxValue) - 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int32.MaxValue) - 1);
 
             // ctor(Double): Int32.MaxValue
-            Assert.True(VerifyCtorDouble(((Double)Int32.MaxValue)), " Verification Failed");
+            VerifyCtorDouble(((Double)Int32.MaxValue));
 
             // ctor(Double): Int32.MaxValue+1
-            Assert.True(VerifyCtorDouble(((Double)Int32.MaxValue) + 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int32.MaxValue) + 1);
 
             // ctor(Double): Int64.MaxValue-1
-            Assert.True(VerifyCtorDouble(((Double)Int64.MaxValue) - 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int64.MaxValue) - 1);
 
             // ctor(Double): Int64.MaxValue
-            Assert.True(VerifyCtorDouble(((Double)Int64.MaxValue)), " Verification Failed");
+            VerifyCtorDouble(((Double)Int64.MaxValue));
 
             // ctor(Double): Int64.MaxValue+1
-            Assert.True(VerifyCtorDouble(((Double)Int64.MaxValue) + 1), " Verification Failed");
+            VerifyCtorDouble(((Double)Int64.MaxValue) + 1);
 
             // ctor(Double): Single.MaxValue
-            Assert.True(VerifyCtorDouble((Double)Single.MaxValue), " Verification Failed");
+            VerifyCtorDouble((Double)Single.MaxValue);
 
             // ctor(Double): Double.MaxValue
-            Assert.True(VerifyCtorDouble(Double.MaxValue), " Verification Failed");
+            VerifyCtorDouble(Double.MaxValue);
 
             // ctor(Double): Random Positive
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorDouble((Double)(Double.MaxValue * s_random.NextDouble())), " Verification Failed");
+                VerifyCtorDouble((Double)(Double.MaxValue * s_random.NextDouble()));
             }
 
             // ctor(Double): Random Negative
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorDouble((Double.MaxValue * s_random.NextDouble()) - Double.MaxValue), " Verification Failed");
+                VerifyCtorDouble((Double.MaxValue * s_random.NextDouble()) - Double.MaxValue);
             }
 
             // ctor(Double): Small Random Positive with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorDouble((Double)(s_random.Next(0, 100) + s_random.NextDouble())), " Verification Failed");
+                VerifyCtorDouble((Double)(s_random.Next(0, 100) + s_random.NextDouble()));
             }
 
             // ctor(Double): Small Random Negative with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorDouble(((Double)(s_random.Next(-100, 0) - s_random.NextDouble()))), " Verification Failed");
+                VerifyCtorDouble(((Double)(s_random.Next(-100, 0) - s_random.NextDouble())));
             }
 
             // ctor(Double): Large Random Positive with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorDouble((Double)((Int64.MaxValue / 100 * s_random.NextDouble()) + s_random.NextDouble())), " Verification Failed");
+                VerifyCtorDouble((Double)((Int64.MaxValue / 100 * s_random.NextDouble()) + s_random.NextDouble()));
             }
 
             // ctor(Double): Large Random Negative with fractional part
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorDouble(((Double)((-(Int64.MaxValue / 100) * s_random.NextDouble()) - s_random.NextDouble()))), " Verification Failed");
+                VerifyCtorDouble(((Double)((-(Int64.MaxValue / 100) * s_random.NextDouble()) - s_random.NextDouble())));
             }
 
             // ctor(Double): Double.Epsilon
-            Assert.True(VerifyCtorDouble(Double.Epsilon), " Verification Failed");
+            VerifyCtorDouble(Double.Epsilon);
 
             // ctor(Double): Double.NegativeInfinity
             Assert.Throws<OverflowException>(() =>
@@ -607,38 +498,38 @@ namespace System.Numerics.Tests
             });
 
             // ctor(Double): Smallest Exponent
-            Assert.True(VerifyCtorDouble((Double)Math.Pow(2, -1022)), " Verification Failed");
+            VerifyCtorDouble((Double)Math.Pow(2, -1022));
 
             // ctor(Double): Largest Exponent
-            Assert.True(VerifyCtorDouble((Double)Math.Pow(2, 1023)), " Verification Failed");
+            VerifyCtorDouble((Double)Math.Pow(2, 1023));
 
-            // ctor(Double): Largest number less then 1
-            value = 0;
+            // ctor(Double): Largest number less than 1
+            Double value = 0;
             for (int i = 1; i <= 53; ++i)
             {
                 value += (Double)(Math.Pow(2, -i));
             }
-            Assert.True(VerifyCtorDouble(value), " Verification Failed");
+            VerifyCtorDouble(value);
 
-            // ctor(Double): Smallest number greater then 1
+            // ctor(Double): Smallest number greater than 1
             value = (Double)(1 + Math.Pow(2, -52));
-            Assert.True(VerifyCtorDouble(value), " Verification Failed");
+            VerifyCtorDouble(value);
 
-            // ctor(Double): Largest number less then 2
+            // ctor(Double): Largest number less than 2
             value = 0;
             for (int i = 1; i <= 52; ++i)
             {
                 value += (Double)(Math.Pow(2, -i));
             }
             value += 2;
-            Assert.True(VerifyCtorDouble(value), " Verification Failed");
+            VerifyCtorDouble(value);
         }
-        private static bool VerifyCtorDouble(Double value)
-        {
-            bool ret = true;
-            BigInteger bigInteger;
-            Double expectedValue;
 
+        private static void VerifyCtorDouble(Double value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+
+            Double expectedValue;
             if (value < 0)
             {
                 expectedValue = (Double)Math.Ceiling(value);
@@ -648,27 +539,16 @@ namespace System.Numerics.Tests
                 expectedValue = (Double)Math.Floor(value);
             }
 
-            bigInteger = new BigInteger(value);
-
-            if (expectedValue != (Double)bigInteger)
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to Double {1}", bigInteger, expectedValue);
-                ret = false;
-            }
+            Assert.Equal(expectedValue, (Double)bigInteger);
 
             // Single can only accurately represent integers between -16777216 and 16777216 exclusive.
             // ToString starts to become inaccurate at this point.
             if (expectedValue < 9007199254740992 && -9007199254740992 < expectedValue)
             {
-                if (!expectedValue.ToString("G17").Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase))
-                {
-                    Console.WriteLine("Single.ToString() and BigInteger.ToString() not equal");
-                    ret = false;
-                }
+                Assert.True(expectedValue.ToString("G17").Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase), "Double.ToString() and BigInteger.ToString() not equal");
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == expectedValue), " Verification Failed");
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
         }
 
         [Fact]
@@ -677,19 +557,19 @@ namespace System.Numerics.Tests
             Decimal value;
 
             // ctor(Decimal): Decimal.MinValue
-            Assert.True(VerifyCtorDecimal(Decimal.MinValue), " Verification Failed");
+            VerifyCtorDecimal(Decimal.MinValue);
 
             // ctor(Decimal): -1
-            Assert.True(VerifyCtorDecimal(-1), " Verification Failed");
+            VerifyCtorDecimal(-1);
 
             // ctor(Decimal): 0
-            Assert.True(VerifyCtorDecimal(0), " Verification Failed");
+            VerifyCtorDecimal(0);
 
             // ctor(Decimal): 1
-            Assert.True(VerifyCtorDecimal(1), " Verification Failed");
+            VerifyCtorDecimal(1);
 
             // ctor(Decimal): Decimal.MaxValue
-            Assert.True(VerifyCtorDecimal(Decimal.MaxValue), " Verification Failed");
+            VerifyCtorDecimal(Decimal.MaxValue);
 
             // ctor(Decimal): Random Positive
             for (int i = 0; i < s_samples; i++)
@@ -700,7 +580,7 @@ namespace System.Numerics.Tests
                     s_random.Next(Int32.MinValue, Int32.MaxValue),
                     false,
                     (byte)s_random.Next(0, 29));
-                Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+                VerifyCtorDecimal(value);
             }
 
             // ctor(Decimal): Random Negative
@@ -712,7 +592,7 @@ namespace System.Numerics.Tests
                     s_random.Next(Int32.MinValue, Int32.MaxValue),
                     true,
                     (byte)s_random.Next(0, 29));
-                Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+                VerifyCtorDecimal(value);
             }
 
             // ctor(Decimal): Smallest Exponent
@@ -720,40 +600,40 @@ namespace System.Numerics.Tests
             {
                 value = new Decimal(1, 0, 0, false, 0);
             }
-            Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+            VerifyCtorDecimal(value);
 
             // ctor(Decimal): Largest Exponent and zero integer
             unchecked
             {
                 value = new Decimal(0, 0, 0, false, 28);
             }
-            Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+            VerifyCtorDecimal(value);
 
             // ctor(Decimal): Largest Exponent and non zero integer
             unchecked
             {
                 value = new Decimal(1, 0, 0, false, 28);
             }
-            Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+            VerifyCtorDecimal(value);
 
-            // ctor(Decimal): Largest number less then 1
+            // ctor(Decimal): Largest number less than 1
             value = 1 - new Decimal(1, 0, 0, false, 28);
-            Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+            VerifyCtorDecimal(value);
 
-            // ctor(Decimal): Smallest number greater then 1
+            // ctor(Decimal): Smallest number greater than 1
             value = 1 + new Decimal(1, 0, 0, false, 28);
-            Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+            VerifyCtorDecimal(value);
 
-            // ctor(Decimal): Largest number less then 2
+            // ctor(Decimal): Largest number less than 2
             value = 2 - new Decimal(1, 0, 0, false, 28);
-            Assert.True(VerifyCtorDecimal(value), " Verification Failed");
+            VerifyCtorDecimal(value);
         }
-        private static bool VerifyCtorDecimal(Decimal value)
-        {
-            bool ret = true;
-            Decimal expectedValue;
-            BigInteger bigInteger;
 
+        private static void VerifyCtorDecimal(Decimal value)
+        {
+            BigInteger bigInteger = new BigInteger(value);
+
+            Decimal expectedValue;
             if (value < 0)
             {
                 expectedValue = Math.Ceiling(value);
@@ -763,39 +643,20 @@ namespace System.Numerics.Tests
                 expectedValue = Math.Floor(value);
             }
 
-            bigInteger = new BigInteger(value);
-
-            if (!expectedValue.ToString().Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine("Decimal.ToString() and BigInteger.ToString()");
-                ret = false;
-            }
-            if (expectedValue != (Decimal)bigInteger)
-            {
-                Console.WriteLine("Round tripped Decimal");
-                ret = false;
-            }
+            Assert.True(expectedValue.ToString().Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase), "Decimal.ToString() and BigInteger.ToString()");
+            Assert.Equal(expectedValue, (Decimal)bigInteger);
 
             if (expectedValue != Math.Floor(Decimal.MaxValue))
             {
-                if ((Decimal)(expectedValue + 1) != (Decimal)(bigInteger + 1))
-                {
-                    Console.WriteLine("BigInteger added to 1");
-                    ret = false;
-                }
+                Assert.Equal((Decimal)(expectedValue + 1), (Decimal)(bigInteger + 1));
             }
 
             if (expectedValue != Math.Ceiling(Decimal.MinValue))
             {
-                if ((Decimal)(expectedValue - 1) != (Decimal)(bigInteger - 1))
-                {
-                    Console.WriteLine("BigInteger subtracted by 1");
-                    ret = false;
-                }
+                Assert.Equal((Decimal)(expectedValue - 1), (Decimal)(bigInteger - 1));
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, 0 == expectedValue), " Verification Failed");
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
         }
 
         [Fact]
@@ -811,45 +672,47 @@ namespace System.Numerics.Tests
             });
 
             // ctor(byte[]): array is empty
-            Assert.True(VerifyCtorByteArray(new byte[0], 0), " Verification Failed");
+            VerifyCtorByteArray(new byte[0], 0);
 
             // ctor(byte[]): array is 1 byte
             tempUInt64 = (UInt32)s_random.Next(0, 256);
             tempByteArray = BitConverter.GetBytes(tempUInt64);
             if (tempByteArray[0] > 127)
             {
-                Assert.True(VerifyCtorByteArray(new byte[] { tempByteArray[0] }), " Verification Failed");
-                Assert.True(VerifyCtorByteArray(new byte[] { tempByteArray[0], 0 }, tempUInt64), " Verification Failed");
+                VerifyCtorByteArray(new byte[] { tempByteArray[0] });
+                VerifyCtorByteArray(new byte[] { tempByteArray[0], 0 }, tempUInt64);
             }
             else
             {
-                Assert.True(VerifyCtorByteArray(new byte[] { tempByteArray[0] }, tempUInt64), " Verification Failed");
+                VerifyCtorByteArray(new byte[] { tempByteArray[0] }, tempUInt64);
             }
 
             // ctor(byte[]): Small array with all zeros
-            Assert.True(VerifyCtorByteArray(new byte[] { 0, 0, 0, 0 }), " Verification Failed");
+            VerifyCtorByteArray(new byte[] { 0, 0, 0, 0 });
 
             // ctor(byte[]): Large array with all zeros
-            Assert.True(VerifyCtorByteArray(
-                new byte[] {
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 0}), "Test Failed");
+            VerifyCtorByteArray(
+               new byte[] {
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0
+                });
 
             // ctor(byte[]): Small array with all ones
-            Assert.True(VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }), " Verification Failed");
+            VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
 
             // ctor(byte[]): Large array with all ones
-            Assert.True(VerifyCtorByteArray(
+            VerifyCtorByteArray(
                 new byte[] {
-                0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF}), "Test Failed");
+                    0xFF, 0xFF, 0xFF, 0xFF,
+                    0xFF, 0xFF, 0xFF, 0xFF,
+                    0xFF, 0xFF, 0xFF, 0xFF,
+                    0xFF, 0xFF, 0xFF, 0xFF,
+                    0xFF, 0xFF, 0xFF, 0xFF
+                });
 
             // ctor(byte[]): array with a lot of leading zeros
             for (int i = 0; i < s_samples; i++)
@@ -857,19 +720,20 @@ namespace System.Numerics.Tests
                 tempUInt64 = (UInt32)s_random.Next(Int32.MinValue, Int32.MaxValue);
                 tempByteArray = BitConverter.GetBytes(tempUInt64);
 
-                Assert.True(VerifyCtorByteArray(
+                VerifyCtorByteArray(
                     new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    0, 0, 0, 0,
-                    0, 0, 0, 0,
-                    0, 0, 0, 0,
-                    0, 0, 0, 0,
-                    0, 0, 0, 0,
-                    0, 0, 0, 0},
-                    tempUInt64), "Test Failed");
+                        tempByteArray[0],
+                        tempByteArray[1],
+                        tempByteArray[2],
+                        tempByteArray[3],
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0
+                    },
+                    tempUInt64);
             }
 
             // ctor(byte[]): array 4 bytes
@@ -880,30 +744,33 @@ namespace System.Numerics.Tests
 
                 if (tempUInt64 > Int32.MaxValue)
                 {
-                    Assert.True(VerifyCtorByteArray(
+                    VerifyCtorByteArray(
+                        new byte[] {
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3]
+                        });
+                    VerifyCtorByteArray(
                        new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3]}), "Test Failed");
-                    Assert.True(VerifyCtorByteArray(
-                       new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    0},
-                        tempUInt64), "Test Failed");
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            0
+                       },
+                       tempUInt64);
                 }
                 else
                 {
-                    Assert.True(VerifyCtorByteArray(
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3]},
-                        tempUInt64), "Test Failed");
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3]
+                        },
+                        tempUInt64);
                 }
             }
 
@@ -917,33 +784,35 @@ namespace System.Numerics.Tests
 
                 if (tempUInt64 >= (UInt64)0x00080000)
                 {
-                    Assert.True(VerifyCtorByteArray(
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    tempByteArray[4]}), "Test Failed");
-                    Assert.True(VerifyCtorByteArray(
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            tempByteArray[4]
+                        });
+
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    tempByteArray[4],
-                    0},
-                        tempUInt64), "Test Failed");
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            tempByteArray[4],
+                            0
+                        }, tempUInt64);
                 }
                 else
                 {
-                    Assert.True(VerifyCtorByteArray(
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    tempByteArray[4]},
-                        tempUInt64), "Test Failed");
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            tempByteArray[4]
+                        }, tempUInt64);
                 }
             }
 
@@ -957,83 +826,88 @@ namespace System.Numerics.Tests
 
                 if (tempUInt64 > Int64.MaxValue)
                 {
-                    Assert.True(VerifyCtorByteArray(
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    tempByteArray[4],
-                    tempByteArray[5],
-                    tempByteArray[6],
-                    tempByteArray[7]}), "Test Failed");
-                    Assert.True(VerifyCtorByteArray(
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            tempByteArray[4],
+                            tempByteArray[5],
+                            tempByteArray[6],
+                            tempByteArray[7]
+                        });
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    tempByteArray[4],
-                    tempByteArray[5],
-                    tempByteArray[6],
-                    tempByteArray[7],
-                    0},
-                        tempUInt64), "Test Failed");
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            tempByteArray[4],
+                            tempByteArray[5],
+                            tempByteArray[6],
+                            tempByteArray[7],
+                            0
+                        }, tempUInt64);
                 }
                 else
                 {
-                    Assert.True(VerifyCtorByteArray(
+                    VerifyCtorByteArray(
                         new byte[] {
-                    tempByteArray[0],
-                    tempByteArray[1],
-                    tempByteArray[2],
-                    tempByteArray[3],
-                    tempByteArray[4],
-                    tempByteArray[5],
-                    tempByteArray[6],
-                    tempByteArray[7]},
-                        tempUInt64), "Test Failed");
+                            tempByteArray[0],
+                            tempByteArray[1],
+                            tempByteArray[2],
+                            tempByteArray[3],
+                            tempByteArray[4],
+                            tempByteArray[5],
+                            tempByteArray[6],
+                            tempByteArray[7]
+                        },
+                        tempUInt64);
                 }
             }
 
             // ctor(byte[]): array 9 bytes
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyCtorByteArray(
+                VerifyCtorByteArray(
                     new byte[] {
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256),
-                    (byte)s_random.Next(0, 256)}), "Test Failed");
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256),
+                        (byte)s_random.Next(0, 256)
+                    });
             }
 
             // ctor(byte[]): array is UInt32.MaxValue
-            Assert.True(VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0 }, UInt32.MaxValue), " Verification Failed");
+            VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0 }, UInt32.MaxValue);
 
             // ctor(byte[]): array is UInt32.MaxValue + 1
-            Assert.True(VerifyCtorByteArray(new byte[] { 0, 0, 0, 0, 1 }, (UInt64)UInt32.MaxValue + 1), " Verification Failed");
+            VerifyCtorByteArray(new byte[] { 0, 0, 0, 0, 1 }, (UInt64)UInt32.MaxValue + 1);
 
             // ctor(byte[]): array is UInt64.MaxValue
-            Assert.True(VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 }, UInt64.MaxValue), " Verification Failed");
+            VerifyCtorByteArray(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 }, UInt64.MaxValue);
 
             // ctor(byte[]): UInt64.MaxValue + 1
-            Assert.True(VerifyCtorByteArray(
+            VerifyCtorByteArray(
                 new byte[] {
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                1}), "Test Failed");
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    1
+                });
 
             // ctor(byte[]): UInt64.MaxValue + 2^64
-            Assert.True(VerifyCtorByteArray(
+            VerifyCtorByteArray(
                 new byte[] {
-                0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF,
-                1}), "Test Failed");
+                    0xFF, 0xFF, 0xFF, 0xFF,
+                    0xFF, 0xFF, 0xFF, 0xFF,
+                    1
+                });
 
             // ctor(byte[]): array is random > UInt64
             for (int i = 0; i < s_samples; i++)
@@ -1043,7 +917,7 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray[arrayIndex] = (byte)s_random.Next(0, 256);
                 }
-                Assert.True(VerifyCtorByteArray(tempByteArray), " Verification Failed");
+                VerifyCtorByteArray(tempByteArray);
             }
 
             // ctor(byte[]): array is large
@@ -1054,58 +928,33 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray[arrayIndex] = (byte)s_random.Next(0, 256);
                 }
-                Assert.True(VerifyCtorByteArray(tempByteArray), " Verification Failed");
+                VerifyCtorByteArray(tempByteArray);
             }
         }
-        private static bool VerifyCtorByteArray(byte[] value, UInt64 expectedValue)
+
+        private static void VerifyCtorByteArray(byte[] value, UInt64 expectedValue)
         {
-            bool ret = true;
-            BigInteger bigInteger;
+            BigInteger bigInteger = new BigInteger(value);
 
-            bigInteger = new BigInteger(value);
-
-            if (!bigInteger.Equals(expectedValue))
-            {
-                Console.WriteLine("Expected BigInteger {0} to be equal to UInt64 {1}", bigInteger, expectedValue);
-                ret = false;
-            }
-            if (!expectedValue.ToString().Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine("UInt64.ToString() and BigInteger.ToString()");
-                ret = false;
-            }
-            if (expectedValue != (UInt64)bigInteger)
-            {
-                Console.WriteLine("BigInteger casted to a UInt64");
-                ret = false;
-            }
+            Assert.Equal(expectedValue, bigInteger);
+            Assert.True(expectedValue.ToString().Equals(bigInteger.ToString(), StringComparison.OrdinalIgnoreCase), "UInt64.ToString() and BigInteger.ToString()");
+            Assert.Equal(expectedValue, (UInt64)bigInteger);
 
             if (expectedValue != UInt64.MaxValue)
             {
-                if ((UInt64)(expectedValue + 1) != (UInt64)(bigInteger + 1))
-                {
-                    Console.WriteLine("BigInteger added to 1");
-                    ret = false;
-                }
+                Assert.Equal((UInt64)(expectedValue + 1), (UInt64)(bigInteger + 1));
             }
 
             if (expectedValue != UInt64.MinValue)
             {
-                if ((UInt64)(expectedValue - 1) != (UInt64)(bigInteger - 1))
-                {
-                    Console.WriteLine("BigInteger subtracted by 1");
-                    ret = false;
-                }
+                Assert.Equal((UInt64)(expectedValue - 1), (UInt64)(bigInteger - 1));
             }
 
-            Assert.True(VerifyCtorByteArray(value), " Verification Failed");
-            return ret;
+            VerifyCtorByteArray(value);
         }
 
-
-        private static bool VerifyCtorByteArray(byte[] value)
+        private static void VerifyCtorByteArray(byte[] value)
         {
-            bool ret = true;
             BigInteger bigInteger;
             byte[] roundTrippedByteArray;
             bool isZero = IsZero(value);
@@ -1116,33 +965,23 @@ namespace System.Numerics.Tests
 
             for (int i = Math.Min(value.Length, roundTrippedByteArray.Length) - 1; 0 <= i; --i)
             {
-                if (value[i] != roundTrippedByteArray[i])
-                {
-                    Console.WriteLine("Round Tripped ByteArray at {0}", i);
-                    ret = false;
-                }
+                Assert.True(value[i] == roundTrippedByteArray[i], String.Format("Round Tripped ByteArray at {0}", i));
             }
             if (value.Length < roundTrippedByteArray.Length)
             {
                 for (int i = value.Length; i < roundTrippedByteArray.Length; ++i)
                 {
-                    if (0 != roundTrippedByteArray[i])
-                    {
-                        Console.WriteLine("Round Tripped ByteArray is larger than the original array and byte is non zero at {0}", i);
-                        ret = false;
-                    }
+                    Assert.True(0 == roundTrippedByteArray[i],
+                        String.Format("Round Tripped ByteArray is larger than the original array and byte is non zero at {0}", i));
                 }
             }
             else if (value.Length > roundTrippedByteArray.Length)
             {
                 for (int i = roundTrippedByteArray.Length; i < value.Length; ++i)
                 {
-                    if (((0 != value[i]) && ((roundTrippedByteArray[roundTrippedByteArray.Length - 1] & 0x80) == 0)) ||
-                        ((0xFF != value[i]) && ((roundTrippedByteArray[roundTrippedByteArray.Length - 1] & 0x80) != 0)))
-                    {
-                        Console.WriteLine("Round Tripped ByteArray is smaller than the original array and byte is non zero at {0}", i);
-                        ret = false;
-                    }
+                    Assert.False((((0 != value[i]) && ((roundTrippedByteArray[roundTrippedByteArray.Length - 1] & 0x80) == 0)) ||
+                        ((0xFF != value[i]) && ((roundTrippedByteArray[roundTrippedByteArray.Length - 1] & 0x80) != 0))),
+                        String.Format("Round Tripped ByteArray is smaller than the original array and byte is non zero at {0}", i));
                 }
             }
 
@@ -1226,19 +1065,11 @@ namespace System.Numerics.Tests
                     tempBigInteger = tempBigInteger + (new BigInteger(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0xFF }));
                 }
 
-                if (BitConverter.ToInt64(tempByteArray, 0) != (Int64)tempBigInteger)
-                {
-                    Console.WriteLine("BigInteger after subtracting all bits greater then Int64");
-                    ret = false;
-                }
+                Assert.Equal(BitConverter.ToInt64(tempByteArray, 0), (Int64)tempBigInteger);
             }
             else
             {
-                if (BitConverter.ToInt64(value, 0) != (Int64)bigInteger)
-                {
-                    Console.WriteLine("BigInteger not equal to Int64");
-                    ret = false;
-                }
+                Assert.Equal(BitConverter.ToInt64(value, 0), (Int64)bigInteger);
             }
 
             if (IsOutOfRangeUInt64(value))
@@ -1269,114 +1100,61 @@ namespace System.Numerics.Tests
                     }
                 }
 
-                if (BitConverter.ToUInt64(tempByteArray, 0) != (UInt64)tempBigInteger)
-                {
-                    Console.WriteLine("BigInteger after subtracting all bits greater then UInt64");
-                    ret = false;
-                }
+                Assert.Equal(BitConverter.ToUInt64(tempByteArray, 0), (UInt64)tempBigInteger);
             }
             else
             {
-                if (BitConverter.ToUInt64(value, 0) != (UInt64)bigInteger)
-                {
-                    Console.WriteLine("BigInteger not equal to UInt64");
-                    ret = false;
-                }
+                Assert.Equal(BitConverter.ToUInt64(value, 0), (UInt64)bigInteger);
             }
 
-            Assert.True(VerifyBigintegerUsingIdentities(bigInteger, isZero), " Verification Failed");
-
-            return ret;
+            VerifyBigIntegerUsingIdentities(bigInteger, isZero);
         }
 
         private static Single ConvertInt32ToSingle(Int32 value)
         {
             return BitConverter.ToSingle(BitConverter.GetBytes(value), 0);
         }
+
         private static Double ConvertInt64ToDouble(Int64 value)
         {
             return BitConverter.ToDouble(BitConverter.GetBytes(value), 0);
         }
-        private static bool VerifyBigintegerUsingIdentities(BigInteger bigInteger, bool isZero)
+
+        private static void VerifyBigIntegerUsingIdentities(BigInteger bigInteger, bool isZero)
         {
-            bool ret = true;
-            BigInteger tempBigInteger;
+            BigInteger tempBigInteger = new BigInteger(bigInteger.ToByteArray());
 
-            tempBigInteger = new BigInteger(bigInteger.ToByteArray());
-
-            if (bigInteger != tempBigInteger)
-            {
-                Console.WriteLine("BigInteger {0} copied using ctor(byte[]) gave different value {1}", bigInteger, tempBigInteger);
-                ret = false;
-            }
+            Assert.Equal(bigInteger, tempBigInteger);
 
             if (isZero)
             {
-                if (BigInteger.Zero != bigInteger)
-                {
-                    Console.WriteLine("Comparing constructed BigInteger with BigInteger.Zero fails");
-                    ret = false;
-                }
+                Assert.Equal(BigInteger.Zero, bigInteger);
             }
             else
             {
-                if (BigInteger.Zero == bigInteger)
-                {
-                    Console.WriteLine("Expected BigInteger to not be equal to zero {0}", bigInteger);
-                    ret = false;
-                }
-
-                if (BigInteger.One != bigInteger / bigInteger)
-                {
-                    Console.WriteLine("BigInteger divided by itself should be One");
-                    ret = false;
-                }
+                Assert.NotEqual(BigInteger.Zero, bigInteger);
+                Assert.Equal(BigInteger.One, bigInteger / bigInteger);
             }
 
             // (x + 1) - 1 = x
-            if (bigInteger != (bigInteger + BigInteger.One) - BigInteger.One)
-            {
-                Console.WriteLine("Add 1 to the BigInteger then subtract 1");
-                ret = false;
-            }
+            Assert.Equal(bigInteger, ((bigInteger + BigInteger.One) - BigInteger.One));
 
             // (x + 1) - x = 1
-            if (BigInteger.One != (bigInteger + BigInteger.One) - bigInteger)
-            {
-                Console.WriteLine("Add 1 to the BigInteger then subtract the BigInteger");
-                ret = false;
-            }
+            Assert.Equal(BigInteger.One, ((bigInteger + BigInteger.One) - bigInteger));
 
             // x - x = 0
-            if (BigInteger.Zero != bigInteger - bigInteger)
-            {
-                Console.WriteLine("Subtract the BigInteger form itself");
-                ret = false;
-            }
+            Assert.Equal(BigInteger.Zero, (bigInteger - bigInteger));
 
             // x + x = 2x
-            if (2 * bigInteger != bigInteger + bigInteger)
-            {
-                Console.WriteLine("Expected Adding the BigInteger to istself to be equal to 2 times the BigInteger");
-                ret = false;
-            }
+            Assert.Equal((2 * bigInteger), (bigInteger + bigInteger));
 
             // x/1 = x
-            if (bigInteger != bigInteger / BigInteger.One)
-            {
-                Console.WriteLine("BigInteger divided by 1");
-                ret = false;
-            }
+            Assert.Equal(bigInteger, (bigInteger / BigInteger.One));
 
             // 1 * x = x
-            if (bigInteger != BigInteger.One * bigInteger)
-            {
-                Console.WriteLine("BigInteger multiplied by 1");
-                ret = false;
-            }
-
-            return ret;
+            Assert.Equal(bigInteger, (BigInteger.One * bigInteger));
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; ++i)
@@ -1389,12 +1167,17 @@ namespace System.Numerics.Tests
 
             return true;
         }
+
         private static bool IsOutOfRangeUInt64(byte[] value)
         {
             if (value.Length == 0)
+            {
                 return false;
+            }
             if ((0x80 & value[value.Length - 1]) != 0)
+            {
                 return true;
+            }
 
             byte zeroValue = 0;
 
@@ -1413,10 +1196,13 @@ namespace System.Numerics.Tests
 
             return false;
         }
+
         private static bool IsOutOfRangeInt64(byte[] value)
         {
             if (value.Length == 0)
+            {
                 return false;
+            }
 
             bool isNeg = ((0x80 & value[value.Length - 1]) != 0);
             byte zeroValue = 0;
@@ -1440,17 +1226,6 @@ namespace System.Numerics.Tests
             }
 
             return (!((0 == (0x80 & value[7])) ^ isNeg));
-        }
-        private static String Print(byte[] bytes)
-        {
-            String ret = String.Empty;
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-
-            return ret;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
@@ -1,19 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
-    public class divideTest
+    public class DivideTest
     {
         private static int s_samples = 10;
-
         private static Random s_random = new Random(100);
-
-
+        
         [Fact]
         public static void RunDivideTwoLargeBI()
         {
@@ -25,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
             }
         }
 
@@ -40,7 +37,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
             }
         }
 
@@ -55,14 +52,13 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
             }
         }
-
 
         [Fact]
         public static void RunDivideOneLargeOneZeroBI()
@@ -75,10 +71,8 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-
-                bool v = VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
-                Assert.True(v, " Verification Failed");
-
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
+                
                 Assert.Throws<DivideByZeroException>(() =>
                 {
                     VerifyDivideString(Print(tempByteArray2) + Print(tempByteArray1) + "bDivide");
@@ -97,7 +91,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivide");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -113,13 +107,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X/1 = X
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " bDivide", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " bDivide", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " bDivide", Int32.MaxValue.ToString());
+            VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " bDivide", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(BigInteger.One + " " + randBigInt + "bDivide", randBigInt.Substring(0, randBigInt.Length - 1)), " Verification Failed");
+                VerifyIdentityString(BigInteger.One + " " + randBigInt + "bDivide", randBigInt.Substring(0, randBigInt.Length - 1));
             }
         }
 
@@ -131,13 +125,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: 0/X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bDivide", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " bDivide", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bDivide", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " bDivide", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " bDivide", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " bDivide", BigInteger.Zero.ToString());
             }
         }
 
@@ -147,51 +141,48 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyDivideString(Math.Pow(2, 32) + " 2 bDivide"), " Verification Failed");
+            VerifyDivideString(Math.Pow(2, 32) + " 2 bDivide");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyDivideString(Math.Pow(2, 33) + " 2 bDivide"), " Verification Failed");
+            VerifyDivideString(Math.Pow(2, 33) + " 2 bDivide");
         }
 
-        private static bool VerifyDivideString(string opstring)
+        private static void VerifyDivideString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
 
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
+        private static void VerifyIdentityString(string opstring1, string opstring2)
         {
-            bool ret = true;
-
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -206,12 +197,15 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; i++)
             {
                 if (value[i] != 0)
+                {
                     return false;
+                }
             }
             return true;
         }
@@ -227,27 +221,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
@@ -178,49 +178,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            while (IsZero(value))
-            {
-                for (int i = 0; i < value.Length; ++i)
-                {
-                    value[i] = (byte)random.Next(0, 256);
-                }
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0)
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
+        
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
@@ -185,53 +185,23 @@ namespace System.Numerics.Tests
             while (sc.DoNextOperation())
             {
                 Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
-                Assert.True(sc.VerifyOut(), "Out parameters not matching");
+                sc.VerifyOutParameter();
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            while (IsZero(value))
-            {
-                for (int i = 0; i < value.Length; ++i)
-                {
-                    value[i] = (byte)random.Next(0, 256);
-                }
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0)
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
+        
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -10,11 +9,10 @@ namespace System.Numerics.Tests
     public class divremTest
     {
         private static int s_samples = 10;
-
         private static Random s_random = new Random(100);
 
         [Fact]
-        public static void RunDivRem_TwoLArgeBI()
+        public static void RunDivRem_TwoLargeBI()
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
@@ -24,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
             }
         }
 
@@ -39,27 +37,26 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
             }
         }
-
-
+        
         [Fact]
         public static void RunDivRem_OneSmallOneLargeBI()
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            // DivRem Method - One large and one small BigIntegers
+            // DivRem Method - One Large and one small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
             }
         }
 
@@ -69,12 +66,12 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            // DivRem Method - One large BigIntegers and zero
+            // DivRem Method - One Large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -94,7 +91,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -109,113 +106,94 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyDivRemString(Math.Pow(2, 32) + " 2 bDivRem"), " Verification Failed");
+            VerifyDivRemString(Math.Pow(2, 32) + " 2 bDivRem");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyDivRemString(Math.Pow(2, 33) + " 2 bDivRem"), " Verification Failed");
+            VerifyDivRemString(Math.Pow(2, 33) + " 2 bDivRem");
         }
 
-        public static bool RunDivRemTests(Random random)
+        [Fact]
+        public static void RunDivRemTests()
         {
-            bool ret = true;
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
             // DivRem Method - Two Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random);
-                tempByteArray2 = GetRandomByteArray(random);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = GetRandomByteArray(s_random);
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
             }
 
             // DivRem Method - Two Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random, 2);
-                tempByteArray2 = GetRandomByteArray(random, 2);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = GetRandomByteArray(s_random, 2);
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
             }
 
-            // DivRem Method - One large and one small BigIntegers
+            // DivRem Method - One Large and one small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random);
-                tempByteArray2 = GetRandomByteArray(random, 2);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = GetRandomByteArray(s_random, 2);
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
 
-                tempByteArray1 = GetRandomByteArray(random, 2);
-                tempByteArray2 = GetRandomByteArray(random);
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = GetRandomByteArray(s_random);
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
             }
 
-            // DivRem Method - One large BigIntegers and zero
+            // DivRem Method - One Large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random);
+                tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
 
-                try
-                {
-                    VerifyDivRemString(Print(tempByteArray2) + Print(tempByteArray1) + "bDivRem");
-                    ret = false;
-                }
-                catch (DivideByZeroException)
-                {
-                    //   caught expected exception.
-                }
+                Assert.Throws<DivideByZeroException>(() => { VerifyDivRemString(Print(tempByteArray2) + Print(tempByteArray1) + "bDivRem"); });
             }
 
             // DivRem Method - One small BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random, 2);
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem"), " Verification Failed");
+                VerifyDivRemString(Print(tempByteArray1) + Print(tempByteArray2) + "bDivRem");
 
-                try
-                {
-                    VerifyDivRemString(Print(tempByteArray2) + Print(tempByteArray1) + "bDivRem");
-                    ret = false;
-                }
-                catch (DivideByZeroException)
-                {
-                    //   caught expected exception.
-                }
+                Assert.Throws<DivideByZeroException>(() => { VerifyDivRemString(Print(tempByteArray2) + Print(tempByteArray1) + "bDivRem"); });
             }
 
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyDivRemString(Math.Pow(2, 32) + " 2 bDivRem"), " Verification Failed");
+            VerifyDivRemString(Math.Pow(2, 32) + " 2 bDivRem");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyDivRemString(Math.Pow(2, 33) + " 2 bDivRem"), " Verification Failed");
-            return ret;
+            VerifyDivRemString(Math.Pow(2, 33) + " 2 bDivRem");
         }
 
-        private static bool VerifyDivRemString(string opstring)
+        private static void VerifyDivRemString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
-                ret &= Eval(sc.VerifyOut(), String.Format("Out parameters not matching"));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
+                Assert.True(sc.VerifyOut(), "Out parameters not matching");
             }
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -230,12 +208,15 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; i++)
             {
                 if (value[i] != 0)
+                {
                     return false;
+                }
             }
             return true;
         }
@@ -251,27 +232,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/gcd.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/gcd.cs
@@ -132,34 +132,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/gcd.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/gcd.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -20,15 +19,15 @@ namespace System.Numerics.Tests
 
             tempByteArray1 = new byte[] { (byte)0, (byte)0, (byte)0, (byte)0, (byte)1 };
             tempByteArray2 = new byte[] { (byte)0 };
-            Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+            VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
 
             tempByteArray1 = new byte[] { (byte)0, (byte)0, (byte)0, (byte)0, (byte)41 };
             tempByteArray2 = new byte[] { (byte)0 };
-            Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+            VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
 
             tempByteArray1 = new byte[] { (byte)0, (byte)0, (byte)0, (byte)0, (byte)2 };
             tempByteArray2 = new byte[] { (byte)0 };
-            Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+            VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
         }
 
         [Fact]
@@ -42,7 +41,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
             }
 
             // GCD Method - Two Small BigIntegers
@@ -50,7 +49,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
             }
 
             // GCD Method - One large and one small BigIntegers
@@ -58,11 +57,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
             }
 
             // GCD Method - One large BigIntegers and zero
@@ -70,11 +69,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
             }
 
             // GCD Method - One small BigIntegers and zero
@@ -82,64 +81,62 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD"), " Verification Failed");
+                VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
             }
 
             // Identity GCD(GCD(x,y),z) == GCD(GCD(y,z),x)
-            //Check some identities
+            // Check some identities
             // (x+y)+z = (y+z)+x
 
-            Assert.True(VerifyIdentityString(
-                    Int64.MaxValue.ToString() + " " + Int32.MaxValue.ToString() + " bGCD " + Int16.MaxValue.ToString() + " bGCD",
-                    Int32.MaxValue.ToString() + " " + Int16.MaxValue.ToString() + " bGCD " + Int64.MaxValue.ToString() + " bGCD"
-            ), "Test Failed");
+            VerifyIdentityString( 
+                Int64.MaxValue.ToString() + " " + Int32.MaxValue.ToString() + " bGCD " + Int16.MaxValue.ToString() + " bGCD",
+                Int32.MaxValue.ToString() + " " + Int16.MaxValue.ToString() + " bGCD " + Int64.MaxValue.ToString() + " bGCD"
+            );
 
             byte[] x = GetRandomByteArray(s_random);
             byte[] y = GetRandomByteArray(s_random);
             byte[] z = GetRandomByteArray(s_random);
 
-            Assert.True(VerifyIdentityString(Print(x) + Print(y) + Print(z) + "bGCD bGCD", Print(y) + Print(z) + Print(x) + "bGCD bGCD"), " Verification Failed");
+            VerifyIdentityString(Print(x) + Print(y) + Print(z) + "bGCD bGCD", Print(y) + Print(z) + Print(x) + "bGCD bGCD");
         }
 
-        private static bool VerifyGCDString(string opstring)
+        private static void VerifyGCDString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -163,27 +160,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/log.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log.cs
@@ -156,21 +156,14 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static Byte[] GetRandomPosByteArray(Random random, int size)
@@ -201,15 +194,7 @@ namespace System.Numerics.Tests
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
 
         private static bool ApproxEqual(double value1, double value2)

--- a/src/System.Runtime.Numerics/tests/BigInteger/log.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -20,22 +19,22 @@ namespace System.Numerics.Tests
             BigInteger bi;
 
             // Log Method - Log(1,+Infinity)
-            Assert.True((0 == BigInteger.Log(1, Double.PositiveInfinity)), " Verification Failed");
+            Assert.Equal(0, BigInteger.Log(1, Double.PositiveInfinity));
 
             // Log Method - Log(1,0)
-            Assert.True(VerifyLogString("0 1 bLog"), " Verification Failed");
+            VerifyLogString("0 1 bLog");
 
             // Log Method - Log(0, >1)
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 10);
-                Assert.True(VerifyLogString(Print(tempByteArray1) + "0 bLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + "0 bLog");
             }
 
             // Log Method - Log(0, 0>x>1)
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True((Double.PositiveInfinity == BigInteger.Log(0, s_random.NextDouble())), " Verification Failed");
+                Assert.Equal(Double.PositiveInfinity, BigInteger.Log(0, s_random.NextDouble()));
             }
 
             // Log Method - base = 0
@@ -46,38 +45,38 @@ namespace System.Numerics.Tests
                 {
                     bi = new BigInteger(GetRandomPosByteArray(s_random, 8));
                 }
-                Assert.True((Double.IsNaN(BigInteger.Log(bi, 0))), " Verification Failed");
+                Assert.True((Double.IsNaN(BigInteger.Log(bi, 0))));
             }
 
             // Log Method - base = 1
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyLogString("1 " + Print(tempByteArray1) + "bLog"), " Verification Failed");
+                VerifyLogString("1 " + Print(tempByteArray1) + "bLog");
             }
 
             // Log Method - base = NaN
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True((Double.IsNaN(BigInteger.Log(new BigInteger(GetRandomByteArray(s_random, 10)), Double.NaN))), " Verification Failed");
+                Assert.True(Double.IsNaN(BigInteger.Log(new BigInteger(GetRandomByteArray(s_random, 10)), Double.NaN)));
             }
 
             // Log Method - base = +Infinity
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True((Double.IsNaN(BigInteger.Log(new BigInteger(GetRandomByteArray(s_random, 10)), Double.PositiveInfinity))), " Verification Failed");
+                Assert.True(Double.IsNaN(BigInteger.Log(new BigInteger(GetRandomByteArray(s_random, 10)), Double.PositiveInfinity)));
             }
 
             // Log Method - Log(0,1)
-            Assert.True(VerifyLogString("1 0 bLog"), " Verification Failed");
+            VerifyLogString("1 0 bLog");
 
             // Log Method - base < 0
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 10);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 1);
-                Assert.True(VerifyLogString(Print(tempByteArray2) + Print(tempByteArray1) + "bLog"), " Verification Failed");
-                Assert.True((Double.IsNaN(BigInteger.Log(new BigInteger(GetRandomByteArray(s_random, 10)), -s_random.NextDouble()))), " Verification Failed");
+                VerifyLogString(Print(tempByteArray2) + Print(tempByteArray1) + "bLog");
+                Assert.True(Double.IsNaN(BigInteger.Log(new BigInteger(GetRandomByteArray(s_random, 10)), -s_random.NextDouble())));
             }
 
             // Log Method - value < 0
@@ -85,7 +84,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomNegByteArray(s_random, 10);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 1);
-                Assert.True(VerifyLogString(Print(tempByteArray2) + Print(tempByteArray1) + "bLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray2) + Print(tempByteArray1) + "bLog");
             }
 
             // Log Method - Small BigInteger and 0<base<0.5 
@@ -93,7 +92,7 @@ namespace System.Numerics.Tests
             {
                 BigInteger temp = new BigInteger(GetRandomPosByteArray(s_random, 10));
                 Double newbase = Math.Min(s_random.NextDouble(), 0.5);
-                Assert.True((ApproxEqual(BigInteger.Log(temp, newbase), Math.Log((double)temp, newbase))), " Verification Failed");
+                Assert.True(ApproxEqual(BigInteger.Log(temp, newbase), Math.Log((double)temp, newbase)));
             }
 
             // Log Method - Large BigInteger and 0<base<0.5 
@@ -101,7 +100,7 @@ namespace System.Numerics.Tests
             {
                 BigInteger temp = new BigInteger(GetRandomPosByteArray(s_random, s_random.Next(1, 100)));
                 Double newbase = Math.Min(s_random.NextDouble(), 0.5);
-                Assert.True((ApproxEqual(BigInteger.Log(temp, newbase), Math.Log((double)temp, newbase))), " Verification Failed");
+                Assert.True(ApproxEqual(BigInteger.Log(temp, newbase), Math.Log((double)temp, newbase)));
             }
 
             // Log Method - two small BigIntegers
@@ -109,7 +108,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 3);
-                Assert.True(VerifyLogString(Print(tempByteArray1) + Print(tempByteArray2) + "bLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + Print(tempByteArray2) + "bLog");
             }
 
             // Log Method - one small and one large BigIntegers
@@ -117,7 +116,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 1);
                 tempByteArray2 = GetRandomPosByteArray(s_random, s_random.Next(1, 100));
-                Assert.True(VerifyLogString(Print(tempByteArray1) + Print(tempByteArray2) + "bLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + Print(tempByteArray2) + "bLog");
             }
 
             // Log Method - two large BigIntegers
@@ -125,45 +124,43 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, s_random.Next(1, 100));
                 tempByteArray2 = GetRandomPosByteArray(s_random, s_random.Next(1, 100));
-                Assert.True(VerifyLogString(Print(tempByteArray1) + Print(tempByteArray2) + "bLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + Print(tempByteArray2) + "bLog");
             }
         }
 
-        private static bool VerifyLogString(string opstring)
+        private static void VerifyLogString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -175,6 +172,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomPosByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -187,6 +185,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomNegByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -212,42 +211,29 @@ namespace System.Numerics.Tests
 
             return ret;
         }
+
         private static bool ApproxEqual(double value1, double value2)
         {
             //Special case values;
             if (Double.IsNaN(value1))
+            {
                 return Double.IsNaN(value2);
+            }
             if (Double.IsNegativeInfinity(value1))
+            {
                 return Double.IsNegativeInfinity(value2);
+            }
             if (Double.IsPositiveInfinity(value1))
+            {
                 return Double.IsPositiveInfinity(value2);
+            }
             if (value2 == 0)
+            {
                 return (value1 == 0);
-
+            }
 
             double result = Math.Abs((value1 / value2) - 1);
             return (result <= Double.Parse("1e-15"));
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/log02.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log02.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -15,108 +14,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunLogTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Log Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyLogString(Print(tempByteArray1) + "uLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + "uLog");
             }
 
             // Log Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyLogString(Print(tempByteArray1) + "uLog"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + "uLog");
             }
 
             // Log Method - zero
-            Assert.True(VerifyLogString("0 uLog"), " Verification Failed");
+            VerifyLogString("0 uLog");
 
             // Log Method - -1
-            Assert.True(VerifyLogString("-1 uLog"), " Verification Failed");
+            VerifyLogString("-1 uLog");
 
             // Log Method - 1
-            Assert.True(VerifyLogString("1 uLog"), " Verification Failed");
+            VerifyLogString("1 uLog");
 
-            temp = Int32.MinValue;
             // Log Method - Int32.MinValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog"), " Verification Failed");
+            VerifyLogString(Int32.MinValue.ToString() + " uLog");
 
             // Log Method - Int32.MinValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int32.MinValue.ToString() + " -1 b+ uLog");
 
             // Log Method - Int32.MinValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int32.MinValue.ToString() + " 1 b+ uLog");
 
-            temp = Int32.MaxValue;
             // Log Method - Int32.MaxValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog"), " Verification Failed");
+            VerifyLogString(Int32.MaxValue.ToString() + " uLog");
 
             // Log Method - Int32.MaxValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int32.MaxValue.ToString() + " -1 b+ uLog");
 
             // Log Method - Int32.MaxValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int32.MaxValue.ToString() + " 1 b+ uLog");
 
-            temp = Int64.MinValue;
             // Log Method - Int64.MinValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog"), " Verification Failed");
+            VerifyLogString(Int64.MinValue.ToString() + " uLog");
 
             // Log Method - Int64.MinValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int64.MinValue.ToString() + " -1 b+ uLog");
 
             // Log Method - Int64.MinValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int64.MinValue.ToString() + " 1 b+ uLog");
 
-            temp = Int64.MaxValue;
             // Log Method - Int64.MaxValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog"), " Verification Failed");
+            VerifyLogString(Int64.MaxValue.ToString() + " uLog");
 
             // Log Method - Int64.MaxValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int64.MaxValue.ToString() + " -1 b+ uLog");
 
             // Log Method - Int64.MaxValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog"), " Verification Failed");
+            VerifyLogString(Int64.MaxValue.ToString() + " 1 b+ uLog");
         }
 
-        private static bool VerifyLogString(string opstring)
+        private static void VerifyLogString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +113,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/log02.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log02.cs
@@ -85,34 +85,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/log10.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log10.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -15,108 +14,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunLogTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Log Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyLogString(Print(tempByteArray1) + "uLog10"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + "uLog10");
             }
 
             // Log Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyLogString(Print(tempByteArray1) + "uLog10"), " Verification Failed");
+                VerifyLogString(Print(tempByteArray1) + "uLog10");
             }
 
             // Log Method - zero
-            Assert.True(VerifyLogString("0 uLog10"), " Verification Failed");
+            VerifyLogString("0 uLog10");
 
             // Log Method - -1
-            Assert.True(VerifyLogString("-1 uLog10"), " Verification Failed");
+            VerifyLogString("-1 uLog10");
 
             // Log Method - 1
-            Assert.True(VerifyLogString("1 uLog10"), " Verification Failed");
+            VerifyLogString("1 uLog10");
 
-            temp = Int32.MinValue;
             // Log Method - Int32.MinValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog10"), " Verification Failed");
+            VerifyLogString(Int32.MinValue.ToString() + " uLog10");
 
             // Log Method - Int32.MinValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int32.MinValue.ToString() + " -1 b+ uLog10");
 
             // Log Method - Int32.MinValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int32.MinValue.ToString() + " 1 b+ uLog10");
 
-            temp = Int32.MaxValue;
             // Log Method - Int32.MaxValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog10"), " Verification Failed");
+            VerifyLogString(Int32.MaxValue.ToString() + " uLog10");
 
             // Log Method - Int32.MaxValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int32.MaxValue.ToString() + " -1 b+ uLog10");
 
             // Log Method - Int32.MaxValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int32.MaxValue.ToString() + " 1 b+ uLog10");
 
-            temp = Int64.MinValue;
             // Log Method - Int64.MinValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog10"), " Verification Failed");
+            VerifyLogString(Int64.MinValue.ToString() + " uLog10");
 
             // Log Method - Int64.MinValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int64.MinValue.ToString() + " -1 b+ uLog10");
 
             // Log Method - Int64.MinValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int64.MinValue.ToString() + " 1 b+ uLog10");
 
-            temp = Int64.MaxValue;
             // Log Method - Int64.MaxValue
-            Assert.True(VerifyLogString(temp.ToString() + " uLog10"), " Verification Failed");
+            VerifyLogString(Int64.MaxValue.ToString() + " uLog10");
 
             // Log Method - Int64.MaxValue-1
-            Assert.True(VerifyLogString(temp.ToString() + " -1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int64.MaxValue.ToString() + " -1 b+ uLog10");
 
             // Log Method - Int64.MaxValue+1
-            Assert.True(VerifyLogString(temp.ToString() + " 1 b+ uLog10"), " Verification Failed");
+            VerifyLogString(Int64.MaxValue.ToString() + " 1 b+ uLog10");
         }
 
-        private static bool VerifyLogString(string opstring)
+        private static void VerifyLogString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +113,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/log10.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/log10.cs
@@ -85,34 +85,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/max.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/max.cs
@@ -129,34 +129,19 @@ namespace System.Numerics.Tests
             }
         }
         
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/max.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/max.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
             // Max Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
             // Max Method - One large and one small BigIntegers
@@ -39,11 +38,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
             // Max Method - One large BigIntegers and zero
@@ -51,11 +50,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
             // Max Method - One small BigIntegers and zero
@@ -63,11 +62,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
 
@@ -76,11 +75,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
             // Max Method - One small BigIntegers and -1
@@ -88,11 +87,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
 
@@ -101,11 +100,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 1 };
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = new byte[] { 1 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
 
             // Max Method - One small BigIntegers and 1
@@ -113,49 +112,28 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 1 };
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
 
                 tempByteArray1 = new byte[] { 1 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax"), " Verification Failed");
+                VerifyMaxString(Print(tempByteArray1) + Print(tempByteArray2) + "bMax");
             }
         }
 
-        private static bool VerifyMaxString(string opstring)
+        private static void VerifyMaxString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
-        }
-
+        
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -179,27 +157,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/min.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/min.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
             // Min Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
             // Min Method - One large and one small BigIntegers
@@ -39,11 +38,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
             // Min Method - One large BigIntegers and zero
@@ -51,11 +50,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
             // Min Method - One small BigIntegers and zero
@@ -63,11 +62,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
 
@@ -76,11 +75,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
             // Min Method - One small BigIntegers and -1
@@ -88,11 +87,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
 
@@ -101,11 +100,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 1 };
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = new byte[] { 1 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
 
             // Min Method - One small BigIntegers and 1
@@ -113,49 +112,28 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 1 };
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
 
                 tempByteArray1 = new byte[] { 1 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin"), " Verification Failed");
+                VerifyMinString(Print(tempByteArray1) + Print(tempByteArray2) + "bMin");
             }
         }
 
-        private static bool VerifyMinString(string opstring)
+        private static void VerifyMinString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -179,27 +157,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/min.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/min.cs
@@ -129,34 +129,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -106,15 +105,14 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
             byte[] tempByteArray3 = new byte[0];
-
-
+            
             // ModPow Method - Three Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
                 tempByteArray3 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow");
             }
         }
 
@@ -131,17 +129,17 @@ namespace System.Numerics.Tests
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random);
                 tempByteArray3 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow");
 
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
                 tempByteArray3 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 1);
                 tempByteArray3 = GetRandomByteArray(s_random);
-                Assert.True(VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow");
             }
         }
 
@@ -152,14 +150,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
             byte[] tempByteArray3 = new byte[0];
 
-
             // ModPow Method - Two large and one small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomPosByteArray(s_random);
                 tempByteArray3 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow");
             }
         }
 
@@ -169,26 +166,25 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
             byte[] tempByteArray3 = new byte[0];
-
-
+            
             // ModPow Method - zero power
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow");
 
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow");
 
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + BigInteger.Zero.ToString() + " " + Print(tempByteArray1) + "tModPow");
             }
         }
 
@@ -198,26 +194,25 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
             byte[] tempByteArray3 = new byte[0];
-
-
+            
             // ModPow Method - zero base
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow");
 
                 tempByteArray1 = GetRandomPosByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow");
 
                 tempByteArray1 = GetRandomPosByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow");
 
                 tempByteArray1 = GetRandomPosByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow"), " Verification Failed");
+                VerifyModPowString(Print(tempByteArray2) + Print(tempByteArray1) + BigInteger.Zero.ToString() + " tModPow");
             }
         }
 
@@ -227,19 +222,19 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
             byte[] tempByteArray3 = new byte[0];
-
-
+            
             // Axiom (x^y)%z = modpow(x,y,z)
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 1);
                 tempByteArray3 = GetRandomByteArray(s_random);
-                Assert.True(VerifyIdentityString(Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow",
-                                            Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "bPow" + " bRemainder"), "Test Failed");
+                VerifyIdentityString(
+                    Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "tModPow",
+                    Print(tempByteArray3) + Print(tempByteArray2) + Print(tempByteArray1) + "bPow" + " bRemainder"
+                );
             }
         }
-
 
         [Fact]
         public static void ModPowBoundary()
@@ -248,56 +243,54 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
             byte[] tempByteArray3 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyModPowString(Math.Pow(2, 35) + " " + Math.Pow(2, 32) + " 2 tModPow"), " Verification Failed");
+            VerifyModPowString(Math.Pow(2, 35) + " " + Math.Pow(2, 32) + " 2 tModPow");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyModPowString(Math.Pow(2, 35) + " " + Math.Pow(2, 33) + " 2 tModPow"), " Verification Failed");
+            VerifyModPowString(Math.Pow(2, 35) + " " + Math.Pow(2, 33) + " 2 tModPow");
         }
-
-
-        private static bool VerifyModPowString(string opstring)
+        
+        private static void VerifyModPowString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
 
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
+
         private static Byte[] GetRandomPosByteArray(Random random)
         {
             return GetRandomPosByteArray(random, random.Next(1, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -312,6 +305,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomPosByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -324,6 +318,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomNegByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -336,6 +331,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; i++)
@@ -357,28 +353,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/modpow.cs
@@ -281,32 +281,22 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomPosByteArray(Random random)
+        private static byte[] GetRandomPosByteArray(Random random)
         {
             return GetRandomPosByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            while (IsZero(value))
-            {
-                for (int i = 0; i < value.Length; ++i)
-                {
-                    value[i] = (byte)random.Next(0, 256);
-                }
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
 
-        private static Byte[] GetRandomPosByteArray(Random random, int size)
+        private static byte[] GetRandomPosByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
 
@@ -319,7 +309,7 @@ namespace System.Numerics.Tests
             return value;
         }
 
-        private static Byte[] GetRandomNegByteArray(Random random, int size)
+        private static byte[] GetRandomNegByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
 
@@ -331,28 +321,10 @@ namespace System.Numerics.Tests
 
             return value;
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0)
-                    return false;
-            }
-            return true;
-        }
-
+        
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -210,34 +210,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -24,7 +23,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(random);
                 tempByteArray2 = GetRandomByteArray(random);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
             }
         }
 
@@ -40,7 +39,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(random, 2);
                 tempByteArray2 = GetRandomByteArray(random, 2);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
             }
         }
 
@@ -58,11 +57,11 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray1 = GetRandomByteArray(random);
                     tempByteArray2 = GetRandomByteArray(random, 2);
-                    Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                    VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
 
                     tempByteArray1 = GetRandomByteArray(random, 2);
                     tempByteArray2 = GetRandomByteArray(random);
-                    Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                    VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
                 }
                 catch (IndexOutOfRangeException)
                 {
@@ -85,11 +84,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(random);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
             }
         }
 
@@ -105,11 +104,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(random, 2);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
             }
         }
 
@@ -121,13 +120,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X*1 = X
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " bMultiply", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.One + " bMultiply", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " bMultiply", Int32.MaxValue.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.One + " bMultiply", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.One + " bMultiply", randBigInt + "u+"), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.One + " bMultiply", randBigInt + "u+");
             }
         }
 
@@ -139,14 +138,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X*0 = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bMultiply", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " bMultiply", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bMultiply", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " bMultiply", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(random));
-                ;
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " bMultiply", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " bMultiply", BigInteger.Zero.ToString());
             }
         }
 
@@ -158,15 +156,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: a*b = b*a
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + Int64.MaxValue + " bMultiply", Int64.MaxValue + " " + Int32.MaxValue + " bMultiply"), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + Int64.MaxValue + " bMultiply", Int64.MaxValue + " " + Int32.MaxValue + " bMultiply");
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt1 = Print(GetRandomByteArray(random));
-                ;
                 String randBigInt2 = Print(GetRandomByteArray(random));
-                ;
-                Assert.True(VerifyIdentityString(randBigInt1 + randBigInt2 + "bMultiply", randBigInt2 + randBigInt1 + "bMultiply"), " Verification Failed");
+                VerifyIdentityString(randBigInt1 + randBigInt2 + "bMultiply", randBigInt2 + randBigInt1 + "bMultiply");
             }
         }
 
@@ -177,50 +173,48 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 32) + " 2 bMultiply"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 32) + " 2 bMultiply");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 33) + " 2 bMultiply"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 33) + " 2 bMultiply");
         }
 
-        private static bool VerifyMultiplyString(string opstring)
+        private static void VerifyMultiplyString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -244,27 +238,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/negate.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/negate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -22,101 +21,99 @@ namespace System.Numerics.Tests
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinusString(Print(tempByteArray1) + "uNegate"), " Verification Failed");
+                VerifyMinusString(Print(tempByteArray1) + "uNegate");
             }
 
             // Negate Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinusString(Print(tempByteArray1) + "uNegate"), " Verification Failed");
+                VerifyMinusString(Print(tempByteArray1) + "uNegate");
             }
 
             // Negate Method - zero
-            Assert.True(VerifyMinusString("0 uNegate"), " Verification Failed");
+            VerifyMinusString("0 uNegate");
 
             // Negate Method - -1
-            Assert.True(VerifyMinusString("-1 uNegate"), " Verification Failed");
+            VerifyMinusString("-1 uNegate");
 
             // Negate Method - 1
-            Assert.True(VerifyMinusString("1 uNegate"), " Verification Failed");
+            VerifyMinusString("1 uNegate");
 
             temp = Int32.MinValue;
             // Negate Method - Int32.MinValue
-            Assert.True(VerifyMinusString(temp.ToString() + " uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " uNegate");
 
             // Negate Method - Int32.MinValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " -1 b+ uNegate");
 
             // Negate Method - Int32.MinValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " 1 b+ uNegate");
 
             temp = Int32.MaxValue;
             // Negate Method - Int32.MaxValue
-            Assert.True(VerifyMinusString(temp.ToString() + " uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " uNegate");
 
             // Negate Method - Int32.MaxValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " -1 b+ uNegate");
 
             // Negate Method - Int32.MaxValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " 1 b+ uNegate");
 
             temp = Int64.MinValue;
             // Negate Method - Int64.MinValue
-            Assert.True(VerifyMinusString(temp.ToString() + " uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " uNegate");
 
             // Negate Method - Int64.MinValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " -1 b+ uNegate");
 
             // Negate Method - Int64.MinValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " 1 b+ uNegate");
 
             temp = Int64.MaxValue;
             // Negate Method - Int64.MaxValue
-            Assert.True(VerifyMinusString(temp.ToString() + " uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " uNegate");
 
             // Negate Method - Int64.MaxValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " -1 b+ uNegate");
 
             // Negate Method - Int64.MaxValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ uNegate"), " Verification Failed");
+            VerifyMinusString(temp.ToString() + " 1 b+ uNegate");
         }
 
-        private static bool VerifyMinusString(string opstring)
+        private static void VerifyMinusString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +137,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/negate.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/negate.cs
@@ -109,34 +109,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_add.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_add.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
             }
 
             // Add Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
             }
 
             // Add Method - One large and one small BigIntegers
@@ -41,14 +40,15 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray1 = GetRandomByteArray(s_random);
                     tempByteArray2 = GetRandomByteArray(s_random, 2);
-                    Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                    VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
 
                     tempByteArray1 = GetRandomByteArray(s_random, 2);
                     tempByteArray2 = GetRandomByteArray(s_random);
-                    Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                    VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
                 }
                 catch (IndexOutOfRangeException)
                 {
+                    // TODO: Refactor this
                     Console.WriteLine("Array1: " + Print(tempByteArray1));
                     Console.WriteLine("Array2: " + Print(tempByteArray2));
                     throw;
@@ -60,11 +60,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
             }
 
             // Add Method - One small BigIntegers and zero
@@ -72,88 +72,86 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+"), " Verification Failed");
+                VerifyAdditionString(Print(tempByteArray1) + Print(tempByteArray2) + "b+");
             }
 
             // 32 bit boundary n1=0 n2=0 c=0
-            Assert.True(VerifyAdditionString("0 0 bAdd"), " Verification Failed");
+            VerifyAdditionString("0 0 bAdd");
 
             // 32 bit boundary n1=0 n2=0 c=1
-            Assert.True(VerifyAdditionString((Math.Pow(2, 31) + Math.Pow(2, 30)) + " " + (Math.Pow(2, 31) + Math.Pow(2, 30)) + " b+"), " Verification Failed");
+            VerifyAdditionString((Math.Pow(2, 31) + Math.Pow(2, 30)) + " " + (Math.Pow(2, 31) + Math.Pow(2, 30)) + " b+");
 
             // 32 bit boundary n1=0 n2=1 c=0
-            Assert.True(VerifyAdditionString("0" + " " + Math.Pow(2, 32) + " b+"), " Verification Failed");
+            VerifyAdditionString("0" + " " + Math.Pow(2, 32) + " b+");
 
             // 32 bit boundary n1=0 n2=1 c=1
-            Assert.True(VerifyAdditionString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " b+"), " Verification Failed");
+            VerifyAdditionString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " b+");
 
             // 32 bit boundary n1=1 n2=0 c=0
-            Assert.True(VerifyAdditionString(Math.Pow(2, 32) + " " + "0" + " b+"), " Verification Failed");
+            VerifyAdditionString(Math.Pow(2, 32) + " " + "0" + " b+");
 
             // 32 bit boundary n1=1 n2=0 c=1
-            Assert.True(VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + Math.Pow(2, 31) + " b+"), " Verification Failed");
+            VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + Math.Pow(2, 31) + " b+");
 
             // 32 bit boundary n1=0 n2=1 c=0
-            Assert.True(VerifyAdditionString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " b+"), " Verification Failed");
+            VerifyAdditionString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " b+");
 
             // 32 bit boundary n1=0 n2=1 c=1
-            Assert.True(VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " b+"), " Verification Failed");
+            VerifyAdditionString((Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 32) + Math.Pow(2, 31)) + " b+");
 
             // Identity (x+y)+z == (y+z)+x
-            //Check some identities
+            // Check some identities
             // (x+y)+z = (y+z)+x
 
-            Assert.True(VerifyIdentityString(
-                    Int64.MaxValue.ToString() + " " + Int32.MaxValue.ToString() + " b+ " + Int16.MaxValue.ToString() + " b+",
-                    Int32.MaxValue.ToString() + " " + Int16.MaxValue.ToString() + " b+ " + Int64.MaxValue.ToString() + " b+"
-            ), "Test Failed");
+            VerifyIdentityString(
+                Int64.MaxValue.ToString() + " " + Int32.MaxValue.ToString() + " b+ " + Int16.MaxValue.ToString() + " b+",
+                Int32.MaxValue.ToString() + " " + Int16.MaxValue.ToString() + " b+ " + Int64.MaxValue.ToString() + " b+"
+            );
 
             byte[] x = GetRandomByteArray(s_random);
             byte[] y = GetRandomByteArray(s_random);
             byte[] z = GetRandomByteArray(s_random);
 
-            Assert.True(VerifyIdentityString(Print(x) + Print(y) + Print(z) + "b+ b+", Print(y) + Print(z) + Print(x) + "b+ b+"), " Verification Failed");
+            VerifyIdentityString(Print(x) + Print(y) + Print(z) + "b+ b+", Print(y) + Print(z) + Print(x) + "b+ b+");
         }
 
-        private static bool VerifyAdditionString(string opstring)
+        private static void VerifyAdditionString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -177,27 +175,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_add.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_add.cs
@@ -147,34 +147,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_and.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_and.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One large and one small BigIntegers
@@ -39,11 +38,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One large BigIntegers and zero
@@ -51,11 +50,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One small BigIntegers and zero
@@ -63,11 +62,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One large BigIntegers and -1
@@ -75,11 +74,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One small BigIntegers and -1
@@ -87,11 +86,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One large BigIntegers and Int.MaxValue+1
@@ -99,11 +98,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
 
             // And Method - One small BigIntegers and Int.MaxValue+1
@@ -111,43 +110,21 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
 
                 tempByteArray1 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&"), " Verification Failed");
+                VerifyAndString(Print(tempByteArray1) + Print(tempByteArray2) + "b&");
             }
         }
 
-        private static bool VerifyAndString(string opstring)
+        private static void VerifyAndString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
@@ -177,27 +154,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_and.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_and.cs
@@ -127,33 +127,18 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_decrement.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_decrement.cs
@@ -86,34 +86,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_decrement.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_decrement.cs
@@ -15,108 +15,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunDecrementTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Decrement Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDecrementString(Print(tempByteArray1) + "u--"), " Verification Failed");
+                VerifyDecrementString(Print(tempByteArray1) + "u--");
             }
 
             // Decrement Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDecrementString(Print(tempByteArray1) + "u--"), " Verification Failed");
+                VerifyDecrementString(Print(tempByteArray1) + "u--");
             }
 
             // Decrement Method - zero
-            Assert.True(VerifyDecrementString("0 u--"), " Verification Failed");
+            VerifyDecrementString("0 u--");
 
             // Decrement Method - -1
-            Assert.True(VerifyDecrementString("-1 u--"), " Verification Failed");
+            VerifyDecrementString("-1 u--");
 
             // Decrement Method - 1
-            Assert.True(VerifyDecrementString("1 u--"), " Verification Failed");
+            VerifyDecrementString("1 u--");
 
-            temp = Int32.MinValue;
             // Decrement Method - Int32.MinValue
-            Assert.True(VerifyDecrementString(temp.ToString() + " u--"), " Verification Failed");
+            VerifyDecrementString(Int32.MinValue.ToString() + " u--");
 
             // Decrement Method - Int32.MinValue-1
-            Assert.True(VerifyDecrementString(temp.ToString() + " -1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int32.MinValue.ToString() + " -1 b+ u--");
 
             // Decrement Method - Int32.MinValue+1
-            Assert.True(VerifyDecrementString(temp.ToString() + " 1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int32.MinValue.ToString() + " 1 b+ u--");
 
-            temp = Int32.MaxValue;
             // Decrement Method - Int32.MaxValue
-            Assert.True(VerifyDecrementString(temp.ToString() + " u--"), " Verification Failed");
+            VerifyDecrementString(Int32.MaxValue.ToString() + " u--");
 
             // Decrement Method - Int32.MaxValue-1
-            Assert.True(VerifyDecrementString(temp.ToString() + " -1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int32.MaxValue.ToString() + " -1 b+ u--");
 
             // Decrement Method - Int32.MaxValue+1
-            Assert.True(VerifyDecrementString(temp.ToString() + " 1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int32.MaxValue.ToString() + " 1 b+ u--");
 
-            temp = Int64.MinValue;
             // Decrement Method - Int64.MinValue
-            Assert.True(VerifyDecrementString(temp.ToString() + " u--"), " Verification Failed");
+            VerifyDecrementString(Int64.MinValue.ToString() + " u--");
 
             // Decrement Method - Int64.MinValue-1
-            Assert.True(VerifyDecrementString(temp.ToString() + " -1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int64.MinValue.ToString() + " -1 b+ u--");
 
             // Decrement Method - Int64.MinValue+1
-            Assert.True(VerifyDecrementString(temp.ToString() + " 1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int64.MinValue.ToString() + " 1 b+ u--");
 
-            temp = Int64.MaxValue;
             // Decrement Method - Int64.MaxValue
-            Assert.True(VerifyDecrementString(temp.ToString() + " u--"), " Verification Failed");
+            VerifyDecrementString(Int64.MaxValue.ToString() + " u--");
 
             // Decrement Method - Int64.MaxValue-1
-            Assert.True(VerifyDecrementString(temp.ToString() + " -1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int64.MaxValue.ToString() + " -1 b+ u--");
 
             // Decrement Method - Int64.MaxValue+1
-            Assert.True(VerifyDecrementString(temp.ToString() + " 1 b+ u--"), " Verification Failed");
+            VerifyDecrementString(Int64.MaxValue.ToString() + " 1 b+ u--");
         }
 
-        private static bool VerifyDecrementString(string opstring)
+        private static void VerifyDecrementString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +114,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -11,8 +10,7 @@ namespace System.Numerics.Tests
     {
         private static int s_samples = 10;
         private static Random s_random = new Random(100);
-
-
+        
         [Fact]
         public static void RunDividePositivenonZero()
         {
@@ -24,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/");
             }
 
             // Divide Method - Two Small BigIntegers
@@ -32,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/");
             }
 
             // Divide Method - One large and one small BigIntegers
@@ -40,11 +38,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/");
             }
         }
 
@@ -53,14 +51,13 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
+            
             // Divide Method - One large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -73,7 +70,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/"), " Verification Failed");
+                VerifyDivideString(Print(tempByteArray1) + Print(tempByteArray2) + "b/");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -87,16 +84,15 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
+            
             // Axiom: X/1 = X
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " b/", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " b/", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " b/", Int32.MaxValue.ToString());
+            VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " b/", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(BigInteger.One + " " + randBigInt + "b/", randBigInt.Substring(0, randBigInt.Length - 1)), " Verification Failed");
+                VerifyIdentityString(BigInteger.One + " " + randBigInt + "b/", randBigInt.Substring(0, randBigInt.Length - 1));
             }
         }
 
@@ -106,16 +102,15 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
+            
             // Axiom: 0/X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b/", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b/", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b/", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b/", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " b/", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " b/", BigInteger.Zero.ToString());
             }
         }
 
@@ -124,53 +119,50 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyDivideString(Math.Pow(2, 32) + " 2 b/"), " Verification Failed");
+            VerifyDivideString(Math.Pow(2, 32) + " 2 b/");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyDivideString(Math.Pow(2, 33) + " 2 b/"), " Verification Failed");
+            VerifyDivideString(Math.Pow(2, 33) + " 2 b/");
         }
 
 
-        private static bool VerifyDivideString(string opstring)
+        private static void VerifyDivideString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -185,6 +177,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; i++)
@@ -206,27 +199,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
@@ -158,47 +158,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            while (IsZero(value))
-            {
-                for (int i = 0; i < value.Length; ++i)
-                {
-                    value[i] = (byte)random.Next(0, 256);
-                }
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0)
-                    return false;
-            }
-            return true;
-        }
-
+        
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_increment.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_increment.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -15,108 +14,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunIncrementTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Increment Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyIncrementString(Print(tempByteArray1) + "u++"), " Verification Failed");
+                VerifyIncrementString(Print(tempByteArray1) + "u++");
             }
 
             // Increment Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyIncrementString(Print(tempByteArray1) + "u++"), " Verification Failed");
+                VerifyIncrementString(Print(tempByteArray1) + "u++");
             }
 
             // Increment Method - zero
-            Assert.True(VerifyIncrementString("0 u++"), " Verification Failed");
+            VerifyIncrementString("0 u++");
 
             // Increment Method - -1
-            Assert.True(VerifyIncrementString("-1 u++"), " Verification Failed");
+            VerifyIncrementString("-1 u++");
 
             // Increment Method - 1
-            Assert.True(VerifyIncrementString("1 u++"), " Verification Failed");
+            VerifyIncrementString("1 u++");
 
-            temp = Int32.MinValue;
             // Increment Method - Int32.MinValue
-            Assert.True(VerifyIncrementString(temp.ToString() + " u++"), " Verification Failed");
+            VerifyIncrementString(Int32.MinValue.ToString() + " u++");
 
             // Increment Method - Int32.MinValue-1
-            Assert.True(VerifyIncrementString(temp.ToString() + " -1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int32.MinValue.ToString() + " -1 b+ u++");
 
             // Increment Method - Int32.MinValue+1
-            Assert.True(VerifyIncrementString(temp.ToString() + " 1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int32.MinValue.ToString() + " 1 b+ u++");
 
-            temp = Int32.MaxValue;
             // Increment Method - Int32.MaxValue
-            Assert.True(VerifyIncrementString(temp.ToString() + " u++"), " Verification Failed");
+            VerifyIncrementString(Int32.MaxValue.ToString() + " u++");
 
             // Increment Method - Int32.MaxValue-1
-            Assert.True(VerifyIncrementString(temp.ToString() + " -1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int32.MaxValue.ToString() + " -1 b+ u++");
 
             // Increment Method - Int32.MaxValue+1
-            Assert.True(VerifyIncrementString(temp.ToString() + " 1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int32.MaxValue.ToString() + " 1 b+ u++");
 
-            temp = Int64.MinValue;
             // Increment Method - Int64.MinValue
-            Assert.True(VerifyIncrementString(temp.ToString() + " u++"), " Verification Failed");
+            VerifyIncrementString(Int64.MinValue.ToString() + " u++");
 
             // Increment Method - Int64.MinValue-1
-            Assert.True(VerifyIncrementString(temp.ToString() + " -1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int64.MinValue.ToString() + " -1 b+ u++");
 
             // Increment Method - Int64.MinValue+1
-            Assert.True(VerifyIncrementString(temp.ToString() + " 1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int64.MinValue.ToString() + " 1 b+ u++");
 
-            temp = Int64.MaxValue;
             // Increment Method - Int64.MaxValue
-            Assert.True(VerifyIncrementString(temp.ToString() + " u++"), " Verification Failed");
+            VerifyIncrementString(Int64.MaxValue.ToString() + " u++");
 
             // Increment Method - Int64.MaxValue-1
-            Assert.True(VerifyIncrementString(temp.ToString() + " -1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int64.MaxValue.ToString() + " -1 b+ u++");
 
             // Increment Method - Int64.MaxValue+1
-            Assert.True(VerifyIncrementString(temp.ToString() + " 1 b+ u++"), " Verification Failed");
+            VerifyIncrementString(Int64.MaxValue.ToString() + " 1 b+ u++");
         }
 
-        private static bool VerifyIncrementString(string opstring)
+        private static void VerifyIncrementString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
-        }
-
+        
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +113,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_increment.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_increment.cs
@@ -85,34 +85,19 @@ namespace System.Numerics.Tests
             }
         }
         
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
@@ -153,21 +153,14 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static Byte[] GetRandomPosByteArray(Random random, int size)
@@ -198,15 +191,7 @@ namespace System.Numerics.Tests
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Large BigIntegers - small + Shift
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Large BigIntegers - 32 bit Shift
@@ -39,14 +38,14 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)32 };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
             // LeftShift Method - Large BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 2);
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Large BigIntegers - small - Shift
@@ -54,7 +53,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(-31, 0) };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Large BigIntegers - -32 bit Shift
@@ -62,7 +61,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)0xe0 };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Large BigIntegers - 0 bit Shift
@@ -70,7 +69,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)0 };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Small BigIntegers - large + Shift
@@ -78,7 +77,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Small BigIntegers - small + Shift
@@ -86,7 +85,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Small BigIntegers - 32 bit Shift
@@ -94,14 +93,14 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)32 };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
             // LeftShift Method - Small BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 2);
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Small BigIntegers - small - Shift
@@ -109,7 +108,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(-31, 0) };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Small BigIntegers - -32 bit Shift
@@ -117,7 +116,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)0xe0 };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Small BigIntegers - 0 bit Shift
@@ -125,7 +124,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)0 };
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Positive BigIntegers - Shift to 0
@@ -133,7 +132,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(-1000, -8 * tempByteArray1.Length));
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
             // LeftShift Method - Negative BigIntegers - Shift to -1
@@ -141,45 +140,24 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomNegByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(-1000, -8 * tempByteArray1.Length));
-                Assert.True(VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<"), " Verification Failed");
+                VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
         }
 
-        private static bool VerifyLeftShiftString(string opstring)
+        private static void VerifyLeftShiftString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -191,6 +169,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomPosByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -203,6 +182,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomNegByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -227,27 +207,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_minus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_minus.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -15,108 +14,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunMinusTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Minus Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMinusString(Print(tempByteArray1) + "u-"), " Verification Failed");
+                VerifyMinusString(Print(tempByteArray1) + "u-");
             }
 
             // Minus Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMinusString(Print(tempByteArray1) + "u-"), " Verification Failed");
+                VerifyMinusString(Print(tempByteArray1) + "u-");
             }
 
             // Minus Method - zero
-            Assert.True(VerifyMinusString("0 u-"), " Verification Failed");
+            VerifyMinusString("0 u-");
 
             // Minus Method - -1
-            Assert.True(VerifyMinusString("-1 u-"), " Verification Failed");
+            VerifyMinusString("-1 u-");
 
             // Minus Method - 1
-            Assert.True(VerifyMinusString("1 u-"), " Verification Failed");
+            VerifyMinusString("1 u-");
 
-            temp = Int32.MinValue;
             // Minus Method - Int32.MinValue
-            Assert.True(VerifyMinusString(temp.ToString() + " u-"), " Verification Failed");
+            VerifyMinusString(Int32.MinValue.ToString() + " u-");
 
             // Minus Method - Int32.MinValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int32.MinValue.ToString() + " -1 b+ u-");
 
             // Minus Method - Int32.MinValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int32.MinValue.ToString() + " 1 b+ u-");
 
-            temp = Int32.MaxValue;
             // Minus Method - Int32.MaxValue
-            Assert.True(VerifyMinusString(temp.ToString() + " u-"), " Verification Failed");
+            VerifyMinusString(Int32.MaxValue.ToString() + " u-");
 
             // Minus Method - Int32.MaxValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int32.MaxValue.ToString() + " -1 b+ u-");
 
             // Minus Method - Int32.MaxValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int32.MaxValue.ToString() + " 1 b+ u-");
 
-            temp = Int64.MinValue;
             // Minus Method - Int64.MinValue
-            Assert.True(VerifyMinusString(temp.ToString() + " u-"), " Verification Failed");
+            VerifyMinusString(Int64.MinValue.ToString() + " u-");
 
             // Minus Method - Int64.MinValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int64.MinValue.ToString() + " -1 b+ u-");
 
             // Minus Method - Int64.MinValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int64.MinValue.ToString() + " 1 b+ u-");
 
-            temp = Int64.MaxValue;
             // Minus Method - Int64.MaxValue
-            Assert.True(VerifyMinusString(temp.ToString() + " u-"), " Verification Failed");
+            VerifyMinusString(Int64.MaxValue.ToString() + " u-");
 
             // Minus Method - Int64.MaxValue-1
-            Assert.True(VerifyMinusString(temp.ToString() + " -1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int64.MaxValue.ToString() + " -1 b+ u-");
 
             // Minus Method - Int64.MaxValue+1
-            Assert.True(VerifyMinusString(temp.ToString() + " 1 b+ u-"), " Verification Failed");
+            VerifyMinusString(Int64.MaxValue.ToString() + " 1 b+ u-");
         }
 
-        private static bool VerifyMinusString(string opstring)
+        private static void VerifyMinusString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +113,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_minus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_minus.cs
@@ -85,34 +85,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_modulus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_modulus.cs
@@ -197,47 +197,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            while (IsZero(value))
-            {
-                for (int i = 0; i < value.Length; ++i)
-                {
-                    value[i] = (byte)random.Next(0, 256);
-                }
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0)
-                    return false;
-            }
-            return true;
-        }
-
+        
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_modulus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_modulus.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -24,7 +23,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%");
             }
 
             // Remainder Method - Two Small BigIntegers
@@ -32,7 +31,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%");
             }
 
             // Remainder Method - One large and one small BigIntegers
@@ -40,11 +39,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%");
             }
         }
 
@@ -54,14 +53,12 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-
-
             // Remainder Method - One large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -74,7 +71,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "b%");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -89,13 +86,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyRemainderString(Math.Pow(2, 32) + " 2 b%"), " Verification Failed");
+            VerifyRemainderString(Math.Pow(2, 32) + " 2 b%");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyRemainderString(Math.Pow(2, 33) + " 2 b%"), " Verification Failed");
+            VerifyRemainderString(Math.Pow(2, 33) + " 2 b%");
         }
 
         [Fact]
@@ -105,13 +102,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X%X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + Int32.MaxValue + " b%", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + Int64.MaxValue + " b%", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + Int32.MaxValue + " b%", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + Int64.MaxValue + " b%", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + randBigInt + "b%", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + randBigInt + "b%", BigInteger.Zero.ToString());
             }
         }
 
@@ -122,8 +119,8 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X%(X + Y) = X where Y is 1 if x>=0 and -1 if x<0
-            Assert.True(VerifyIdentityString((new BigInteger(Int32.MaxValue) + 1) + " " + Int32.MaxValue + " b%", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString((new BigInteger(Int64.MaxValue) + 1) + " " + Int64.MaxValue + " b%", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString((new BigInteger(Int32.MaxValue) + 1) + " " + Int32.MaxValue + " b%", Int32.MaxValue.ToString());
+            VerifyIdentityString((new BigInteger(Int64.MaxValue) + 1) + " " + Int64.MaxValue + " b%", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
@@ -134,7 +131,7 @@ namespace System.Numerics.Tests
                 {
                     modify = BigInteger.Negate(modify);
                 }
-                Assert.True(VerifyIdentityString(randBigInt + modify.ToString() + " bAdd " + randBigInt + "b%", randBigInt.Substring(0, randBigInt.Length - 1)), " Verification Failed");
+                VerifyIdentityString(randBigInt + modify.ToString() + " bAdd " + randBigInt + "b%", randBigInt.Substring(0, randBigInt.Length - 1));
             }
         }
 
@@ -143,16 +140,15 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
+            
             // Axiom: X%1 = 0
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " b%", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " b%", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " b%", BigInteger.Zero.ToString());
+            VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " b%", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(BigInteger.One + " " + randBigInt + "b%", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(BigInteger.One + " " + randBigInt + "b%", BigInteger.Zero.ToString());
             }
         }
 
@@ -162,48 +158,43 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-
             // Axiom: 0%X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b%", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b%", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b%", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b%", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " b%", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " b%", BigInteger.Zero.ToString());
             }
         }
 
-        private static bool VerifyRemainderString(string opstring)
+        private static void VerifyRemainderString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
 
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
+        private static void VerifyIdentityString(string opstring1, string opstring2)
         {
-            bool ret = true;
-
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
@@ -247,28 +238,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Multiply Method - Two Small BigIntegers
@@ -31,7 +31,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Multiply Method - One large and one small BigIntegers
@@ -41,14 +41,15 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray1 = GetRandomByteArray(s_random);
                     tempByteArray2 = GetRandomByteArray(s_random, 2);
-                    Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                    VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
 
                     tempByteArray1 = GetRandomByteArray(s_random, 2);
                     tempByteArray2 = GetRandomByteArray(s_random);
-                    Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                    VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
                 }
                 catch (IndexOutOfRangeException)
                 {
+                    // TODO: Refactor this
                     Console.WriteLine("Array1: " + Print(tempByteArray1));
                     Console.WriteLine("Array2: " + Print(tempByteArray2));
                     throw;
@@ -61,18 +62,17 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
+            
             // Multiply Method - One large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Multiply Method - One small BigIntegers and zero
@@ -80,11 +80,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
         }
 
@@ -94,15 +94,14 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-
             // Axiom: X*1 = X
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " b*", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.One + " b*", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " b*", Int32.MaxValue.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.One + " b*", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.One + " b*", randBigInt + "u+"), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.One + " b*", randBigInt + "u+");
             }
         }
 
@@ -114,14 +113,13 @@ namespace System.Numerics.Tests
 
 
             // Axiom: X*0 = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                ;
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " b*", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " b*", BigInteger.Zero.ToString());
             }
         }
 
@@ -131,13 +129,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 32) + " 2 b*"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 32) + " 2 b*");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 33) + " 2 b*"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 33) + " 2 b*");
         }
 
         [Fact]
@@ -146,35 +144,35 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 32) + " 2 b*"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 32) + " 2 b*");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 33) + " 2 b*"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 33) + " 2 b*");
         }
 
-        public static bool RunMultiplyTests(Random random)
+        [Fact]
+        public static void RunMultiplyTests()
         {
-            bool ret = true;
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
             // Multiply Method - Two Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random);
-                tempByteArray2 = GetRandomByteArray(random);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = GetRandomByteArray(s_random);
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Multiply Method - Two Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random, 2);
-                tempByteArray2 = GetRandomByteArray(random, 2);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = GetRandomByteArray(s_random, 2);
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Multiply Method - One large and one small BigIntegers
@@ -182,16 +180,17 @@ namespace System.Numerics.Tests
             {
                 try
                 {
-                    tempByteArray1 = GetRandomByteArray(random);
-                    tempByteArray2 = GetRandomByteArray(random, 2);
-                    Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                    tempByteArray1 = GetRandomByteArray(s_random);
+                    tempByteArray2 = GetRandomByteArray(s_random, 2);
+                    VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
 
-                    tempByteArray1 = GetRandomByteArray(random, 2);
-                    tempByteArray2 = GetRandomByteArray(random);
-                    Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                    tempByteArray1 = GetRandomByteArray(s_random, 2);
+                    tempByteArray2 = GetRandomByteArray(s_random);
+                    VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
                 }
                 catch (IndexOutOfRangeException)
                 {
+                    // TODO: Refactor this
                     Console.WriteLine("Array1: " + Print(tempByteArray1));
                     Console.WriteLine("Array2: " + Print(tempByteArray2));
                     throw;
@@ -201,109 +200,99 @@ namespace System.Numerics.Tests
             // Multiply Method - One large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random);
+                tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
 
                 tempByteArray1 = new byte[] { 0 };
-                tempByteArray2 = GetRandomByteArray(random);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                tempByteArray2 = GetRandomByteArray(s_random);
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Multiply Method - One small BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
-                tempByteArray1 = GetRandomByteArray(random, 2);
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
 
                 tempByteArray1 = new byte[] { 0 };
-                tempByteArray2 = GetRandomByteArray(random, 2);
-                Assert.True(VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*"), " Verification Failed");
+                tempByteArray2 = GetRandomByteArray(s_random, 2);
+                VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
             }
 
             // Axiom: X*1 = X
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " b*", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.One + " b*", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " b*", Int32.MaxValue.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.One + " b*", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
-                String randBigInt = Print(GetRandomByteArray(random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.One + " b*", randBigInt + "u+"), " Verification Failed");
+                String randBigInt = Print(GetRandomByteArray(s_random));
+                VerifyIdentityString(randBigInt + BigInteger.One + " b*", randBigInt + "u+");
             }
 
-
             // Axiom: X*0 = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " b*", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
-                String randBigInt = Print(GetRandomByteArray(random));
-                ;
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " b*", BigInteger.Zero.ToString()), " Verification Failed");
+                String randBigInt = Print(GetRandomByteArray(s_random));
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " b*", BigInteger.Zero.ToString());
             }
 
             // Axiom: a*b = b*a
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + Int64.MaxValue + " b*", Int64.MaxValue + " " + Int32.MaxValue + " b*"), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + Int64.MaxValue + " b*", Int64.MaxValue + " " + Int32.MaxValue + " b*");
 
             for (int i = 0; i < s_samples; i++)
             {
-                String randBigInt1 = Print(GetRandomByteArray(random));
-                ;
-                String randBigInt2 = Print(GetRandomByteArray(random));
-                ;
-                Assert.True(VerifyIdentityString(randBigInt1 + randBigInt2 + "b*", randBigInt2 + randBigInt1 + "b*"), " Verification Failed");
+                String randBigInt1 = Print(GetRandomByteArray(s_random));
+                String randBigInt2 = Print(GetRandomByteArray(s_random));
+                VerifyIdentityString(randBigInt1 + randBigInt2 + "b*", randBigInt2 + randBigInt1 + "b*");
             }
-
-
-
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 32) + " 2 b*"), " Verification Failed");
+            VerifyMultiplyString(Math.Pow(2, 32) + " 2 b*");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyMultiplyString(Math.Pow(2, 33) + " 2 b*"), " Verification Failed");
-
-            return ret;
+            VerifyMultiplyString(Math.Pow(2, 33) + " 2 b*");
         }
 
-        private static bool VerifyMultiplyString(string opstring)
+        private static void VerifyMultiplyString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -327,27 +316,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
@@ -288,34 +288,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_not.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_not.cs
@@ -85,34 +85,19 @@ namespace System.Numerics.Tests
             }
         }
         
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_not.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_not.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -15,108 +14,82 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunNotTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Not Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyNotString(Print(tempByteArray1) + "u~"), " Verification Failed");
+                VerifyNotString(Print(tempByteArray1) + "u~");
             }
 
             // Not Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyNotString(Print(tempByteArray1) + "u~"), " Verification Failed");
+                VerifyNotString(Print(tempByteArray1) + "u~");
             }
 
             // Not Method - zero
-            Assert.True(VerifyNotString("0 u~"), " Verification Failed");
+            VerifyNotString("0 u~");
 
             // Not Method - -1
-            Assert.True(VerifyNotString("-1 u~"), " Verification Failed");
+            VerifyNotString("-1 u~");
 
             // Not Method - 1
-            Assert.True(VerifyNotString("1 u~"), " Verification Failed");
+            VerifyNotString("1 u~");
 
-            temp = Int32.MinValue;
             // Not Method - Int32.MinValue
-            Assert.True(VerifyNotString(temp.ToString() + " u~"), " Verification Failed");
+            VerifyNotString(Int32.MinValue.ToString() + " u~");
 
             // Not Method - Int32.MinValue-1
-            Assert.True(VerifyNotString(temp.ToString() + " -1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int32.MinValue.ToString() + " -1 b+ u~");
 
             // Not Method - Int32.MinValue+1
-            Assert.True(VerifyNotString(temp.ToString() + " 1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int32.MinValue.ToString() + " 1 b+ u~");
 
-            temp = Int32.MaxValue;
             // Not Method - Int32.MaxValue
-            Assert.True(VerifyNotString(temp.ToString() + " u~"), " Verification Failed");
+            VerifyNotString(Int32.MaxValue.ToString() + " u~");
 
             // Not Method - Int32.MaxValue-1
-            Assert.True(VerifyNotString(temp.ToString() + " -1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int32.MaxValue.ToString() + " -1 b+ u~");
 
             // Not Method - Int32.MaxValue+1
-            Assert.True(VerifyNotString(temp.ToString() + " 1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int32.MaxValue.ToString() + " 1 b+ u~");
 
-            temp = Int64.MinValue;
             // Not Method - Int64.MinValue
-            Assert.True(VerifyNotString(temp.ToString() + " u~"), " Verification Failed");
+            VerifyNotString(Int64.MinValue.ToString() + " u~");
 
             // Not Method - Int64.MinValue-1
-            Assert.True(VerifyNotString(temp.ToString() + " -1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int64.MinValue.ToString() + " -1 b+ u~");
 
             // Not Method - Int64.MinValue+1
-            Assert.True(VerifyNotString(temp.ToString() + " 1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int64.MinValue.ToString() + " 1 b+ u~");
 
-            temp = Int64.MaxValue;
             // Not Method - Int64.MaxValue
-            Assert.True(VerifyNotString(temp.ToString() + " u~"), " Verification Failed");
+            VerifyNotString(Int64.MaxValue.ToString() + " u~");
 
             // Not Method - Int64.MaxValue-1
-            Assert.True(VerifyNotString(temp.ToString() + " -1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int64.MaxValue.ToString() + " -1 b+ u~");
 
             // Not Method - Int64.MaxValue+1
-            Assert.True(VerifyNotString(temp.ToString() + " 1 b+ u~"), " Verification Failed");
+            VerifyNotString(Int64.MaxValue.ToString() + " 1 b+ u~");
         }
 
-        private static bool VerifyNotString(string opstring)
+        private static void VerifyNotString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
-        }
-
+        
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +113,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_or.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_or.cs
@@ -127,34 +127,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_or.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_or.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One large and one small BigIntegers
@@ -39,11 +38,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One large BigIntegers and zero
@@ -51,11 +50,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One small BigIntegers and zero
@@ -63,11 +62,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One large BigIntegers and -1
@@ -75,11 +74,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One small BigIntegers and -1
@@ -87,11 +86,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One large BigIntegers and Int.MaxValue+1
@@ -99,11 +98,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
 
             // Or Method - One small BigIntegers and Int.MaxValue+1
@@ -111,49 +110,28 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
 
                 tempByteArray1 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|"), " Verification Failed");
+                VerifyOrString(Print(tempByteArray1) + Print(tempByteArray2) + "b|");
             }
         }
 
-        private static bool VerifyOrString(string opstring)
+        private static void VerifyOrString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -177,27 +155,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_plus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_plus.cs
@@ -90,34 +90,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_plus.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_plus.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -22,101 +21,80 @@ namespace System.Numerics.Tests
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifyPlusString(Print(tempByteArray1) + "u+"), " Verification Failed");
+                VerifyPlusString(Print(tempByteArray1) + "u+");
             }
 
             // Plus Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyPlusString(Print(tempByteArray1) + "u+"), " Verification Failed");
+                VerifyPlusString(Print(tempByteArray1) + "u+");
             }
 
             // Plus Method - zero
-            Assert.True(VerifyPlusString("0 u+"), " Verification Failed");
+            VerifyPlusString("0 u+");
 
             // Plus Method - -1
-            Assert.True(VerifyPlusString("-1 u+"), " Verification Failed");
+            VerifyPlusString("-1 u+");
 
             // Plus Method - 1
-            Assert.True(VerifyPlusString("1 u+"), " Verification Failed");
+            VerifyPlusString("1 u+");
 
             temp = Int32.MinValue;
             // Plus Method - Int32.MinValue
-            Assert.True(VerifyPlusString(temp.ToString() + " u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " u+");
 
             // Plus Method - Int32.MinValue-1
-            Assert.True(VerifyPlusString(temp.ToString() + " -1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " -1 b+ u+");
 
             // Plus Method - Int32.MinValue+1
-            Assert.True(VerifyPlusString(temp.ToString() + " 1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " 1 b+ u+");
 
             temp = Int32.MaxValue;
             // Plus Method - Int32.MaxValue
-            Assert.True(VerifyPlusString(temp.ToString() + " u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " u+");
 
             // Plus Method - Int32.MaxValue-1
-            Assert.True(VerifyPlusString(temp.ToString() + " -1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " -1 b+ u+");
 
             // Plus Method - Int32.MaxValue+1
-            Assert.True(VerifyPlusString(temp.ToString() + " 1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " 1 b+ u+");
 
             temp = Int64.MinValue;
             // Plus Method - Int64.MinValue
-            Assert.True(VerifyPlusString(temp.ToString() + " u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " u+");
 
             // Plus Method - Int64.MinValue-1
-            Assert.True(VerifyPlusString(temp.ToString() + " -1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " -1 b+ u+");
 
             // Plus Method - Int64.MinValue+1
-            Assert.True(VerifyPlusString(temp.ToString() + " 1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " 1 b+ u+");
 
             temp = Int64.MaxValue;
             // Plus Method - Int64.MaxValue
-            Assert.True(VerifyPlusString(temp.ToString() + " u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " u+");
 
             // Plus Method - Int64.MaxValue-1
-            Assert.True(VerifyPlusString(temp.ToString() + " -1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " -1 b+ u+");
 
             // Plus Method - Int64.MaxValue+1
-            Assert.True(VerifyPlusString(temp.ToString() + " 1 b+ u+"), " Verification Failed");
+            VerifyPlusString(temp.ToString() + " 1 b+ u+");
         }
 
-        private static bool VerifyPlusString(string opstring)
+        private static void VerifyPlusString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +118,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,12 +22,7 @@ namespace System.Numerics.Tests
                 BigInteger a1 = (a << (i + 31));
                 BigInteger a2 = a1 >> i;
 
-                if (a2 != b)
-                {
-                    Console.WriteLine("Unexpected Results for i={0}: Expected: {1} Got: {2}", i, b.ToString("X"), a2.ToString("X"));
-                    Console.WriteLine("Intermediate: {0}", a1.ToString("X"));
-                    Assert.True(false, "Incorrect verification");
-                }
+                Assert.Equal(b, a2);
             }
         }
 
@@ -43,7 +37,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Large BigIntegers - small + Shift
@@ -51,7 +45,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Large BigIntegers - 32 bit Shift
@@ -59,14 +53,14 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)32 };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
             // RightShift Method - Large BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 2);
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Large BigIntegers - small - Shift
@@ -74,7 +68,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(-31, 0) };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Large BigIntegers - -32 bit Shift
@@ -82,7 +76,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)0xe0 };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Large BigIntegers - 0 bit Shift
@@ -90,7 +84,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)0 };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Small BigIntegers - large + Shift
@@ -98,7 +92,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Small BigIntegers - small + Shift
@@ -106,8 +100,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
-
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Small BigIntegers - 32 bit Shift
@@ -115,14 +108,14 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)32 };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
             // RightShift Method - Small BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 2);
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Small BigIntegers - small - Shift
@@ -130,7 +123,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(-31, 0) };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Small BigIntegers - -32 bit Shift
@@ -138,7 +131,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)0xe0 };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Small BigIntegers - 0 bit Shift
@@ -146,7 +139,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)0 };
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Positive BigIntegers - Shift to 0
@@ -154,7 +147,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(8 * tempByteArray1.Length, 1000));
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
             // RightShift Method - Negative BigIntegers - Shift to -1
@@ -162,45 +155,24 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomNegByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(8 * tempByteArray1.Length, 1000));
-                Assert.True(VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>"), " Verification Failed");
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
         }
 
-        private static bool VerifyRightShiftString(string opstring)
+        private static void VerifyRightShiftString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -212,6 +184,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomPosByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -224,6 +197,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomNegByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -248,27 +222,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -168,21 +168,14 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static Byte[] GetRandomPosByteArray(Random random, int size)
@@ -213,15 +206,7 @@ namespace System.Numerics.Tests
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_subtract.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_subtract.cs
@@ -113,34 +113,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_subtract.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_subtract.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
             }
 
             // Subtract Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
             }
 
             // Subtract Method - One large and one small BigIntegers
@@ -41,14 +40,15 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray1 = GetRandomByteArray(s_random);
                     tempByteArray2 = GetRandomByteArray(s_random, 2);
-                    Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                    VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
 
                     tempByteArray1 = GetRandomByteArray(s_random, 2);
                     tempByteArray2 = GetRandomByteArray(s_random);
-                    Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                    VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
                 }
                 catch (IndexOutOfRangeException)
                 {
+                    // TODO: Refactor this
                     Console.WriteLine("Array1: " + Print(tempByteArray1));
                     Console.WriteLine("Array2: " + Print(tempByteArray2));
                     throw;
@@ -60,11 +60,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
             }
 
             // Subtract Method - One small BigIntegers and zero
@@ -72,53 +72,52 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "b-");
             }
 
             // 32 bit boundary c=0 n1=0 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 34) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 34) + " b-");
 
             // 32 bit boundary c=0 n1=0 n2=1
-            Assert.True(VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 34) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 34) + " b-");
 
             // 32 bit boundary c=0 n1=1 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 32) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 32) + " b-");
 
             // 32 bit boundary c=0 n1=1 n2=1
-            Assert.True(VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " b-");
 
             // 32 bit boundary c=1 n1=0 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 33) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 33) + " b-");
 
             // 32 bit boundary c=1 n1=0 n2=1
-            Assert.True(VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 32) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 32) + " b-");
 
             // 32 bit boundary c=1 n1=1 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 33)) + " b-"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 33)) + " b-");
 
             // 32 bit boundary c=1 n1=1 n2=1
-            Assert.True(VerifySubtractString((Math.Pow(2, 33) + Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 34) + Math.Pow(2, 33) + Math.Pow(2, 31)) + " b-"), "Verification failed.");
+            VerifySubtractString((Math.Pow(2, 33) + Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 34) + Math.Pow(2, 33) + Math.Pow(2, 31)) + " b-");
         }
 
-        private static bool VerifySubtractString(string opstring)
+        private static void VerifySubtractString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -142,27 +141,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_xor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_xor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - Two Small BigIntegers
@@ -31,7 +30,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One large and one small BigIntegers
@@ -39,11 +38,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One large BigIntegers and zero
@@ -51,11 +50,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One small BigIntegers and zero
@@ -63,11 +62,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One large BigIntegers and -1
@@ -75,11 +74,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One small BigIntegers and -1
@@ -87,11 +86,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0xFF };
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = new byte[] { 0xFF };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One large BigIntegers and Int.MaxValue+1
@@ -99,11 +98,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
 
             // Xor Method - One small BigIntegers and Int.MaxValue+1
@@ -111,49 +110,28 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
 
                 tempByteArray1 = new byte[] { 0x00, 0x00, 0x00, 0x80, 0x00 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^"), " Verification Failed");
+                VerifyXorString(Print(tempByteArray1) + Print(tempByteArray2) + "b^");
             }
         }
 
-        private static bool VerifyXorString(string opstring)
+        private static void VerifyXorString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
-        }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
-
-            StackCalc sc1 = new StackCalc(opstring1);
-            while (sc1.DoNextOperation())
-            {	//Run the full calculation
-                sc1.DoNextOperation();
-            }
-
-            StackCalc sc2 = new StackCalc(opstring2);
-            while (sc2.DoNextOperation())
-            {	//Run the full calculation
-                sc2.DoNextOperation();
-            }
-
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -177,27 +155,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_xor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_xor.cs
@@ -127,34 +127,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
@@ -49,13 +48,13 @@ namespace System.Numerics.Tests
             NumberStyles invalid = (NumberStyles)0x7c00;
             Assert.Throws<ArgumentException>(() =>
             {
-                Eval(BigInteger.Parse("1", invalid).ToString("d"), "1", String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse("1").ToString("d"), "1"));
+                BigInteger.Parse("1", invalid).ToString("d");
             });
             Assert.Throws<ArgumentException>(() =>
             {
                 BigInteger junk;
                 BigInteger.TryParse("1", invalid, null, out junk);
-                Eval(junk.ToString("d"), "1", String.Format("Roundtrip between TryParse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", junk.ToString("d"), "1"));
+                Assert.Equal(junk.ToString("d"), "1");
             });
 
             //FormatProvider tests
@@ -71,99 +70,99 @@ namespace System.Numerics.Tests
             // ***************************
             // *** FormatProvider - Currencies
             // ***************************
-            Assert.True(VerifyFormatParse("@ 12#34#56!", NumberStyles.Any, nfi, new BigInteger(123456)), " Verification Failed");
-            Assert.True(VerifyFormatParse("(12#34#56!@)", NumberStyles.Any, nfi, new BigInteger(-123456)), " Verification Failed");
+            VerifyFormatParse("@ 12#34#56!", NumberStyles.Any, nfi, new BigInteger(123456));
+            VerifyFormatParse("(12#34#56!@)", NumberStyles.Any, nfi, new BigInteger(-123456));
 
             //Numbers
             // ***************************
             // *** FormatProvider - Numbers
             // ***************************
-            Assert.True(VerifySimpleFormatParse(">1234567", nfi, new BigInteger(1234567)), " Verification Failed");
-            Assert.True(VerifySimpleFormatParse("<1234567", nfi, new BigInteger(-1234567)), " Verification Failed");
-            Assert.True(VerifyFormatParse("123&4567^", NumberStyles.Any, nfi, new BigInteger(1234567)), " Verification Failed");
-            Assert.True(VerifyFormatParse("123&4567^ <", NumberStyles.Any, nfi, new BigInteger(-1234567)), " Verification Failed");
+            VerifySimpleFormatParse(">1234567", nfi, new BigInteger(1234567));
+            VerifySimpleFormatParse("<1234567", nfi, new BigInteger(-1234567));
+            VerifyFormatParse("123&4567^", NumberStyles.Any, nfi, new BigInteger(1234567));
+            VerifyFormatParse("123&4567^ <", NumberStyles.Any, nfi, new BigInteger(-1234567));
         }
 
         public static void VerifyDefaultParse(Random random)
         {
             // BasicTests
-            Assert.True(VerifyFailParseToString(null, new ArgumentNullException().GetType()), " Verification Failed");
-            Assert.True(VerifyFailParseToString(String.Empty, new FormatException().GetType()), " Verification Failed");
-            Assert.True(VerifyParseToString("0"), " Verification Failed");
-            Assert.True(VerifyParseToString("000"), " Verification Failed");
-            Assert.True(VerifyParseToString("1"), " Verification Failed");
-            Assert.True(VerifyParseToString("001"), " Verification Failed");
+            VerifyFailParseToString(null, typeof(ArgumentNullException));
+            VerifyFailParseToString(String.Empty, typeof(FormatException));
+            VerifyParseToString("0");
+            VerifyParseToString("000");
+            VerifyParseToString("1");
+            VerifyParseToString("001");
 
             // SimpleNumbers - Small
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 10, random)), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 10, random));
             }
 
             // SimpleNumbers - Large
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(100, 1000, random)), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(100, 1000, random));
             }
 
             // Leading White
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString("\u0009\u0009\u0009" + GetDigitSequence(1, 100, random)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000A\u000A\u000A" + GetDigitSequence(1, 100, random)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000B\u000B\u000B" + GetDigitSequence(1, 100, random)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000C\u000C\u000C" + GetDigitSequence(1, 100, random)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000D\u000D\u000D" + GetDigitSequence(1, 100, random)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u0020\u0020\u0020" + GetDigitSequence(1, 100, random)), " Verification Failed");
+                VerifyParseToString("\u0009\u0009\u0009" + GetDigitSequence(1, 100, random));
+                VerifyParseToString("\u000A\u000A\u000A" + GetDigitSequence(1, 100, random));
+                VerifyParseToString("\u000B\u000B\u000B" + GetDigitSequence(1, 100, random));
+                VerifyParseToString("\u000C\u000C\u000C" + GetDigitSequence(1, 100, random));
+                VerifyParseToString("\u000D\u000D\u000D" + GetDigitSequence(1, 100, random));
+                VerifyParseToString("\u0020\u0020\u0020" + GetDigitSequence(1, 100, random));
             }
 
             // Trailing White
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0009\u0009\u0009"), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000A\u000A\u000A"), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000B\u000B\u000B"), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000C\u000C\u000C"), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000D\u000D\u000D"), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0020\u0020\u0020"), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0009\u0009\u0009");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000A\u000A\u000A");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000B\u000B\u000B");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000C\u000C\u000C");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000D\u000D\u000D");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0020\u0020\u0020");
             }
 
             // Leading Sign
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + GetDigitSequence(1, 100, random)), " Verification Failed");
-                Assert.True(VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + GetDigitSequence(1, 100, random)), " Verification Failed");
+                VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + GetDigitSequence(1, 100, random));
+                VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + GetDigitSequence(1, 100, random));
             }
 
             // Trailing Sign
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, new FormatException().GetType()), " Verification Failed");
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign, new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, typeof(FormatException));
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign, typeof(FormatException));
             }
 
             // Parentheses
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString("(" + GetDigitSequence(1, 100, random) + ")", new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString("(" + GetDigitSequence(1, 100, random) + ")", typeof(FormatException));
             }
 
             // Decimal Point - end
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, typeof(FormatException));
             }
 
             // Decimal Point - middle
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + "000", new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + "000", typeof(FormatException));
             }
 
             // Decimal Point - non-zero decimal
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + GetDigitSequence(20, 25, random), new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + GetDigitSequence(20, 25, random), typeof(FormatException));
             }
 
             // Thousands
@@ -176,116 +175,116 @@ namespace System.Numerics.Tests
                 sizes = CultureInfo.CurrentUICulture.NumberFormat.NumberGroupSizes;
                 seperator = CultureInfo.CurrentUICulture.NumberFormat.NumberGroupSeparator;
                 digits = GenerateGroups(sizes, seperator, random);
-                Assert.True(VerifyFailParseToString(digits, new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(digits, typeof(FormatException));
             }
 
             // Exponent
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + "e" + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + GetDigitSequence(1, 3, random), new FormatException().GetType()), " Verification Failed");
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 100, random) + "e" + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + GetDigitSequence(1, 3, random), new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + "e" + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + GetDigitSequence(1, 3, random), typeof(FormatException));
+                VerifyFailParseToString(GetDigitSequence(1, 100, random) + "e" + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + GetDigitSequence(1, 3, random), typeof(FormatException));
             }
 
             // Currency Symbol
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(CultureInfo.CurrentUICulture.NumberFormat.CurrencySymbol + GetDigitSequence(1, 100, random), new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(CultureInfo.CurrentUICulture.NumberFormat.CurrencySymbol + GetDigitSequence(1, 100, random), typeof(FormatException));
             }
 
             // Hex Specifier
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetHexDigitSequence(1, 100, random), new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetHexDigitSequence(1, 100, random), typeof(FormatException));
             }
 
             // Invalid Chars
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyFailParseToString(GetDigitSequence(1, 50, random) + GetRandomInvalidChar(random) + GetDigitSequence(1, 50, random), new FormatException().GetType()), " Verification Failed");
+                VerifyFailParseToString(GetDigitSequence(1, 50, random) + GetRandomInvalidChar(random) + GetDigitSequence(1, 50, random), typeof(FormatException));
             }
         }
 
         public static void VerifyNumberStyles(NumberStyles ns, Random random)
         {
-            Assert.True(VerifyParseToString(null, ns, false, null), " Verification Failed");
-            Assert.True(VerifyParseToString(String.Empty, ns, false), " Verification Failed");
-            Assert.True(VerifyParseToString("0", ns, true), " Verification Failed");
-            Assert.True(VerifyParseToString("000", ns, true), " Verification Failed");
-            Assert.True(VerifyParseToString("1", ns, true), " Verification Failed");
-            Assert.True(VerifyParseToString("001", ns, true), " Verification Failed");
+            VerifyParseToString(null, ns, false, null);
+            VerifyParseToString(String.Empty, ns, false);
+            VerifyParseToString("0", ns, true);
+            VerifyParseToString("000", ns, true);
+            VerifyParseToString("1", ns, true);
+            VerifyParseToString("001", ns, true);
 
             // SimpleNumbers - Small
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 10, random), ns, true), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 10, random), ns, true);
             }
 
             // SimpleNumbers - Large
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(100, 1000, random), ns, true), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(100, 1000, random), ns, true);
             }
 
             // Leading White
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString("\u0009\u0009\u0009" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000A\u000A\u000A" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000B\u000B\u000B" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000C\u000C\u000C" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u000D\u000D\u000D" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString("\u0020\u0020\u0020" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0)), " Verification Failed");
+                VerifyParseToString("\u0009\u0009\u0009" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0));
+                VerifyParseToString("\u000A\u000A\u000A" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0));
+                VerifyParseToString("\u000B\u000B\u000B" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0));
+                VerifyParseToString("\u000C\u000C\u000C" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0));
+                VerifyParseToString("\u000D\u000D\u000D" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0));
+                VerifyParseToString("\u0020\u0020\u0020" + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingWhite) != 0));
             }
 
             // Trailing White
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0009\u0009\u0009", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000A\u000A\u000A", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000B\u000B\u000B", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000C\u000C\u000C", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000D\u000D\u000D", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0020\u0020\u0020", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0)), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0009\u0009\u0009", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0));
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000A\u000A\u000A", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0));
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000B\u000B\u000B", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0));
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000C\u000C\u000C", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0));
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u000D\u000D\u000D", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0));
+                VerifyParseToString(GetDigitSequence(1, 100, random) + "\u0020\u0020\u0020", ns, ((ns & NumberStyles.AllowTrailingWhite) != 0));
             }
 
             // Leading Sign
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingSign) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingSign) != 0)), " Verification Failed");
+                VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingSign) != 0));
+                VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowLeadingSign) != 0));
             }
 
             // Trailing Sign
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, ns, ((ns & NumberStyles.AllowTrailingSign) != 0)), " Verification Failed");
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign, ns, ((ns & NumberStyles.AllowTrailingSign) != 0)), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign, ns, ((ns & NumberStyles.AllowTrailingSign) != 0));
+                VerifyParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign, ns, ((ns & NumberStyles.AllowTrailingSign) != 0));
             }
 
             // Parentheses
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString("(" + GetDigitSequence(1, 100, random) + ")", ns, ((ns & NumberStyles.AllowParentheses) != 0)), " Verification Failed");
+                VerifyParseToString("(" + GetDigitSequence(1, 100, random) + ")", ns, ((ns & NumberStyles.AllowParentheses) != 0));
             }
 
             // Decimal Point - end
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, ns, ((ns & NumberStyles.AllowDecimalPoint) != 0)), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, ns, ((ns & NumberStyles.AllowDecimalPoint) != 0));
             }
 
             // Decimal Point - middle
             for (int i = 0; i < s_samples; i++)
             {
                 string digits = GetDigitSequence(1, 100, random);
-                Assert.True(VerifyParseToString(digits + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + "000", ns, ((ns & NumberStyles.AllowDecimalPoint) != 0), digits), " Verification Failed");
+                VerifyParseToString(digits + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + "000", ns, ((ns & NumberStyles.AllowDecimalPoint) != 0), digits);
             }
 
             // Decimal Point - non-zero decimal
             for (int i = 0; i < s_samples; i++)
             {
                 string digits = GetDigitSequence(1, 100, random);
-                Assert.True(VerifyParseToString(digits + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + GetDigitSequence(20, 25, random), ns, false, digits), " Verification Failed");
+                VerifyParseToString(digits + CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator + GetDigitSequence(20, 25, random), ns, false, digits);
             }
 
             // Thousands
@@ -298,7 +297,7 @@ namespace System.Numerics.Tests
                 sizes = CultureInfo.CurrentUICulture.NumberFormat.NumberGroupSizes;
                 seperator = CultureInfo.CurrentUICulture.NumberFormat.NumberGroupSeparator;
                 digits = GenerateGroups(sizes, seperator, random);
-                Assert.True(VerifyParseToString(digits, ns, ((ns & NumberStyles.AllowThousands) != 0)), " Verification Failed");
+                VerifyParseToString(digits, ns, ((ns & NumberStyles.AllowThousands) != 0));
             }
 
             // Exponent
@@ -309,7 +308,7 @@ namespace System.Numerics.Tests
                 int expValue = Int32.Parse(exp);
                 string zeros = new string('0', expValue);
                 //Positive Exponents
-                Assert.True(VerifyParseToString(digits + "e" + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + exp, ns, ((ns & NumberStyles.AllowExponent) != 0), digits + zeros), " Verification Failed");
+                VerifyParseToString(digits + "e" + CultureInfo.CurrentUICulture.NumberFormat.PositiveSign + exp, ns, ((ns & NumberStyles.AllowExponent) != 0), digits + zeros);
                 //Negative Exponents
                 bool valid = ((ns & NumberStyles.AllowExponent) != 0);
                 for (int j = digits.Length; (valid && (j > 0) && (j > digits.Length - expValue)); j--)
@@ -321,167 +320,129 @@ namespace System.Numerics.Tests
                 }
                 if (digits.Length - Int32.Parse(exp) > 0)
                 {
-                    Assert.True(VerifyParseToString(digits + "e" + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + exp, ns, valid, digits.Substring(0, digits.Length - Int32.Parse(exp))), " Verification Failed");
+                    VerifyParseToString(digits + "e" + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + exp, ns, valid, digits.Substring(0, digits.Length - Int32.Parse(exp)));
                 }
                 else
                 {
-                    Assert.True(VerifyParseToString(digits + "e" + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + exp, ns, valid, "0"), " Verification Failed");
+                    VerifyParseToString(digits + "e" + CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + exp, ns, valid, "0");
                 }
             }
 
             // Currency Symbol
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.CurrencySymbol + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowCurrencySymbol) != 0)), " Verification Failed");
+                VerifyParseToString(CultureInfo.CurrentUICulture.NumberFormat.CurrencySymbol + GetDigitSequence(1, 100, random), ns, ((ns & NumberStyles.AllowCurrencySymbol) != 0));
             }
 
             // Hex Specifier
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetHexDigitSequence(1, 15, random) + "A", ns, ((ns & NumberStyles.AllowHexSpecifier) != 0)), " Verification Failed");
+                VerifyParseToString(GetHexDigitSequence(1, 15, random) + "A", ns, ((ns & NumberStyles.AllowHexSpecifier) != 0));
             }
 
             // Invalid Chars
             for (int i = 0; i < s_samples; i++)
             {
-                Assert.True(VerifyParseToString(GetDigitSequence(1, 100, random) + GetRandomInvalidChar(random) + GetDigitSequence(1, 10, random), ns, false), " Verification Failed");
+                VerifyParseToString(GetDigitSequence(1, 100, random) + GetRandomInvalidChar(random) + GetDigitSequence(1, 10, random), ns, false);
             }
         }
 
-        private static bool VerifyParseToString(string num1)
+        private static void VerifyParseToString(string num1)
         {
-            bool ret = true;
             BigInteger test;
 
-            ret &= Eval(BigInteger.Parse(num1), Fix(num1.Trim()), String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1), Fix(num1.Trim())));
-            ret &= BigInteger.TryParse(num1, out test);
-            ret &= Eval(test, Fix(num1.Trim()), String.Format("Roundtrip between TryParse() and ToString() failed.  ToString returned: {0} num1: {1}", test, Fix(num1.Trim())));
-
-            return ret;
+            Eval(BigInteger.Parse(num1), Fix(num1.Trim()));
+            Assert.True(BigInteger.TryParse(num1, out test));
+            Eval(test, Fix(num1.Trim()));
         }
-        private static bool VerifyFailParseToString(string num1, Type expect)
+
+        private static void VerifyFailParseToString(string num1, Type expectedExceptionType)
         {
-            bool ret = true;
+            if (expectedExceptionType == typeof(FormatException))
+            {
+                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1).ToString("d"); });
+            }
+            else if (expectedExceptionType == typeof(ArgumentNullException))
+            {
+                Assert.Throws<ArgumentNullException>(() => { BigInteger.Parse(num1).ToString("d"); });
+            }
+            else
+            {
+                Assert.True(false, "Unsupported exception type expected");
+            }
+
             BigInteger test;
-
-            try
-            {
-                Eval(BigInteger.Parse(num1).ToString("d"), num1.Trim(), String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1).ToString("d"), num1.Trim()));
-                Console.WriteLine("{0} did not throw expected exception", num1);
-                ret = false;
-            }
-            catch (Exception e)
-            {
-                if (!(e.GetType() == expect))
-                {
-                    Console.WriteLine("Wrong exception thrown.\n" + e);
-                    ret = false;
-                }
-            }
-            ret &= Eval(!BigInteger.TryParse(num1, out test), true, String.Format("TryParse expected on fail on {0}", num1));
-
-            return ret;
+            Assert.False(BigInteger.TryParse(num1, out test), String.Format("Expected TryParse to fail on {0}", num1));
         }
-        private static bool VerifyParseToString(string num1, NumberStyles ns, bool failureNotExpected)
+
+        private static void VerifyParseToString(string num1, NumberStyles ns, bool failureNotExpected)
         {
-            return VerifyParseToString(num1, ns, failureNotExpected, Fix(num1.Trim(), ((ns & NumberStyles.AllowHexSpecifier) != 0), failureNotExpected));
+            VerifyParseToString(num1, ns, failureNotExpected, Fix(num1.Trim(), ((ns & NumberStyles.AllowHexSpecifier) != 0), failureNotExpected));
         }
-        private static bool VerifyParseToString(string num1, NumberStyles ns, bool failureNotExpected, string value)
+
+        private static void VerifyParseToString(string num1, NumberStyles ns, bool failureNotExpected, string expected)
         {
-            bool ret = true;
             BigInteger test;
 
             if (failureNotExpected)
             {
                 try
                 {
-                    ret &= Eval(BigInteger.Parse(num1, ns), value, String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1, ns), value));
-                    ret &= BigInteger.TryParse(num1, ns, null, out test);
-                    ret &= Eval(test, value, String.Format("Roundtrip between TryParse() and ToString() failed.  ToString returned: {0} num1: {1}", test, value));
+                    Eval(BigInteger.Parse(num1, ns), expected);
+                    Assert.True(BigInteger.TryParse(num1, ns, null, out test));
+                    Eval(test, expected);
                 }
                 catch (Exception e)
                 {
-                    ret &= Eval(false, String.Format("Got Unexpected exception parsing: {0} \n {1}", num1, e));
+                    Assert.True(false, String.Format("Got unexpected exception parsing: {0} \n {1}", num1, e));
                 }
             }
             else
             {
-                try
+                if (num1 == null)
                 {
-                    Eval(BigInteger.Parse(num1, ns), value, String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1, ns).ToString("d"), value));
-                    Console.WriteLine("{0} did not throw expected exception", num1);
-                    ret = false;
+                    Assert.Throws<ArgumentNullException>(() => { BigInteger.Parse(num1, ns); });
                 }
-                catch (Exception)
+                else
                 {
-                    //Intentionally blank
+                    Assert.Throws<FormatException>(() => { BigInteger.Parse(num1, ns); });
                 }
-                ret &= Eval(!BigInteger.TryParse(num1, ns, null, out test), true, String.Format("TryParse expected on fail on {0}", num1));
+                Assert.False(BigInteger.TryParse(num1, ns, null, out test), String.Format("Expected TryParse to fail on {0}", num1));
             }
+        }
 
-            return ret;
-        }
-        private static bool VerifySimpleFormatParse(string num1, NumberFormatInfo nfi, BigInteger expected)
+        private static void VerifySimpleFormatParse(string num1, NumberFormatInfo nfi, BigInteger expected, bool failureExpected = false)
         {
-            return VerifySimpleFormatParse(num1, nfi, expected, true);
-        }
-        private static bool VerifySimpleFormatParse(string num1, NumberFormatInfo nfi, BigInteger expected, bool failureNotExpected)
-        {
-            bool ret = true;
             BigInteger test;
 
-            if (failureNotExpected)
+            if (!failureExpected)
             {
-                ret &= Eval(BigInteger.Parse(num1, nfi), expected, String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1, nfi), expected));
-                ret &= BigInteger.TryParse(num1, NumberStyles.Any, nfi, out test);
-                ret &= Eval(test, expected, String.Format("Roundtrip between TryParse() and ToString() failed.  ToString returned: {0} num1: {1}", test, expected));
+                Assert.Equal(expected, BigInteger.Parse(num1, nfi));
+                Assert.True(BigInteger.TryParse(num1, NumberStyles.Any, nfi, out test));
+                Assert.Equal(expected, test);
             }
             else
             {
-                try
-                {
-                    Eval(BigInteger.Parse(num1, nfi), expected, String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1, nfi).ToString("d"), expected));
-                    Console.WriteLine("{0} did not throw expected exception", num1);
-                    ret = false;
-                }
-                catch (Exception)
-                {
-                    //Intentionally blank
-                }
-                ret &= Eval(!BigInteger.TryParse(num1, NumberStyles.Any, nfi, out test), true, String.Format("TryParse expected on fail on {0}", num1));
+                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1, nfi); });
+                Assert.False(BigInteger.TryParse(num1, NumberStyles.Any, nfi, out test), String.Format("Expected TryParse to fail on {0}", num1));
             }
-            return ret;
         }
-        private static bool VerifyFormatParse(string num1, NumberStyles ns, NumberFormatInfo nfi, BigInteger expected)
+        
+        private static void VerifyFormatParse(string num1, NumberStyles ns, NumberFormatInfo nfi, BigInteger expected, bool failureExpected = false)
         {
-            return VerifyFormatParse(num1, ns, nfi, expected, true);
-        }
-        private static bool VerifyFormatParse(string num1, NumberStyles ns, NumberFormatInfo nfi, BigInteger expected, bool failureNotExpected)
-        {
-            bool ret = true;
             BigInteger test;
 
-            if (failureNotExpected)
+            if (!failureExpected)
             {
-                ret &= Eval(BigInteger.Parse(num1, ns, nfi), expected, String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1, ns, nfi), expected));
-                ret &= BigInteger.TryParse(num1, NumberStyles.Any, nfi, out test);
-                ret &= Eval(test, expected, String.Format("Roundtrip between TryParse() and ToString() failed.  ToString returned: {0} num1: {1}", test, expected));
+                Assert.Equal(expected, BigInteger.Parse(num1, ns, nfi));
+                Assert.True(BigInteger.TryParse(num1, NumberStyles.Any, nfi, out test));
+                Assert.Equal(expected, test);
             }
             else
             {
-                try
-                {
-                    Eval(BigInteger.Parse(num1, ns, nfi), expected, String.Format("Roundtrip between Parse() and ToString() failed.  RoundTrip returned: {0}  num1: {1}", BigInteger.Parse(num1, ns, nfi).ToString("d"), expected));
-                    Console.WriteLine("{0} did not throw expected exception", num1);
-                    ret = false;
-                }
-                catch (Exception)
-                {
-                    //Intentionally blank
-                }
-                ret &= Eval(!BigInteger.TryParse(num1, ns, nfi, out test), true, String.Format("TryParse expected on fail on {0}", num1));
+                Assert.Throws<FormatException>(() => { BigInteger.Parse(num1, ns, nfi); });                
+                Assert.False(BigInteger.TryParse(num1, ns, nfi, out test), String.Format("Expected TryParse to fail on {0}", num1));
             }
-            return ret;
         }
 
         private static String GetDigitSequence(int min, int max, Random random)
@@ -504,6 +465,7 @@ namespace System.Numerics.Tests
 
             return result;
         }
+
         private static String GetHexDigitSequence(int min, int max, Random random)
         {
             String result = String.Empty;
@@ -526,6 +488,7 @@ namespace System.Numerics.Tests
 
             return result;
         }
+
         private static String GetRandomInvalidChar(Random random)
         {
             Char[] digits = new Char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C', 'D', 'E', 'F' };
@@ -536,25 +499,32 @@ namespace System.Numerics.Tests
                 for (int i = 0; i < digits.Length; i++)
                 {
                     if (result == (char)digits[i])
+                    {
                         result = '5';
+                    }
                 }
 
                 // Remove the comma: 'AllowThousands' NumberStyle does not enforce the GroupSizes.
                 if (result == ',')
+                {
                     result = '5';
+                }
             }
 
             String res = new String(result, 1);
             return res;
         }
+
         private static String Fix(String input)
         {
             return Fix(input, false);
         }
+
         private static String Fix(String input, bool isHex)
         {
             return Fix(input, isHex, true);
         }
+
         private static String Fix(String input, bool isHex, bool failureNotExpected)
         {
             String output = input;
@@ -582,6 +552,7 @@ namespace System.Numerics.Tests
 
             return output;
         }
+
         private static String ConvertHexToDecimal(string input)
         {
             char[] inArr = input.ToCharArray();
@@ -643,12 +614,12 @@ namespace System.Numerics.Tests
             }
             return y2;
         }
+
         private static String GenerateGroups(int[] sizes, string seperator, Random random)
         {
             List<int> total_sizes = new List<int>();
             int total;
             int num_digits = random.Next(10, 100);
-            ;
             string digits = String.Empty;
 
             total = 0;
@@ -678,7 +649,9 @@ namespace System.Numerics.Tests
             for (int j = total_sizes.Count - 1; j > 0; j--)
             {
                 if ((first) && (total_sizes[j] >= num_digits))
+                {
                     continue;
+                }
                 int group_size = num_digits - total_sizes[j - 1];
                 if (first)
                 {
@@ -731,23 +704,9 @@ namespace System.Numerics.Tests
             return nfi;
         }
 
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(BigInteger x, String y, String errorMsg)
+        public static void Eval(BigInteger x, String expected)
         {
             bool IsPos = (x >= 0);
-            bool ret = true;
-            String y2 = null;
-
             if (!IsPos)
             {
                 x = -x;
@@ -755,7 +714,7 @@ namespace System.Numerics.Tests
 
             if (x == 0)
             {
-                Assert.True(y.Equals("0"), " Verification Failed");
+                Assert.Equal(expected, "0");
             }
             else
             {
@@ -766,34 +725,10 @@ namespace System.Numerics.Tests
                     x = x / 10;
                 }
                 number.Reverse();
-                y2 = new String(number.ToArray());
-                //            if (y.Length > 50)
-                //            {
-                //                Assert.IsTrue((y2.StartsWith(y.Substring(0, 50), StringComparison.OrdinalIgnoreCase)), " Verification Failed" );
-                //                Assert.IsTrue((y.Length == y2.Length), " Verification Failed" );
-                //            }
-                //            else
-                //            {
-                Assert.True(y2.Equals(y, StringComparison.OrdinalIgnoreCase), " Verification Failed");
-                //            }
-            }
+                String actual = new String(number.ToArray());
 
-            if (!ret)
-            {
-                Console.WriteLine("Error: " + errorMsg);
-                Console.WriteLine("got:      " + y2);
-                Console.WriteLine("expected: " + y);
+                Assert.Equal(expected, actual);
             }
-            return ret;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -18,19 +17,18 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-
             // Pow Method - 0^(1)
-            Assert.True(VerifyPowString(BigInteger.One.ToString() + " " + BigInteger.Zero.ToString() + " bPow"), " Verification Failed");
+            VerifyPowString(BigInteger.One.ToString() + " " + BigInteger.Zero.ToString() + " bPow");
 
             // Pow Method - 0^(0)
-            Assert.True(VerifyPowString(BigInteger.Zero.ToString() + " " + BigInteger.Zero.ToString() + " bPow"), " Verification Failed");
+            VerifyPowString(BigInteger.Zero.ToString() + " " + BigInteger.Zero.ToString() + " bPow");
 
             // Pow Method - Two Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 1);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyPowString(Print(tempByteArray1) + Print(tempByteArray2) + "bPow"), " Verification Failed");
+                VerifyPowString(Print(tempByteArray1) + Print(tempByteArray2) + "bPow");
             }
 
             // Pow Method - One large and one small BigIntegers
@@ -38,7 +36,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 1);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyPowString(Print(tempByteArray1) + Print(tempByteArray2) + "bPow"), " Verification Failed");
+                VerifyPowString(Print(tempByteArray1) + Print(tempByteArray2) + "bPow");
             }
 
             // Pow Method - One large BigIntegers and zero
@@ -46,7 +44,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyPowString(Print(tempByteArray2) + Print(tempByteArray1) + "bPow"), " Verification Failed");
+                VerifyPowString(Print(tempByteArray2) + Print(tempByteArray1) + "bPow");
             }
 
             // Pow Method - One small BigIntegers and zero
@@ -54,8 +52,8 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyPowString(Print(tempByteArray1) + Print(tempByteArray2) + "bPow"), " Verification Failed");
-                Assert.True(VerifyPowString(Print(tempByteArray2) + Print(tempByteArray1) + "bPow"), " Verification Failed");
+                VerifyPowString(Print(tempByteArray1) + Print(tempByteArray2) + "bPow");
+                VerifyPowString(Print(tempByteArray2) + Print(tempByteArray1) + "bPow");
             }
         }
 
@@ -66,13 +64,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X^1 = X
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " bPow", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " bPow", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " bPow", Int32.MaxValue.ToString());
+            VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " bPow", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(BigInteger.One + " " + randBigInt + "bPow", randBigInt.Substring(0, randBigInt.Length - 1)), " Verification Failed");
+                VerifyIdentityString(BigInteger.One + " " + randBigInt + "bPow", randBigInt.Substring(0, randBigInt.Length - 1));
             }
         }
 
@@ -83,13 +81,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X^0 = 1
-            Assert.True(VerifyIdentityString(BigInteger.Zero + " " + Int32.MaxValue + " bPow", BigInteger.One.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(BigInteger.Zero + " " + Int64.MaxValue + " bPow", BigInteger.One.ToString()), " Verification Failed");
+            VerifyIdentityString(BigInteger.Zero + " " + Int32.MaxValue + " bPow", BigInteger.One.ToString());
+            VerifyIdentityString(BigInteger.Zero + " " + Int64.MaxValue + " bPow", BigInteger.One.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(BigInteger.Zero + " " + randBigInt + "bPow", BigInteger.One.ToString()), " Verification Failed");
+                VerifyIdentityString(BigInteger.Zero + " " + randBigInt + "bPow", BigInteger.One.ToString());
             }
         }
 
@@ -100,12 +98,12 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: 0^X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bPow", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bPow", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomPosByteArray(s_random, 4));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " bPow", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " bPow", BigInteger.Zero.ToString());
             }
         }
 
@@ -116,12 +114,12 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: 1^X = 1
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " bPow", BigInteger.One.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.One + " bPow", BigInteger.One.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomPosByteArray(s_random, 4));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.One + " bPow", BigInteger.One.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.One + " bPow", BigInteger.One.ToString());
             }
         }
 
@@ -131,13 +129,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyPowString("2 " + Math.Pow(2, 32) + " bPow"), " Verification Failed");
+            VerifyPowString("2 " + Math.Pow(2, 32) + " bPow");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyPowString("2 " + Math.Pow(2, 33) + " bPow"), " Verification Failed");
+            VerifyPowString("2 " + Math.Pow(2, 33) + " bPow");
         }
 
         [Fact]
@@ -170,41 +168,39 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static bool VerifyPowString(string opstring)
+        private static void VerifyPowString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 10));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -216,6 +212,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomPosByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -228,6 +225,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static Byte[] GetRandomNegByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -252,27 +250,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
@@ -196,21 +196,14 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 10));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetRandomByteArray(random, size);
         }
 
         private static Byte[] GetRandomPosByteArray(Random random, int size)
@@ -241,15 +234,7 @@ namespace System.Numerics.Tests
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/properties.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/properties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using Tools;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -43,7 +44,7 @@ namespace System.Numerics.Tests
                     BigInteger tempBigInteger = bigInteger / BigInteger.Zero;
                 });
 
-                if (!IsZero(tempByteArray))
+                if (!MyBigIntImp.IsZero(tempByteArray))
                 {
                     Assert.Equal(BigInteger.Zero, BigInteger.Zero / bigInteger);
                 }
@@ -112,34 +113,9 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
-            return GetRandomByteArray(random, random.Next(0, 1024));
-        }
-
-        private static Byte[] GetRandomByteArray(Random random, int size)
-        {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
-        }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; ++i)
-            {
-                if (0 != value[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return MyBigIntImp.GetRandomByteArray(random, random.Next(0, 1024));
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/properties.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/properties.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
@@ -82,11 +81,12 @@ namespace System.Numerics.Tests
         {
             BigInteger bigInteger;
             byte[] tempByteArray;
-            // BigInteger.MinusOne == -1
 
+            // BigInteger.MinusOne == -1
             Assert.Equal(
                 CultureInfo.CurrentUICulture.NumberFormat.NegativeSign + "1",
-                BigInteger.MinusOne.ToString());
+                BigInteger.MinusOne.ToString()
+            );
             Assert.Equal(new BigInteger((Int64)(-1)), BigInteger.MinusOne);
             Assert.Equal(new BigInteger((Double)(-1)), BigInteger.MinusOne);
             Assert.Equal(new BigInteger(new byte[] { 0xff, 0xff, 0xff, 0xff }), BigInteger.MinusOne);
@@ -102,11 +102,13 @@ namespace System.Numerics.Tests
 
                 Assert.Equal(
                      BigInteger.Negate(new BigInteger(tempByteArray)),
-                     BigInteger.MinusOne * bigInteger);
+                     BigInteger.MinusOne * bigInteger
+                );
 
                 Assert.Equal(
                     BigInteger.Negate(new BigInteger(tempByteArray)),
-                    bigInteger / BigInteger.MinusOne);
+                    bigInteger / BigInteger.MinusOne
+                );
             }
         }
 
@@ -114,6 +116,7 @@ namespace System.Numerics.Tests
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -125,6 +128,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; ++i)
@@ -136,28 +140,6 @@ namespace System.Numerics.Tests
             }
 
             return true;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/remainder.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/remainder.cs
@@ -176,47 +176,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            while (IsZero(value))
-            {
-                for (int i = 0; i < value.Length; ++i)
-                {
-                    value[i] = (byte)random.Next(0, 256);
-                }
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
-
-        private static bool IsZero(byte[] value)
-        {
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0)
-                    return false;
-            }
-            return true;
-        }
-
+        
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/remainder.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/remainder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -24,7 +23,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder");
             }
 
             // Remainder Method - Two Small BigIntegers
@@ -32,7 +31,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder");
             }
 
             // Remainder Method - One large and one small BigIntegers
@@ -40,11 +39,11 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder");
 
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder");
             }
         }
 
@@ -53,14 +52,13 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
+            
             // Remainder Method - One large BigIntegers and zero
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -73,7 +71,7 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder"), " Verification Failed");
+                VerifyRemainderString(Print(tempByteArray1) + Print(tempByteArray2) + "bRemainder");
 
                 Assert.Throws<DivideByZeroException>(() =>
                 {
@@ -87,15 +85,14 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
-
-
-            //Check interesting cases for boundary conditions
-            //You'll either be shifting a 0 or 1 across the boundary
+            
+            // Check interesting cases for boundary conditions
+            // You'll either be shifting a 0 or 1 across the boundary
             // 32 bit boundary  n2=0
-            Assert.True(VerifyRemainderString(Math.Pow(2, 32) + " 2 bRemainder"), " Verification Failed");
+            VerifyRemainderString(Math.Pow(2, 32) + " 2 bRemainder");
 
             // 32 bit boundary  n1=0 n2=1
-            Assert.True(VerifyRemainderString(Math.Pow(2, 33) + " 2 bRemainder"), " Verification Failed");
+            VerifyRemainderString(Math.Pow(2, 33) + " 2 bRemainder");
         }
 
         [Fact]
@@ -105,38 +102,38 @@ namespace System.Numerics.Tests
             byte[] tempByteArray2 = new byte[0];
 
             // Axiom: X%1 = 0
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(BigInteger.One + " " + Int32.MaxValue + " bRemainder", BigInteger.Zero.ToString());
+            VerifyIdentityString(BigInteger.One + " " + Int64.MaxValue + " bRemainder", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(BigInteger.One + " " + randBigInt + "bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(BigInteger.One + " " + randBigInt + "bRemainder", BigInteger.Zero.ToString());
             }
 
             // Axiom: 0%X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + BigInteger.Zero + " bRemainder", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + BigInteger.Zero + " bRemainder", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + BigInteger.Zero + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + BigInteger.Zero + " bRemainder", BigInteger.Zero.ToString());
             }
 
             // Axiom: X%X = 0
-            Assert.True(VerifyIdentityString(Int32.MaxValue + " " + Int32.MaxValue + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString(Int64.MaxValue + " " + Int64.MaxValue + " bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
+            VerifyIdentityString(Int32.MaxValue + " " + Int32.MaxValue + " bRemainder", BigInteger.Zero.ToString());
+            VerifyIdentityString(Int64.MaxValue + " " + Int64.MaxValue + " bRemainder", BigInteger.Zero.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
                 String randBigInt = Print(GetRandomByteArray(s_random));
-                Assert.True(VerifyIdentityString(randBigInt + randBigInt + "bRemainder", BigInteger.Zero.ToString()), " Verification Failed");
+                VerifyIdentityString(randBigInt + randBigInt + "bRemainder", BigInteger.Zero.ToString());
             }
 
             // Axiom: X%(X + Y) = X where Y is 1 if x>=0 and -1 if x<0
-            Assert.True(VerifyIdentityString((new BigInteger(Int32.MaxValue) + 1) + " " + Int32.MaxValue + " bRemainder", Int32.MaxValue.ToString()), " Verification Failed");
-            Assert.True(VerifyIdentityString((new BigInteger(Int64.MaxValue) + 1) + " " + Int64.MaxValue + " bRemainder", Int64.MaxValue.ToString()), " Verification Failed");
+            VerifyIdentityString((new BigInteger(Int32.MaxValue) + 1) + " " + Int32.MaxValue + " bRemainder", Int32.MaxValue.ToString());
+            VerifyIdentityString((new BigInteger(Int64.MaxValue) + 1) + " " + Int64.MaxValue + " bRemainder", Int64.MaxValue.ToString());
 
             for (int i = 0; i < s_samples; i++)
             {
@@ -147,45 +144,43 @@ namespace System.Numerics.Tests
                 {
                     modify = BigInteger.Negate(modify);
                 }
-                Assert.True(VerifyIdentityString(randBigInt + modify.ToString() + " bAdd " + randBigInt + "bRemainder", randBigInt.Substring(0, randBigInt.Length - 1)), " Verification Failed");
+                VerifyIdentityString(randBigInt + modify.ToString() + " bAdd " + randBigInt + "bRemainder", randBigInt.Substring(0, randBigInt.Length - 1));
             }
         }
 
-        private static bool VerifyRemainderString(string opstring)
+        private static void VerifyRemainderString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(1, 100));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -200,6 +195,7 @@ namespace System.Numerics.Tests
 
             return value;
         }
+
         private static bool IsZero(byte[] value)
         {
             for (int i = 0; i < value.Length; i++)
@@ -221,27 +217,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/sign.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/sign.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -15,108 +14,101 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunSignTests()
         {
-            long temp;
             byte[] tempByteArray1 = new byte[0];
 
             // Sign Method - Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
-                Assert.True(VerifySignString(Print(tempByteArray1) + "uSign"), " Verification Failed");
+                VerifySignString(Print(tempByteArray1) + "uSign");
             }
 
             // Sign Method - Small BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifySignString(Print(tempByteArray1) + "uSign"), " Verification Failed");
+                VerifySignString(Print(tempByteArray1) + "uSign");
             }
 
             // Sign Method - zero
-            Assert.True(VerifySignString("0 uSign"), " Verification Failed");
+            VerifySignString("0 uSign");
 
             // Sign Method - -1
-            Assert.True(VerifySignString("-1 uSign"), " Verification Failed");
+            VerifySignString("-1 uSign");
 
             // Sign Method - 1
-            Assert.True(VerifySignString("1 uSign"), " Verification Failed");
+            VerifySignString("1 uSign");
 
-            temp = Int32.MinValue;
             // Sign Method - Int32.MinValue
-            Assert.True(VerifySignString(temp.ToString() + " uSign"), " Verification Failed");
+            VerifySignString(Int32.MinValue.ToString() + " uSign");
 
             // Sign Method - Int32.MinValue-1
-            Assert.True(VerifySignString(temp.ToString() + " -1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int32.MinValue.ToString() + " -1 b+ uSign");
 
             // Sign Method - Int32.MinValue+1
-            Assert.True(VerifySignString(temp.ToString() + " 1 b+ uSign"), " Verification Failed");
-
-            temp = Int32.MaxValue;
+            VerifySignString(Int32.MinValue.ToString() + " 1 b+ uSign");
+            
             // Sign Method - Int32.MaxValue
-            Assert.True(VerifySignString(temp.ToString() + " uSign"), " Verification Failed");
+            VerifySignString(Int32.MaxValue.ToString() + " uSign");
 
             // Sign Method - Int32.MaxValue-1
-            Assert.True(VerifySignString(temp.ToString() + " -1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int32.MaxValue.ToString() + " -1 b+ uSign");
 
             // Sign Method - Int32.MaxValue+1
-            Assert.True(VerifySignString(temp.ToString() + " 1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int32.MaxValue.ToString() + " 1 b+ uSign");
 
-            temp = Int64.MinValue;
             // Sign Method - Int64.MinValue
-            Assert.True(VerifySignString(temp.ToString() + " uSign"), " Verification Failed");
+            VerifySignString(Int64.MinValue.ToString() + " uSign");
 
             // Sign Method - Int64.MinValue-1
-            Assert.True(VerifySignString(temp.ToString() + " -1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int64.MinValue.ToString() + " -1 b+ uSign");
 
             // Sign Method - Int64.MinValue+1
-            Assert.True(VerifySignString(temp.ToString() + " 1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int64.MinValue.ToString() + " 1 b+ uSign");
 
-            temp = Int64.MaxValue;
             // Sign Method - Int64.MaxValue
-            Assert.True(VerifySignString(temp.ToString() + " uSign"), " Verification Failed");
+            VerifySignString(Int64.MaxValue.ToString() + " uSign");
 
             // Sign Method - Int64.MaxValue-1
-            Assert.True(VerifySignString(temp.ToString() + " -1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int64.MaxValue.ToString() + " -1 b+ uSign");
 
             // Sign Method - Int64.MaxValue+1
-            Assert.True(VerifySignString(temp.ToString() + " 1 b+ uSign"), " Verification Failed");
+            VerifySignString(Int64.MaxValue.ToString() + " 1 b+ uSign");
         }
 
-        private static bool VerifySignString(string opstring)
+        private static void VerifySignString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
-        private static bool VerifyIdentityString(string opstring1, string opstring2)
-        {
-            bool ret = true;
 
+        private static void VerifyIdentityString(string opstring1, string opstring2)
+        {
             StackCalc sc1 = new StackCalc(opstring1);
             while (sc1.DoNextOperation())
-            {	//Run the full calculation
+            {	
+                //Run the full calculation
                 sc1.DoNextOperation();
             }
 
             StackCalc sc2 = new StackCalc(opstring2);
             while (sc2.DoNextOperation())
-            {	//Run the full calculation
+            {
+                //Run the full calculation
                 sc2.DoNextOperation();
             }
 
-            ret &= Eval(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger1: {0} BigInteger2: {1}", sc1.snCalc.Peek(), sc2.snCalc.Peek()));
-
-            return ret;
+            Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -140,27 +132,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/sign.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/sign.cs
@@ -104,34 +104,19 @@ namespace System.Numerics.Tests
             Assert.Equal(sc1.snCalc.Peek().ToString(), sc2.snCalc.Peek().ToString());
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
 using Xunit;
 
@@ -21,23 +19,13 @@ namespace Tools
 
         public StackCalc(string _input)
         {
-#if Verbose
-            Console.WriteLine("StackCalculator is {0}", _input);
-#endif
             myCalc = new Stack<System.Numerics.BigInteger>();
             snCalc = new Stack<System.Numerics.BigInteger>();
+
             string delimStr = " ";
             char[] delimiter = delimStr.ToCharArray();
             input = _input.Split(delimiter);
 
-#if Verbose
-            Console.WriteLine("StackCalculatorInputs are");
-            int i = 0;
-            foreach (var s in input)
-            {
-                Console.WriteLine("\t Input {0} is :{1}", i++, s);
-            }
-#endif
             operators = new Queue<string>(input);
         }
 
@@ -46,6 +34,7 @@ namespace Tools
             string op = "";
             bool ret = false;
             bool checkValues = false;
+
             BigInteger snnum1 = 0;
             BigInteger snnum2 = 0;
             BigInteger snnum3 = 0;
@@ -58,9 +47,7 @@ namespace Tools
                 return false;
             }
             op = operators.Dequeue();
-#if Verbose
-            Console.WriteLine("\t ***** DoNextOperation {0}", op);
-#endif
+
             if (op.StartsWith("u"))
             {
                 checkValues = true;
@@ -69,7 +56,8 @@ namespace Tools
                 snCalc.Push(DoUnaryOperatorSN(snnum1, op));
 
                 mynum1 = myCalc.Pop();
-                myCalc.Push(DoUnaryOperatorMine(mynum1, op));
+                myCalc.Push(MyBigIntImp.DoUnaryOperatorMine(mynum1, op));
+
                 ret = true;
             }
             else if (op.StartsWith("b"))
@@ -82,37 +70,23 @@ namespace Tools
 
                 mynum1 = myCalc.Pop();
                 mynum2 = myCalc.Pop();
-                myCalc.Push(DoBinaryOperatorMine(mynum1, mynum2, op));
+                myCalc.Push(MyBigIntImp.DoBinaryOperatorMine(mynum1, mynum2, op));
+
                 ret = true;
             }
             else if (op.StartsWith("t"))
             {
                 checkValues = true;
-#if Verbose
-                Console.WriteLine("\t ***** sncalc length is {0}:", snCalc.Count);
-#endif
                 snnum1 = snCalc.Pop();
-
-#if Verbose
-                Console.WriteLine("\t sncalc element 1 is: {0}", snnum1);
-#endif
                 snnum2 = snCalc.Pop();
-
-#if Verbose
-                Console.WriteLine("\t sncalc element 2 is: {0}", snnum2);
-#endif
                 snnum3 = snCalc.Pop();
-
-#if Verbose
-                Console.WriteLine("\t sncalc element 3 is: {0}", snnum3);
-#endif
 
                 snCalc.Push(DoTertanaryOperatorSN(snnum1, snnum2, snnum3, op));
 
                 mynum1 = myCalc.Pop();
                 mynum2 = myCalc.Pop();
                 mynum3 = myCalc.Pop();
-                myCalc.Push(DoTertanaryOperatorMine(mynum1, mynum2, mynum3, op));
+                myCalc.Push(MyBigIntImp.DoTertanaryOperatorMine(mynum1, mynum2, mynum3, op));
 
                 ret = true;
             }
@@ -156,9 +130,8 @@ namespace Tools
         private BigInteger DoConstruction()
         {
             List<byte> bytes = new List<byte>();
-            string op = "";
             BigInteger ret = new BigInteger(0);
-            op = operators.Dequeue();
+            string op = operators.Dequeue();
 
             while (String.CompareOrdinal(op, "endmake") != 0)
             {
@@ -172,7 +145,7 @@ namespace Tools
             }
             catch (IndexOutOfRangeException)
             {
-                Console.WriteLine(Print(bytes.ToArray()));
+                Assert.True(false, Print(bytes.ToArray()));
                 throw;
             }
 
@@ -188,9 +161,9 @@ namespace Tools
                 case "u~":
                     return (~(num1));
                 case "uLog10":
-                    return ApproximateBigInteger(BigInteger.Log10(num1));
+                    return MyBigIntImp.ApproximateBigInteger(BigInteger.Log10(num1));
                 case "uLog":
-                    return ApproximateBigInteger(BigInteger.Log(num1));
+                    return MyBigIntImp.ApproximateBigInteger(BigInteger.Log(num1));
                 case "uAbs":
                     return BigInteger.Abs(num1);
                 case "uNegate":
@@ -204,11 +177,12 @@ namespace Tools
                 case "u+":
                     return (+(num1));
                 default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
+                    Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;
             }
             return new BigInteger();
         }
+
         private BigInteger DoBinaryOperatorSN(BigInteger num1, BigInteger num2, string op)
         {
             switch (op)
@@ -238,7 +212,7 @@ namespace Tools
                 case "b+":
                     return num1 + num2;
                 case "bLog":
-                    return ApproximateBigInteger(BigInteger.Log(num1, (double)num2));
+                    return MyBigIntImp.ApproximateBigInteger(BigInteger.Log(num1, (double)num2));
                 case "bGCD":
                     return BigInteger.GreatestCommonDivisor(num1, num2);
                 case "bPow":
@@ -260,868 +234,41 @@ namespace Tools
                 case "bAdd":
                     return BigInteger.Add(num1, num2);
                 default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
+                    Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;
             }
             return new BigInteger();
         }
+
         private BigInteger DoTertanaryOperatorSN(BigInteger num1, BigInteger num2, BigInteger num3, string op)
         {
-#if Verbose
-            Console.WriteLine("DoTertanaryOperatorSN inputs are: {0} {1} {2}", num1, num2, num3);
-#endif
             switch (op)
             {
                 case "tModPow":
                     return BigInteger.ModPow(num1, num2, num3);
                 default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
+                    Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;
             }
             return new BigInteger();
         }
-
-        private BigInteger DoUnaryOperatorMine(BigInteger num1, string op)
-        {
-            List<byte> bytes1 = new List<byte>(num1.ToByteArray());
-            int factor;
-            double result;
-
-            switch (op)
-            {
-                case "uSign":
-                    if (IsZero(bytes1)) return new BigInteger(0);
-                    if (IsZero(Max(bytes1, new List<byte>(new byte[] { 0 })))) return new BigInteger(-1);
-                    return new BigInteger(1);
-                case "u~":
-                    return new BigInteger(Not(bytes1).ToArray());
-                case "uLog10":
-                    factor = (int)BigInteger.Log(num1, 10);
-                    if (factor > 100)
-                    {
-                        for (int i = 0; i < factor - 100; i++)
-                        {
-                            num1 = num1 / 10;
-                        }
-                    }
-                    result = Math.Log10((double)num1);
-                    if (factor > 100)
-                    {
-                        for (int i = 0; i < factor - 100; i++)
-                        {
-                            result = result + 1;
-                        }
-                    }
-                    return ApproximateBigInteger(result);
-                case "uLog":
-                    factor = (int)BigInteger.Log(num1, 10);
-                    if (factor > 100)
-                    {
-                        for (int i = 0; i < factor - 100; i++)
-                        {
-                            num1 = num1 / 10;
-                        }
-                    }
-                    result = Math.Log((double)num1);
-                    if (factor > 100)
-                    {
-                        for (int i = 0; i < factor - 100; i++)
-                        {
-                            result = result + Math.Log(10);
-                        }
-                    }
-                    return ApproximateBigInteger(result);
-                case "uAbs":
-                    if ((bytes1[bytes1.Count - 1] & 0x80) != 0) bytes1 = Negate(bytes1);
-                    return new BigInteger(bytes1.ToArray());
-                case "u--":
-                    return new BigInteger(Add(bytes1, new List<byte>(new byte[] { 0xff })).ToArray());
-                case "u++":
-                    return new BigInteger(Add(bytes1, new List<byte>(new byte[] { 1 })).ToArray());
-                case "uNegate":
-                case "u-":
-                    return new BigInteger(Negate(bytes1).ToArray());
-                case "u+":
-                    return num1;
-                default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
-                    break;
-            }
-            return new BigInteger();
-        }
-        private BigInteger DoBinaryOperatorMine(BigInteger num1, BigInteger num2, string op)
-        {
-            List<byte> bytes1 = new List<byte>(num1.ToByteArray());
-            List<byte> bytes2 = new List<byte>(num2.ToByteArray());
-
-            switch (op)
-            {
-                case "bMin":
-                    return new BigInteger(Negate(Max(Negate(bytes1), Negate(bytes2))).ToArray());
-                case "bMax":
-                    return new BigInteger(Max(bytes1, bytes2).ToArray());
-                case "b>>":
-                    return new BigInteger(ShiftLeft(bytes1, Negate(bytes2)).ToArray());
-                case "b<<":
-                    return new BigInteger(ShiftLeft(bytes1, bytes2).ToArray());
-                case "b^":
-                    return new BigInteger(Xor(bytes1, bytes2).ToArray());
-                case "b|":
-                    return new BigInteger(Or(bytes1, bytes2).ToArray());
-                case "b&":
-                    return new BigInteger(And(bytes1, bytes2).ToArray());
-                case "bLog":
-                    return ApproximateBigInteger(Math.Log((double)num1, (double)num2));
-                case "bGCD":
-                    return new BigInteger(GCD(bytes1, bytes2).ToArray());
-                case "bPow":
-                    int arg2 = (int)num2;
-                    bytes2 = new List<byte>(new BigInteger(arg2).ToByteArray());
-                    return new BigInteger(Pow(bytes1, bytes2).ToArray());
-                case "bDivRem":
-                    BigInteger ret = new BigInteger(Divide(bytes1, bytes2).ToArray());
-                    bytes1 = new List<byte>(num1.ToByteArray());
-                    bytes2 = new List<byte>(num2.ToByteArray());
-                    SetMYOutCheck(new BigInteger(Remainder(bytes1, bytes2).ToArray()));
-                    return ret;
-                case "bRemainder":
-                case "b%":
-                    return new BigInteger(Remainder(bytes1, bytes2).ToArray());
-                case "bDivide":
-                case "b/":
-                    return new BigInteger(Divide(bytes1, bytes2).ToArray());
-                case "bMultiply":
-                case "b*":
-                    return new BigInteger(Multiply(bytes1, bytes2).ToArray());
-                case "bSubtract":
-                case "b-":
-                    bytes2 = Negate(bytes2);
-                    goto case "bAdd";
-                case "bAdd":
-                case "b+":
-                    return new BigInteger(Add(bytes1, bytes2).ToArray());
-                default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
-                    break;
-            }
-            return new BigInteger();
-        }
-        private BigInteger DoTertanaryOperatorMine(BigInteger num1, BigInteger num2, BigInteger num3, string op)
-        {
-            List<byte> bytes1 = new List<byte>(num1.ToByteArray());
-            List<byte> bytes2 = new List<byte>(num2.ToByteArray());
-            List<byte> bytes3 = new List<byte>(num3.ToByteArray());
-
-            switch (op)
-            {
-                case "tModPow":
-                    return new BigInteger(ModPow(bytes1, bytes2, bytes3).ToArray());
-                default:
-                    Console.WriteLine("Invalid operation found: {0}", op);
-                    break;
-            }
-            return new BigInteger();
-        }
-
+        
         private void SetSNOutCheck(BigInteger value)
         {
             _snOut = value;
         }
-        private void SetMYOutCheck(BigInteger value)
+
+        public void VerifyOutParameter()
         {
-            _myOut = value;
-        }
-        public bool VerifyOut()
-        {
-            bool ret = (_snOut == _myOut);
+            Assert.True(_snOut == MyBigIntImp.outParam, "Out parameters not matching");
 
             _snOut = 0;
-            _myOut = 0;
-
-            return ret;
+            MyBigIntImp.outParam = 0;
         }
 
-        private static List<byte> Add(List<byte> bytes1, List<byte> bytes2)
-        {
-            List<byte> bnew = new List<byte>();
-            bool num1neg = (bytes1[bytes1.Count - 1] & 0x80) != 0;
-            bool num2neg = (bytes2[bytes2.Count - 1] & 0x80) != 0;
-            byte extender = 0;
-            bool bnewneg;
-            bool carry;
-
-            NormalizeLengths(bytes1, bytes2);
-
-            carry = false;
-            for (int i = 0; i < bytes1.Count; i++)
-            {
-                int temp = bytes1[i] + bytes2[i];
-
-                if (carry) temp++;
-                carry = false;
-
-                if (temp > byte.MaxValue)
-                {
-                    temp -= byte.MaxValue + 1;
-                    carry = true;
-                }
-
-                bnew.Add((byte)temp);
-            }
-            bnewneg = (bnew[bnew.Count - 1] & 0x80) != 0;
-
-            if ((num1neg == num2neg) & (num1neg != bnewneg))
-            {
-                if (num1neg) extender = 0xff;
-                bnew.Add(extender);
-            }
-
-            return bnew;
-        }
-        private static List<byte> Negate(List<byte> bytes)
-        {
-            bool carry;
-            List<byte> bnew = new List<byte>();
-            bool bsame;
-
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                bytes[i] ^= 0xFF;
-            }
-            carry = false;
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                int temp = (i == 0 ? 0x01 : 0x00) + bytes[i];
-                if (carry) temp++;
-                carry = false;
-
-                if (temp > byte.MaxValue)
-                {
-                    temp -= byte.MaxValue + 1;
-                    carry = true;
-                }
-
-                bnew.Add((byte)temp);
-            }
-
-            bsame = ((bnew[bnew.Count - 1] & 0x80) != 0);
-            bsame &= ((bnew[bnew.Count - 1] & 0x7f) == 0);
-            for (int i = bnew.Count - 2; i >= 0; i--)
-            {
-                bsame &= (bnew[i] == 0);
-            }
-            if (bsame)
-            {
-                bnew.Add((byte)0);
-            }
-
-            return bnew;
-        }
-        private static List<byte> Multiply(List<byte> bytes1, List<byte> bytes2)
-        {
-            NormalizeLengths(bytes1, bytes2);
-            List<byte> bresult = new List<byte>();
-
-            for (int i = 0; i < bytes1.Count; i++)
-            {
-                bresult.Add((byte)0x00);
-                bresult.Add((byte)0x00);
-            }
-
-            NormalizeLengths(bytes2, bresult);
-            NormalizeLengths(bytes1, bresult);
-            BitArray ba2 = new BitArray(bytes2.ToArray());
-            for (int i = ba2.Length - 1; i >= 0; i--)
-            {
-                if (ba2[i])
-                {
-                    bresult = Add(bytes1, bresult);
-                }
-
-                if (i != 0)
-                {
-                    bresult = ShiftLeftDrop(bresult);
-                }
-            }
-            bresult = SetLength(bresult, bytes2.Count);
-
-            return bresult;
-        }
-        private static List<byte> Divide(List<byte> bytes1, List<byte> bytes2)
-        {
-            bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
-            bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
-
-            if (!numPos) bytes1 = Negate(bytes1);
-            if (!denPos) bytes2 = Negate(bytes2);
-
-            bool qPos = (numPos == denPos);
-
-            Trim(bytes1);
-            Trim(bytes2);
-
-            BitArray ba1 = new BitArray(bytes1.ToArray());
-            BitArray ba2 = new BitArray(bytes2.ToArray());
-
-            int ba11loc = 0;
-            for (int i = ba1.Length - 1; i >= 0; i--)
-            {
-                if (ba1[i])
-                {
-                    ba11loc = i;
-                    break;
-                }
-            }
-            int ba21loc = 0;
-            for (int i = ba2.Length - 1; i >= 0; i--)
-            {
-                if (ba2[i])
-                {
-                    ba21loc = i;
-                    break;
-                }
-            }
-            int shift = ba11loc - ba21loc;
-            if (shift < 0) return new List<byte>(new byte[] { (byte)0 });
-            BitArray br = new BitArray(shift + 1, false);
-
-            for (int i = 0; i < shift; i++)
-            {
-                bytes2 = ShiftLeftGrow(bytes2);
-            }
-
-            while (shift >= 0)
-            {
-                bytes2 = Negate(bytes2);
-                bytes1 = Add(bytes1, bytes2);
-                bytes2 = Negate(bytes2);
-                if (bytes1[bytes1.Count - 1] < 128)
-                {
-                    br[shift] = true;
-                }
-                else
-                {
-                    bytes1 = Add(bytes1, bytes2);
-                }
-                bytes2 = ShiftRight(bytes2);
-                shift--;
-            }
-            List<byte> result = GetBytes(br);
-
-            if (!qPos)
-            {
-                result = Negate(result);
-            }
-
-            return result;
-        }
-        private static List<byte> Remainder(List<byte> bytes1, List<byte> bytes2)
-        {
-            bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
-            bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
-
-            if (!numPos) bytes1 = Negate(bytes1);
-            if (!denPos) bytes2 = Negate(bytes2);
-
-            Trim(bytes1);
-            Trim(bytes2);
-
-            BitArray ba1 = new BitArray(bytes1.ToArray());
-            BitArray ba2 = new BitArray(bytes2.ToArray());
-
-            int ba11loc = 0;
-            for (int i = ba1.Length - 1; i >= 0; i--)
-            {
-                if (ba1[i])
-                {
-                    ba11loc = i;
-                    break;
-                }
-            }
-            int ba21loc = 0;
-            for (int i = ba2.Length - 1; i >= 0; i--)
-            {
-                if (ba2[i])
-                {
-                    ba21loc = i;
-                    break;
-                }
-            }
-            int shift = ba11loc - ba21loc;
-            if (shift < 0)
-            {
-                if (!numPos)
-                {
-                    bytes1 = Negate(bytes1);
-                }
-                return bytes1;
-            }
-            BitArray br = new BitArray(shift + 1, false);
-
-            for (int i = 0; i < shift; i++)
-            {
-                bytes2 = ShiftLeftGrow(bytes2);
-            }
-
-            while (shift >= 0)
-            {
-                bytes2 = Negate(bytes2);
-                bytes1 = Add(bytes1, bytes2);
-                bytes2 = Negate(bytes2);
-                if (bytes1[bytes1.Count - 1] < 128)
-                {
-                    br[shift] = true;
-                }
-                else
-                {
-                    bytes1 = Add(bytes1, bytes2);
-                }
-                bytes2 = ShiftRight(bytes2);
-                shift--;
-            }
-
-            if (!numPos)
-            {
-                bytes1 = Negate(bytes1);
-            }
-            return bytes1;
-        }
-        private static List<byte> Pow(List<byte> bytes1, List<byte> bytes2)
-        {
-            if (IsZero(bytes2)) return new List<byte>(new byte[] { 1 });
-
-            BitArray ba2 = new BitArray(bytes2.ToArray());
-            int last1 = 0;
-            List<byte> result = null;
-
-            for (int i = ba2.Length - 1; i >= 0; i--)
-            {
-                if (ba2[i])
-                {
-                    last1 = i;
-                    break;
-                }
-            }
-
-            for (int i = 0; i <= last1; i++)
-            {
-                if (ba2[i])
-                {
-                    if (result == null)
-                    {
-                        result = bytes1;
-                    }
-                    else
-                    {
-                        result = Multiply(result, bytes1);
-                    }
-                    Trim(bytes1);
-                    Trim(result);
-                }
-                if (i != last1)
-                {
-                    bytes1 = Multiply(bytes1, bytes1);
-                    Trim(bytes1);
-                }
-            }
-            return (result == null) ? new List<byte>(new byte[] { 1 }) : result;
-        }
-        private static List<byte> ModPow(List<byte> bytes1, List<byte> bytes2, List<byte> bytes3)
-        {
-            if (IsZero(bytes2))
-            {
-                return Remainder(new List<byte>(new byte[] { 1 }), bytes3);
-            }
-
-            BitArray ba2 = new BitArray(bytes2.ToArray());
-            int last1 = 0;
-            List<byte> result = null;
-
-            for (int i = ba2.Length - 1; i >= 0; i--)
-            {
-                if (ba2[i])
-                {
-                    last1 = i;
-                    break;
-                }
-            }
-
-            bytes1 = Remainder(bytes1, Copy(bytes3));
-            for (int i = 0; i <= last1; i++)
-            {
-                if (ba2[i])
-                {
-                    if (result == null)
-                    {
-                        result = bytes1;
-                    }
-                    else
-                    {
-                        result = Multiply(result, bytes1);
-                        result = Remainder(result, Copy(bytes3));
-                    }
-                    Trim(bytes1);
-                    Trim(result);
-                }
-                if (i != last1)
-                {
-                    bytes1 = Multiply(bytes1, bytes1);
-                    bytes1 = Remainder(bytes1, Copy(bytes3));
-                    Trim(bytes1);
-                }
-            }
-            return (result == null) ? Remainder(new List<byte>(new byte[] { 1 }), bytes3) : result;
-        }
-        private static List<byte> GCD(List<byte> bytes1, List<byte> bytes2)
-        {
-            List<byte> temp;
-
-            bool numPos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
-            bool denPos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
-
-            if (!numPos) bytes1 = Negate(bytes1);
-            if (!denPos) bytes2 = Negate(bytes2);
-
-            Trim(bytes1);
-            Trim(bytes2);
-
-            while (!IsZero(bytes2))
-            {
-                temp = Copy(bytes2);
-                bytes2 = Remainder(bytes1, bytes2);
-                bytes1 = temp;
-            }
-            return bytes1;
-        }
-        private static List<byte> Max(List<byte> bytes1, List<byte> bytes2)
-        {
-            bool b1Pos = ((bytes1[bytes1.Count - 1] & 0x80) == 0);
-            bool b2Pos = ((bytes2[bytes2.Count - 1] & 0x80) == 0);
-
-            if (b1Pos != b2Pos)
-            {
-                if (b1Pos) return bytes1;
-                if (b2Pos) return bytes2;
-            }
-
-            List<byte> sum = Add(bytes1, Negate(Copy(bytes2)));
-
-            if ((sum[sum.Count - 1] & 0x80) != 0)
-            {
-                return bytes2;
-            }
-
-            return bytes1;
-        }
-        private static List<byte> And(List<byte> bytes1, List<byte> bytes2)
-        {
-            List<byte> bnew = new List<byte>();
-            NormalizeLengths(bytes1, bytes2);
-
-            for (int i = 0; i < bytes1.Count; i++)
-            {
-                bnew.Add((byte)(bytes1[i] & bytes2[i]));
-            }
-
-            return bnew;
-        }
-        private static List<byte> Or(List<byte> bytes1, List<byte> bytes2)
-        {
-            List<byte> bnew = new List<byte>();
-            NormalizeLengths(bytes1, bytes2);
-
-            for (int i = 0; i < bytes1.Count; i++)
-            {
-                bnew.Add((byte)(bytes1[i] | bytes2[i]));
-            }
-
-            return bnew;
-        }
-        private static List<byte> Xor(List<byte> bytes1, List<byte> bytes2)
-        {
-            List<byte> bnew = new List<byte>();
-            NormalizeLengths(bytes1, bytes2);
-
-            for (int i = 0; i < bytes1.Count; i++)
-            {
-                bnew.Add((byte)(bytes1[i] ^ bytes2[i]));
-            }
-
-            return bnew;
-        }
-        private static List<byte> Not(List<byte> bytes)
-        {
-            List<byte> bnew = new List<byte>();
-
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                bnew.Add((byte)(bytes[i] ^ 0xFF));
-            }
-
-            return bnew;
-        }
-        private static List<byte> ShiftLeft(List<byte> bytes1, List<byte> bytes2)
-        {
-            int byteShift = (int)new BigInteger(Divide(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
-            sbyte bitShift = (sbyte)new BigInteger(Remainder(bytes2, new List<byte>(new byte[] { 8 })).ToArray());
-
-            for (int i = 0; i < Math.Abs(bitShift); i++)
-            {
-                if (bitShift < 0)
-                {
-                    bytes1 = ShiftRight(bytes1);
-                }
-                else
-                {
-                    bytes1 = ShiftLeftGrow(bytes1);
-                }
-            }
-
-            if (byteShift < 0)
-            {
-                byteShift = -byteShift;
-                if (byteShift >= bytes1.Count)
-                {
-                    if ((bytes1[bytes1.Count - 1] & 0x80) != 0)
-                    {
-                        bytes1 = new List<byte>(new byte[] { 0xFF });
-                    }
-                    else
-                    {
-                        bytes1 = new List<byte>(new byte[] { 0 });
-                    }
-                }
-                else
-                {
-                    List<byte> temp = new List<byte>();
-                    for (int i = byteShift; i < bytes1.Count; i++)
-                    {
-                        temp.Add(bytes1[i]);
-                    }
-                    bytes1 = temp;
-                }
-            }
-            else
-            {
-                List<byte> temp = new List<byte>();
-                for (int i = 0; i < byteShift; i++)
-                {
-                    temp.Add((byte)0);
-                }
-                for (int i = 0; i < bytes1.Count; i++)
-                {
-                    temp.Add(bytes1[i]);
-                }
-                bytes1 = temp;
-            }
-
-            return bytes1;
-        }
-        private static List<byte> ShiftLeftGrow(List<byte> bytes)
-        {
-            List<byte> bresult = new List<byte>();
-
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                byte newbyte = bytes[i];
-
-                if (newbyte > 127) newbyte -= 128;
-                newbyte = (byte)(newbyte * 2);
-                if ((i != 0) && (bytes[i - 1] >= 128)) newbyte++;
-
-                bresult.Add(newbyte);
-            }
-            if ((bytes[bytes.Count - 1] > 63) && (bytes[bytes.Count - 1] < 128))
-            {
-                bresult.Add((byte)0);
-            }
-            if ((bytes[bytes.Count - 1] > 127) && (bytes[bytes.Count - 1] < 192))
-            {
-                bresult.Add((byte)0xFF);
-            }
-
-            return bresult;
-        }
-        private static List<byte> ShiftLeftDrop(List<byte> bytes)
-        {
-            List<byte> bresult = new List<byte>();
-
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                byte newbyte = bytes[i];
-
-                if (newbyte > 127) newbyte -= 128;
-                newbyte = (byte)(newbyte * 2);
-                if ((i != 0) && (bytes[i - 1] >= 128)) newbyte++;
-
-                bresult.Add(newbyte);
-            }
-
-            return bresult;
-        }
-        private static List<byte> ShiftRight(List<byte> bytes)
-        {
-            List<byte> bresult = new List<byte>();
-
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                byte newbyte = bytes[i];
-
-                newbyte = (byte)(newbyte / 2);
-                if ((i != (bytes.Count - 1)) && ((bytes[i + 1] & 0x01) == 1))
-                {
-                    newbyte += 128;
-                }
-                if ((i == (bytes.Count - 1)) && ((bytes[bytes.Count - 1] & 0x80) != 0))
-                {
-                    newbyte += 128;
-                }
-                bresult.Add(newbyte);
-            }
-
-            return bresult;
-        }
-        private static List<byte> SetLength(List<byte> bytes, int size)
-        {
-            List<byte> bresult = new List<byte>();
-
-            for (int i = 0; i < size; i++)
-            {
-                bresult.Add(bytes[i]);
-            }
-
-            return bresult;
-        }
-        private static List<byte> Copy(List<byte> bytes)
-        {
-            List<byte> ret = new List<byte>();
-            for (int i = 0; i < bytes.Count; i++)
-            {
-                ret.Add(bytes[i]);
-            }
-            return ret;
-        }
-        private static BigInteger ApproximateBigInteger(double value)
-        {
-            //Special case values;
-            if (Double.IsNaN(value)) return new BigInteger(-101);
-            if (Double.IsNegativeInfinity(value)) return new BigInteger(-102);
-            if (Double.IsPositiveInfinity(value)) return new BigInteger(-103);
-
-            BigInteger result = new BigInteger(value);
-
-            if (result != 0)
-            {
-                bool pos = (value > 0);
-                if (!pos) value = -value;
-
-                int size = (int)Math.Floor(Math.Log10(value));
-
-                //keep only the first 17 significant digits;
-                if (size > 17)
-                {
-                    result = result - (result % BigInteger.Pow(10, size - 17));
-                }
-
-                if (!pos) value = -value;
-            }
-
-            return result;
-        }
-        private static void NormalizeLengths(List<byte> bytes1, List<byte> bytes2)
-        {
-            bool num1neg = (bytes1[bytes1.Count - 1] & 0x80) != 0;
-            bool num2neg = (bytes2[bytes2.Count - 1] & 0x80) != 0;
-            byte extender = 0;
-
-            if (bytes1.Count < bytes2.Count)
-            {
-                if (num1neg)
-                {
-                    extender = 0xff;
-                }
-                while (bytes1.Count < bytes2.Count)
-                {
-                    bytes1.Add(extender);
-                }
-            }
-            if (bytes2.Count < bytes1.Count)
-            {
-                if (num2neg)
-                {
-                    extender = 0xff;
-                }
-                while (bytes2.Count < bytes1.Count)
-                {
-                    bytes2.Add(extender);
-                }
-            }
-        }
-        private static void Trim(List<byte> bytes)
-        {
-            while (bytes.Count > 1)
-            {
-                if ((bytes[bytes.Count - 1] & 0x80) == 0)
-                {
-                    if ((bytes[bytes.Count - 1] == 0) & ((bytes[bytes.Count - 2] & 0x80) == 0))
-                    {
-                        bytes.RemoveAt(bytes.Count - 1);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-                else
-                {
-                    if ((bytes[bytes.Count - 1] == 0xFF) & ((bytes[bytes.Count - 2] & 0x80) != 0))
-                    {
-                        bytes.RemoveAt(bytes.Count - 1);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-        }
-        private static List<byte> GetBytes(BitArray ba)
-        {
-            int length = ((ba.Length) / 8) + 1;
-
-            List<byte> mask = new List<byte>(new byte[] { 0 });
-
-            for (int i = length - 1; i >= 0; i--)
-            {
-                for (int j = 7; j >= 0; j--)
-                {
-                    mask = ShiftLeftGrow(mask);
-                    if ((8 * i + j < ba.Length) && (ba[8 * i + j]))
-                    {
-                        mask[0] |= (byte)1;
-                    }
-                }
-            }
-
-            return mask;
-        }
         private static String Print(byte[] bytes)
         {
-            string ret = String.Empty;
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i].ToString("x");
-            }
-            return ret;
-        }
-        private static bool IsZero(List<byte> list)
-        {
-            byte[] value = list.ToArray();
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (value[i] != 0) return false;
-            }
-            return true;
+           return MyBigIntImp.PrintFormatX(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/subtract.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/subtract.cs
@@ -107,34 +107,19 @@ namespace System.Numerics.Tests
             }
         }
 
-        private static Byte[] GetRandomByteArray(Random random)
+        private static byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
 
-        private static Byte[] GetRandomByteArray(Random random, int size)
+        private static byte[] GetRandomByteArray(Random random, int size)
         {
-            byte[] value = new byte[size];
-
-            for (int i = 0; i < value.Length; ++i)
-            {
-                value[i] = (byte)random.Next(0, 256);
-            }
-
-            return value;
+            return MyBigIntImp.GetNonZeroRandomByteArray(random, size);
         }
 
         private static String Print(byte[] bytes)
         {
-            String ret = "make ";
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                ret += bytes[i] + " ";
-            }
-            ret += "endmake ";
-
-            return ret;
+            return MyBigIntImp.Print(bytes);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/BigInteger/subtract.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/subtract.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Tools;
 using Xunit;
 
@@ -22,14 +21,14 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
             }
 
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
             }
 
             for (int i = 0; i < s_samples; i++)
@@ -38,11 +37,11 @@ namespace System.Numerics.Tests
                 {
                     tempByteArray1 = GetRandomByteArray(s_random);
                     tempByteArray2 = GetRandomByteArray(s_random, 2);
-                    Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                    VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
 
                     tempByteArray1 = GetRandomByteArray(s_random, 2);
                     tempByteArray2 = GetRandomByteArray(s_random);
-                    Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                    VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
                 }
                 catch (IndexOutOfRangeException)
                 {
@@ -56,64 +55,63 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
             }
 
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { 0 };
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
 
                 tempByteArray1 = new byte[] { 0 };
                 tempByteArray2 = GetRandomByteArray(s_random, 2);
-                Assert.True(VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract"), " Verification Failed");
+                VerifySubtractString(Print(tempByteArray1) + Print(tempByteArray2) + "bSubtract");
             }
 
             // 32 bit boundary c=0 n1=0 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 34) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 34) + " bSubtract");
 
             // 32 bit boundary c=0 n1=0 n2=1
-            Assert.True(VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 34) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 34) + " bSubtract");
 
             // 32 bit boundary c=0 n1=1 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 32) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 32) + " bSubtract");
 
             // 32 bit boundary c=0 n1=1 n2=1
-            Assert.True(VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 32) + " " + Math.Pow(2, 32) + " bSubtract");
 
             // 32 bit boundary c=1 n1=0 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 33) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 31) + " " + Math.Pow(2, 33) + " bSubtract");
 
             // 32 bit boundary c=1 n1=0 n2=1
-            Assert.True(VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 32) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 33) + " " + Math.Pow(2, 32) + " bSubtract");
 
             // 32 bit boundary c=1 n1=1 n2=0
-            Assert.True(VerifySubtractString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 33)) + " bSubtract"), " Verification Failed");
+            VerifySubtractString(Math.Pow(2, 31) + " " + (Math.Pow(2, 32) + Math.Pow(2, 33)) + " bSubtract");
 
             // 32 bit boundary c=1 n1=1 n2=1
-            Assert.True(VerifySubtractString((Math.Pow(2, 33) + Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 34) + Math.Pow(2, 33) + Math.Pow(2, 31)) + " bSubtract"), " Verification Failed");
+            VerifySubtractString((Math.Pow(2, 33) + Math.Pow(2, 32) + Math.Pow(2, 31)) + " " + (Math.Pow(2, 34) + Math.Pow(2, 33) + Math.Pow(2, 31)) + " bSubtract");
         }
 
-        private static bool VerifySubtractString(string opstring)
+        private static void VerifySubtractString(string opstring)
         {
-            bool ret = true;
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
             {
-                ret &= Eval(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString(), String.Format("Out of Sync stacks found.  BigInteger {0} Mine {1}", sc.snCalc.Peek(), sc.myCalc.Peek()));
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
-            return ret;
         }
 
         private static Byte[] GetRandomByteArray(Random random)
         {
             return GetRandomByteArray(random, random.Next(0, 1024));
         }
+
         private static Byte[] GetRandomByteArray(Random random, int size)
         {
             byte[] value = new byte[size];
@@ -137,27 +135,6 @@ namespace System.Numerics.Tests
             ret += "endmake ";
 
             return ret;
-        }
-
-        public static bool Eval<T>(T expected, T actual, String errorMsg)
-        {
-            bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-            if (!retValue)
-                return Eval(retValue, errorMsg +
-                " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-                " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-            return true;
-        }
-        public static bool Eval(bool expression, string message)
-        {
-            if (!expression)
-            {
-                Console.WriteLine(message);
-            }
-
-            return expression;
         }
     }
 }


### PR DESCRIPTION
* Completes the removal of Console.WriteLine() from BigInteger tests and general refactoring to better use XUnit Asserts. (Progress against https://github.com/dotnet/corefx/issues/915.) 
* Generalizes the switch statement in Driver.cs's Worker class.
* Removes duplicate code in StackCalculator.cs by referencing the identical implementations in MyBigInt.cs.
* Removes duplicate implementations of Print(), GetRandomByteArray(), and IsZero() by moving them to MyBigInt.cs.
* Enables a set of existing but unused tests:
  * RunDivRemTests
  * RunIsEvenTests
  * RunIsOneTests
  * ModPowValidSmallNumbers
  * RunMultiplyTests

  (If there is history for why theses tests were disabled/never enabled, please let me know, but it looks like a set of refactoring mistakes.)

The first five commits are basically VS regex find-replace with the exception of the [changes to Driver.cs](https://github.com/dotnet/corefx/commit/2b7616cc33009422a662f34891406c755eecb4a6) mentioned above. The last four are more general refactoring to reduce copy/past function implementations.

Please let me know how (or if) you want these commits squashed before merging.