### PR TITLE
Fix case-insensitivity of ProcessStartInfo.Environment

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -5,6 +5,8 @@ namespace System.Diagnostics
 {
     public sealed partial class ProcessStartInfo
     {
+        private const bool CaseSensitiveEnvironmentVariables = true;
+
         public string UserName
         {
             get { throw new PlatformNotSupportedException(); }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
@@ -9,6 +9,8 @@ namespace System.Diagnostics
         private SecureString _password;
         private bool _loadUserProfile;
 
+        private const bool CaseSensitiveEnvironmentVariables = false;
+
         public string UserName
         {
             get { return _userName ?? string.Empty; }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -85,7 +85,9 @@ namespace System.Diagnostics
                 if (_environmentVariables == null)
                 {
                     IDictionary envVars = System.Environment.GetEnvironmentVariables();
-                    _environmentVariables = new Dictionary<string, string>(envVars.Count);
+                    _environmentVariables = new Dictionary<string, string>(
+                        envVars.Count,
+                        CaseSensitiveEnvironmentVariables ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
                     foreach (DictionaryEntry entry in envVars)
                     {
                         _environmentVariables.Add((string)entry.Key, (string)entry.Value);

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -483,6 +483,7 @@ namespace System.Diagnostics.ProcessTests
             Environment2.Add("NewKey", "NewValue");
             Environment2.Add("NewKey2", "NewValue2");
             Assert.True(Environment2.ContainsKey("NewKey"));
+            Assert.True(Environment2.ContainsKey("newkey")); // Windows is case-insensitive (will need to adapt this when we support tests on Unix)
             Assert.False(Environment2.ContainsKey("NewKey99"));
 
             //Iterating
@@ -518,6 +519,7 @@ namespace System.Diagnostics.ProcessTests
 
             //Contains
             Assert.True(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey", "NewValue")));
+            Assert.True(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("nEwKeY", "NewValue"))); // case-insensitive keys on Windows
             Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey99", "NewValue99")));
 
             //Exception not thrown with invalid key
@@ -537,8 +539,11 @@ namespace System.Diagnostics.ProcessTests
             string stringout = null;
             bool retval = false;
             retval = Environment2.TryGetValue("NewKey", out stringout);
-            Assert.Equal("NewValue", stringout);
             Assert.True(retval);
+            Assert.Equal("NewValue", stringout);
+            retval = Environment2.TryGetValue("NeWkEy", out stringout);
+            Assert.True(retval);
+            Assert.Equal("NewValue", stringout);
 
             stringout = null;
             retval = false;
@@ -579,7 +584,7 @@ namespace System.Diagnostics.ProcessTests
             Assert.Throws<System.Collections.Generic.KeyNotFoundException>(() => { string a1 = Environment2["1bB"]; });
 
             Assert.True(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey2", "NewValue2")));
-            Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("newkey2", "NewValue2")));
+            Assert.True(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NEWKeY2", "NewValue2"))); // case-insensitive keys on Windows
             Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("NewKey2", "newvalue2")));
             Assert.False(Environment2.Contains(new System.Collections.Generic.KeyValuePair<string, string>("newkey2", "newvalue2")));
 


### PR DESCRIPTION
On desktop, ProcessStartInfo.Environment returns a collection that ignores the case of keys when doing comparisons.  In contrast, currently in .NET Core, comparisons are done as case-sensitive.  This commit makes Windows use case-insensitive comparisons while Unix continues to use case-sensitive comparisons.