### PR TITLE
Fix missed string resource refactoring in T4

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
@@ -28,7 +28,7 @@ namespace System.Numerics
     *        2. Allows reflection to work:
     *            - If a method is called via reflection, it will not be "intrinsified", which would cause issues if we did
     *              not provide an implementation for that case (i.e. if it only included a case which assumed 16-byte registers)
-    *    (NOTE: It is assumed that Vector.IsHardwareAccelerated will be a compile-time constant, eliminating these checks 
+    *    (NOTE: It is assumed that Vector.IsHardwareAccelerated will be a compile-time constant, eliminating these checks
     *        from the JIT'd code.)
     *
     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -65,15 +65,15 @@ namespace System.Numerics
         }
         private static int count = InitializeCount();
 
-        /// <summary> 
-        /// Returns a vector containing all zeroes. 
+        /// <summary>
+        /// Returns a vector containing all zeroes.
         /// </summary>
         [JitIntrinsic]
         public static Vector<T> Zero { get { return zero; } }
         private static readonly Vector<T> zero = new Vector<T>(GetZeroValue());
 
-        /// <summary> 
-        /// Returns a vector containing all ones. 
+        /// <summary>
+        /// Returns a vector containing all ones.
         /// </summary>
         [JitIntrinsic]
         public static Vector<T> One { get { return one; } }
@@ -348,14 +348,14 @@ namespace System.Numerics
             }
         }
 
-        /// <summary> 
+        /// <summary>
         /// Constructs a vector from the given array. The size of the given array must be at least Vector'T.Count.
         /// </summary>
         [JitIntrinsic]
         public unsafe Vector(T[] values) : this(values, 0) { }
 
-        /// <summary> 
-        /// Constructs a vector from the given array, starting from the given index. 
+        /// <summary>
+        /// Constructs a vector from the given array, starting from the given index.
         /// The array must contain at least Vector'T.Count from the given index.
         /// </summary>
         public unsafe Vector(T[] values, int index)
@@ -747,7 +747,7 @@ namespace System.Numerics
         #endregion Constructors
 
         #region Public Instance Methods
-        /// <summary> 
+        /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
         /// </summary>
         /// <param name="destination">The destination array which the values are copied into</param>
@@ -759,7 +759,7 @@ namespace System.Numerics
             CopyTo(destination, 0);
         }
 
-        /// <summary> 
+        /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
         /// </summary>
         /// <param name="destination">The destination array which the values are copied into</param>
@@ -1037,7 +1037,7 @@ namespace System.Numerics
             }
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns the element at the given index.
         /// </summary>
         [JitIntrinsic]
@@ -1505,7 +1505,7 @@ namespace System.Numerics
         }
 
         /// <summary>
-        /// Returns a String representing this vector, using the specified format string to format individual elements 
+        /// Returns a String representing this vector, using the specified format string to format individual elements
         /// and the given IFormatProvider.
         /// </summary>
         /// <param name="format">The format of individual elements.</param>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -33,7 +33,7 @@ namespace System.Numerics
     *        2. Allows reflection to work:
     *            - If a method is called via reflection, it will not be "intrinsified", which would cause issues if we did
     *              not provide an implementation for that case (i.e. if it only included a case which assumed 16-byte registers)
-    *    (NOTE: It is assumed that Vector.IsHardwareAccelerated will be a compile-time constant, eliminating these checks 
+    *    (NOTE: It is assumed that Vector.IsHardwareAccelerated will be a compile-time constant, eliminating these checks
     *        from the JIT'd code.)
     *
     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -60,7 +60,7 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-                    throw new NotSupportedException(SR.GetString("Reflection_MethodNotSupported"));
+                    throw new NotSupportedException(SR.Reflection_MethodNotSupported);
                 }
                 else
                 {
@@ -70,15 +70,15 @@ namespace System.Numerics
         }
         private static int count = InitializeCount();
 
-        /// <summary> 
-        /// Returns a vector containing all zeroes. 
+        /// <summary>
+        /// Returns a vector containing all zeroes.
         /// </summary>
         [JitIntrinsic]
         public static Vector<T> Zero { get { return zero; } }
         private static readonly Vector<T> zero = new Vector<T>(GetZeroValue());
 
-        /// <summary> 
-        /// Returns a vector containing all ones. 
+        /// <summary>
+        /// Returns a vector containing all ones.
         /// </summary>
         [JitIntrinsic]
         public static Vector<T> One { get { return one; } }
@@ -106,7 +106,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
         #endregion Static Initialization
@@ -160,14 +160,14 @@ namespace System.Numerics
             }
         }
 
-        /// <summary> 
+        /// <summary>
         /// Constructs a vector from the given array. The size of the given array must be at least Vector'T.Count.
         /// </summary>
         [JitIntrinsic]
         public unsafe Vector(T[] values) : this(values, 0) { }
 
-        /// <summary> 
-        /// Constructs a vector from the given array, starting from the given index. 
+        /// <summary>
+        /// Constructs a vector from the given array, starting from the given index.
         /// The array must contain at least Vector'T.Count from the given index.
         /// </summary>
         public unsafe Vector(T[] values, int index)
@@ -255,7 +255,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 #pragma warning restore 3001 // void* is not a CLS-Compliant argument type
@@ -267,7 +267,7 @@ namespace System.Numerics
         #endregion Constructors
 
         #region Public Instance Methods
-        /// <summary> 
+        /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
         /// </summary>
         /// <param name="destination">The destination array which the values are copied into</param>
@@ -279,7 +279,7 @@ namespace System.Numerics
             CopyTo(destination, 0);
         }
 
-        /// <summary> 
+        /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
         /// </summary>
         /// <param name="destination">The destination array which the values are copied into</param>
