### PR TITLE
Enable and fix System.IO.Pipes tests

### DIFF
--- a/src/System.IO.Pipes/System.IO.Pipes.sln
+++ b/src/System.IO.Pipes/System.IO.Pipes.sln
@@ -10,7 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1F3D70
 		..\.nuget\packages.config = ..\.nuget\packages.config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Pipes.BasicTests", "tests\System.IO.Pipes.BasicTests.csproj", "{142469EC-D665-4FE2-845A-FDA69F9CC557}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Pipes.Tests", "tests\System.IO.Pipes.Tests.csproj", "{142469EC-D665-4FE2-845A-FDA69F9CC557}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/System.IO.Pipes/tests/AnonymousPipesSimpleTest.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipesSimpleTest.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using Microsoft.Win32.SafeHandles;
-using System;
 using System.IO.Pipes;
 using System.Threading.Tasks;
+using Xunit;
 
 public class AnonymousPipesSimpleTest
 {
@@ -23,8 +22,8 @@ public class AnonymousPipesSimpleTest
                 byte[] sent = new byte[] { 123 };
                 byte[] received = new byte[] { 0 };
                 server.Write(sent, 0, 1);
-                int bytesReceived = client.Read(received, 0, 1);
-                Assert.Equal(1, bytesReceived);
+
+                Assert.Equal(1, client.Read(received, 0, 1));
                 Assert.Equal(sent[0], received[0]);
             }
         }
@@ -44,8 +43,8 @@ public class AnonymousPipesSimpleTest
                 byte[] sent = new byte[] { 123 };
                 byte[] received = new byte[] { 0 };
                 client.Write(sent, 0, 1);
-                int bytesReceived = server.Read(received, 0, 1);
-                Assert.Equal(1, bytesReceived);
+
+                Assert.Equal(1, server.Read(received, 0, 1));
                 Assert.Equal(sent[0], received[0]);
             }
         }
@@ -59,16 +58,9 @@ public class AnonymousPipesSimpleTest
         }
         if (stream.CanRead)
         {
-            if (stream.ReadByte() != 123)
-            {
-                Console.WriteLine("First byte read != 123");
-            }
-            if (stream.ReadByte() != 124)
-            {
-                Console.WriteLine("Second byte read != 124");
-            }
+            Assert.Equal(123, stream.ReadByte());
+            Assert.Equal(124, stream.ReadByte());
         }
-        Console.WriteLine("*** Operations finished. ***");
     }
 
     public static void StartClient(PipeDirection direction, SafePipeHandle clientPipeHandle)
@@ -77,23 +69,6 @@ public class AnonymousPipesSimpleTest
         {
             DoStreamOperations(client);
         }
-        // If you don't see this message that means that this task crashed.
-        Console.WriteLine("*** Client operations succeeded. ***");
-    }
-
-    public static Task StartClientAsync(PipeDirection direction, SafePipeHandle clientPipeHandle)
-    {
-        return Task.Run(() => StartClient(direction, clientPipeHandle));
-    }
-
-    public static void DoServerOperations(AnonymousPipeServerStream server)
-    {
-        DoStreamOperations(server);
-    }
-
-    public static Task DoServerOperationsAsync(AnonymousPipeServerStream server)
-    {
-        return Task.Run(() => DoServerOperations(server));
     }
 
     [Fact]
@@ -102,37 +77,41 @@ public class AnonymousPipesSimpleTest
         // calling every API related to server and client to detect any bad PInvokes
         using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.Out))
         {
-            Task clientTask = StartClientAsync(PipeDirection.In, server.ClientSafePipeHandle);
+            Task clientTask = Task.Run(() => StartClient(PipeDirection.In, server.ClientSafePipeHandle));
 
-            Console.WriteLine("server.CanRead = {0}", server.CanRead);
-            Console.WriteLine("server.CanSeek = {0}", server.CanSeek);
-            Console.WriteLine("server.CanTimeout = {0}", server.CanTimeout);
-            Console.WriteLine("server.CanWrite = {0}", server.CanWrite);
-            Console.WriteLine("server.GetClientHandleAsString() = {0}", server.GetClientHandleAsString());
-            Console.WriteLine("server.IsAsync = {0}", server.IsAsync);
-            Console.WriteLine("server.IsConnected = {0}", server.IsConnected);
-            Console.WriteLine("server.OutBufferSize = {0}", server.OutBufferSize);
-            Console.WriteLine("server.ReadMode = {0}", server.ReadMode);
-            Console.WriteLine("server.SafePipeHandle = {0}", server.SafePipeHandle);
-            Console.WriteLine("server.TransmissionMode = {0}", server.TransmissionMode);
+            Assert.False(server.CanRead);
+            Assert.False(server.CanSeek);
+            Assert.False(server.CanTimeout);
+            Assert.True(server.CanWrite);
+            Assert.False(string.IsNullOrWhiteSpace(server.GetClientHandleAsString()));
+            Assert.False(server.IsAsync);
+            Assert.True(server.IsConnected);
+            Assert.Equal(0, server.OutBufferSize);
+            Assert.Equal(PipeTransmissionMode.Byte, server.ReadMode);
+            Assert.NotNull(server.SafePipeHandle);
+            Assert.Equal(PipeTransmissionMode.Byte, server.TransmissionMode);
+
             server.Write(new byte[] { 123 }, 0, 1);
             server.WriteAsync(new byte[] { 124 }, 0, 1).Wait();
             server.Flush();
-            Console.WriteLine("Waiting for Pipe Drain.");
             server.WaitForPipeDrain();
+
             clientTask.Wait();
             server.DisposeLocalCopyOfClientHandle();
         }
