### PR TITLE
Remove SecurityTransparent attribute from Linq

### DIFF
--- a/src/System.Linq/src/Properties/AssemblyInfo.cs
+++ b/src/System.Linq/src/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-[assembly: System.Security.SecurityTransparent]

--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -24,7 +24,6 @@
     <Compile Include="..\..\Common\src\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="System\Linq\Enumerable.cs" />
     <Compile Include="System\Linq\Errors.cs" />
     <Compile Include="Var.cs" />


### PR DESCRIPTION
The System.Linq.dll assembly is being attributed as SecurityTransparent.
This is causing MethodAccessExceptions when it tries to access
functionality from other assemblies, e.g. Debug.Assert, since no other
assembly in CoreFX is attributed as transparent.