### PR TITLE
Give System.Linq.Tests.csproj a P2P reference to System.Linq.csproj

### DIFF
--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -21,5 +21,11 @@
     <Compile Include="CachedEnumerator.cs" />
     <Compile Include="EmptyEnumerable.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Linq.csproj">
+      <Project>{ca488507-3b6e-4494-b7be-7b4eeeb2c4d1}</Project>
+      <Name>System.Linq</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq/tests/packages.config
+++ b/src/System.Linq/tests/packages.config
@@ -5,6 +5,5 @@
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
   <package id="xunit.core.netcore" version="1.0.0-prerelease" />
   <package id="System.Collections" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Linq" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime" version="4.0.20-beta-22412" targetFramework="portable-net45+win" />
 </packages>


### PR DESCRIPTION
The System.Linq.Tests project was pulling in System.Linq.dll via a NuGet package, not via a P2P reference.  This meant that a) a potentially older version of System.Linq was being tested, and b) no PDB was being generated in the tests folder, resulting in no code coverage results.