### PR TITLE
Add tests for System.Collections.* debugger attributes

### DIFF
--- a/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace System.Diagnostics
+{
+    internal static class DebuggerAttributes
+    {
+        internal static object GetFieldValue(object obj, string fieldName)
+        {
+            return GetField(obj, fieldName).GetValue(obj);
+        }
+
+        internal static void ValidateDebuggerTypeProxyProperties(object obj)
+        {
+            // Get the DebuggerTypeProxyAttibute for obj
+            var attrs = 
+                obj.GetType().GetTypeInfo().CustomAttributes
+                .Where(a => a.AttributeType == typeof(DebuggerTypeProxyAttribute))
+                .ToArray();
+            if (attrs.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    string.Format("Expected one DebuggerTypeProxyAttribute on {0}.", obj));
+            }
+            var cad = (CustomAttributeData)attrs[0];
+
+            // Get the proxy type.  As written, this only works if the proxy and the target type
+            // have the same generic parameters, e.g. Dictionary<TKey,TValue> and Proxy<TKey,TValue>.
+            // It will not work with, for example, Dictionary<TKey,TValue>.Keys and Proxy<TKey>,
+            // as the former has two generic parameters and the latter only one.
+            Type proxyType = cad.ConstructorArguments[0].ArgumentType == typeof(Type) ?
+                (Type)cad.ConstructorArguments[0].Value :
+                Type.GetType((string)cad.ConstructorArguments[0].Value);
+            var genericArguments = obj.GetType().GenericTypeArguments;
+            if (genericArguments.Length > 0)
+            {
+                proxyType = proxyType.MakeGenericType(genericArguments);
+            }
+
+            // Create an instance of the proxy type, and make sure we can access all of the instance properties 
+            // on the type without exception
+            object proxyInstance = Activator.CreateInstance(proxyType, obj);
+            foreach (var pi in proxyInstance.GetType().GetTypeInfo().DeclaredProperties)
+            {
+                pi.GetValue(proxyInstance, null);
+            }
+        }
+
+        internal static void ValidateDebuggerDisplayReferences(object obj)
+        {
+            // Get the DebuggerDisplayAttribute for obj
+            var attrs = 
+                obj.GetType().GetTypeInfo().CustomAttributes
+                .Where(a => a.AttributeType == typeof(DebuggerDisplayAttribute))
+                .ToArray();
+            if (attrs.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    string.Format("Expected one DebuggerDisplayAttribute on {0}.", obj));
+            }
+            var cad = (CustomAttributeData)attrs[0];
+
+            // Get the text of the DebuggerDisplayAttribute
+            string attrText = (string)cad.ConstructorArguments[0].Value;
+
+            // Parse the text for all expressions
+            var references = new List<string>();
+            int pos = 0;
+            while (true)
+            {
+                int openBrace = attrText.IndexOf('{', pos);
+                if (openBrace < pos) break;
+                int closeBrace = attrText.IndexOf('}', openBrace);
+                if (closeBrace < openBrace) break;
+
+                string reference = attrText.Substring(openBrace + 1, closeBrace - openBrace - 1).Replace(",nq", "");
+                pos = closeBrace + 1;
+
+                references.Add(reference);
+            }
+            if (references.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    string.Format("The DebuggerDisplayAttribute for {0} doesn't reference any expressions.", obj));
+            }
+
+            // Make sure that each referenced expression is a simple field or property name, and that we can
+            // invoke the property's get accessor or read from the field.
+            foreach (var reference in references)
+            {
+                PropertyInfo pi = GetProperty(obj, reference);
+                if (pi != null)
+                {
+                    object ignored = pi.GetValue(obj, null);
+                    continue;
+                }
+
+                FieldInfo fi = GetField(obj, reference);
+                if (fi != null)
+                {
+                    object ignored = fi.GetValue(obj);
+                    continue;
+                }
+
+                throw new InvalidOperationException(
+                    string.Format("The DebuggerDisplayAttribute for {0} contains the expression \"{1}\".", obj, reference)); 
+            }
+        }
+
+        private static FieldInfo GetField(object obj, string fieldName)
+        {
+            for (Type t = obj.GetType(); t != null; t = t.GetTypeInfo().BaseType)
+            {
+                FieldInfo fi = t.GetTypeInfo().GetDeclaredField(fieldName);
+                if (fi != null)
+                {
+                    return fi;
+                }
+            }
+            return null;
+        }
+
+        private static PropertyInfo GetProperty(object obj, string propertyName)
+        {
+            for (Type t = obj.GetType(); t != null; t = t.GetTypeInfo().BaseType)
+            {
+                PropertyInfo pi = t.GetTypeInfo().GetDeclaredProperty(propertyName);
+                if (pi != null)
+                {
+                    return pi;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
+++ b/src/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -179,6 +177,13 @@ namespace System.Collections.Concurrent.Tests
         {
             Test0_Construction(-1);
             Test0_Construction(10);
+        }
+
+        [Fact]
+        public static void TestDebuggerAttributes()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new BlockingCollection<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new BlockingCollection<int>());
         }
 
         [Fact]

--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -408,6 +405,13 @@ namespace System.Collections.Concurrent.Tests
 
             Task.WaitAll(tasks);
             Assert.True(0 == failCount, "RTest9_ToArray:  One or more thread failed to get the correct bag items from ToArray");
+        }
+
+        [Fact]
+        public static void RTest10_DebuggerAttributes()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentBag<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ConcurrentBag<int>());
         }
 
         #region Helper Methods / Classes

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -535,6 +533,13 @@ namespace System.Collections.Concurrent.Tests
             Assert.False(dictionary.IsEmpty);
             Assert.Equal(1, dictionary.Keys.Count);
             Assert.Equal(1, dictionary.Values.Count);
