### PR TITLE
Add tests for KeyedCollection. Issue #867

### DIFF
--- a/src/Common/tests/Collections/ICollectionTest.cs
+++ b/src/Common/tests/Collections/ICollectionTest.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Linq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Tests.Collections
+{
+    public abstract class ICollectionTest<T> : IEnumerableTest<T>
+    {
+        private readonly bool _expectedIsSynchronized;
+
+        protected ICollectionTest(bool isSynchronized)
+        {
+            _expectedIsSynchronized = isSynchronized;
+            ValidArrayTypes = new[] {typeof (object)};
+            InvalidArrayTypes = new[]
+            {
+                typeof (MyInvalidReferenceType),
+                typeof (MyInvalidValueType)
+            };
+        }
+
+        protected Type[] ValidArrayTypes { get; set; }
+        protected Type[] InvalidArrayTypes { get; set; }
+        protected abstract bool ItemsMustBeUnique { get; }
+        protected abstract bool ItemsMustBeNonNull { get; }
+
+        protected bool ExpectedIsSynchronized
+        {
+            get { return _expectedIsSynchronized; }
+        }
+
+        protected virtual bool CopyToOnlySupportsZeroLowerBounds
+        {
+            get { return true; }
+        }
+
+        protected ICollection GetCollection(object[] items)
+        {
+            IEnumerable obj = GetEnumerable(items);
+            Assert.IsAssignableFrom<ICollection>(obj);
+            return (ICollection) obj;
+        }
+
+        [Fact]
+        public void Count()
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            Assert.Equal(items.Length, collection.Count);
+        }
+
+        [Fact]
+        public void IsSynchronized()
+        {
+            ICollection collection = GetCollection(GenerateItems(16));
+            Assert.Equal(
+                ExpectedIsSynchronized,
+                collection.IsSynchronized);
+        }
+
+        [Fact]
+        public void SyncRootNonNull()
+        {
+            ICollection collection = GetCollection(GenerateItems(16));
+            Assert.NotNull(collection.SyncRoot);
+        }
+
+        [Fact]
+        public void SyncRootConsistent()
+        {
+            ICollection collection = GetCollection(GenerateItems(16));
+            object syncRoot1 = collection.SyncRoot;
+            object syncRoot2 = collection.SyncRoot;
+            Assert.Equal(syncRoot1, syncRoot2);
+        }
+
+        [Fact]
+        public void SyncRootCanBeLocked()
+        {
+            ICollection collection = GetCollection(GenerateItems(16));
+            lock (collection.SyncRoot)
+            {
+            }
+        }
+
+        [Fact]
+        public void SyncRootUnique()
+        {
+            ICollection collection1 = GetCollection(GenerateItems(16));
+            ICollection collection2 = GetCollection(GenerateItems(16));
+            Assert.NotEqual(collection1.SyncRoot, collection2.SyncRoot);
+        }
+
+        [Fact]
+        public void CopyToNull()
+        {
+            ICollection collection = GetCollection(GenerateItems(16));
+            Assert.Throws<ArgumentNullException>(
+                () => collection.CopyTo(null, 0));
+        }
+
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        [InlineData(int.MaxValue)]
+        public void CopyToBadIndex(int index)
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            var items2 = (object[]) items.Clone();
+
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.CopyTo(items2, index));
+
+            CollectionAssert.Equal(items, items2);
+        }
+
+        [Fact]
+        public void CopyToArrayWithNonZeroBounds()
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            if (CopyToOnlySupportsZeroLowerBounds)
+            {
+                Array itemArray = Array.CreateInstance(
+                    typeof (object),
+                    new[] {collection.Count + 8},
+                    new[] {-4});
+                var tempItemArray = (Array) itemArray.Clone();
+                Assert.Throws<ArgumentException>(
+                    () => collection.CopyTo(itemArray, 0));
+                CollectionAssert.Equal(tempItemArray, itemArray);
+            }
+            else
+            {
+                Array itemArray = Array.CreateInstance(
+                    typeof (object),
+                    new[] {collection.Count + 4},
+                    new[] {-4});
+                var tempItemArray = (Array) itemArray.Clone();
+                Assert.Throws<ArgumentException>(
+                    () => collection.CopyTo(itemArray, 1));
+                CollectionAssert.Equal(tempItemArray, itemArray);
+
+                itemArray = Array.CreateInstance(
+                    typeof (object),
+                    new[] {collection.Count + 4},
+                    new[] {-6});
+                tempItemArray = (Array) itemArray.Clone();
+                Assert.Throws<ArgumentException>(
+                    () => collection.CopyTo(itemArray, -1));
+                CollectionAssert.Equal(tempItemArray, itemArray);
+            }
+        }
+
+        [Fact]
+        public void CopyToIndexArrayLength()
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            var tempArray = (object[]) items.Clone();
+            Assert.Throws<ArgumentException>(
+                () => collection.CopyTo(items, collection.Count));
+            CollectionAssert.Equal(tempArray, items);
+        }
+
+        [Fact]
+        public void CopyToCollectionLargerThanArray()
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            object[] itemArray = GenerateItems(collection.Count + 1);
+            var tempItemArray = (object[]) itemArray.Clone();
+            Assert.Throws<ArgumentException>(
+                () => collection.CopyTo(itemArray, 2));
+            CollectionAssert.Equal(tempItemArray, itemArray);
+        }
+
+        [Fact]
+        public void CopyToMDArray()
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            Assert.Throws<ArgumentException>(
+                () =>
+                collection.CopyTo(new object[1, collection.Count], 0));
+        }
+
+        protected void AssertThrows(
+            Type[] exceptionTypes,
+            Action testCode)
+        {
+            Exception exception = Record.Exception(testCode);
+            if (exception == null)
+            {
+                throw new AssertActualExpectedException(
+                    exceptionTypes,
+                    null,
+                    "Expected an exception but got null.");
+            }
+            Type exceptionType = exception.GetType();
+            if (!exceptionTypes.Contains(exceptionType))
+            {
+                throw new AssertActualExpectedException(
+                    exceptionTypes,
+                    exceptionType,
+                    "Caught wrong exception.");
+            }
+        }
+
+        [Fact]
+        public void CopyToInvalidTypes()
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            Type[] expectedExceptionTypes = IsGenericCompatibility
+                                                ? new[]
+                                                {
+                                                    typeof (
+                                                      ArgumentException),
+                                                    typeof (
+                                                      InvalidCastException
+                                                      )
+                                                }
+                                                : new[]
+                                                {
+                                                    typeof (
+                                                      ArgumentException)
+                                                };
+            foreach (Type type in InvalidArrayTypes)
+            {
+                Array itemArray = Array.CreateInstance(
+                    type,
+                    collection.Count);
+                var tempItemArray = (Array) itemArray.Clone();
+
+                AssertThrows(
+                    expectedExceptionTypes,
+                    () => collection.CopyTo(itemArray, 0));
+                CollectionAssert.Equal(tempItemArray, itemArray);
+            }
+        }
+
+        [Theory]
+        [InlineData(16, 20, -5, -1)]
+        [InlineData(16, 21, -4, 1)]
+        [InlineData(16, 20, 0, 0)]
+        [InlineData(16, 20, 0, 4)]
+        [InlineData(16, 24, 0, 4)]
+        public void CopyTo(
+            int size,
+            int arraySize,
+            int arrayLowerBound,
+            int copyToIndex)
+        {
+            object[] items = GenerateItems(16);
+            ICollection collection = GetCollection(items);
+            Array itemArray = Array.CreateInstance(
+                typeof (object),
+                new[] {arraySize},
+                new[] {arrayLowerBound});
+            var tempItemArray = (Array) itemArray.Clone();
+            if (CopyToOnlySupportsZeroLowerBounds
+                && arrayLowerBound != 0)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => collection.CopyTo(itemArray, copyToIndex));
+            }
+            else
+            {
+                collection.CopyTo(itemArray, copyToIndex);
+                Array.Copy(
+                    items,
+                    0,
+                    tempItemArray,
+                    copyToIndex,
+                    items.Length);
+                CollectionAssert.Equal(tempItemArray, itemArray);
+            }
+        }
+
+        [Fact]
+        public void CopyToValidTypes()
+        {
+            foreach (Type type in ValidArrayTypes)
+            {
+                object[] items = GenerateItems(16);
+                ICollection collection = GetCollection(items);
+                Array itemArray = Array.CreateInstance(
+                    type,
+                    collection.Count);
+                collection.CopyTo(itemArray, 0);
+                CollectionAssert.Equal(items, itemArray);
+            }
+        }
+
+        internal class MyInvalidReferenceType
+        {
+        }
+
+        internal struct MyInvalidValueType
+        {
+        }
+    }
+}