+
         using (AnonymousPipeServerStream server = new AnonymousPipeServerStream(PipeDirection.In))
         {
-            Task clientTask = StartClientAsync(PipeDirection.Out, server.ClientSafePipeHandle);
+            Task clientTask = Task.Run(() => StartClient(PipeDirection.Out, server.ClientSafePipeHandle));
 
-            Console.WriteLine("server.InBufferSize = {0}", server.InBufferSize);
+            Assert.Equal(4096, server.InBufferSize);
             byte[] readData = new byte[] { 0, 1 };
-            server.Read(readData, 0, 1);
-            server.ReadAsync(readData, 1, 1).Wait();
+            Assert.Equal(1, server.Read(readData, 0, 1));
+            Assert.Equal(1, server.ReadAsync(readData, 1, 1).Result);
             Assert.Equal(123, readData[0]);
             Assert.Equal(124, readData[1]);
+
+            clientTask.Wait();
         }
     }
 
@@ -143,17 +122,18 @@ public class AnonymousPipesSimpleTest
         {
             using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.Out, server.ClientSafePipeHandle))
             {
-                Task serverTask = DoServerOperationsAsync(server);
-                Console.WriteLine("client.CanRead = {0}", client.CanRead);
-                Console.WriteLine("client.CanSeek = {0}", client.CanSeek);
-                Console.WriteLine("client.CanTimeout = {0}", client.CanTimeout);
-                Console.WriteLine("client.CanWrite = {0}", client.CanWrite);
-                Console.WriteLine("client.IsAsync = {0}", client.IsAsync);
-                Console.WriteLine("client.IsConnected = {0}", client.IsConnected);
-                Console.WriteLine("client.OutBufferSize = {0}", client.OutBufferSize);
-                Console.WriteLine("client.ReadMode = {0}", client.ReadMode);
-                Console.WriteLine("client.SafePipeHandle = {0}", client.SafePipeHandle);
-                Console.WriteLine("client.TransmissionMode = {0}", client.TransmissionMode);
+                Task serverTask = Task.Run(() => DoStreamOperations(server));
+
+                Assert.False(client.CanRead);
+                Assert.False(client.CanSeek);
+                Assert.False(client.CanTimeout);
+                Assert.True(client.CanWrite);
+                Assert.False(client.IsAsync);
+                Assert.True(client.IsConnected);
+                Assert.Equal(0, client.OutBufferSize);
+                Assert.Equal(PipeTransmissionMode.Byte, client.ReadMode);
+                Assert.NotNull(client.SafePipeHandle);
+                Assert.Equal(PipeTransmissionMode.Byte, client.TransmissionMode);
 
                 client.Write(new byte[] { 123 }, 0, 1);
                 client.WriteAsync(new byte[] { 124 }, 0, 1).Wait();
@@ -168,12 +148,12 @@ public class AnonymousPipesSimpleTest
         {
             using (AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle))
             {
-                Task serverTask = DoServerOperationsAsync(server);
+                Task serverTask = Task.Run(() => DoStreamOperations(server));
 
-                Console.WriteLine("client.InBufferSize = {0}", client.InBufferSize);
+                Assert.Equal(4096, client.InBufferSize);
                 byte[] readData = new byte[] { 0, 1 };
-                client.Read(readData, 0, 1);
-                client.ReadAsync(readData, 1, 1).Wait();
+                Assert.Equal(1, client.Read(readData, 0, 1));
+                Assert.Equal(1, client.ReadAsync(readData, 1, 1).Result);
                 Assert.Equal(123, readData[0]);
                 Assert.Equal(124, readData[1]);
 

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <AssemblyName>System.IO.Pipes.BasicTests</AssemblyName>
+    <AssemblyName>System.IO.Pipes.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
     <ProjectGuid>{142469EC-D665-4FE2-845A-FDA69F9CC557}</ProjectGuid>
     <NuGetPackageImportStamp>d2615b94</NuGetPackageImportStamp>

--- a/src/System.IO.Pipes/tests/packages.config
+++ b/src/System.IO.Pipes/tests/packages.config
@@ -5,8 +5,10 @@
   <package id="System.IO" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime" version="4.0.20-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime.Handles" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Security.Principal" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Threading.Overlapped" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
The Pipes tests weren't running because the project was named ".BasicTests" instead of ".Tests".  This commit renames it so that it runs.

Further, while it wasn't running, the tests got broken.  The tests' packages.config wasn't pulling in some required packages, causing type load errors that were then masked as other failures.  This commit updates the packages.config to pull in the needed packages.

Once the tests were enabled, there was a large amount of Console.WriteLine spew.  This commit replaces all of the Console.WriteLines with asserts (or just removes them if they were superfluous).

Finally, as I was going through doing the investigation, I noticed a few random things that could be cleaned up, which this commit does as well.

Fixes #1139