+        }
+
+        [Fact]
+        public static void TestDebuggerAttributes()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentDictionary<string, int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ConcurrentDictionary<string, int>());
         }
 
         [Fact]

--- a/src/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -63,6 +61,13 @@ namespace System.Collections.Concurrent.Tests
             // "Test7_Exceptions:  CopyTo didn't throw ANE when null array passed");
             Assert.Throws<ArgumentOutOfRangeException>( () => queue.CopyTo(new int[1], -1));
             // "Test7_Exceptions:  CopyTo didn't throw AORE when negative array index passed");
+        }
+
+        [Fact]
+        public static void Test8_DebuggerAttributes()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentQueue<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ConcurrentQueue<int>());
         }
 
         [Fact]

--- a/src/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -474,6 +471,13 @@ namespace System.Collections.Concurrent.Tests
             Assert.Throws<NotSupportedException>(
                () => { object obj = collection.SyncRoot; });
                // "TestICollection:  ICollection.SyncRoot didn't throw NotSupportedException! for collection type: ConcurrentStack");
+        }
+
+        [Fact]
+        public static void Test10_DebuggerAttributes()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentStack<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ConcurrentStack<int>());
         }
 
         [Fact]

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -31,6 +31,9 @@
     <Compile Include="PartitionerStaticTests.cs" />
     <Compile Include="RangePartitionerNegativeTests.cs" />
     <Compile Include="PartitionerHelpers.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- References are resolved from packages.config -->
   <ItemGroup>