--- a/src/Common/tests/Collections/IEnumerableTest.cs
+++ b/src/Common/tests/Collections/IEnumerableTest.cs
@@ -1,0 +1,543 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using Xunit;
+
+namespace Tests.Collections
+{
+    public enum CollectionOrder
+    {
+        Unspecified,
+        Sequential
+    }
+
+    public abstract class IEnumerableTest<T>
+    {
+        private const int EnumerableSize = 16;
+
+        protected T DefaultValue
+        {
+            get { return default(T); }
+        }
+
+        protected bool MoveNextAtEndThrowsOnModifiedCollection
+        {
+            get { return true; }
+        }
+
+        protected virtual CollectionOrder CollectionOrder
+        {
+            get { return CollectionOrder.Sequential; }
+        }
+
+        protected abstract bool IsResetNotSupported { get; }
+        protected abstract bool IsGenericCompatibility { get; }
+        protected abstract object GenerateItem();
+
+        protected object[] GenerateItems(int size)
+        {
+            var ret = new object[size];
+            for (var i = 0; i < size; i++)
+            {
+                ret[i] = GenerateItem();
+            }
+            return ret;
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets an instance of the enumerable under test containing the given items.
+        /// </summary>
+        /// <param name="items">The items to initialize the enumerable with.</param>
+        /// <returns>An instance of the enumerable under test containing the given items.</returns>
+        protected abstract IEnumerable GetEnumerable(object[] items);
+
+        /// <summary>
+        ///     When overridden in a derived class, invalidates any enumerators for the given IEnumerable.
+        /// </summary>
+        /// <param name="enumerable">The <see cref="IEnumerable" /> to invalidate enumerators for.</param>
+        /// <returns>The new set of items in the <see cref="IEnumerable" /></returns>
+        protected abstract object[] InvalidateEnumerator(
+            IEnumerable enumerable);
+
+        private void RepeatTest(
+            Action<IEnumerator, object[], int> testCode,
+            int iters = 3)
+        {
+            object[] items = GenerateItems(32);
+            IEnumerable enumerable = GetEnumerable(items);
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            for (var i = 0; i < iters; i++)
+            {
+                testCode(enumerator, items, i);
+                if (IsResetNotSupported)
+                {
+                    enumerator = enumerable.GetEnumerator();
+                }
+                else
+                {
+                    enumerator.Reset();
+                }
+            }
+        }
+
+        private void RepeatTest(
+            Action<IEnumerator, object[]> testCode,
+            int iters = 3)
+        {
+            RepeatTest((e, i, it) => testCode(e, i), iters);
+        }
+
+        [Fact]
+        public void MoveNextHitsAllItems()
+        {
+            RepeatTest(
+                (enumerator, items) =>
+                {
+                    var iterations = 0;
+                    while (enumerator.MoveNext())
+                    {
+                        iterations++;
+                    }
+                    Assert.Equal(items.Length, iterations);
+                });
+        }
+
+        [Fact]
+        public void CurrentThrowsAfterEndOfCollection()
+        {
+            if (IsGenericCompatibility)
+            {
+                return;
+                    // apparently it is okay if enumerator.Current doesn't throw when the collection is generic.
+            }
+
+            RepeatTest(
+                (enumerator, items) =>
+                {
+                    while (enumerator.MoveNext())
+                    {
+                    }
+                    Assert.Throws<InvalidOperationException>(
+                        () => enumerator.Current);
+                });
+        }
+
+        [Fact]
+        public void MoveNextFalseAfterEndOfCollection()
+        {
+            RepeatTest(
+                (enumerator, items) =>
+                {
+                    while (enumerator.MoveNext())
+                    {
+                    }
+
+                    Assert.False(enumerator.MoveNext());
+                });
+        }
+
+        [Fact]
+        public void Current()
+        {
+            // Verify that current returns proper result.
+            RepeatTest(
+                (enumerator, items, iteration) =>
+                {
+                    if (iteration == 1)
+                    {
+                        VerifyEnumerator(
+                            enumerator,
+                            items,
+                            0,
+                            items.Length/2,
+                            true,
+                            false);
+                    }
+                    else
+                    {
+                        VerifyEnumerator(enumerator, items);
+                    }
+                });
+        }
+
+        [Fact]
+        public void Reset()
+        {
+            if (IsResetNotSupported)
+            {
+                RepeatTest(
+                    (enumerator, items) =>
+                    {
+                        Assert.Throws<NotSupportedException>(
+                            () => enumerator.Reset());
+                    });
+                RepeatTest(
+                    (enumerator, items, iter) =>
+                    {
+                        if (iter == 1)
+                        {
+                            VerifyEnumerator(
+                                enumerator,
+                                items,
+                                0,
+                                items.Length/2,
+                                true,
+                                false);
+                            for (var i = 0; i < 3; i++)
+                            {
+                                Assert.Throws<NotSupportedException>(
+                                    () => enumerator.Reset());
+                            }
+                            VerifyEnumerator(
+                                enumerator,
+                                items,
+                                items.Length/2,
+                                items.Length - (items.Length/2),
+                                false,
+                                true);
+                        }
+                        else if (iter == 2)
+                        {
+                            VerifyEnumerator(enumerator, items);
+                            for (var i = 0; i < 3; i++)
+                            {
+                                Assert.Throws<NotSupportedException>(
+                                    () => enumerator.Reset());
+                            }
+                            VerifyEnumerator(
+                                enumerator,
+                                items,
+                                0,
+                                0,
+                                false,
+                                true);
+                        }
+                        else
+                        {
+                            VerifyEnumerator(enumerator, items);
+                        }
+                    });
+            }
+            else
+            {
+                RepeatTest(
+                    (enumerator, items, iter) =>
+                    {
+                        if (iter == 1)
+                        {
+                            VerifyEnumerator(
+                                enumerator,
+                                items,
+                                0,
+                                items.Length/2,
+                                true,
+                                false);
+                            enumerator.Reset();
+                            enumerator.Reset();
+                        }
+                        else if (iter == 3)
+                        {
+                            VerifyEnumerator(enumerator, items);
+                            enumerator.Reset();
+                            enumerator.Reset();
+                        }
+                        else
+                        {
+                            VerifyEnumerator(enumerator, items);
+                        }
+                    },
+                    5);
+            }
+        }
+
+        [Fact]
+        public void ModifyCollectionWithNewEnumerator()
+        {
+            IEnumerable enumerable =
+                GetEnumerable(GenerateItems(EnumerableSize));
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            InvalidateEnumerator(enumerable);
+            VerifyModifiedEnumerator(enumerator, null, true, false);
+        }
+
+        [Fact]
+        public void EnumerateFirstItemThenModify()
+        {
+            object[] items = GenerateItems(EnumerableSize);
+            IEnumerable enumerable = GetEnumerable(items);
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            VerifyEnumerator(enumerator, items, 0, 1, true, false);
+            object currentItem = enumerator.Current;
+            InvalidateEnumerator(enumerable);
+            VerifyModifiedEnumerator(
+                enumerator,
+                currentItem,
+                false,
+                false);
+        }
+
+        [Fact]
+        public void EnumeratePartOfCollectionThenModify()
+        {
+            object[] items = GenerateItems(EnumerableSize);
+            IEnumerable enumerable = GetEnumerable(items);
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            VerifyEnumerator(
+                enumerator,
+                items,
+                0,
+                items.Length/2,
+                true,
+                false);
+
+            object currentItem = enumerator.Current;
+            InvalidateEnumerator(enumerable);
+            VerifyModifiedEnumerator(
+                enumerator,
+                currentItem,
+                false,
+                false);
+        }
+
+        [Fact]
+        public void EnumerateEntireCollectionThenModify()
+        {
+            object[] items = GenerateItems(EnumerableSize);
+            IEnumerable enumerable = GetEnumerable(items);
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            VerifyEnumerator(
+                enumerator,
+                items,
+                0,
+                items.Length,
+                true,
+                false);
+
+            object currentItem = enumerator.Current;
+            InvalidateEnumerator(enumerable);
+            VerifyModifiedEnumerator(
+                enumerator,
+                currentItem,
+                false,
+                true);
+        }
+
+        [Fact]
+        public void EnumerateThenModifyThrows()
+        {
+            object[] items = GenerateItems(EnumerableSize);
+            IEnumerable enumerable = GetEnumerable(items);
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            VerifyEnumerator(
+                enumerator,
+                items,
+                0,
+                items.Length/2,
+                true,
+                false);
+
+            object currentItem = enumerator.Current;
+            InvalidateEnumerator(enumerable);
+            Assert.Equal(currentItem, enumerator.Current);
+            Assert.Throws<InvalidOperationException>(
+                () => enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(
+                () => enumerator.Reset());
+        }
+
+        [Fact]
+        [ActiveIssue(1170)]
+        public void EnumeratePastEndThenModify()
+        {
+            object[] items = GenerateItems(EnumerableSize);
+            IEnumerable enumerable = GetEnumerable(items);
+            IEnumerator enumerator = enumerable.GetEnumerator();
+            // enumerate to the end
+            VerifyEnumerator(enumerator, items);
+
+            // add elements to the collection
+            InvalidateEnumerator(enumerable);
+            // check that it throws proper exceptions
+            VerifyModifiedEnumerator(
+                enumerator,
+                DefaultValue,
+                true,
+                true);
+        }
+
+        private void VerifyModifiedEnumerator(
+            IEnumerator enumerator,
+            object expectedCurrent,
+            bool expectCurrentThrow,
+            bool atEnd)
+        {
+            if (expectCurrentThrow)
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => enumerator.Current);
+            }
+            else
+            {
+                object current = enumerator.Current;
+                for (var i = 0; i < 3; i++)
+                {
+                    Assert.Equal(expectedCurrent, current);
+                    current = enumerator.Current;
+                }
+            }
+
+            if (!atEnd || MoveNextAtEndThrowsOnModifiedCollection)
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => enumerator.MoveNext());
+            }
+            else
+            {
+                Assert.False(enumerator.MoveNext());
+            }
+
+            if (!IsResetNotSupported)
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => enumerator.Reset());
+            }
+        }
+
+        private void VerifyEnumerator(
+            IEnumerator enumerator,
+            object[] expectedItems)
+        {
+            VerifyEnumerator(
+                enumerator,
+                expectedItems,
+                0,
+                expectedItems.Length,
+                true,
+                true);
+        }
+
+        private void VerifyEnumerator(
+            IEnumerator enumerator,
+            object[] expectedItems,
+            int startIndex,
+            int count,
+            bool validateStart,
+            bool validateEnd)
+        {
+            bool needToMatchAllExpectedItems = count - startIndex
+                                               == expectedItems.Length;
+            if (validateStart)
+            {
+                for (var i = 0; i < 3; i++)
+                {
+                    Assert.Throws<InvalidOperationException>(
+                        () => enumerator.Current);
+                }
+            }
+
+            int iterations;
+            if (CollectionOrder == CollectionOrder.Unspecified)
+            {
+                var itemsVisited =
+                    new BitArray(
+                        needToMatchAllExpectedItems
+                            ? count
+                            : expectedItems.Length,
+                        false);
+                for (iterations = 0;
+                     iterations < count && enumerator.MoveNext();
+                     iterations++)
+                {
+                    object currentItem = enumerator.Current;
+                    var itemFound = false;
+                    for (var i = 0; i < itemsVisited.Length; ++i)
+                    {
+                        if (!itemsVisited[i]
+                            && Equals(
+                                currentItem,
+                                expectedItems[
+                                    i
+                                    + (needToMatchAllExpectedItems
+                                           ? startIndex
+                                           : 0)]))
+                        {
+                            itemsVisited[i] = true;
+                            itemFound = true;
+                            break;
+                        }
+                    }
+                    Assert.True(itemFound, "itemFound");
+
+                    for (var i = 0; i < 3; i++)
+                    {
+                        object tempItem = enumerator.Current;
+                        Assert.Equal(currentItem, tempItem);
+                    }
+                }
+                if (needToMatchAllExpectedItems)
+                {
+                    for (var i = 0; i < itemsVisited.Length; i++)
+                    {
+                        Assert.True(itemsVisited[i]);
+                    }
+                }
+                else
+                {
+                    var visitedItemCount = 0;
+                    for (var i = 0; i < itemsVisited.Length; i++)
+                    {
+                        if (itemsVisited[i])
+                        {
+                            ++visitedItemCount;
+                        }
+                    }
+                    Assert.Equal(count, visitedItemCount);
+                }
+            }
+            else if (CollectionOrder == CollectionOrder.Sequential)
+            {
+                for (iterations = 0;
+                     iterations < count && enumerator.MoveNext();
+                     iterations++)
+                {
+                    object currentItem = enumerator.Current;
+                    Assert.Equal(expectedItems[iterations], currentItem);
+                    for (var i = 0; i < 3; i++)
+                    {
+                        object tempItem = enumerator.Current;
+                        Assert.Equal(currentItem, tempItem);
+                    }
+                }
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "CollectionOrder is invalid.");
+            }
+            Assert.Equal(count, iterations);
+
+            if (validateEnd)
+            {
+                for (var i = 0; i < 3; i++)
+                {
+                    Assert.False(
+                        enumerator.MoveNext(),
+                        "enumerator.MoveNext() returned true past the expected end.");
+                }
+
+                if (IsGenericCompatibility)
+                {
+                    return;
+                }
+                // apparently it is okay if enumerator.Current doesn't throw when the collection is generic.
+                for (var i = 0; i < 3; i++)
+                {
+                    Assert.Throws<InvalidOperationException>(
+                        () => enumerator.Current);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/Collections/IListTest.cs
+++ b/src/Common/tests/Collections/IListTest.cs
@@ -1,0 +1,1803 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Tests.Collections
+{
+    public static class CollectionAssert
+    {
+        public static void Equal(
+            IEnumerable expected,
+            IEnumerable actual)
+        {
+            Assert.Equal(
+                expected.OfType<object>(),
+                actual.OfType<object>());
+        }
+
+        public static void Equal(IList expected, IList actual)
+        {
+            Equal((IEnumerable) expected, actual);
+            // explicitly test Count and the indexer
+            Assert.Equal(expected.Count, actual.Count);
+            for (var i = 0; i < expected.Count; i++)
+            {
+                var expectedArray = expected as Array;
+                var actualArray = expected as Array;
+                int expectedLowerBound = expectedArray == null
+                                             ? 0
+                                             : expectedArray
+                                                   .GetLowerBound(0);
+                int actualLowerBound = actualArray == null
+                                           ? 0
+                                           : actualArray.GetLowerBound(
+                                               0);
+                Assert.Equal(
+                    expected[i + expectedLowerBound],
+                    actual[i + actualLowerBound]);
+            }
+        }
+    }
+
+    public static class IListExtensions
+    {
+        public static void AddRange(this IList list, IEnumerable items)
+        {
+            foreach (object item in items)
+            {
+                list.Add(item);
+            }
+        }
+
+        public static void InsertRange(this IList list, object[] items)
+        {
+            list.InsertRange(0, items, 0, items.Length);
+        }
+
+        public static void InsertRange(
+            this IList list,
+            int listStartIndex,
+            object[] items,
+            int startIndex,
+            int count)
+        {
+            int numToInsert = items.Length - startIndex;
+            if (count < numToInsert)
+            {
+                numToInsert = count;
+            }
+            for (var i = 0; i < numToInsert; i++)
+            {
+                list.Insert(listStartIndex + i, items[startIndex + i]);
+            }
+        }
+
+        public static void AddRange(
+            this IList list,
+            object[] items,
+            int startIndex,
+            int count)
+        {
+            int numToAdd = items.Length - startIndex;
+            if (count < numToAdd)
+            {
+                numToAdd = count;
+            }
+            for (var i = 0; i < numToAdd; i++)
+            {
+                list.Add(items[startIndex + i]);
+            }
+        }
+    }
+
+    public abstract class IListTest<T> : ICollectionTest<T>
+    {
+        private readonly bool _expectedIsFixedSize;
+        private readonly bool _expectedIsReadOnly;
+        private bool _searchingThrowsFromInvalidValue;
+
+        protected IListTest(
+            bool isSynchronized,
+            bool isReadOnly,
+            bool isFixedSize) : base(isSynchronized)
+        {
+            _expectedIsReadOnly = isReadOnly;
+            _expectedIsFixedSize = isFixedSize;
+            SearchingThrowsFromInvalidValue = false;
+        }
+
+        protected bool ExpectedIsReadOnly
+        {
+            get { return _expectedIsReadOnly; }
+        }
+
+        protected bool ExpectedIsFixedSize
+        {
+            get { return _expectedIsFixedSize; }
+        }
+
+        protected bool SearchingThrowsFromInvalidValue
+        {
+            get { return _searchingThrowsFromInvalidValue; }
+            set { _searchingThrowsFromInvalidValue = value; }
+        }
+
+        public static object[][] RemoveAtInvalidData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {int.MinValue, 16},
+                    new object[] {-1, 16},
+                    new object[] {0, 0},
+                    new object[] {1, 1},
+                    new object[] {16, 16}
+                };
+            }
+        }
+
+        [Fact]
+        public void IsFixedSize()
+        {
+            Assert.Equal(ExpectedIsFixedSize, GetList(null).IsFixedSize);
+        }
+
+        [Fact]
+        public void IsReadOnly()
+        {
+            Assert.Equal(ExpectedIsReadOnly, GetList(null).IsReadOnly);
+        }
+
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void GetItemArgumentOutOfRange(int index)
+        {
+            IList list = GetList(null);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => list[index]);
+            CollectionAssert.Equal(Array.Empty<object>(), list);
+        }
+
+        [Fact]
+        public void GetItemArgumentOutOfRangeFilledCollection()
+        {
+            object[] items = GenerateItems(32);
+            IList list = GetList(items);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => list[list.Count]);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void GetItemEmpty()
+        {
+            var items = new object[0];
+            IList list = GetList(items);
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                CollectionAssert.Equal(items, list);
+            }
+            else
+            {
+                list.Clear();
+                items = GenerateItems(1);
+                list.AddRange(items);
+                CollectionAssert.Equal(items, list);
+
+                list.Clear();
+                items = GenerateItems(1024);
+                list.AddRange(items);
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void SetItemNotSupported()
+        {
+            if (ExpectedIsReadOnly)
+            {
+                object[] items = GenerateItems(10);
+                IList list = GetList(items);
+                Assert.Throws<NotSupportedException>(
+                    () => list[0] = GenerateItem());
+                CollectionAssert.Equal(items, list);
+
+                Assert.Throws<NotSupportedException>(
+                    () => list[list.Count - 1] = GenerateItem());
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void SetItemArgumentException()
+        {
+            Type[] expectedExceptions;
+            if (ExpectedIsReadOnly)
+            {
+                expectedExceptions = new[]
+                {
+                    typeof (ArgumentOutOfRangeException),
+                    typeof (NotSupportedException)
+                };
+            }
+            else
+            {
+                expectedExceptions = new[]
+                {
+                    typeof (ArgumentOutOfRangeException)
+                };
+            }
+            {
+                object[] items = GenerateItems(10);
+                IList list = GetList(items);
+                AssertThrows(
+                    expectedExceptions,
+                    () => list[int.MinValue] = GenerateItem());
+                CollectionAssert.Equal(items, list);
+
+                AssertThrows(
+                    expectedExceptions,
+                    () => list[-1] = GenerateItem());
+                CollectionAssert.Equal(items, list);
+            }
+
+            {
+                object[] items = GenerateItems(0);
+                IList list = GetList(items);
+                AssertThrows(
+                    expectedExceptions,
+                    () => list[0] = GenerateItem());
+                CollectionAssert.Equal(items, list);
+
+                if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+                {
+                    items = GenerateItems(32);
+                    list.AddRange(items);
+                    AssertThrows(
+                        expectedExceptions,
+                        () => list[list.Count] = GenerateItem());
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void SetItemInvalidValue()
+        {
+            object[] items = GenerateItems(32);
+            IList list = GetList(items);
+            if (IsGenericCompatibility)
+            {
+                foreach (object invalid in GetInvalidValues())
+                {
+                    Type[] expectedExceptions;
+                    if (invalid == null)
+                    {
+                        if (ExpectedIsReadOnly)
+                        {
+                            expectedExceptions = new[]
+                            {
+                                typeof (ArgumentNullException),
+                                typeof (NotSupportedException)
+                            };
+                        }
+                        else
+                        {
+                            expectedExceptions = new[]
+                            {
+                                typeof (ArgumentNullException)
+                            };
+                        }
+                    }
+                    else if (ExpectedIsReadOnly)
+                    {
+                        expectedExceptions = new[]
+                        {
+                            typeof (ArgumentException),
+                            typeof (NotSupportedException)
+                        };
+                    }
+                    else
+                    {
+                        expectedExceptions = new[]
+                        {
+                            typeof (ArgumentException)
+                        };
+                    }
+
+                    object invalid1 = invalid;
+                    AssertThrows(
+                        expectedExceptions,
+                        () => list[0] = invalid1);
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void SetItemNonNull()
+        {
+            if (!ExpectedIsReadOnly)
+            {
+                if (ItemsMustBeNonNull)
+                {
+                    object[] items = GenerateItems(32);
+                    IList list = GetList(items);
+                    Assert.Throws<ArgumentNullException>(
+                        () => list[0] = null);
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void SetItemNullable()
+        {
+            if (!ExpectedIsReadOnly)
+            {
+                if (!ItemsMustBeNonNull)
+                {
+                    object[] items = GenerateItems(32);
+                    IList list = GetList(items);
+                    list[0] = null;
+                    items[0] = null;
+                    CollectionAssert.Equal(items, list);
+
+                    items = GenerateItems(32);
+                    list = GetList(items);
+                    list[list.Count - 1] = null;
+                    items[items.Length - 1] = null;
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void SetItemUnique()
+        {
+            if (!ExpectedIsReadOnly)
+            {
+                if (ItemsMustBeUnique)
+                {
+                    object[] items = GenerateItems(32);
+                    IList list = GetList(items);
+                    Assert.Throws<ArgumentException>(
+                        () => list[0] = items[1]);
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void SetItemNotUnique()
+        {
+            if (!ExpectedIsReadOnly)
+            {
+                if (!ItemsMustBeUnique)
+                {
+                    object[] items = GenerateItems(32);
+                    IList list = GetList(items);
+                    for (var i = 0; i < items.Length; i++)
+                    {
+                        list[i] = items[items.Length - i - 1];
+                    }
+                    Array.Reverse(items);
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void SetItem()
+        {
+            if (!ExpectedIsReadOnly)
+            {
+                object[] items = GenerateItems(32);
+                var origItems = (object[]) items.Clone();
+                IList list = GetList(items);
+
+                // verify setting every item
+                // reverse list, setting items to new elements to maintain uniqueness.
+                for (var i = 0; i < items.Length; i++)
+                {
+                    if (i < items.Length/2)
+                    {
+                        list[items.Length - i - 1] = GenerateItem();
+                    }
+                    list[i] = items[items.Length - i - 1];
+                }
+
+                Array.Reverse(items);
+                CollectionAssert.Equal(items, list);
+
+                // verify setting items back to the original
+                items = origItems;
+                if (ItemsMustBeUnique)
+                {
+                    for (var i = 0; i < items.Length; i++)
+                    {
+                        list[i] = GenerateItem();
+                    }
+                }
+
+                for (var i = 0; i < items.Length; i++)
+                {
+                    list[i] = items[i];
+                }
+
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddFixedSizeOrReadonlyThrows()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                object[] items = GenerateItems(10);
+                IList list = GetList(items);
+                Assert.Throws<NotSupportedException>(
+                    () => list.Add(GenerateItem()));
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddWithNullValueInMiddle()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                const int size = 32;
+                object[] items;
+                IList list = GetList(null);
+                object[] tempItems = GenerateItems(size);
+                for (var i = 0; i < tempItems.Length/2; i++)
+                {
+                    list.Add(tempItems[i]);
+                }
+
+                if (ItemsMustBeNonNull)
+                {
+                    items = tempItems;
+                    Assert.Throws<ArgumentNullException>(
+                        () => list.Add(null));
+                }
+                else
+                {
+                    const int sizeWithNull = size + 1;
+                    items = new object[sizeWithNull];
+                    list.Add(null);
+                    items[sizeWithNull/2] = null;
+                    Array.Copy(tempItems, 0, items, 0, sizeWithNull/2);
+                    Array.Copy(
+                        tempItems,
+                        sizeWithNull/2,
+                        items,
+                        sizeWithNull/2 + 1,
+                        sizeWithNull/2);
+                }
+                for (var i = 0; i < size/2; i++)
+                {
+                    list.Add(tempItems[size/2 + i]);
+                }
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddWithNullValueAtBeginning()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items;
+                if (ItemsMustBeNonNull)
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => list.Add(null));
+                    items = GenerateItems(16);
+                    list.AddRange(items);
+                }
+                else
+                {
+                    const int size = 17;
+                    items = new object[size];
+                    list.Add(null);
+                    items[0] = null;
+                    object[] tempItems = GenerateItems(size - 1);
+                    list.AddRange(tempItems);
+                    Array.Copy(tempItems, 0, items, 1, size - 1);
+                }
+
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddWithNullValueAtEnd()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                object[] items = GenerateItems(16);
+                IList list = GetList(items);
+
+                if (ItemsMustBeNonNull)
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => list.Add(null));
+                }
+                else
+                {
+                    items[items.Length - 1] = null;
+                    list.RemoveAt(list.Count - 1);
+                    list.Add(null);
+                }
+
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddDuplicateValue()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                object[] items;
+                IList list = GetList(null);
+                if (ItemsMustBeUnique)
+                {
+                    items = GenerateItems(16);
+                    list.AddRange(items);
+                    Assert.Throws<ArgumentException>(
+                        () => list.Add(items[0]));
+                }
+                else
+                {
+                    items = new object[32];
+                    object[] tempItems = GenerateItems(16);
+                    list.AddRange(tempItems);
+                    list.AddRange(tempItems);
+
+                    Array.Copy(tempItems, 0, items, 0, 16);
+                    Array.Copy(tempItems, 0, items, 16, 16);
+                }
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddAndClear()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                list.AddRange(GenerateItems(16));
+                list.Clear();
+                object[] items = GenerateItems(8);
+                list.AddRange(items);
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddAndRemove()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                var items = new object[23];
+                IList list = GetList(null);
+                object[] tempItems = GenerateItems(32);
+                for (var i = 0; i < 16; i++)
+                {
+                    list.Add(tempItems[i]);
+                }
+                for (var i = 0; i < 16; i++)
+                {
+                    if ((i & 1) == 0)
+                    {
+                        list.RemoveAt(i/2);
+                    }
+                    else
+                    {
+                        items[i/2] = tempItems[i];
+                    }
+                }
+
+                list.RemoveAt(list.Count - 1);
+                for (var i = 0; i < 16; i++)
+                {
+                    list.Add(tempItems[16 + i]);
+                }
+
+                Array.Copy(tempItems, 16, items, 7, 16);
+
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void AddAndRemoveAll()
+        {
+            IList list = GetList(null);
+            object[] tempItems = GenerateItems(16);
+            list.AddRange(tempItems);
+            int count = tempItems.Length;
+            foreach (object item in tempItems)
+            {
+                list.Remove(item);
+                count--;
+                Assert.Equal(count, list.Count);
+            }
+            Assert.Equal(0, list.Count);
+
+            object[] items = GenerateItems(16);
+            list.AddRange(items);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void AddWithInvalidTypes()
+        {
+            if (IsGenericCompatibility)
+            {
+                object[] items = GenerateItems(32);
+                IList list = GetList(items);
+                foreach (object invalid in GetInvalidValues())
+                {
+                    Type[] expectedExceptions;
+                    if (ExpectedIsFixedSize)
+                    {
+                        expectedExceptions = new[]
+                        {
+                            typeof (ArgumentException),
+                            typeof (NotSupportedException)
+                        };
+                    }
+                    else
+                    {
+                        expectedExceptions = new[]
+                        {
+                            typeof (ArgumentException)
+                        };
+                    }
+                    object invalid1 = invalid;
+                    AssertThrows(
+                        expectedExceptions,
+                        () => list.Add(invalid1));
+                    CollectionAssert.Equal(items, list);
+                }
+            }
+        }
+
+        [Fact]
+        public void ClearWithReadOnlyOrFixedSizeThrows()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                object[] items = GenerateItems(32);
+                IList list = GetList(items);
+
+                Assert.Throws<NotSupportedException>(() => list.Clear());
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void ClearOnEmptyList()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                list.Clear();
+                // no exception should have been generated.
+                Assert.Equal(0, list.Count);
+            }
+        }
+
+        [Fact]
+        public void RepeatClearOnEmptyList()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                list.Clear();
+                list.Clear();
+                list.Clear();
+                // no exception should have been generated.
+                Assert.Equal(0, list.Count);
+            }
+        }
+
+        [Fact]
+        public void AddRemoveClearAdd()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(16);
+                list.AddRange(items);
+
+                for (var i = 0; i < items.Length; i++)
+                {
+                    if ((i & 1) == 0)
+                    {
+                        list.RemoveAt(i/2);
+                    }
+                }
+                list.RemoveAt(list.Count - 1);
+                list.Clear();
+                // no exception should have been generated
+                Assert.Equal(0, list.Count);
+            }
+        }
+
+        [Fact]
+        public void AddRemoveAllClearAdd()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(16);
+                list.AddRange(items);
+
+                foreach (object item in items)
+                {
+                    list.Remove(item);
+                }
+
+                list.Clear();
+                // no exception should have been generated
+                Assert.Equal(0, list.Count);
+            }
+        }
+
+        [Fact]
+        public void ClearOneItem()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                list.Clear();
+                // no exception should have been generated
+                Assert.Equal(0, list.Count);
+            }
+        }
+
+        [Fact]
+        public void EmptyCollectionContainsNonNull()
+        {
+            IList list = GetList(null);
+            Assert.False(list.Contains(GenerateItem()));
+        }
+
+        [Fact]
+        public void EmptyCollectionContainsNull()
+        {
+            IList list = GetList(null);
+            if (ItemsMustBeNonNull && SearchingThrowsFromInvalidValue)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => list.Contains(null));
+            }
+            else
+            {
+                Assert.False(list.Contains(null));
+            }
+        }
+
+        [Fact]
+        public void EmptyCollectionAddThenContainsSame()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                Assert.True(list.Contains(items[0]));
+            }
+        }
+
+        [Fact]
+        public void EmptyCollectionAddThenContainsDifferent()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                Assert.False(list.Contains(GenerateItem()));
+            }
+        }
+
+        [Fact]
+        public void EmptyCollectionAddThenContainsNull()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                if (ItemsMustBeNonNull
+                    && SearchingThrowsFromInvalidValue)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () => list.Contains(null));
+                }
+                else
+                {
+                    Assert.False(list.Contains(null));
+                }
+            }
+        }
+
+        [Fact]
+        public void AddAndContainsNullValue()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly
+                && !ItemsMustBeNonNull)
+            {
+                IList list = GetList(null);
+                list.Add(null);
+                Assert.True(list.Contains(null));
+            }
+        }
+
+        [Fact]
+        public void ContainsValueThatExistsTwice()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly
+                && !ItemsMustBeNonNull && !ItemsMustBeUnique)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(16);
+                list.Add(items);
+                list.Add(items);
+
+                for (var i = 0; i < items.Length; i++)
+                {
+                    Assert.True(list.Contains(items[i]));
+                }
+                Assert.False(list.Contains(GenerateItem()));
+            }
+        }
+
+        [Theory]
+        [InlineData(32, 0)]
+        [InlineData(32, 16)]
+        [InlineData(32, 31)]
+        public void NullInMiddleContains(
+            int collectionSize,
+            int nullIndex)
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly
+                && !ItemsMustBeNonNull)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(collectionSize);
+                list.AddRange(items);
+                list.Insert(nullIndex, null);
+
+                foreach (object item in items)
+                {
+                    Assert.True(list.Contains(item));
+                }
+                Assert.True(list.Contains(null));
+                Assert.False(list.Contains(GenerateItem()));
+            }
+        }
+
+        [Fact]
+        public void ContainsUniqueItems()
+        {
+            object[] items = GenerateItems(32);
+            IList list = GetList(items);
+            for (var i = 0; i < items.Length; i++)
+            {
+                Assert.True(list.Contains(items[i]));
+            }
+            Assert.False(list.Contains(GenerateItem()));
+        }
+
+        [Fact]
+        public void ContainsInvalidValue()
+        {
+            if (IsGenericCompatibility)
+            {
+                foreach (object invalid in GetInvalidValues())
+                {
+                    object invalid1 = invalid;
+                    IList list = GetList(null);
+                    if (SearchingThrowsFromInvalidValue)
+                    {
+                        Assert.Throws<ArgumentException>(
+                            () => list.Contains(invalid1));
+                    }
+                    else
+                    {
+                        Assert.False(list.Contains(invalid1));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void EmptyCollectionIndexOf()
+        {
+            IList list = GetList(null);
+            Assert.Equal(-1, list.IndexOf(GenerateItem()));
+        }
+
+        [Fact]
+        public void EmptyCollectionIndexOfNull()
+        {
+            IList list = GetList(null);
+            if (ItemsMustBeNonNull && SearchingThrowsFromInvalidValue)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => list.IndexOf(null));
+            }
+            else
+            {
+                Assert.Equal(-1, list.IndexOf(null));
+            }
+        }
+
+        [Fact]
+        public void AddIndexOfSameElement()
+        {
+            if (!ExpectedIsReadOnly && !ExpectedIsFixedSize)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                Assert.Equal(0, list.IndexOf(items[0]));
+            }
+        }
+
+        [Fact]
+        public void AddIndexOfDifferentElement()
+        {
+            if (!ExpectedIsReadOnly && !ExpectedIsFixedSize)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                Assert.Equal(-1, list.IndexOf(GenerateItem()));
+            }
+        }
+
+        [Fact]
+        public void AddIndexOfNull()
+        {
+            if (!ExpectedIsReadOnly && !ExpectedIsFixedSize)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(1);
+                list.AddRange(items);
+                if (ItemsMustBeNonNull
+                    && SearchingThrowsFromInvalidValue)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () => list.IndexOf(null));
+                }
+                else
+                {
+                    Assert.Equal(-1, list.IndexOf(null));
+                }
+            }
+        }
+
+        [Fact]
+        public void AddNullIndexOfNull()
+        {
+            if (!ExpectedIsReadOnly && !ExpectedIsFixedSize
+                && !ItemsMustBeNonNull)
+            {
+                IList list = GetList(null);
+                list.Add(null);
+                Assert.Equal(0, list.IndexOf(null));
+            }
+        }
+
+        [Fact]
+        public void IndexOfNonUnique()
+        {
+            if (!ExpectedIsReadOnly && !ExpectedIsFixedSize
+                && !ItemsMustBeUnique)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(16);
+                list.AddRange(items);
+                list.AddRange(items);
+                for (var i = 0; i < items.Length; i++)
+                {
+                    Assert.Equal(i, list.IndexOf(items[i]));
+                }
+
+                Assert.Equal(-1, list.IndexOf(GenerateItem()));
+            }
+        }
+
+        [Theory]
+        [InlineData(32, 0)]
+        [InlineData(32, 16)]
+        [InlineData(32, 31)]
+        public void IndexOfNull(int collectionSize, int nullIndex)
+        {
+            if (!ExpectedIsReadOnly && !ExpectedIsFixedSize
+                && !ItemsMustBeNonNull)
+            {
+                IList list = GetList(null);
+                object[] items = GenerateItems(collectionSize);
+                list.AddRange(items);
+
+                list.Insert(nullIndex, null);
+
+                for (var i = 0; i < nullIndex; i++)
+                {
+                    Assert.Equal(i, list.IndexOf(items[i]));
+                }
+                Assert.Equal(nullIndex, list.IndexOf(null));
+                for (int i = nullIndex; i < collectionSize; i++)
+                {
+                    Assert.Equal(i + 1, list.IndexOf(items[i]));
+                }
+
+                Assert.Equal(-1, list.IndexOf(GenerateItem()));
+            }
+        }
+
+        [Fact]
+        public void IndexOfUniqueItems()
+        {
+            object[] items = GenerateItems(32);
+            IList list = GetList(items);
+
+            for (var i = 0; i < items.Length; i++)
+            {
+                Assert.Equal(i, list.IndexOf(items[i]));
+            }
+
+            Assert.Equal(-1, list.IndexOf(GenerateItem()));
+        }
+
+        [Fact]
+        public void IndexOfInvalidTypes()
+        {
+            if (!IsGenericCompatibility)
+            {
+                return;
+            }
+            foreach (object invalid  in GetInvalidValues())
+            {
+                IList list = GetList(null);
+                object invalid1 = invalid;
+                if (SearchingThrowsFromInvalidValue)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () => list.IndexOf(invalid1));
+                }
+                else
+                {
+                    Assert.Equal(-1, list.IndexOf(invalid1));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(int.MinValue, 16)]
+        [InlineData(-1, 16)]
+        [InlineData(1, 0)]
+        [InlineData(33, 32)]
+        [InlineData(int.MaxValue, 32)]
+        public void InsertInvalidIndexThrows(int index, int size)
+        {
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => list.Insert(index, GenerateItem()));
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertInvalidTypes()
+        {
+            if (!IsGenericCompatibility)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            foreach (object i in GetInvalidValues())
+            {
+                object invalid = i;
+                if (invalid == null)
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => list.Insert(0, null));
+                }
+                else
+                {
+                    Assert.Throws<ArgumentException>(
+                        () => list.Insert(0, invalid));
+                }
+
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void FixedSizeOrReadonlyInsertThrows()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            Assert.Throws<NotSupportedException>(
+                () => list.Insert(0, GenerateItem()));
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertItems()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(32);
+            IList list = GetList(null);
+            for (var i = 0; i < items.Length; i++)
+            {
+                list.Insert(i, items[i]);
+            }
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Theory]
+        [InlineData(0, 32)]
+        [InlineData(16, 32)]
+        [InlineData(32, 32)]
+        public void InsertNull(int index, int size)
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+            if (ItemsMustBeNonNull)
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => list.Insert(index, null));
+            }
+            else
+            {
+                List<object> l = items.ToList();
+                l.Insert(index, null);
+                items = l.ToArray();
+                list.Insert(index, null);
+            }
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertExistingValue()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            if (ItemsMustBeUnique)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => list.Insert(0, items[0]));
+            }
+            else
+            {
+                foreach (object item in items)
+                {
+                    list.Insert(list.Count, item);
+                }
+                items = items.Push(items);
+            }
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertClearInsert()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(null);
+            list.InsertRange(items);
+            list.Clear();
+            items = GenerateItems(16);
+            list.InsertRange(items);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertRemoveInsert()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(32);
+            IList list = GetList(null);
+            list.InsertRange(items);
+            var tempItems = (object[]) items.Clone();
+            for (var i = 0; i < 16; i++)
+            {
+                list.RemoveAt(0);
+            }
+
+            Array.Copy(tempItems, 16, items, 0, 8);
+            Array.Copy(tempItems, 24, items, 24, 8);
+            tempItems = GenerateItems(16);
+            for (var i = 0; i < 16; i++)
+            {
+                list.Insert(8 + i, tempItems[i]);
+            }
+
+            Array.Copy(tempItems, 0, items, 8, 16);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertRemoveAllInsert()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(32);
+            IList list = GetList(null);
+            list.InsertRange(items);
+            for (var i = 0; i < 32; i++)
+            {
+                list.Remove(items[i]);
+            }
+            items = GenerateItems(32);
+            list.InsertRange(items);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertAndAdd()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(48);
+            IList list = GetList(null);
+            list.InsertRange(0, items, 0, 16);
+            list.AddRange(items, 16, 16);
+            list.InsertRange(32, items, 32, 16);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void InsertAndRemove()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(32);
+            var tempItems = new object[33];
+            IList list = GetList(items);
+            for (var i = 0; i < items.Length; i++)
+            {
+                object newObject = GenerateItem();
+                list.Insert(i, newObject);
+                Array.Copy(items, 0, tempItems, 0, i);
+                tempItems[i] = newObject;
+                Array.Copy(items, i, tempItems, i + 1, items.Length - i);
+                CollectionAssert.Equal(tempItems, list);
+                list.RemoveAt(i);
+            }
+        }
+
+        [Fact]
+        public void RemoveReadOnlyFixedSizeThrows()
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            Assert.Throws<NotSupportedException>(
+                () => list.Remove(GenerateItem()));
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void RemoveEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            list.Remove(GenerateItem());
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void RemoveNullEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            if (ItemsMustBeNonNull && SearchingThrowsFromInvalidValue)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => list.Remove(null));
+            }
+            else
+            {
+                list.Remove(null);
+            }
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void AddRemoveValueEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            object item = GenerateItem();
+            list.Add(item);
+            list.Remove(item);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void AddRemoveDifferentValueEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            object item = GenerateItem();
+            list.Add(item);
+            items = items.Push(item);
+            list.Remove(GenerateItem());
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void AddNonNullRemoveNullEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            object item = GenerateItem();
+            list.Add(item);
+            items = items.Push(item);
+            if (ItemsMustBeNonNull && SearchingThrowsFromInvalidValue)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => list.Remove(null));
+            }
+            else
+            {
+                list.Remove(null);
+            }
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void AddRemoveNullEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            if (ItemsMustBeNonNull)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            list.Add(null);
+            list.Remove(null);
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void AddNullRemoveNonNullEmptyCollection()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            if (ItemsMustBeNonNull)
+            {
+                return;
+            }
+            object[] items = GenerateItems(0);
+            IList list = GetList(items);
+            list.Add(null);
+            items = items.Push(null);
+            list.Remove(GenerateItem());
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void RemoveItemsExistsTwice()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            if (ItemsMustBeUnique)
+            {
+                return;
+            }
+
+            object[] items = GenerateItems(16);
+            var tempItems = (object[]) items.Clone();
+            IList list = GetList(items);
+            list.AddRange(items);
+            for (var i = 0; i < items.Length; i++)
+            {
+                int index = i + 1;
+                items =
+                    new object[
+                        tempItems.Length + tempItems.Length - index];
+                Array.Copy(tempItems, index, items, 0, 16 - index);
+                Array.Copy(tempItems, 0, items, 16 - index, 16);
+
+                list.Remove(tempItems[i]);
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Fact]
+        public void RemoveNonExisting()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            list.Remove(GenerateItem());
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void RemoveItems()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            for (var i = 0; i < items.Length; i++)
+            {
+                list.Remove(items[i]);
+                CollectionAssert.Equal(items.Slice(i + 1), list);
+            }
+        }
+
+        [Fact]
+        public void RemoveNull()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            if (ItemsMustBeNonNull)
+            {
+                return;
+            }
+            var items = new object[15];
+            IList list = GetList(null);
+            object[] tempItems = GenerateItems(16);
+            list.AddRange(tempItems);
+            Array.Copy(tempItems, 0, items, 0, 11);
+            Array.Copy(tempItems, 12, items, 11, 4);
+            list.Insert(8, null);
+            list.Remove(tempItems[11]);
+            list.Remove(null);
+            list.Remove(GenerateItem());
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void RemoveInvalidValues()
+        {
+            if (!IsGenericCompatibility)
+            {
+                return;
+            }
+            Type[] expectedExceptions = ExpectedIsFixedSize
+                                            ? new[]
+                                            {
+                                                typeof (
+                                                  ArgumentException),
+                                                typeof (
+                                                  NotSupportedException)
+                                            }
+                                            : new[]
+                                            {
+                                                typeof (
+                                                  ArgumentException)
+                                            };
+
+            object[] items = GenerateItems(16);
+            IList list = GetList(items);
+            foreach (object i in GetInvalidValues())
+            {
+                object invalid = i;
+                if (ExpectedIsFixedSize
+                    || SearchingThrowsFromInvalidValue)
+                {
+                    AssertThrows(
+                        expectedExceptions,
+                        () => list.Remove(invalid));
+                }
+                else
+                {
+                    list.Remove(invalid);
+                }
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Theory]
+        [MemberData("RemoveAtInvalidData")]
+        public void RemoveAtInvalid(int index, int size)
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => list.RemoveAt(index));
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Theory]
+        [MemberData("RemoveAtInvalidData")]
+        public void RemoveAtInvalidReadOnly(int index, int size)
+        {
+            if (!ExpectedIsFixedSize && !ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+            AssertThrows(
+                new[]
+                {
+                    typeof (ArgumentOutOfRangeException),
+                    typeof (NotSupportedException)
+                },
+                () => list.RemoveAt(index));
+            CollectionAssert.Equal(items, list);
+        }
+
+        [Fact]
+        public void RemoveAtFixedSizeThrows()
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                object[] items = GenerateItems(16);
+                IList list = GetList(items);
+                Assert.Throws<NotSupportedException>(
+                    () => list.RemoveAt(0));
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Theory]
+        [InlineData(32)]
+        [InlineData(16)]
+        public void RemoveAtDescending(int size)
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+            for (var i = 0; i < size; i++)
+            {
+                list.RemoveAt(size - i - 1);
+                items = items.Slice(0, items.Length - 1);
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Theory]
+        [InlineData(32)]
+        [InlineData(16)]
+        public void RemoveAt(int size)
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+
+            for (var i = 0; i < size; i++)
+            {
+                list.RemoveAt(0);
+                items = items.Slice(1);
+                CollectionAssert.Equal(items, list);
+            }
+        }
+
+        [Theory]
+        [InlineData(32)]
+        [InlineData(16)]
+        public void RemoveAtEachIndex(int size)
+        {
+            if (ExpectedIsFixedSize || ExpectedIsReadOnly)
+            {
+                return;
+            }
+            object[] items = GenerateItems(size);
+            IList list = GetList(items);
+            for (var i = 0; i < size; i++)
+            {
+                list.RemoveAt(i);
+                CollectionAssert.Equal(items.RemoveAt(i), list);
+                list.Insert(i, items[i]);
+            }
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected abstract IEnumerable GetInvalidValues();
+
+        private IList GetList(object[] items)
+        {
+            ICollection obj = GetCollection(items);
+            Assert.IsAssignableFrom<IList>(obj);
+            return (IList) obj;
+        }
+    }
+
+    public abstract class IListTest<TList, T> : IListTest<T>
+        where TList : IList
+    {
+        private readonly bool _isGenericCompatibility;
+        private readonly bool _isResetNotSupported;
+        private readonly bool _itemsMustBeUnique;
+
+        protected IListTest(
+            bool isSynchronized,
+            bool isReadOnly,
+            bool isFixedSize,
+            bool isResetNotSupported,
+            bool isGenericCompatibility,
+            bool itemsMustBeUnique)
+            : base(isSynchronized, isReadOnly, isFixedSize)
+        {
+            _isResetNotSupported = isResetNotSupported;
+            _isGenericCompatibility = isGenericCompatibility;
+            _itemsMustBeUnique = itemsMustBeUnique;
+            ValidArrayTypes = new[] {typeof (object), typeof (T)};
+            SearchingThrowsFromInvalidValue = false;
+        }
+
+        protected override sealed bool IsResetNotSupported
+        {
+            get { return _isResetNotSupported; }
+        }
+
+        protected override sealed bool IsGenericCompatibility
+        {
+            get { return _isGenericCompatibility; }
+        }
+
+        protected override sealed bool ItemsMustBeUnique
+        {
+            get { return _itemsMustBeUnique; }
+        }
+
+        protected override sealed bool ItemsMustBeNonNull
+        {
+            get { return default(T) != null; }
+        }
+
+        protected override sealed object GenerateItem()
+        {
+            return CreateItem();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected abstract T CreateItem();
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets an instance of the list under test containing the given items.
+        /// </summary>
+        /// <param name="items">The items to initialize the list with.</param>
+        /// <returns>An instance of the list under test containing the given items.</returns>
+        protected abstract TList CreateList(IEnumerable<T> items);
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets an instance of the enumerable under test containing the given items.
+        /// </summary>
+        /// <param name="items">The items to initialize the enumerable with.</param>
+        /// <returns>An instance of the enumerable under test containing the given items.</returns>
+        protected override sealed IEnumerable GetEnumerable(
+            object[] items)
+        {
+            return
+                CreateList(
+                    items == null
+                        ? Enumerable.Empty<T>()
+                        : items.Cast<T>());
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, invalidates any enumerators for the given list.
+        /// </summary>
+        /// <param name="list">The list to invalidate enumerators for.</param>
+        /// <returns>The new contents of the list.</returns>
+        protected abstract IEnumerable<T> InvalidateEnumerator(
+            TList list);
+
+        /// <summary>
+        ///     When overridden in a derived class, invalidates any enumerators for the given IEnumerable.
+        /// </summary>
+        /// <param name="enumerable">The <see cref="IEnumerable" /> to invalidate enumerators for.</param>
+        /// <returns>The new set of items in the <see cref="IEnumerable" /></returns>
+        protected override sealed object[] InvalidateEnumerator(
+            IEnumerable enumerable)
+        {
+            return
+                InvalidateEnumerator((TList) enumerable)
+                    .OfType<object>()
+                    .ToArray();
+        }
+    }
+}

--- a/src/Common/tests/Collections/Utils.cs
+++ b/src/Common/tests/Collections/Utils.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Tests.Collections
+{
+    public static class ArrayExtensions
+    {
+        public static T[] Slice<T>(
+            this T[] array,
+            int startIndex,
+            int length = -1)
+        {
+            if (length == -1)
+                length = array.Length - startIndex;
+            var tmp = new T[length];
+            Array.Copy(array, startIndex, tmp, 0, length);
+            return tmp;
+        }
+
+        public static T[] Push<T>(this T[] array, params T[] arguments)
+        {
+            if (arguments == null && default(T) == null)
+                return array.Push(default(T));
+            if (arguments == null)
+                throw new ArgumentNullException("arguments");
+            var ret = new T[array.Length + arguments.Length];
+            Array.Copy(array, ret, array.Length);
+            Array.Copy(
+                arguments,
+                0,
+                ret,
+                array.Length,
+                arguments.Length);
+            return ret;
+        }
+
+        public static T[] RemoveAt<T>(this T[] array, int removeIndex)
+        {
+            var ret = new T[array.Length - 1];
+            Array.Copy(array, 0, ret, 0, removeIndex);
+            Array.Copy(
+                array,
+                removeIndex + 1,
+                ret,
+                removeIndex,
+                array.Length - 1 - removeIndex);
+            return ret;
+        }
+    }
+}

--- a/src/System.ObjectModel/System.ObjectModel.sln
+++ b/src/System.ObjectModel/System.ObjectModel.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ObjectModel", "src\System.ObjectModel.csproj", "{F24D3391-2928-4E83-AADE-A4461E5CAE50}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ObjectModel.Tests", "tests\System.ObjectModel.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTraitsDiscoverers", "..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj", "{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.ObjectModel/tests/KeyedCollection/ConcreteTestClasses.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/ConcreteTestClasses.cs
@@ -1,0 +1,357 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using Xunit;
+
+namespace System.ObjectModel.Tests
+{
+    public class KeyedCollectionTest
+    {
+        [Fact]
+        public void StringComparer()
+        {
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<string, int>(
+                    System.StringComparer.OrdinalIgnoreCase)
+                {
+                    new KeyedItem<string, int>("foo", 0),
+                    new KeyedItem<string, int>("bar", 1)
+                };
+            Assert.Throws<ArgumentException>(
+                () =>
+                collection.Add(new KeyedItem<string, int>("Foo", 0)));
+            Assert.Throws<ArgumentException>(
+                () =>
+                collection.Add(new KeyedItem<string, int>("fOo", 0)));
+            Assert.Throws<ArgumentException>(
+                () =>
+                collection.Add(new KeyedItem<string, int>("baR", 0)));
+        }
+
+        [Fact]
+        public void ThresholdThrows()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () =>
+                new TestKeyedCollectionOfIKeyedItem<string, int>(-2));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () =>
+                new TestKeyedCollectionOfIKeyedItem<string, int>(
+                    int.MinValue));
+        }
+    }
+
+    public class IListTestKeyedCollectionIntInt :
+        IListTestKeyedCollection<int, int>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return "foo";
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override int CreateItem()
+        {
+            return s_item++;
+        }
+
+        protected override int GetKeyForItem(int item)
+        {
+            return item;
+        }
+    }
+
+    public class IListTestKeyedCollectionStringString :
+        IListTestKeyedCollection<string, string>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return 5;
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override string CreateItem()
+        {
+            return (s_item++).ToString();
+        }
+
+        protected override string GetKeyForItem(string item)
+        {
+            return item;
+        }
+    }
+
+    public class IListTestKeyedCollectionIntString :
+        IListTestKeyedCollection<int, string>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return 5;
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override string CreateItem()
+        {
+            return (s_item++).ToString();
+        }
+
+        protected override int GetKeyForItem(string item)
+        {
+            return item == null ? 0 : int.Parse(item);
+        }
+    }
+
+    public class IListTestKeyedCollectionStringInt :
+        IListTestKeyedCollection<string, int>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return "bar";
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override int CreateItem()
+        {
+            return s_item++;
+        }
+
+        protected override string GetKeyForItem(int item)
+        {
+            return item.ToString();
+        }
+    }
+
+    public class IListTestKeyedCollectionIntIntBadKey :
+        IListTestKeyedCollectionBadKey<int, int>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return "foo";
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override int CreateItem()
+        {
+            return s_item++;
+        }
+
+        protected override int GetKeyForItem(int item)
+        {
+            return item;
+        }
+    }
+
+    public class IListTestKeyedCollectionStringStringBadKey :
+        IListTestKeyedCollectionBadKey<string, string>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return 5;
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override string CreateItem()
+        {
+            return (s_item++).ToString();
+        }
+
+        protected override string GetKeyForItem(string item)
+        {
+            return item;
+        }
+    }
+
+    public class IListTestKeyedCollectionIntStringBadKey :
+        IListTestKeyedCollectionBadKey<int, string>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return 5;
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override string CreateItem()
+        {
+            return (s_item++).ToString();
+        }
+
+        protected override int GetKeyForItem(string item)
+        {
+            return item == null ? 0 : int.Parse(item);
+        }
+    }
+
+    public class IListTestKeyedCollectionStringIntBadKey :
+        IListTestKeyedCollectionBadKey<string, int>
+    {
+        private static int s_item = 1;
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a list of values that are not valid elements in the collection under test.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable" /> containing the invalid values.</returns>
+        protected override IEnumerable GetInvalidValues()
+        {
+            yield return (long) 5;
+            yield return "bar";
+            yield return new object();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets a new, unique item.
+        /// </summary>
+        /// <returns>The new item.</returns>
+        protected override int CreateItem()
+        {
+            return s_item++;
+        }
+
+        protected override string GetKeyForItem(int item)
+        {
+            return item.ToString();
+        }
+    }
+
+    public class KeyedCollectionTestsIntInt :
+        KeyedCollectionTests<int, int>
+    {
+        private int _curValue = 1;
+
+        public override int GetKeyForItem(int item)
+        {
+            return item;
+        }
+
+        public override int GenerateValue()
+        {
+            return _curValue++;
+        }
+    }
+
+    public class KeyedCollectionTestsStringString :
+        KeyedCollectionTests<string, string>
+    {
+        private int _curValue = 1;
+
+        public override string GetKeyForItem(string item)
+        {
+            return item;
+        }
+
+        public override string GenerateValue()
+        {
+            return (_curValue++).ToString();
+        }
+    }
+
+    public class KeyedCollectionTestsIntString :
+        KeyedCollectionTests<int, string>
+    {
+        private int _curValue = 1;
+
+        public override int GetKeyForItem(string item)
+        {
+            return int.Parse(item);
+        }
+
+        public override string GenerateValue()
+        {
+            return (_curValue++).ToString();
+        }
+    }
+
+    public class KeyedCollectionTestsStringInt :
+        KeyedCollectionTests<string, int>
+    {
+        private int _curValue = 1;
+
+        public override string GetKeyForItem(int item)
+        {
+            return item.ToString();
+        }
+
+        public override int GenerateValue()
+        {
+            return _curValue++;
+        }
+    }
+}

