### PR TITLE
Fix spaces in sln

### DIFF
--- a/src/System.IO.FileSystem.Watcher/System.IO.FileSystem.Watcher.sln
+++ b/src/System.IO.FileSystem.Watcher/System.IO.FileSystem.Watcher.sln
@@ -1,42 +1,42 @@
-Microsoft Visual Studio Solution File, Format Version 12.00 
-# Visual Studio 2013 
-VisualStudioVersion = 12.0.30723.0 
-MinimumVisualStudioVersion = 10.0.40219.1 
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.Watcher", "src\System.IO.FileSystem.Watcher.csproj", "{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}" 
-EndProject 
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.Watcher.Tests", "tests\System.IO.FileSystem.Watcher.Tests.csproj", "{20411A66-C7A4-4941-8FA2-66308365FD22}" 
-EndProject 
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTraitsDiscoverers", "..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj", "{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}" 
-EndProject 
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{4B06330D-B839-4D9B-AC32-D510B7AB9FB9}" 
-EndProject 
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{613515D7-B799-4EB8-B262-C54A2279C77B}" 
-EndProject 
-Global 
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution 
-		Debug|Any CPU = Debug|Any CPU 
-		Release|Any CPU = Release|Any CPU 
-	EndGlobalSection 
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution 
-		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU 
-		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Debug|Any CPU.Build.0 = Debug|Any CPU 
-		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Release|Any CPU.ActiveCfg = Release|Any CPU 
-		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Release|Any CPU.Build.0 = Release|Any CPU 
-		{20411A66-C7A4-4941-8FA2-66308365FD22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU 
-		{20411A66-C7A4-4941-8FA2-66308365FD22}.Debug|Any CPU.Build.0 = Debug|Any CPU 
-		{20411A66-C7A4-4941-8FA2-66308365FD22}.Release|Any CPU.ActiveCfg = Release|Any CPU 
-		{20411A66-C7A4-4941-8FA2-66308365FD22}.Release|Any CPU.Build.0 = Release|Any CPU 
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU 
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU 
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU 
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU 
-	EndGlobalSection 
-	GlobalSection(SolutionProperties) = preSolution 
-		HideSolutionNode = FALSE 
-	EndGlobalSection 
-	GlobalSection(NestedProjects) = preSolution 
-		{20411A66-C7A4-4941-8FA2-66308365FD22} = {4B06330D-B839-4D9B-AC32-D510B7AB9FB9} 
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A} = {613515D7-B799-4EB8-B262-C54A2279C77B} 
-		{613515D7-B799-4EB8-B262-C54A2279C77B} = {4B06330D-B839-4D9B-AC32-D510B7AB9FB9} 
-	EndGlobalSection 
-EndGlobal 
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.Watcher", "src\System.IO.FileSystem.Watcher.csproj", "{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.Watcher.Tests", "tests\System.IO.FileSystem.Watcher.Tests.csproj", "{20411A66-C7A4-4941-8FA2-66308365FD22}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTraitsDiscoverers", "..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj", "{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{4B06330D-B839-4D9B-AC32-D510B7AB9FB9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{613515D7-B799-4EB8-B262-C54A2279C77B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20411A66-C7A4-4941-8FA2-66308365FD22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20411A66-C7A4-4941-8FA2-66308365FD22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20411A66-C7A4-4941-8FA2-66308365FD22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20411A66-C7A4-4941-8FA2-66308365FD22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{20411A66-C7A4-4941-8FA2-66308365FD22} = {4B06330D-B839-4D9B-AC32-D510B7AB9FB9}
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A} = {613515D7-B799-4EB8-B262-C54A2279C77B}
+		{613515D7-B799-4EB8-B262-C54A2279C77B} = {4B06330D-B839-4D9B-AC32-D510B7AB9FB9}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The sln file for System.IO.FileSystem.Watcher contains an extra space at the end of each line which causes Visual Studio to be unable to load the sln file.  This change removes the spaces from the sln file.