--- a/src/System.Collections.Concurrent/tests/packages.config
+++ b/src/System.Collections.Concurrent/tests/packages.config
@@ -2,8 +2,10 @@
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Console" version="4.0.0-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
   <package id="System.Diagnostics.Tracing" version="4.0.20-beta-22703" />
   <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
   <package id="System.Runtime" version="4.0.20-beta-22703" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
   <package id="System.Threading" version="4.0.10-beta-22703" />

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -724,7 +724,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal sealed class ImmutableArrayBuilderDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -262,7 +262,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Gets the string to display in the debugger watches window for this instance.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -728,7 +728,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableDictionaryBuilderDebuggerProxy<TKey, TValue>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+DebuggerProxy.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+DebuggerProxy.cs
@@ -11,7 +11,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableDictionaryDebuggerProxy<TKey, TValue>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+DebuggerProxy.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+DebuggerProxy.cs
@@ -10,7 +10,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableHashSetDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -1175,7 +1175,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable list that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableListBuilderDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -3251,7 +3251,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable list that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableListDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue`1.cs
@@ -487,7 +487,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableQueueDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
@@ -652,7 +652,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableSortedDictionaryBuilderDebuggerProxy<TKey, TValue>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -2017,7 +2017,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableSortedDictionaryDebuggerProxy<TKey, TValue>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
@@ -492,7 +492,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableSortedSetBuilderDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -2182,7 +2182,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableSortedSetDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
@@ -420,7 +420,6 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A simple view of the immutable collection that the debugger can show to the developer.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     internal class ImmutableStackDebuggerProxy<T>
     {
         /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -639,6 +640,13 @@ namespace System.Collections.Immutable.Test
             Assert.Equal(20, builder.Capacity);
             Assert.Equal(2, builder.Count);
             Assert.Equal(new[] { 1, 2 }, builder.ToArray());
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableArray.CreateBuilder<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableArray.CreateBuilder<string>(4));
         }
 
         private static ImmutableArray<T>.Builder CreateBuilderWithCount<T>(int count)

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -1255,6 +1256,13 @@ namespace System.Collections.Immutable.Test
                 }
             };
             Task.WaitAll(Task.Run(mutator), Task.Run(mutator));
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableArray.Create<string>()); // verify empty
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableArray.Create(1, 2, 3));  // verify non-empty
         }
 
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -242,6 +243,13 @@ namespace System.Collections.Immutable.Test
             Assert.Equal(1, empty.GetValueOrDefault("a", 1));
             Assert.Equal(5, populated.GetValueOrDefault("a"));
             Assert.Equal(5, populated.GetValueOrDefault("a", 1));
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableDictionary.CreateBuilder<string, int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableDictionary.CreateBuilder<int, string>());
         }
 
         protected override IImmutableDictionary<TKey, TValue> GetEmptyImmutableDictionary<TKey, TValue>()

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -325,6 +326,16 @@ namespace System.Collections.Immutable.Test
             Assert.False(enumerator.MoveNext());
             Assert.Throws<InvalidOperationException>(() => enumerator.Current);
             enumerator.Dispose();
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableDictionary.Create<int, int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableDictionary.Create<string, int>());
+
+            object rootNode = DebuggerAttributes.GetFieldValue(ImmutableDictionary.Create<string, string>(), "_root");
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(rootNode);
         }
 
         protected override IImmutableDictionary<TKey, TValue> Empty<TKey, TValue>()

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -277,6 +278,12 @@ namespace System.Collections.Immutable.Test
             Assert.False(builder.IsReadOnly);
 
             CollectionAssertAreEquivalent(new[] { "a", "b" }, builder.ToArray()); // tests enumerator
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableHashSet.CreateBuilder<int>());
         }
     }
 }

--- a/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
@@ -153,6 +154,13 @@ namespace System.Collections.Immutable.Test
         public void TryGetValueTest()
         {
             this.TryGetValueTestHelper(ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableHashSet.Create<string>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableHashSet.Create<int>(1, 2, 3));
         }
 
         protected override IImmutableSet<T> Empty<T>()

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -297,6 +298,13 @@ namespace System.Collections.Immutable.Test
             Assert.Equal(new[] { 9, 8 }, list.Cast<int>().ToArray());
             list.Clear();
             Assert.Equal(0, list.Count);
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableList.CreateBuilder<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableList.CreateBuilder<string>());
         }
 
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)

--- a/src/System.Collections.Immutable/tests/ImmutableListTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTest.cs
@@ -705,6 +705,16 @@ namespace System.Collections.Immutable.Test
             Assert.Throws<NotSupportedException>(() => list[0] = 1);
         }
 
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableList.Create<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableList.Create<double>(1, 2, 3));
+
+            object rootNode = DebuggerAttributes.GetFieldValue(ImmutableList.Create<string>("1", "2", "3"), "_root");
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(rootNode);
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             return ImmutableList<T>.Empty.AddRange(contents);

--- a/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
@@ -228,6 +229,13 @@ namespace System.Collections.Immutable.Test
         {
             // We already test Create(), so just prove that Empty has the same effect.
             Assert.Same(ImmutableQueue.Create<int>(), ImmutableQueue<int>.Empty);
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableQueue.Create<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableQueue.Create<string>());
         }
 
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -250,6 +251,13 @@ namespace System.Collections.Immutable.Test
             Assert.Equal(1, empty.GetValueOrDefault("a", 1));
             Assert.Equal(5, populated.GetValueOrDefault("a"));
             Assert.Equal(5, populated.GetValueOrDefault("a", 1));
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableSortedDictionary.CreateBuilder<string, int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableSortedDictionary.CreateBuilder<int, string>());
         }
 
         protected override IImmutableDictionary<TKey, TValue> GetEmptyImmutableDictionary<TKey, TValue>()

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -349,6 +349,16 @@ namespace System.Collections.Immutable.Test
             Assert.Throws<InvalidOperationException>(() => enumerator.Current);
             enumerator.Dispose();
         }
+        
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableSortedDictionary.Create<string, int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableSortedDictionary.Create<int, int>());
+
+            object rootNode = DebuggerAttributes.GetFieldValue(ImmutableSortedDictionary.Create<string, string>(), "_root");
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(rootNode);
+        }
 
         ////[Fact] // not really a functional test -- but very useful to enable when collecting perf traces.
         public void EnumerationPerformance()

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -325,6 +326,13 @@ namespace System.Collections.Immutable.Test
 
             Assert.Throws<ArgumentOutOfRangeException>(() => builder[-1]);
             Assert.Throws<ArgumentOutOfRangeException>(() => builder[3]);
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableSortedSet.CreateBuilder<string>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableSortedSet.CreateBuilder<int>());
         }
     }
 }

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -319,6 +319,16 @@ namespace System.Collections.Immutable.Test
             enumerator.Dispose();
         }
 
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableSortedSet.Create<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableSortedSet.Create<string>("1", "2", "3"));
+
+            object rootNode = DebuggerAttributes.GetFieldValue(ImmutableSortedSet.Create<object>(), "_root");
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(rootNode);
+        }
+
         protected override IImmutableSet<T> Empty<T>()
         {
             return ImmutableSortedSet<T>.Empty;

--- a/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
@@ -240,6 +241,13 @@ namespace System.Collections.Immutable.Test
 
             Assert.Throws<ArgumentNullException>(() => ImmutableStack.CreateRange((IEnumerable<int>)null));
             Assert.Throws<ArgumentNullException>(() => ImmutableStack.Create((int[])null));
+        }
+
+        [Fact]
+        public void DebuggerAttributesValid()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableStack.Create<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(ImmutableStack.Create<string>("1", "2", "3"));
         }
 
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)

--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -58,6 +58,9 @@
     <Compile Include="RequiresTests.cs" />
     <Compile Include="SimpleElementImmutablesTestBase.cs" />
     <Compile Include="TestExtensionsMethods.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="ClassDiagram1.cd" />

--- a/src/System.Collections.NonGeneric/tests/ArrayList/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayList/CtorTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Collections.ArrayListTests
@@ -84,6 +83,13 @@ namespace System.Collections.ArrayListTests
             // []  Attempt invalid construction (parm)
             //
             Assert.Throws<ArgumentNullException>(() => arrListColl = new ArrayList(null));
+        }
+
+        [Fact]
+        public void DebuggerAttributeTests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ArrayList());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ArrayList());
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Hashtable/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Hashtable/CtorTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Collections.HashtableTests
@@ -19,7 +18,6 @@ namespace System.Collections.HashtableTests
             //
             // [] Constructor: Create Hashtable using default settings.
             //
-            Console.Out.WriteLine("Create Hashtable using default settings");
             hash = new Hashtable();
             Assert.NotNull(hash);
 
@@ -307,6 +305,13 @@ namespace System.Collections.HashtableTests
             {
                 hash = new Hashtable((int)100000000, .5f);
             });
+        }
+
+        [Fact]
+        public void DebuggerAttributeTests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new Hashtable());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Hashtable());
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor.cs
+++ b/src/System.Collections.NonGeneric/tests/Queue/Queue_ctor.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System;
 using System.Collections;
 using Xunit;
+using System.Diagnostics;
 
 public class Queue_ctor
 {
@@ -71,6 +72,13 @@ public class Queue_ctor
         }
 
         Assert.True(bResult);
+    }
+
+    [Fact]
+    public void DebuggerAttributeTests()
+    {
+        DebuggerAttributes.ValidateDebuggerDisplayReferences(new Queue());
+        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Queue());
     }
 
 }

--- a/src/System.Collections.NonGeneric/tests/SortedList/CtorTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/CtorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Text;
 using Xunit;
 
@@ -106,6 +107,13 @@ namespace System.Collections.SortedListTests
             Assert.True(((CtorTestClass)sl2.GetKey(1)).GetString().Equals("bcd"));
 
             Assert.True(((CtorTestClass)sl2.GetKey(2)).GetString().Equals("cde"));
+        }
+
+        [Fact]
+        public void DebuggerAttributeTests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new SortedList());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new SortedList());
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Stack/StackBasicTests.cs
+++ b/src/System.Collections.NonGeneric/tests/Stack/StackBasicTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Collections.StackTests
@@ -358,7 +359,12 @@ public class StackBasicTests
     {
         Assert.Throws<ArgumentNullException>(() => { Stack stack = new Stack(null); });
     }
-
-
+        
+    [Fact]
+    public void DebuggerAttributeTests()
+    {
+        DebuggerAttributes.ValidateDebuggerDisplayReferences(new Stack());
+        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new Stack());
+    }
 }
 }

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -142,6 +142,9 @@
     <Compile Include="Stack\Stack_Contains_obj.cs" />
     <Compile Include="Stack\Stack_get_SyncRoot.cs" />
     <Compile Include="Stack\Stack_ToArray.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">

--- a/src/System.Collections.NonGeneric/tests/packages.config
+++ b/src/System.Collections.NonGeneric/tests/packages.config
@@ -5,6 +5,8 @@
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Globalization" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.IO" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Linq" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime" version="4.0.20-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />

--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace Test
 {
@@ -143,5 +144,13 @@ namespace Test
             ObservableCollection<Guid> col = new ObservableCollection<Guid>((IEnumerable<Guid>)anArray);
             Assert.False(((ICollection<Guid>)col).IsReadOnly);
         }
+
+        [Fact]
+        public static void DebuggerAttributeTests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ObservableCollection<int>());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ObservableCollection<int>());
+        }
+
     }
 }

--- a/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace Collections
 {
@@ -206,6 +207,16 @@ namespace Collections
             Assert.Throws<NotSupportedException>(() => dictAsIDictionary.Clear());
 
             helper.VerifyCollection(dictionary, expectedArr); //verifying that the collection has not changed.
+        }
+
+        [Fact]
+        public static void DebuggerAttributeTests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ReadOnlyDictionary<int, int>(new Dictionary<int, int>()));
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ReadOnlyDictionary<int, int>(new Dictionary<int, int>()));
+
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ReadOnlyDictionary<int, int>(new Dictionary<int, int>()).Keys);
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ReadOnlyDictionary<int, int>(new Dictionary<int, int>()).Values);
         }
     }
 

--- a/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollectionTests.cs
+++ b/src/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollectionTests.cs
@@ -6,13 +6,14 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace Test
 {
     /// <summary>
     /// Tests the public properties and constructor in ObservableCollection<T>.
     /// </summary>
-     public class ReadOnlyObservableCollectionTests
+    public class ReadOnlyObservableCollectionTests
     {
         [Fact]
         public static void Ctor_Tests()
@@ -195,6 +196,13 @@ namespace Test
             Assert.Throws<NotSupportedException>(() => readOnlyColAsIList.RemoveAt(0));
             Assert.Throws<NotSupportedException>(() => readOnlyColAsIList.Clear());
             helper.VerifyReadOnlyCollection(readOnlyCol, anArray);
+        }
+
+        [Fact]
+        public static void DebuggerAttribute_Tests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ReadOnlyObservableCollection<int>(new ObservableCollection<int>()));
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ReadOnlyObservableCollection<int>(new ObservableCollection<int>()));
         }
     }
 

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -21,6 +21,9 @@
     <Compile Include="ReadOnlyDictionary\ReadOnlyDictionaryTests.cs" />
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollection_EventsTests.cs" />
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollectionTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.ObjectModel.csproj">

--- a/src/System.ObjectModel/tests/packages.config
+++ b/src/System.ObjectModel/tests/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
   <package id="System.Runtime" version="4.0.20-beta-22703" />
   <package id="System.Threading" version="4.0.10-beta-22703" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DebugAttributeTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DebugAttributeTests.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
 using Xunit;
 
 namespace System.Threading.Tasks.Dataflow.Tests
@@ -69,30 +66,30 @@ namespace System.Threading.Tasks.Dataflow.Tests
                     Tuple.Create<bool,bool,object>(true, true, new BufferBlock<int>().AsObservable()),
 
                     // Supporting and Internal Types
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new ActionBlock<int>(i => {}, dboExBuffering), "_defaultTarget")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new ActionBlock<int>(i => {}, dboExNoBuffering), "_defaultTarget")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(GetFieldValue(new ActionBlock<int>(i => {}), "_defaultTarget"), "_messages")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new ActionBlock<int>(i => {}, dboExSpsc), "_spscTarget")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(GetFieldValue(new ActionBlock<int>(i => {}, dboExSpsc), "_spscTarget"), "_messages")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BufferBlock<int>(), "_source")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BufferBlock<int>(new DataflowBlockOptions { BoundedCapacity = 10 }), "_source")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new TransformBlock<int,int>(i => i, dboExBuffering), "_source")),
-                    Tuple.Create<bool,bool,object>(true, true, GetFieldValue(new TransformBlock<int,int>(i => i, dboExNoBuffering), "_reorderingBuffer")),
-                    Tuple.Create<bool,bool,object>(true, true, GetFieldValue(GetFieldValue(new TransformBlock<int,int>(i => i, dboExBuffering), "_source"), "_targetRegistry")),
-                    Tuple.Create<bool,bool,object>(true, true, GetFieldValue(GetFieldValue(WithLinkedTarget<TransformBlock<int,int>,int>(new TransformBlock<int,int>(i => i, dboExNoBuffering)), "_source"), "_targetRegistry")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new ActionBlock<int>(i => {}, dboExBuffering), "_defaultTarget")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new ActionBlock<int>(i => {}, dboExNoBuffering), "_defaultTarget")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(DebuggerAttributes.GetFieldValue(new ActionBlock<int>(i => {}), "_defaultTarget"), "_messages")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new ActionBlock<int>(i => {}, dboExSpsc), "_spscTarget")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(DebuggerAttributes.GetFieldValue(new ActionBlock<int>(i => {}, dboExSpsc), "_spscTarget"), "_messages")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BufferBlock<int>(), "_source")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BufferBlock<int>(new DataflowBlockOptions { BoundedCapacity = 10 }), "_source")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new TransformBlock<int,int>(i => i, dboExBuffering), "_source")),
+                    Tuple.Create<bool,bool,object>(true, true, DebuggerAttributes.GetFieldValue(new TransformBlock<int,int>(i => i, dboExNoBuffering), "_reorderingBuffer")),
+                    Tuple.Create<bool,bool,object>(true, true, DebuggerAttributes.GetFieldValue(DebuggerAttributes.GetFieldValue(new TransformBlock<int,int>(i => i, dboExBuffering), "_source"), "_targetRegistry")),
+                    Tuple.Create<bool,bool,object>(true, true, DebuggerAttributes.GetFieldValue(DebuggerAttributes.GetFieldValue(WithLinkedTarget<TransformBlock<int,int>,int>(new TransformBlock<int,int>(i => i, dboExNoBuffering)), "_source"), "_targetRegistry")),
                     Tuple.Create<bool,bool,object>(true, true, new JoinBlock<int,int>().Target1),
                     Tuple.Create<bool,bool,object>(true, true, new JoinBlock<int,int>(dboGroupGreedy).Target1),
                     Tuple.Create<bool,bool,object>(true, true, new JoinBlock<int,int>(dboGroupNonGreedy).Target1),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new JoinBlock<int,int>().Target1, "_sharedResources")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new JoinBlock<int,int>().Target1, "_sharedResources")),
                     Tuple.Create<bool,bool,object>(true, true, new BatchedJoinBlock<int,int>(42).Target1),
                     Tuple.Create<bool,bool,object>(true, true, new BatchedJoinBlock<int,int>(42, dboGroupGreedy).Target1),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BatchBlock<int>(42), "_target")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BatchBlock<int>(42, dboGroupGreedy), "_target")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BatchBlock<int>(42, dboGroupNonGreedy), "_target")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BatchBlock<int>(42), "_target")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BatchBlock<int>(42, dboGroupGreedy), "_target")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BatchBlock<int>(42, dboGroupNonGreedy), "_target")),
                     Tuple.Create<bool,bool,object>(true, false, new BufferBlock<int>().LinkTo(new ActionBlock<int>(i => {}))), // ActionOnDispose
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BroadcastBlock<int>(i => i), "_source")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BroadcastBlock<int>(i => i, dboGroupGreedy), "_source")),
-                    Tuple.Create<bool,bool,object>(true, false, GetFieldValue(new BroadcastBlock<int>(i => i, dboGroupNonGreedy), "_source")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BroadcastBlock<int>(i => i), "_source")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BroadcastBlock<int>(i => i, dboGroupGreedy), "_source")),
+                    Tuple.Create<bool,bool,object>(true, false, DebuggerAttributes.GetFieldValue(new BroadcastBlock<int>(i => i, dboGroupNonGreedy), "_source")),
                     Tuple.Create<bool,bool,object>(true, true, CreateNopLinkSource<int>()),
                     Tuple.Create<bool,bool,object>(true, true, CreateFilteringSource<int>()),
                     Tuple.Create<bool,bool,object>(true, true, CreateSendSource<int>()),
@@ -106,8 +103,13 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 };
 
                 // Test all DDAs and DTPAs
-                Assert.All(from obj in objectsToTest where obj.Item1 select obj.Item3, obj => TestDebuggerDisplayReferences(obj));
-                Assert.All(from obj in objectsToTest where obj.Item2 select obj.Item3, obj => TestDebuggerTypeProxyProperties(obj));
+                foreach (var obj in objectsToTest)
+                {
+                    if (obj.Item1)
+                        DebuggerAttributes.ValidateDebuggerDisplayReferences(obj.Item3);
+                    if (obj.Item2)
+                        DebuggerAttributes.ValidateDebuggerTypeProxyProperties(obj.Item3);
+                }
             }
         }
 
@@ -121,75 +123,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
         {
             block.LinkTo(DataflowBlock.NullTarget<T>());
             return block;
-        }
-
-        private static object GetFieldValue(object obj, string fieldName)
-        {
-            Type t = obj.GetType();
-            FieldInfo fi = null;
-            while (t != null)
-            {
-                fi = t.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-
-                if (fi != null) break;
-                t = t.GetTypeInfo().BaseType;
-            }
-            return fi.GetValue(obj);
-        }
-
-        private static void TestDebuggerTypeProxyProperties(object obj)
-        {
-            var attrs = obj.GetType().GetTypeInfo().GetCustomAttributes(typeof(DebuggerTypeProxyAttribute), false).ToArray();
-            Assert.Equal(expected: 1, actual: attrs.Length);
-
-            DebuggerTypeProxyAttribute dtpa = (DebuggerTypeProxyAttribute)attrs[0];
-            string attrText = dtpa.ProxyTypeName;
-            var proxyType = Type.GetType(attrText);
-            var genericArguments = obj.GetType().GetGenericArguments();
-            if (genericArguments.Any())
-            {
-                proxyType = proxyType.MakeGenericType(genericArguments);
-            }
-            object proxyInstance = Activator.CreateInstance(proxyType, obj); // make sure we can instantiate it
-
-            PropertyInfo[] propertyInfos = proxyInstance.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            foreach (var pi in propertyInfos)
-            {
-                pi.GetValue(proxyInstance, null); // make sure we can access all its properties
-            }
-        }
-
-        private static void TestDebuggerDisplayReferences(object obj)
-        {
-            var attrs = obj.GetType().GetTypeInfo().GetCustomAttributes(typeof(DebuggerDisplayAttribute), false).ToArray();
-            Assert.Equal(expected: 1, actual: attrs.Length);
-
-            DebuggerDisplayAttribute dda = (DebuggerDisplayAttribute)attrs[0];
-            string attrText = dda.Value;
-
-            var references = new List<string>();
-            int pos = 0;
-            while (true)
-            {
-                int openBrace = attrText.IndexOf('{', pos);
-                if (openBrace < pos) break;
-                int closeBrace = attrText.IndexOf('}', openBrace);
-                if (closeBrace < openBrace) break;
-
-                string reference = attrText.Substring(openBrace + 1, closeBrace - openBrace - 1).Replace(",nq", "");
-                pos = closeBrace + 1;
-
-                references.Add(reference);
-            }
-            Assert.NotEqual(0, actual: references.Count);
-
-            foreach (var reference in references)
-            {
-                PropertyInfo pi = obj.GetType().GetProperty(reference, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                FieldInfo fi = obj.GetType().GetField(reference, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                Assert.False(pi == null & fi == null); // must be either a property or a field
-                object result = pi != null ? pi.GetValue(obj, null) : fi.GetValue(obj); // make sure we can access the property or field
-            }
         }
 
         private static ISourceBlock<T> CreateNopLinkSource<T>()

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">


### PR DESCRIPTION
Our collection types are some of the biggest users of DebuggerDisplayAttribute and DebuggerTypeProxyAttribute.  In the past as we've done refactorings, we've broken these on multiple occasions, and such breaks are often only discovered later on by someone using the types in the IDE.

This change adds some basic tests to exercise these debugger attributes, verifying their existence, that fields/properties they refer to exist, that properties on type proxies don't throw exceptions, etc.  We already had some debugger attribute tests in the System.Threading.Tasks.Dataflow library's tests; I've extracted those into some common helpers which I then use in the various test projects.

These helpers could be used in more test projects in the future.  They could also be expanded to cover more scenarios, as desired.

Related to #938.