### PR TITLE
Fix null deref in UnixFileStream ctor

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -145,7 +145,7 @@ namespace System.IO
             _bufferLength = bufferSize;
             _useAsyncIO = useAsyncIO;
 
-            if (_parent.CanSeek)
+            if (CanSeek)
             {
                 SeekCore(0, SeekOrigin.Current);
             }


### PR DESCRIPTION
UnixFileStream's ctor that accepts a SafefileHandle was calling _parent.CanSeek, but no calls to _parent should be made in the ctor of a FileStreamBase because the _parent FileStream's _innerStream hasn't yet been assigned to this FileStreamBase instance being constructed.