--- a/src/System.ObjectModel/tests/KeyedCollection/TestMethods.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/TestMethods.cs
@@ -1,0 +1,2149 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Tests.Collections;
+using Xunit;
+
+namespace System.ObjectModel.Tests
+{
+    public abstract class KeyedCollectionTests<TKey, TValue>
+        where TValue : IComparable<TValue> where TKey : IEquatable<TKey>
+    {
+        private static readonly bool s_keyNullable = default(TKey)
+                                                     == null;
+
+        private static int s_sometimesNullIndex;
+
+        public static Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+            GetNeverNullKeyMethod
+        {
+            get
+            {
+                return
+                    new Named
+                        <KeyedCollectionGetKeyedValue<TKey, TValue>>(
+                        "GetNeverNullKey",
+                        GetNeverNullKey);
+            }
+        }
+
+        public static Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+            GetSometimesNullKeyMethod
+        {
+            get
+            {
+                return
+                    new Named
+                        <KeyedCollectionGetKeyedValue<TKey, TValue>>(
+                        "GetSometimesNullKey",
+                        GetSometimesNullKey);
+            }
+        }
+
+        public static Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+            GetAlwaysNullKeyMethod
+        {
+            get
+            {
+                return
+                    new Named
+                        <KeyedCollectionGetKeyedValue<TKey, TValue>>(
+                        "GetAlwaysNullKey",
+                        GetAlwaysNullKey);
+            }
+        }
+
+        public static IEnumerable<object[]> CollectionSizes
+        {
+            get
+            {
+                yield return new object[] {0};
+                yield return new object[] {33};
+            }
+        }
+
+        public static IEnumerable<object[]> ClassData2
+        {
+            get
+            {
+                yield return new object[] {0, GetNeverNullKeyMethod};
+                yield return new object[] {33, GetNeverNullKeyMethod};
+            }
+        }
+
+        public static IEnumerable<object[]> ClassData
+        {
+            get
+            {
+                yield return new object[] {0, GetNeverNullKeyMethod};
+                yield return new object[] {33, GetNeverNullKeyMethod};
+                if (s_keyNullable)
+                {
+                    yield return
+                        new object[] {0, GetSometimesNullKeyMethod};
+                    yield return
+                        new object[] {33, GetSometimesNullKeyMethod};
+                    yield return
+                        new object[] {0, GetAlwaysNullKeyMethod};
+                    yield return
+                        new object[] {33, GetAlwaysNullKeyMethod};
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> ThresholdData
+        {
+            get
+            {
+                yield return
+                    new object[]
+                    {
+                        32,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Add<T>",
+                            Helper.AddItems)
+                    };
+                yield return
+                    new object[]
+                    {
+                        -1,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Add<T>",
+                            Helper.AddItems)
+                    };
+                yield return
+                    new object[]
+                    {
+                        32,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Insert<T>",
+                            Helper.InsertItems)
+                    };
+                yield return
+                    new object[]
+                    {
+                        -1,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Insert<T>",
+                            Helper.InsertItems)
+                    };
+                yield return
+                    new object[]
+                    {
+                        32,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Add",
+                            Helper.AddItemsObject)
+                    };
+                yield return
+                    new object[]
+                    {
+                        -1,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Add",
+                            Helper.AddItemsObject)
+                    };
+                yield return
+                    new object[]
+                    {
+                        32,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Add",
+                            Helper.InsertItemsObject)
+                    };
+                yield return
+                    new object[]
+                    {
+                        -1,
+                        new Named
+                            <
+                                AddItemsFunc
+                                    <TKey, IKeyedItem<TKey, TValue>>>(
+                            "Add",
+                            Helper.InsertItemsObject)
+                    };
+            }
+        }
+
+        public static IEnumerable<object[]> ContainsKeyData
+        {
+            get
+            {
+                var sizes = new[]
+                {
+                    new object[] {0},
+                    new object[] {1},
+                    new object[] {16},
+                    new object[] {33}
+                };
+                object[][] generatorMethods;
+                if (s_keyNullable)
+                {
+                    generatorMethods = new[]
+                    {
+                        new object[] {GetNeverNullKeyMethod},
+                        new object[] {GetSometimesNullKeyMethod},
+                        new object[] {GetAlwaysNullKeyMethod}
+                    };
+                }
+                else
+                {
+                    generatorMethods = new[]
+                    {
+                        new object[] {GetNeverNullKeyMethod}
+                    };
+                }
+                return from size in sizes
+                       from method in generatorMethods
+                       select size.Push(method);
+            }
+        }
+
+        public static IEnumerable<object[]> DictionaryData
+        {
+            get
+            {
+                yield return new object[] {10, 0, 0, 0, 0};
+                yield return new object[] {0, 10, 0, 0, 0};
+                yield return new object[] {10, 0, 5, 0, 0};
+                yield return new object[] {0, 10, 5, 0, 0};
+                yield return new object[] {10, 10, 10, 0, 0};
+                yield return new object[] {10, 0, 0, 5, 0};
+                yield return new object[] {0, 10, 0, 5, 0};
+                yield return new object[] {10, 10, 0, 10, 0};
+                yield return new object[] {10, 0, 3, 3, 0};
+                yield return new object[] {0, 10, 3, 3, 0};
+                yield return new object[] {10, 10, 5, 5, 0};
+                yield return new object[] {10, 0, 0, 0, 32};
+                yield return new object[] {0, 10, 0, 0, 32};
+                yield return new object[] {10, 0, 5, 0, 32};
+                yield return new object[] {0, 10, 5, 0, 32};
+                yield return new object[] {10, 10, 10, 0, 32};
+                yield return new object[] {10, 0, 0, 5, 32};
+                yield return new object[] {0, 10, 0, 5, 32};
+                yield return new object[] {10, 10, 0, 10, 32};
+                yield return new object[] {10, 0, 3, 3, 32};
+                yield return new object[] {0, 10, 3, 3, 32};
+                yield return new object[] {10, 10, 5, 5, 32};
+            }
+        }
+
+        public abstract TKey GetKeyForItem(TValue item);
+        public abstract TValue GenerateValue();
+
+        public object GenerateValueObject()
+        {
+            return GenerateValue();
+        }
+
+        private static IKeyedItem<TKey, TValue> GetNeverNullKey(
+            Func<TValue> getValue,
+            Func<TValue, TKey> getKeyForItem)
+        {
+            TValue item = getValue();
+            return new KeyedItem<TKey, TValue>(
+                getKeyForItem(item),
+                item);
+        }
+
+        private static IKeyedItem<TKey, TValue> GetSometimesNullKey(
+            Func<TValue> getValue,
+            Func<TValue, TKey> getKeyForItem)
+        {
+            TValue item = getValue();
+            return
+                new KeyedItem<TKey, TValue>(
+                    (s_sometimesNullIndex++ & 1) == 0
+                        ? default(TKey)
+                        : getKeyForItem(item),
+                    item);
+        }
+
+        private static IKeyedItem<TKey, TValue> GetAlwaysNullKey(
+            Func<TValue> getValue,
+            Func<TValue, TKey> getKeyForItem)
+        {
+            return new KeyedItem<TKey, TValue>(
+                default(TKey),
+                getValue());
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void AddNullKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+
+            // Verify Adding a value where the key is null
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+
+            var tmpKeyedItem = new KeyedItem<TKey, TValue>(
+                default(TKey),
+                item3);
+            keys = keys.Push(key1);
+            items = items.Push(keyedItem1, tmpKeyedItem);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+
+            collection.Add(keyedItem1);
+            collection.Add(tmpKeyedItem);
+
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void AddExistingKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+
+            //[] Verify setting a value where the key already exists in the collection
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+
+            var tmpKeyedItem = new KeyedItem<TKey, TValue>(key1, item3);
+            keys = keys.Push(key1);
+            items = items.Push(keyedItem1);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+
+            collection.Add(keyedItem1);
+
+            Assert.Throws<ArgumentException>(
+                () => { collection.Add(tmpKeyedItem); });
+
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void AddUniqueKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+
+            //[] Verify setting a value where the key is unique
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+
+            var tmpKeyedItem = new KeyedItem<TKey, TValue>(key3, item3);
+            keys = keys.Push(key1, key3);
+            items = items.Push(keyedItem1, tmpKeyedItem);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1, tmpKeyedItem);
+
+            collection.Add(keyedItem1);
+            collection.Add(tmpKeyedItem);
+
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void NonGenericAddNullKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            IList nonGenericCollection = collection;
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            var tmpKeyedItem = new KeyedItem<TKey, TValue>(
+                default(TKey),
+                item3);
+            keys = keys.Push(key1);
+            items = items.Push(keyedItem1, tmpKeyedItem);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+
+            collection.Add(keyedItem1);
+            nonGenericCollection.Add(tmpKeyedItem);
+
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void NonGenericAddExistingKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            IList nonGenericCollection = collection;
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            var tmpKeyedItem = new KeyedItem<TKey, TValue>(key1, item3);
+            keys = keys.Push(key1);
+            items = items.Push(keyedItem1);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+
+            collection.Add(keyedItem1);
+
+            Assert.Throws<ArgumentException>(
+                () => { nonGenericCollection.Add(tmpKeyedItem); });
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void NonGenericAddUniqueKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            IList nonGenericCollection = collection;
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            var tmpKeyedItem = new KeyedItem<TKey, TValue>(key3, item3);
+            keys = keys.Push(key1, key3);
+            items = items.Push(keyedItem1, tmpKeyedItem);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1, tmpKeyedItem);
+
+            collection.Add(keyedItem1);
+            nonGenericCollection.Add(tmpKeyedItem);
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, key2);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys =
+                itemsWithKeys.Push(
+                    new[] {keyedItem1, keyedItem2}.Where(
+                        ki => ki.Key != null)
+                                                  .ToArray
+                        <IKeyedItem<TKey, TValue>>());
+
+            collection.MyChangeItemKey(keyedItem2, key3);
+            keyedItem2.Key = key3;
+            keys[keys.Length - 1] = key3;
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemKeyThrowsPreexistingKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, key2);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys =
+                itemsWithKeys.Push(
+                    new[] {keyedItem1, keyedItem2}.Where(
+                        ki => ki.Key != null)
+                                                  .ToArray
+                        <IKeyedItem<TKey, TValue>>());
+
+            Assert.Throws<ArgumentException>(
+                () => collection.MyChangeItemKey(keyedItem2, key1));
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemKeySameKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, key2);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys =
+                itemsWithKeys.Push(
+                    new[] {keyedItem1, keyedItem2}.Where(
+                        ki => ki.Key != null)
+                                                  .ToArray
+                        <IKeyedItem<TKey, TValue>>());
+
+            collection.MyChangeItemKey(keyedItem2, key2);
+
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemDoesNotExistThrows(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var keyedItem3 = new KeyedItem<TKey, TValue>(key3, item3);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, key2);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys =
+                itemsWithKeys.Push(
+                    new[] {keyedItem1, keyedItem2}.Where(
+                        ki => ki.Key != null)
+                                                  .ToArray
+                        <IKeyedItem<TKey, TValue>>());
+            Assert.Throws<ArgumentException>(
+                () => collection.MyChangeItemKey(keyedItem3, key3));
+            Assert.Throws<ArgumentException>(
+                () => collection.MyChangeItemKey(keyedItem3, key2));
+            var tempKeyedItem = new KeyedItem<TKey, TValue>(key1, item2);
+            Assert.Throws<ArgumentException>(
+                () => collection.MyChangeItemKey(tempKeyedItem, key2));
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemKeyNullToNull(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(keyedItem1);
+                var tempKeyedItem =
+                    new KeyedItem<TKey, TValue>(default(TKey), item2);
+                collection.Add(tempKeyedItem);
+                keys = keys.Push(key1);
+                items = items.Push(keyedItem1, tempKeyedItem);
+                itemsWithKeys =
+                    itemsWithKeys.Push(
+                        new[] {keyedItem1}.Where(ki => ki.Key != null)
+                                          .ToArray
+                            <IKeyedItem<TKey, TValue>>());
+
+                collection.MyChangeItemKey(tempKeyedItem, default(TKey));
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemKeyNullToNonNull(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(keyedItem1);
+                var tempKeyedItem =
+                    new KeyedItem<TKey, TValue>(default(TKey), item2);
+                collection.Add(tempKeyedItem);
+                keys = keys.Push(key1);
+                items = items.Push(keyedItem1, tempKeyedItem);
+                itemsWithKeys =
+                    itemsWithKeys.Push(
+                        new[] {keyedItem1, tempKeyedItem}.Where(
+                            ki => ki.Key != null)
+                                                         .ToArray
+                            <IKeyedItem<TKey, TValue>>());
+
+                collection.MyChangeItemKey(tempKeyedItem, key2);
+                tempKeyedItem.Key = key2;
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void ChangeItemKeyNonNullToNull(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var keyedItem2 = new KeyedItem<TKey, TValue>(
+                    key2,
+                    item2);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(keyedItem1);
+                collection.Add(keyedItem2);
+                keys = keys.Push(key1);
+                items = items.Push(keyedItem1, keyedItem2);
+                itemsWithKeys =
+                    itemsWithKeys.Push(
+                        new[] {keyedItem1}.Where(ki => ki.Key != null)
+                                          .ToArray
+                            <IKeyedItem<TKey, TValue>>());
+
+                collection.MyChangeItemKey(keyedItem2, default(TKey));
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("CollectionSizes")]
+        public void ChangeItemKeyNullItemNotPresent(int collectionSize)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                TValue[] items;
+                TValue[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                var collection =
+                    new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+                collection.AddItems(
+                    GenerateValue,
+                    GetKeyForItem,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(item1);
+                Assert.Throws<ArgumentException>(
+                    () =>
+                    collection.MyChangeItemKey(default(TValue), key2));
+                collection.Verify(
+                    keys.Push(key1),
+                    items.Push(item1),
+                    itemsWithKeys.Push(item1));
+            }
+        }
+
+        [Theory]
+        [MemberData("CollectionSizes")]
+        public void ChangeItemKeyNullItemPresent(int collectionSize)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                TValue[] items;
+                TValue[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                var collection =
+                    new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+                collection.AddItems(
+                    GenerateValue,
+                    GetKeyForItem,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(item1);
+                collection.Add(default(TValue));
+                collection.MyChangeItemKey(default(TValue), key2);
+                collection.Verify(
+                    keys.Push(key1),
+                    items.Push(item1, default(TValue)),
+                    itemsWithKeys.Push(item1));
+            }
+        }
+
+        [Theory]
+        [MemberData("CollectionSizes")]
+        public void ChangeItemKeyNullKeyNotPresent(int collectionSize)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                TValue[] items;
+                TValue[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                var collection =
+                    new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+                collection.AddItems(
+                    GenerateValue,
+                    GetKeyForItem,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(item1);
+                collection.MyChangeItemKey(item1, default(TKey));
+                collection.Verify(
+                    keys,
+                    items.Push(item1),
+                    itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("CollectionSizes")]
+        public void ChangeItemKeyNullKeyPresent(int collectionSize)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                TValue[] items;
+                TValue[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                var collection =
+                    new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+                collection.AddItems(
+                    GenerateValue,
+                    GetKeyForItem,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(item1);
+                collection.Add(default(TValue));
+                collection.MyChangeItemKey(item1, default(TKey));
+                collection.Verify(
+                    keys,
+                    items.Push(item1, default(TValue)),
+                    itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("CollectionSizes")]
+        public void ChangeItemKeyNullItemNullKeyPresent(
+            int collectionSize)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                TValue[] items;
+                TValue[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                var collection =
+                    new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+                collection.AddItems(
+                    GenerateValue,
+                    GetKeyForItem,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                collection.Add(item1);
+                collection.Add(default(TValue));
+                collection.MyChangeItemKey(
+                    default(TValue),
+                    default(TKey));
+                collection.Verify(
+                    keys,
+                    items.Push(item1, default(TValue)),
+                    itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeyKeyAlreadyChanged(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, collectionSize >= 32 ? key2 : key3);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1, keyedItem2);
+            keyedItem2.Key = key3;
+            if (collectionSize >= 32)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => collection.MyChangeItemKey(keyedItem2, key3));
+            }
+            else
+            {
+                collection.MyChangeItemKey(keyedItem2, key3);
+            }
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeyKeyAlreadyChangedNewKeyIsOldKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, collectionSize >= 32 ? key2 : key3);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1, keyedItem2);
+            keyedItem2.Key = key3;
+            if (collectionSize >= 32)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => collection.MyChangeItemKey(keyedItem2, key2));
+            }
+            else
+            {
+                collection.MyChangeItemKey(keyedItem2, key2);
+            }
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeyKeyAlreadyChangedNewKeyIsDifferent(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            TValue item1 = GenerateValue();
+            TValue item2 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TValue item4 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key2 = GetKeyForItem(item2);
+            TKey key3 = GetKeyForItem(item3);
+            TKey key4 = GetKeyForItem(item4);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+            var keyedItem2 = new KeyedItem<TKey, TValue>(key2, item2);
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+
+            collection.Add(keyedItem1);
+            collection.Add(keyedItem2);
+            keys = keys.Push(key1, collectionSize >= 32 ? key2 : key3);
+            items = items.Push(keyedItem1, keyedItem2);
+            itemsWithKeys = itemsWithKeys.Push(keyedItem1, keyedItem2);
+            keyedItem2.Key = key3;
+            if (collectionSize >= 32)
+            {
+                Assert.Throws<ArgumentException>(
+                    () => collection.MyChangeItemKey(keyedItem2, key4));
+            }
+            else
+            {
+                collection.MyChangeItemKey(keyedItem2, key4);
+            }
+            collection.Verify(keys, items, itemsWithKeys);
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeyNullToNewKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TValue item3 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key3 = GetKeyForItem(item3);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+
+                collection.Add(keyedItem1);
+                var tempKeyedItem =
+                    new KeyedItem<TKey, TValue>(default(TKey), item2);
+                collection.Add(tempKeyedItem);
+                keys = keys.Push(key1);
+                if (collectionSize < 32)
+                {
+                    keys = keys.Push(key3);
+                }
+                items = items.Push(keyedItem1, tempKeyedItem);
+                itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                if (collectionSize < 32)
+                {
+                    itemsWithKeys = itemsWithKeys.Push(tempKeyedItem);
+                }
+                tempKeyedItem.Key = key3;
+                if (collectionSize >= 32)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () =>
+                        collection.MyChangeItemKey(tempKeyedItem, key3));
+                }
+                else
+                {
+                    collection.MyChangeItemKey(tempKeyedItem, key3);
+                }
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeyNullToOldKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TValue item3 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key3 = GetKeyForItem(item3);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+
+                collection.Add(keyedItem1);
+                var tempKeyedItem =
+                    new KeyedItem<TKey, TValue>(default(TKey), item2);
+                collection.Add(tempKeyedItem);
+                keys = keys.Push(key1);
+                if (collectionSize < 32)
+                {
+                    keys = keys.Push(key3);
+                }
+                items = items.Push(keyedItem1, tempKeyedItem);
+                itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                if (collectionSize < 32)
+                {
+                    itemsWithKeys = itemsWithKeys.Push(tempKeyedItem);
+                }
+                tempKeyedItem.Key = key3;
+                if (collectionSize >= 32)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () =>
+                        collection.MyChangeItemKey(
+                            tempKeyedItem,
+                            default(TKey)));
+                }
+                else
+                {
+                    collection.MyChangeItemKey(
+                        tempKeyedItem,
+                        default(TKey));
+                }
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeyNullToOtherKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TValue item3 = GenerateValue();
+                TValue item4 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key3 = GetKeyForItem(item3);
+                TKey key4 = GetKeyForItem(item4);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+
+                collection.Add(keyedItem1);
+                var tempKeyedItem =
+                    new KeyedItem<TKey, TValue>(default(TKey), item2);
+                collection.Add(tempKeyedItem);
+                keys = keys.Push(key1);
+                if (collectionSize < 32)
+                {
+                    keys = keys.Push(key3);
+                }
+                items = items.Push(keyedItem1, tempKeyedItem);
+                itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                if (collectionSize < 32)
+                {
+                    itemsWithKeys = itemsWithKeys.Push(tempKeyedItem);
+                }
+                tempKeyedItem.Key = key3;
+                if (collectionSize >= 32)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () =>
+                        collection.MyChangeItemKey(tempKeyedItem, key4));
+                }
+                else
+                {
+                    collection.MyChangeItemKey(tempKeyedItem, key4);
+                }
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeySetKeyNonNullToNull(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var keyedItem2 = new KeyedItem<TKey, TValue>(
+                    key2,
+                    item2);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+
+                collection.Add(keyedItem1);
+                collection.Add(keyedItem2);
+                keys = keys.Push(key1);
+                items = items.Push(keyedItem1, keyedItem2);
+                itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                keyedItem2.Key = default(TKey);
+                collection.MyChangeItemKey(keyedItem2, default(TKey));
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void ChangeItemKeySetKeyNonNullToNullChangeKeyNonNull(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var keyedItem2 = new KeyedItem<TKey, TValue>(
+                    key2,
+                    item2);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+
+                collection.Add(keyedItem1);
+                collection.Add(keyedItem2);
+                keys = keys.Push(key1);
+                items = items.Push(keyedItem1, keyedItem2);
+                itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                keyedItem2.Key = default(TKey);
+                if (collectionSize >= 32)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () =>
+                        collection.MyChangeItemKey(keyedItem2, key2));
+                }
+                else
+                {
+                    collection.MyChangeItemKey(keyedItem2, key2);
+                }
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData2")]
+        public void
+            ChangeItemKeySetKeyNonNullToNullChangeKeySomethingElse(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            if (default(TKey) == null)
+            {
+                TKey[] keys;
+                IKeyedItem<TKey, TValue>[] items;
+                IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                TValue item1 = GenerateValue();
+                TValue item2 = GenerateValue();
+                TValue item4 = GenerateValue();
+                TKey key1 = GetKeyForItem(item1);
+                TKey key2 = GetKeyForItem(item2);
+                TKey key4 = GetKeyForItem(item4);
+                var keyedItem1 = new KeyedItem<TKey, TValue>(
+                    key1,
+                    item1);
+                var keyedItem2 = new KeyedItem<TKey, TValue>(
+                    key2,
+                    item2);
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+                collection.AddItems(
+                    generateKeyedItem.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionSize,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+
+                collection.Add(keyedItem1);
+                collection.Add(keyedItem2);
+                keys = keys.Push(key1);
+                items = items.Push(keyedItem1, keyedItem2);
+                itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                keyedItem2.Key = default(TKey);
+                if (collectionSize >= 32 && keyedItem2.Key != null)
+                {
+                    Assert.Throws<ArgumentException>(
+                        () =>
+                        collection.MyChangeItemKey(keyedItem2, key4));
+                }
+                else
+                {
+                    collection.MyChangeItemKey(keyedItem2, key4);
+                }
+                collection.Verify(keys, items, itemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(4)]
+        [InlineData(25)]
+        [InlineData(33)]
+        public void Clear(int collectionSize)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                GetNeverNullKeyMethod.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            bool haveDict = collection.GetDictionary() != null;
+            collection.Clear();
+            collection.Verify(
+                new TKey[0],
+                new IKeyedItem<TKey, TValue>[0],
+                new IKeyedItem<TKey, TValue>[0]);
+            Assert.Equal(haveDict, collection.GetDictionary() != null);
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void Contains(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            if (s_keyNullable)
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => collection.Contains(default(TKey)));
+            }
+            else
+            {
+                Assert.False(collection.Contains(default(TKey)));
+            }
+        }
+
+        private void VerifyDictionary(
+            KeyedCollection<TKey, IKeyedItem<TKey, TValue>> dictionary,
+            TKey[] expectedKeys,
+            IKeyedItem<TKey, TValue>[] expectedItems)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException("dictionary");
+            }
+            if (expectedKeys.Length != expectedItems.Length)
+            {
+                throw new ArgumentException(
+                    "Expected keys length and expected items length must be the same.");
+            }
+            Assert.Equal(expectedItems.Length, dictionary.Count);
+
+            for (var i = 0; i < expectedKeys.Length; ++i)
+            {
+                Assert.Equal(
+                    expectedItems[i],
+                    dictionary[expectedKeys[i]]);
+            }
+        }
+
+        [Theory]
+        [MemberData("ThresholdData")]
+        public void Threshold(
+            int collectionDictionaryThreshold,
+            Named<AddItemsFunc<TKey, IKeyedItem<TKey, TValue>>> addItems)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            if (collectionDictionaryThreshold >= 0)
+            {
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>(
+                        collectionDictionaryThreshold);
+                // dictionary is created when the threshold is exceeded
+                addItems.Value(
+                    collection,
+                    GetNeverNullKeyMethod.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionDictionaryThreshold,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                Assert.Null(collection.GetDictionary());
+
+                collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>(
+                        collectionDictionaryThreshold);
+                addItems.Value(
+                    collection,
+                    GetNeverNullKeyMethod.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    collectionDictionaryThreshold + 1,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                Assert.NotNull(collection.GetDictionary());
+                VerifyDictionary(collection, keys, itemsWithKeys);
+            }
+            else
+            {
+                var collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>(
+                        collectionDictionaryThreshold);
+                // dictionary is created when the threshold is exceeded
+                addItems.Value(
+                    collection,
+                    GetNeverNullKeyMethod.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    1024,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                Assert.Null(collection.GetDictionary());
+
+                collection =
+                    new TestKeyedCollectionOfIKeyedItem<TKey, TValue>(
+                        collectionDictionaryThreshold);
+                addItems.Value(
+                    collection,
+                    GetNeverNullKeyMethod.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    2048,
+                    out keys,
+                    out items,
+                    out itemsWithKeys);
+                Assert.Null(collection.GetDictionary());
+            }
+        }
+
+        [Theory]
+        [MemberData("ContainsKeyData")]
+        public void ContainsKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            IKeyedItem<TKey, TValue> itemNotIn =
+                generateKeyedItem.Value(GenerateValue, GetKeyForItem);
+            // this is to make overload resolution pick the correct Contains function. replacing keyNotIn with null causes the Contains<TValue> overload to be used. We want the Contains<TKey> version.
+            TKey keyNotIn = itemNotIn.Key;
+            if (keyNotIn == null)
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => collection.Contains(keyNotIn));
+            }
+            else
+            {
+                Assert.False(collection.Contains(keyNotIn));
+            }
+            foreach (TKey k in keys)
+            {
+                TKey key = k;
+                if (key == null)
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => collection.Contains(key));
+                    continue;
+                }
+                Assert.True(collection.Contains(key));
+            }
+        }
+
+        [Theory]
+        [MemberData("ContainsKeyData")]
+        public void RemoveKey(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            collection.Verify(keys, items, itemsWithKeys);
+
+            IKeyedItem<TKey, TValue> itemNotIn =
+                generateKeyedItem.Value(GenerateValue, GetKeyForItem);
+            // this is to make overload resolution pick the correct Contains function. replacing keyNotIn with null causes the Contains<TValue> overload to be used. We want the Contains<TKey> version.
+            TKey keyNotIn = itemNotIn.Key;
+            if (keyNotIn == null)
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => collection.Remove(keyNotIn));
+            }
+            else
+            {
+                Assert.False(collection.Remove(keyNotIn));
+            }
+            collection.Verify(keys, items, itemsWithKeys);
+            var tempKeys = (TKey[]) keys.Clone();
+            var tempItems = (IKeyedItem<TKey, TValue>[]) items.Clone();
+            var tempItemsWithKeys =
+                (IKeyedItem<TKey, TValue>[]) itemsWithKeys.Clone();
+
+            for (var i = 0; i < itemsWithKeys.Length; i++)
+            {
+                TKey key = keys[i];
+                if (key == null)
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => collection.Remove(key));
+                }
+                else
+                {
+                    Assert.True(collection.Remove(key));
+                    tempItems =
+                        tempItems.RemoveAt(
+                            Array.IndexOf(tempItems, itemsWithKeys[i]));
+                    tempItemsWithKeys = itemsWithKeys.Slice(
+                        i + 1,
+                        itemsWithKeys.Length - i - 1);
+                    tempKeys = keys.Slice(i + 1, keys.Length - i - 1);
+                }
+                collection.Verify(
+                    tempKeys,
+                    tempItems,
+                    tempItemsWithKeys);
+            }
+        }
+
+        [Theory]
+        [MemberData("ContainsKeyData")]
+        public void KeyIndexer(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TKey[] keys;
+            IKeyedItem<TKey, TValue>[] items;
+            IKeyedItem<TKey, TValue>[] itemsWithKeys;
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>();
+            collection.AddItems(
+                generateKeyedItem.Value.Bind(
+                    GenerateValue,
+                    GetKeyForItem),
+                ki => ki.Key,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            IKeyedItem<TKey, TValue> itemNotIn =
+                generateKeyedItem.Value(GenerateValue, GetKeyForItem);
+            // this is to make overload resolution pick the correct Contains function. replacing keyNotIn with null causes the Contains<TValue> overload to be used. We want the Contains<TKey> version.
+            TKey keyNotIn = itemNotIn.Key;
+            if (keyNotIn == null)
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => collection[keyNotIn]);
+            }
+            else
+            {
+                Assert.Throws<KeyNotFoundException>(
+                    () => collection[keyNotIn]);
+            }
+            foreach (TKey k in keys)
+            {
+                TKey key = k;
+                if (key == null)
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => collection[key]);
+                    continue;
+                }
+                IKeyedItem<TKey, TValue> tmp = collection[key];
+            }
+        }
+
+        [Theory]
+        [MemberData("CollectionSizes")]
+        public void KeyIndexerSet(int collectionSize)
+        {
+            TKey[] keys;
+            TValue[] items;
+            TValue[] itemsWithKeys;
+            var collection =
+                new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+            collection.AddItems(
+                GenerateValue,
+                GetKeyForItem,
+                collectionSize,
+                out keys,
+                out items,
+                out itemsWithKeys);
+            foreach (TValue item in itemsWithKeys)
+            {
+                collection[collection.IndexOf(item)] = item;
+            }
+        }
+
+        [Theory]
+        [MemberData("DictionaryData")]
+        public void Dictionary(
+            int addCount,
+            int insertCount,
+            int removeCount,
+            int removeKeyCount,
+            int collectionDictionaryThreshold)
+        {
+            var collection =
+                new TestKeyedCollectionOfIKeyedItem<TKey, TValue>(
+                    collectionDictionaryThreshold);
+            TKey[] tempKeys;
+            IKeyedItem<TKey, TValue>[] tempItems;
+            IKeyedItem<TKey, TValue>[] tempItemsWithKeys;
+            var keys = new TKey[0];
+            var itemsWithKeys = new IKeyedItem<TKey, TValue>[0];
+
+            if (addCount > 0)
+            {
+                collection.AddItems(
+                    GetNeverNullKeyMethod.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    addCount,
+                    out tempKeys,
+                    out tempItems,
+                    out tempItemsWithKeys);
+                keys = keys.Push(tempKeys);
+                itemsWithKeys = itemsWithKeys.Push(tempItemsWithKeys);
+                VerifyDictionary(collection, keys, itemsWithKeys);
+            }
+            if (insertCount > 0)
+            {
+                collection.InsertItems(
+                    GetNeverNullKeyMethod.Value.Bind(
+                        GenerateValue,
+                        GetKeyForItem),
+                    ki => ki.Key,
+                    insertCount,
+                    out tempKeys,
+                    out tempItems,
+                    out tempItemsWithKeys);
+                keys = keys.Push(tempKeys);
+                itemsWithKeys = itemsWithKeys.Push(tempItemsWithKeys);
+                VerifyDictionary(collection, keys, itemsWithKeys);
+            }
+
+            if (removeCount > 0)
+            {
+                for (var i = 0; i < removeCount; i++)
+                {
+                    int index = (((i*43691 << 2)/7 >> 1)*5039)
+                                %collection.Count;
+                    collection.RemoveAt(index);
+                    keys = keys.RemoveAt(index);
+                    itemsWithKeys = itemsWithKeys.RemoveAt(index);
+                    VerifyDictionary(collection, keys, itemsWithKeys);
+                }
+            }
+
+            if (removeKeyCount > 0)
+            {
+                for (var i = 0; i < removeCount; i++)
+                {
+                    int index = (((i*127 << 2)/7 >> 1)*5039)
+                                %collection.Count;
+                    IKeyedItem<TKey, TValue> item = collection[index];
+                    collection.Remove(item.Key);
+                    keys = keys.RemoveAt(index);
+                    itemsWithKeys = itemsWithKeys.RemoveAt(index);
+                    VerifyDictionary(collection, keys, itemsWithKeys);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData("ClassData")]
+        public void Insert(
+            int collectionSize,
+            Named<KeyedCollectionGetKeyedValue<TKey, TValue>>
+                generateKeyedItem)
+        {
+            TValue item1 = GenerateValue();
+            TValue item3 = GenerateValue();
+            TKey key1 = GetKeyForItem(item1);
+            TKey key3 = GetKeyForItem(item3);
+            var keyedItem1 = new KeyedItem<TKey, TValue>(key1, item1);
+
+            var inserts =
+                new Action
+                    <KeyedCollection<TKey, IKeyedItem<TKey, TValue>>,
+                        int, IKeyedItem<TKey, TValue>>[]
+                {
+                    (c, i, item) => c.Insert(i, item),
+                    (c, i, item) => ((IList) c).Insert(i, item)
+                };
+
+            foreach (
+                Action
+                    <KeyedCollection<TKey, IKeyedItem<TKey, TValue>>,
+                        int, IKeyedItem<TKey, TValue>> i in inserts)
+            {
+                Action
+                    <KeyedCollection<TKey, IKeyedItem<TKey, TValue>>,
+                        int, IKeyedItem<TKey, TValue>> insert = i;
+                {
+                    // Insert key is null
+                    TKey[] keys;
+                    IKeyedItem<TKey, TValue>[] items;
+                    IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                    var collection =
+                        new TestKeyedCollectionOfIKeyedItem
+                            <TKey, TValue>();
+                    collection.AddItems(
+                        generateKeyedItem.Value.Bind(
+                            GenerateValue,
+                            GetKeyForItem),
+                        ki => ki.Key,
+                        collectionSize,
+                        out keys,
+                        out items,
+                        out itemsWithKeys);
+                    var tempKeyedItem =
+                        new KeyedItem<TKey, TValue>(
+                            default(TKey),
+                            item3);
+                    keys = keys.Push(key1);
+                    items = items.Push(keyedItem1, tempKeyedItem);
+                    itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                    insert(collection, collection.Count, keyedItem1);
+                    insert(collection, collection.Count, tempKeyedItem);
+                    collection.Verify(keys, items, itemsWithKeys);
+                }
+
+                {
+                    // Insert key already exists
+                    TKey[] keys;
+                    IKeyedItem<TKey, TValue>[] items;
+                    IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                    var collection =
+                        new TestKeyedCollectionOfIKeyedItem
+                            <TKey, TValue>();
+                    collection.AddItems(
+                        generateKeyedItem.Value.Bind(
+                            GenerateValue,
+                            GetKeyForItem),
+                        ki => ki.Key,
+                        collectionSize,
+                        out keys,
+                        out items,
+                        out itemsWithKeys);
+                    var tempKeyedItem = new KeyedItem<TKey, TValue>(
+                        key1,
+                        item3);
+                    keys = keys.Push(key1);
+                    items = items.Push(keyedItem1);
+                    itemsWithKeys = itemsWithKeys.Push(keyedItem1);
+                    insert(collection, collection.Count, keyedItem1);
+                    Assert.Throws<ArgumentException>(
+                        () =>
+                        insert(
+                            collection,
+                            collection.Count,
+                            tempKeyedItem));
+                    collection.Verify(keys, items, itemsWithKeys);
+                }
+
+                {
+                    // Insert key is unique
+                    TKey[] keys;
+                    IKeyedItem<TKey, TValue>[] items;
+                    IKeyedItem<TKey, TValue>[] itemsWithKeys;
+                    var collection =
+                        new TestKeyedCollectionOfIKeyedItem
+                            <TKey, TValue>();
+                    collection.AddItems(
+                        generateKeyedItem.Value.Bind(
+                            GenerateValue,
+                            GetKeyForItem),
+                        ki => ki.Key,
+                        collectionSize,
+                        out keys,
+                        out items,
+                        out itemsWithKeys);
+                    var tempKeyedItem = new KeyedItem<TKey, TValue>(
+                        key3,
+                        item3);
+                    keys = keys.Push(key1, key3);
+                    items = items.Push(keyedItem1, tempKeyedItem);
+                    itemsWithKeys = itemsWithKeys.Push(
+                        keyedItem1,
+                        tempKeyedItem);
+                    insert(collection, collection.Count, keyedItem1);
+                    insert(collection, collection.Count, tempKeyedItem);
+                    collection.Verify(keys, items, itemsWithKeys);
+                }
+            }
+        }
+    }
+
+    public abstract class IListTestKeyedCollection<TKey, TValue> :
+        IListTest<KeyedCollection<TKey, TValue>, TValue>
+    {
+        protected IListTestKeyedCollection()
+            : base(false, false, false, false, true, true)
+        {
+        }
+
+        protected abstract TKey GetKeyForItem(TValue item);
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets an instance of the list under test containing the given items.
+        /// </summary>
+        /// <param name="items">The items to initialize the list with.</param>
+        /// <returns>An instance of the list under test containing the given items.</returns>
+        protected override KeyedCollection<TKey, TValue> CreateList(
+            IEnumerable<TValue> items)
+        {
+            var ret =
+                new TestKeyedCollection<TKey, TValue>(GetKeyForItem);
+            if (items == null)
+            {
+                return ret;
+            }
+            foreach (TValue item in items)
+            {
+                ret.Add(item);
+            }
+            return ret;
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, invalidates any enumerators for the given list.
+        /// </summary>
+        /// <param name="list">The list to invalidate enumerators for.</param>
+        /// <returns>The new contents of the list.</returns>
+        protected override IEnumerable<TValue> InvalidateEnumerator(
+            KeyedCollection<TKey, TValue> list)
+        {
+            TValue item = CreateItem();
+            list.Add(item);
+            return list;
+        }
+    }
+
+    public abstract class IListTestKeyedCollectionBadKey<TKey, TValue> :
+        IListTest<KeyedCollection<BadKey<TKey>, TValue>, TValue>
+        where TKey : IEquatable<TKey>
+    {
+        protected IListTestKeyedCollectionBadKey()
+            : base(false, false, false, false, true, true)
+        {
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, Gets an instance of the list under test containing the given items.
+        /// </summary>
+        /// <param name="items">The items to initialize the list with.</param>
+        /// <returns>An instance of the list under test containing the given items.</returns>
+        protected override KeyedCollection<BadKey<TKey>, TValue>
+            CreateList(IEnumerable<TValue> items)
+        {
+            var ret =
+                new TestKeyedCollection<BadKey<TKey>, TValue>(
+                    item => new BadKey<TKey>(GetKeyForItem(item)),
+                    new BadKeyComparer<TKey>());
+            if (items == null)
+            {
+                return ret;
+            }
+            foreach (TValue item in items)
+            {
+                ret.Add(item);
+            }
+            return ret;
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, invalidates any enumerators for the given list.
+        /// </summary>
+        /// <param name="list">The list to invalidate enumerators for.</param>
+        /// <returns>The new contents of the list.</returns>
+        protected override IEnumerable<TValue> InvalidateEnumerator(
+            KeyedCollection<BadKey<TKey>, TValue> list)
+        {
+            TValue item = CreateItem();
+            list.Add(item);
+            return list;
+        }
+
+        protected abstract TKey GetKeyForItem(TValue item);
+    }
+}

--- a/src/System.ObjectModel/tests/KeyedCollection/Utils.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/Utils.cs
@@ -1,0 +1,578 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using Tests.Collections;
+using Xunit;
+
+namespace System.ObjectModel.Tests
+{
+    public class BadKey<T> : IComparable<BadKey<T>>,
+                             IEquatable<BadKey<T>>
+    {
+        private readonly T _key;
+
+        public BadKey(T key)
+        {
+            _key = key;
+        }
+
+        public T Key
+        {
+            get { return _key; }
+        }
+
+        /// <summary>
+        ///     Compares the current object with another object of the same type.
+        /// </summary>
+        /// <returns>
+        ///     A value that indicates the relative order of the objects being compared. The return value has the following
+        ///     meanings: Value Meaning Less than zero This object is less than the <paramref name="other" /> parameter.Zero This
+        ///     object is equal to <paramref name="other" />. Greater than zero This object is greater than
+        ///     <paramref name="other" />.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public int CompareTo(BadKey<T> other)
+        {
+            return 0;
+        }
+
+        /// <summary>
+        ///     Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        ///     true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(BadKey<T> other)
+        {
+            return true;
+        }
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+
+        /// <summary>
+        ///     Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        ///     true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            return true;
+        }
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        ///     A string that represents the current object.
+        /// </returns>
+        public override string ToString()
+        {
+            return Key == null ? "<null>" : Key.ToString();
+        }
+    }
+
+    public class BadKeyComparer<T> : IEqualityComparer<BadKey<T>>
+        where T : IEquatable<T>
+    {
+        /// <summary>
+        ///     Determines whether the specified objects are equal.
+        /// </summary>
+        /// <returns>
+        ///     true if the specified objects are equal; otherwise, false.
+        /// </returns>
+        /// <param name="x">The first object of type <paramref name="T" /> to compare.</param>
+        /// <param name="y">The second object of type <paramref name="T" /> to compare.</param>
+        public bool Equals(BadKey<T> x, BadKey<T> y)
+        {
+            if (x == null)
+            {
+                return y == null;
+            }
+            if (y == null)
+            {
+                return false;
+            }
+            if (x.Key == null)
+            {
+                return y.Key == null;
+            }
+            return x.Key.Equals(y.Key);
+        }
+
+        /// <summary>
+        ///     Returns a hash code for the specified object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for the specified object.
+        /// </returns>
+        /// <param name="obj">The <see cref="T:System.Object" /> for which a hash code is to be returned.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     The type of <paramref name="obj" /> is a reference type and
+        ///     <paramref name="obj" /> is null.
+        /// </exception>
+        public int GetHashCode(BadKey<T> obj)
+        {
+            if (obj == null)
+            {
+                return 0;
+            }
+            if (obj.Key == null)
+            {
+                return 0;
+            }
+            return obj.Key.GetHashCode();
+        }
+    }
+
+    public delegate void AddItemsFunc<TKey, TValue>(
+        KeyedCollection<TKey, TValue> collection,
+        Func<TValue> generateItem,
+        Func<TValue, TKey> getKey,
+        int numItems,
+        out TKey[] keys,
+        out TValue[] items,
+        out TValue[] itemsWithKeys);
+
+    public static class Helper
+    {
+        public static IDictionary<TKey, TValue> GetDictionary
+            <TKey, TValue>(
+            this KeyedCollection<TKey, TValue> collection)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+            MethodInfo propGet =
+                typeof (KeyedCollection<TKey, TValue>).GetTypeInfo()
+                                                      .DeclaredProperties
+                                                      .Where(
+                                                          f =>
+                                                          f.Name
+                                                          == "Dictionary")
+                                                      .Select(
+                                                          f =>
+                                                          f.GetMethod)
+                                                      .Where(
+                                                          gm =>
+                                                          gm != null)
+                                                      .FirstOrDefault(
+                                                          gm =>
+                                                          gm.IsFamily);
+            if (propGet == null)
+            {
+                throw new InvalidOperationException(
+                    "Could not get dictionary property from KeyedCollection");
+            }
+            object obj = propGet.Invoke(collection, new object[0]);
+            return (IDictionary<TKey, TValue>) obj;
+        }
+
+        public static Func<IKeyedItem<T1, T2>> Bind<T1, T2>(
+            this KeyedCollectionGetKeyedValue<T1, T2> function,
+            Func<T2> val1,
+            Func<T2, T1> val2)
+        {
+            return () => function(val1, val2);
+        }
+
+        public static void Verify<TKey, TValue>(
+            this KeyedCollection<TKey, TValue> collection,
+            TKey[] expectedKeys,
+            TValue[] expectedItems,
+            TValue[] expectedItemsWithKeys)
+        {
+            if (expectedItemsWithKeys.Length != expectedKeys.Length)
+            {
+                throw new ArgumentException(
+                    "Expected Keys length and Expected Items length must be the same");
+            }
+
+            Assert.Equal(expectedItems.Length, collection.Count);
+            // uses enumerator
+            CollectionAssert.Equal(expectedItems, collection);
+            // use int indexer
+            for (var i = 0; i < expectedItems.Length; ++i)
+            {
+                Assert.Equal(expectedItems[i], collection[i]);
+            }
+
+            // use key indexer
+            for (var i = 0; i < expectedItemsWithKeys.Length; ++i)
+            {
+                Assert.Equal(
+                    expectedItemsWithKeys[i],
+                    collection[expectedKeys[i]]);
+            }
+
+            // check that all keys are contained
+            Assert.DoesNotContain(
+                expectedKeys,
+                key => !collection.Contains(key));
+
+            // check that all values are contained
+            Assert.DoesNotContain(
+                expectedItems,
+                item => !collection.Contains(item));
+        }
+
+        public static void AddItems<TKey, TValue>(
+            this KeyedCollection<TKey, TValue> collection,
+            Func<TValue> generateItem,
+            Func<TValue, TKey> getKey,
+            int numItems,
+            out TKey[] keys,
+            out TValue[] items,
+            out TValue[] itemsWithKeys)
+        {
+            items = new TValue[numItems];
+            keys = new TKey[numItems];
+            itemsWithKeys = new TValue[numItems];
+            var keyIndex = 0;
+
+            for (var i = 0; i < numItems; ++i)
+            {
+                TValue item = generateItem();
+                TKey key = getKey(item);
+
+                collection.Add(item);
+                items[i] = item;
+
+                if (null != key)
+                {
+                    keys[keyIndex] = key;
+                    itemsWithKeys[keyIndex] = item;
+                    ++keyIndex;
+                }
+            }
+
+            keys = keys.Slice(0, keyIndex);
+            itemsWithKeys = itemsWithKeys.Slice(0, keyIndex);
+        }
+
+        public static void InsertItems<TKey, TValue>(
+            this KeyedCollection<TKey, TValue> collection,
+            Func<TValue> generateItem,
+            Func<TValue, TKey> getKey,
+            int numItems,
+            out TKey[] keys,
+            out TValue[] items,
+            out TValue[] itemsWithKeys)
+        {
+            items = new TValue[numItems];
+            keys = new TKey[numItems];
+            itemsWithKeys = new TValue[numItems];
+            var keyIndex = 0;
+
+            for (var i = 0; i < numItems; ++i)
+            {
+                TValue item = generateItem();
+                TKey key = getKey(item);
+
+                collection.Insert(collection.Count, item);
+                items[i] = item;
+
+                if (null != key)
+                {
+                    keys[keyIndex] = key;
+                    itemsWithKeys[keyIndex] = item;
+                    ++keyIndex;
+                }
+            }
+
+            keys = keys.Slice(0, keyIndex);
+            itemsWithKeys = itemsWithKeys.Slice(0, keyIndex);
+        }
+
+        public static void InsertItemsObject<TKey, TValue>(
+            this KeyedCollection<TKey, TValue> collection,
+            Func<TValue> generateItem,
+            Func<TValue, TKey> getKey,
+            int numItems,
+            out TKey[] keys,
+            out TValue[] items,
+            out TValue[] itemsWithKeys)
+        {
+            items = new TValue[numItems];
+            keys = new TKey[numItems];
+            itemsWithKeys = new TValue[numItems];
+            var keyIndex = 0;
+
+            for (var i = 0; i < numItems; ++i)
+            {
+                TValue item = generateItem();
+                TKey key = getKey(item);
+
+                ((IList) collection).Insert(collection.Count, item);
+                items[i] = item;
+
+                if (null != key)
+                {
+                    keys[keyIndex] = key;
+                    itemsWithKeys[keyIndex] = item;
+                    ++keyIndex;
+                }
+            }
+
+            keys = keys.Slice(0, keyIndex);
+            itemsWithKeys = itemsWithKeys.Slice(0, keyIndex);
+        }
+
+        public static void AddItemsObject<TKey, TValue>(
+            this KeyedCollection<TKey, TValue> collection,
+            Func<TValue> generateItem,
+            Func<TValue, TKey> getKey,
+            int numItems,
+            out TKey[] keys,
+            out TValue[] items,
+            out TValue[] itemsWithKeys)
+        {
+            items = new TValue[numItems];
+            keys = new TKey[numItems];
+            itemsWithKeys = new TValue[numItems];
+            var keyIndex = 0;
+
+            for (var i = 0; i < numItems; ++i)
+            {
+                TValue item = generateItem();
+                TKey key = getKey(item);
+
+                ((IList) collection).Add(item);
+                items[i] = item;
+
+                if (null != key)
+                {
+                    keys[keyIndex] = key;
+                    itemsWithKeys[keyIndex] = item;
+                    ++keyIndex;
+                }
+            }
+
+            keys = keys.Slice(0, keyIndex);
+            itemsWithKeys = itemsWithKeys.Slice(0, keyIndex);
+        }
+    }
+
+    public struct Named<T>
+    {
+        private readonly string _name;
+        private readonly T _value;
+
+        public Named(string name, T value) : this()
+        {
+            _name = name;
+            _value = value;
+        }
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        public T Value
+        {
+            get { return _value; }
+        }
+
+        /// <summary>
+        ///     Returns the fully qualified type name of this instance.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="T:System.String" /> containing a fully qualified type name.
+        /// </returns>
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+
+    public interface IKeyedItem<out TKey, out TValue>
+    {
+        TKey Key { get; }
+        TValue Item { get; }
+    }
+
+    public class KeyedItem<TKey, TValue> :
+        IComparable<KeyedItem<TKey, TValue>>, IKeyedItem<TKey, TValue>,
+        IEquatable<KeyedItem<TKey, TValue>>
+        where TValue : IComparable<TValue>
+    {
+        private readonly TValue _item;
+
+        public KeyedItem(TKey key, TValue item)
+        {
+            Key = key;
+            _item = item;
+        }
+
+        /// <summary>
+        ///     Compares the current object with another object of the same type.
+        /// </summary>
+        /// <returns>
+        ///     A value that indicates the relative order of the objects being compared. The return value has the following
+        ///     meanings: Value Meaning Less than zero This object is less than the <paramref name="other" /> parameter.Zero This
+        ///     object is equal to <paramref name="other" />. Greater than zero This object is greater than
+        ///     <paramref name="other" />.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public int CompareTo(KeyedItem<TKey, TValue> other)
+        {
+            if (other == null)
+            {
+                return -1;
+            }
+            if (Item == null)
+            {
+                return other.Item == null ? 0 : -1;
+            }
+            return Item.CompareTo(other.Item);
+        }
+
+        /// <summary>
+        ///     Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        ///     true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(KeyedItem<TKey, TValue> other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            if (Item == null)
+            {
+                return other.Item == null;
+            }
+            return Item.Equals(other.Item);
+        }
+
+        public TKey Key { get; set; }
+
+        public TValue Item
+        {
+            get { return _item; }
+        }
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            if (Item == null)
+            {
+                return 0;
+            }
+            return Item.GetHashCode();
+        }
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        ///     A string that represents the current object.
+        /// </returns>
+        public override string ToString()
+        {
+            string value = Item == null ? "<null>" : Item.ToString();
+            string key = Key == null ? "<null>" : Key.ToString();
+
+            return "key=" + key + " value=" + value;
+        }
+    }
+
+    public class TestKeyedCollection<TKey, TValue> :
+        KeyedCollection<TKey, TValue>
+    {
+        private readonly Func<TValue, TKey> _getKey;
+
+        public TestKeyedCollection(Func<TValue, TKey> getKey)
+            : base(null, 32)
+        {
+            if (getKey == null)
+            {
+                throw new ArgumentNullException("getKey");
+            }
+            _getKey = getKey;
+        }
+
+        public TestKeyedCollection(
+            Func<TValue, TKey> getKey,
+            IEqualityComparer<TKey> comp) : base(comp, 32)
+        {
+            if (getKey == null)
+            {
+                throw new ArgumentNullException("getKey");
+            }
+            _getKey = getKey;
+        }
+
+        protected override TKey GetKeyForItem(TValue item)
+        {
+            return _getKey(item);
+        }
+
+        public void MyChangeItemKey(TValue item, TKey newKey)
+        {
+            ChangeItemKey(item, newKey);
+        }
+    }
+
+    public class TestKeyedCollectionOfIKeyedItem<TKey, TValue> :
+        KeyedCollection<TKey, IKeyedItem<TKey, TValue>>
+        where TKey : IEquatable<TKey>
+    {
+        public TestKeyedCollectionOfIKeyedItem(
+            int collectionDictionaryThreshold = 32)
+            : base(null, collectionDictionaryThreshold)
+        {
+        }
+
+        public TestKeyedCollectionOfIKeyedItem(
+            IEqualityComparer<TKey> comp,
+            int collectionDictionaryThreshold = 32)
+            : base(comp, collectionDictionaryThreshold)
+        {
+        }
+
+        protected override TKey GetKeyForItem(
+            IKeyedItem<TKey, TValue> item)
+        {
+            return item.Key;
+        }
+
+        public void MyChangeItemKey(
+            IKeyedItem<TKey, TValue> item,
+            TKey newKey)
+        {
+            ChangeItemKey(item, newKey);
+        }
+    }
+
+    public delegate IKeyedItem<TKey, TValue>
+        KeyedCollectionGetKeyedValue<TKey, TValue>(
+        Func<TValue> getValue,
+        Func<TValue, TKey> getKeyForItem);
+}

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -14,8 +14,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\Collections\IEnumerableTest.cs" />
+    <Compile Include="$(CommonTestPath)\Collections\ICollectionTest.cs" />
+    <Compile Include="$(CommonTestPath)\Collections\IListTest.cs" />
+    <Compile Include="$(CommonTestPath)\Collections\Utils.cs" />
     <Compile Include="ComponentModel\INotifyPropertyChangingTests.cs" />
     <Compile Include="ComponentModel\PropertyChangingEventArgsTests.cs" />
