### PR TITLE
Remove assert which notifies of a race condition in System.IO.FileSystem...

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -169,7 +169,6 @@ namespace System.IO
             }
             catch (ObjectDisposedException)
             { //Ignore
-                Debug.Assert(IsHandleInvalid, "ObjectDisposedException from something other than SafeHandle?");
             }
             catch (ArgumentNullException)
             { //Ignore


### PR DESCRIPTION
....Watcher...

but doesn't provide any real value.

This code is racing with a call to close on the handle. The check for IsHandleInvalid
returns false, but then someone closes the handle before this code runs. We'd
either need to lock or swallow the exception.  This change ignores the assert since
1) it isn't giving us any new information, and 2) that's what the release code
has been doing anyways.