### PR TITLE
System.Reflection.Metadata: Fix reference path to System.Collections.Immutable

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -176,7 +176,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.34-rc-00001\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Reflection.Metadata/src/packages.config
+++ b/src/System.Reflection.Metadata/src/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.34-rc-00001" targetFramework="portable-net45+win" />
+  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="portable-net45+win" />
 </packages>

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -98,7 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.34-rc-00001\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>true</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
The 1.1.34-rc-00001 version of the package doesn't have `+wp8` in it's path.

I found this while building the lib on Mono, but I'm not sure how this builds on .NET given that the path is wrong?