### PR TITLE
Fix issue #1100. StartInfo may return incorrect information for *running* processes.

### DIFF
--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -244,6 +244,9 @@
     <value>Cannot load Performance Counter data because an unexpected registry key value type was read from '{0}'.</value>
   </data>
   <data name="CantGetProcessStartInfo" xml:space="preserve">
-    <value>Process was not started by this object and this object process id does not much current process id, so requested information cannot be determined.</value>
+    <value>Process was not started by this object, so requested information cannot be determined.</value>
+  </data>
+  <data name="CantSetProcessStartInfo" xml:space="preserve">
+    <value>Process is already associated with a real process, so the requested operation cannot be performed.</value>
   </data>
 </root>

--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -243,4 +243,7 @@
   <data name="CounterDataCorrupt" xml:space="preserve">
     <value>Cannot load Performance Counter data because an unexpected registry key value type was read from '{0}'.</value>
   </data>
+  <data name="CantGetProcessStartInfo" xml:space="preserve">
+    <value>Process was not started by this object and this object process id does not much current process id, so requested information cannot be determined.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -482,7 +482,7 @@ namespace System.Diagnostics
             {
                 if (_startInfo == null)
                 {
-                    if (Associated && Process.GetCurrentProcessId() != Id)
+                    if (Associated)
                     {
                         throw new InvalidOperationException(SR.CantGetProcessStartInfo);
                     }
@@ -497,6 +497,12 @@ namespace System.Diagnostics
                 {
                     throw new ArgumentNullException("value");
                 }
+                
+                if (Associated)
+                {
+                    throw new InvalidOperationException(SR.CantSetProcessStartInfo);
+                }
+
                 _startInfo = value;
             }
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -482,6 +482,11 @@ namespace System.Diagnostics
             {
                 if (_startInfo == null)
                 {
+                    if (Associated && Process.GetCurrentProcessId() != Id)
+                    {
+                        throw new InvalidOperationException(SR.CantGetProcessStartInfo);
+                    }
+
                     _startInfo = new ProcessStartInfo();
                 }
                 return _startInfo;

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -649,7 +649,7 @@ namespace System.Diagnostics.ProcessTests
                 Assert.Equal(ProcessName, process.StartInfo.FileName);
 
                 process.Kill();
-                process.WaitForExit(WaitInMS);
+                Assert.True(process.WaitForExit(WaitInMS));
             }
 
             {
@@ -659,7 +659,7 @@ namespace System.Diagnostics.ProcessTests
                 Assert.Throws<System.InvalidOperationException>(() => (process.StartInfo = new ProcessStartInfo()));
 
                 process.Kill();
-                process.WaitForExit(WaitInMS);
+                Assert.True(process.WaitForExit(WaitInMS));
             }
 
             {

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -672,12 +672,6 @@ namespace System.Diagnostics.ProcessTests
                 Process process = Process.GetCurrentProcess();
                 Assert.Throws<System.InvalidOperationException>(() => process.StartInfo);
             }
-
-            {
-                Process process = Process.Start(ProcessName);
-                process.Start();
-                Assert.Equal(ProcessName, process.StartInfo.FileName);
-            }
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -638,5 +638,46 @@ namespace System.Diagnostics.ProcessTests
             }
             );
         }
+
+        [Fact]
+        public void Process_StartInfo()
+        {
+            {
+                Process process = CreateProcessInfinite();
+                process.Start();
+
+                Assert.Equal(ProcessName, process.StartInfo.FileName);
+
+                process.Kill();
+                process.WaitForExit(WaitInMS);
+            }
+
+            {
+                Process process = CreateProcessInfinite();
+                process.Start();
+
+                Assert.Throws<System.InvalidOperationException>(() => (process.StartInfo = new ProcessStartInfo()));
+
+                process.Kill();
+                process.WaitForExit(WaitInMS);
+            }
+
+            {
+                Process process = new Process();
+                process.StartInfo = new ProcessStartInfo(ProcessName);
+                Assert.Equal(ProcessName, process.StartInfo.FileName);
+            }
+
+            {
+                Process process = Process.GetCurrentProcess();
+                Assert.Throws<System.InvalidOperationException>(() => process.StartInfo);
+            }
+
+            {
+                Process process = Process.Start(ProcessName);
+                process.Start();
+                Assert.Equal(ProcessName, process.StartInfo.FileName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix issue #1100. Implemented throwing exception mechanism in a way as @davkean  suggests in his comment to this task: 
> My proposal in this case, is to throw InvalidOperationException (with a good error message) when accessing the Process.StartInfo for Processes that you didn't start yourself. This will prevent people being confused by this behavior.