### PR TITLE
Enable FileSystemWatcher test to actually validate internal buffer size ...

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
@@ -48,7 +48,7 @@ public partial class FileSystemWatcher_4000_Tests
             {
                 File.SetLastWriteTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(i));
             }
-
+            unblockHandler.Set();
             // This time we should not see an error
             Utility.ExpectNoEvent(eventOccured, "error");
         }


### PR DESCRIPTION
...changes

This is regarding issue #1165.

This change fixes the test so that it actually behaves as expected and validates a change in internal buffer size. 

This change does not actually address the issue originally reported.  The issue originally reported is because we don't have control over native handles being released by the OS.  If we believe that is a significant concern, then we may want to move all File System tests out of this testing loop.

In issue #1165, I mentioned that this test was not sandboxed well enough.  That was incorrect.  The utility used to create a test file, creates a somewhat unique filename, and then the watcher's filter is set so that we are exclusively monitoring the sandboxed file.  I think this is sufficient in this case.