### PR TITLE
Fix build warning

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -85,9 +85,13 @@ namespace System.Diagnostics
                 if (_environmentVariables == null)
                 {
                     IDictionary envVars = System.Environment.GetEnvironmentVariables();
+
+#pragma warning disable 0429 // CaseSensitiveEnvironmentVaribles is constant but varies depending on if we build for Unix or Windows
                     _environmentVariables = new Dictionary<string, string>(
                         envVars.Count,
                         CaseSensitiveEnvironmentVariables ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+#pragma warning restore 0429
+
                     foreach (DictionaryEntry entry in envVars)
                     {
                         _environmentVariables.Add((string)entry.Key, (string)entry.Value);


### PR DESCRIPTION
PR #1137 introduced this warning.  The problem is that we use "const"
(correctly) for CaseSensitiveEnvironmentVariables, since it doesn't
change at runtime, it's something that is fixed depending on the
platform we target.  However, that causes the C# compiler to think
there's dead code when we branch on the value, since only one branch
can ever be hit at build time.

Simply disable the warning (at a small scope) in this case.