+    <Compile Include="KeyedCollection\TestMethods.cs" />
+    <Compile Include="KeyedCollection\ConcreteTestClasses.cs" />
+    <Compile Include="KeyedCollection\Utils.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_MethodsTest.cs" />
     <Compile Include="ReadOnlyDictionary\ReadOnlyDictionaryTests.cs" />
@@ -26,6 +33,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">
+      <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
+      <Name>XunitTraitsDiscoverers</Name>
+    </ProjectReference>
     <ProjectReference Include="..\src\System.ObjectModel.csproj">
       <Project>{F24D3391-2928-4E83-AADE-A4461E5CAE50}</Project>
       <Name>System.ObjectModel</Name>

--- a/src/System.ObjectModel/tests/packages.config
+++ b/src/System.ObjectModel/tests/packages.config
@@ -1,5 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="System.Collections" version="4.0.10-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Threading" version="4.0.10-beta-22703" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
This change adds tests for `KeyedCollection<TKey, TValue>` ported from internal test assets, bringing test coverage from 0 to 96%
This also includes tests for `IList`, `ICollection`, and `IEnumerable` that can be used across all tests involving collections.
I will be bringing over tests for `IList<T>`, `ICollection<T>`, and `IEnumerable<T>` in a future PR.

<!---
@huboard:{"order":1122.5,"milestone_order":1171,"custom_state":""}
-->