@@ -296,11 +296,11 @@ namespace System.Numerics
             }
             if (startIndex < 0 || startIndex >= destination.Length)
             {
-                throw new ArgumentOutOfRangeException(SR.GetString("Arg_ArgumentOutOfRangeException", startIndex));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, startIndex));
             }
             if ((destination.Length - startIndex) < Count)
             {
-                throw new ArgumentException(SR.GetString("Arg_ElementsInSourceIsGreaterThanDestination", startIndex));
+                throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, startIndex));
             }
 
             if (Vector.IsHardwareAccelerated)
@@ -349,7 +349,7 @@ namespace System.Numerics
             }
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns the element at the given index.
         /// </summary>
         [JitIntrinsic]
@@ -359,7 +359,7 @@ namespace System.Numerics
             {
                 if (index >= Count || index < 0)
                 {
-                    throw new IndexOutOfRangeException(SR.GetString("Arg_ArgumentOutOfRangeException", index));
+                    throw new IndexOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
                 }
 <#    foreach (Type type in supportedTypes)
     {
@@ -376,7 +376,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -438,7 +438,7 @@ namespace System.Numerics
                 {
 #>
                         && this.<#=GetRegisterFieldName(type, g)#> == other.<#=GetRegisterFieldName(type, g)#><#=(g == (GetNumFields(type, totalSize) -1)) ? ";" : ""#>
-<#            
+<#
                 }
 #>
 <#
@@ -450,7 +450,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -481,7 +481,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -506,7 +506,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -531,7 +531,7 @@ namespace System.Numerics
         }
 
         /// <summary>
-        /// Returns a String representing this vector, using the specified format string to format individual elements 
+        /// Returns a String representing this vector, using the specified format string to format individual elements
         /// and the given IFormatProvider.
         /// </summary>
         /// <param name="format">The format of individual elements.</param>
@@ -585,7 +585,7 @@ namespace System.Numerics
 #>
                     else
                     {
-                        throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                 }
                 else
@@ -642,7 +642,7 @@ namespace System.Numerics
 #>
                     else
                     {
-                        throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                 }
                 else
@@ -700,7 +700,7 @@ namespace System.Numerics
 #>
                     else
                     {
-                        throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                 }
                 else
@@ -838,7 +838,7 @@ namespace System.Numerics
 #>
                     else
                     {
-                        throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                 }
                 else
@@ -1018,7 +1018,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The source vector</param>
         /// <returns>The reinterpreted vector.</returns>
-<# 
+<#
         if (nonClsCompliantTypes.Contains(type))
         {
 #>
@@ -1061,7 +1061,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1087,7 +1087,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1115,7 +1115,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1141,7 +1141,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1169,7 +1169,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1195,7 +1195,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1223,7 +1223,7 @@ namespace System.Numerics
         [JitIntrinsic]
         internal static unsafe Vector<T> Abs(Vector<T> value)
         {
-<#    
+<#
     foreach (Type type in supportedTypes)
     {
         if (unsignedTypes.Contains(type))
@@ -1233,13 +1233,13 @@ namespace System.Numerics
             {
                 return value;
             }
-<# 
+<#
         }
     }
 #>
             if (Vector.IsHardwareAccelerated)
             {
-<#    
+<#
     foreach (Type type in supportedTypes.Except(unsignedTypes))
     {
 #>
@@ -1257,7 +1257,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1283,7 +1283,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1310,7 +1310,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1326,7 +1326,7 @@ namespace System.Numerics
                 {
 #>
                     vec.<#=GetRegisterFieldName(type, g)#> = left.<#=GetRegisterFieldName(type, g)#> < right.<#=GetRegisterFieldName(type, g)#> ? left.<#=GetRegisterFieldName(type, g)#> : right.<#=GetRegisterFieldName(type, g)#>;
-<# 
+<#
                 }
 #>
                     return vec;
@@ -1336,7 +1336,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1363,7 +1363,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1379,7 +1379,7 @@ namespace System.Numerics
                 {
 #>
                     vec.<#=GetRegisterFieldName(type, g)#> = left.<#=GetRegisterFieldName(type, g)#> > right.<#=GetRegisterFieldName(type, g)#> ? left.<#=GetRegisterFieldName(type, g)#> : right.<#=GetRegisterFieldName(type, g)#>;
-<# 
+<#
                 }
 #>
                     return vec;
@@ -1389,7 +1389,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1419,7 +1419,7 @@ namespace System.Numerics
                 {
 #>
                     product += (<#=type.Name#>)(left.<#=GetRegisterFieldName(type, g)#> * right.<#=GetRegisterFieldName(type, g)#>);
-<# 
+<#
                 }
 #>
                     return (T)(object)product;
@@ -1429,7 +1429,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1456,7 +1456,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
             else
@@ -1481,7 +1481,7 @@ namespace System.Numerics
 #>
                 else
                 {
-                    throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
                 }
             }
         }
@@ -1503,7 +1503,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1522,7 +1522,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1541,7 +1541,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1560,7 +1560,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1579,7 +1579,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1598,7 +1598,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1617,7 +1617,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1637,7 +1637,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1657,7 +1657,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
 
@@ -1676,7 +1676,7 @@ namespace System.Numerics
 #>
             else
             {
-                throw new NotSupportedException(SR.GetString("Arg_TypeNotSupported", typeof(T)));
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
         #endregion


### PR DESCRIPTION
The previous repo-wide refactoring of string resources in SR missed
cases in T4 templates. As soon as you make any modifications the
generated file gets overwritten and the project no longer builds. This
commit fixes the source template to match the intended changes.