### PR TITLE
Fixing race condition in Process tests.

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="Process_UseShellExecute.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\System.Diagnostics.Process.csproj">
       <Project>{63634289-90d7-4947-8bf3-dbbe98d76c85}</Project>
       <Name>System.Diagnostics.Process</Name>
@@ -36,11 +39,5 @@
       <Name>ProcessTest_ConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>
-  <!--  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <WCFMetadata Include="Service References\" />
-  </ItemGroup> -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
@@ -12,6 +12,7 @@
   <package id="System.Security.SecureString" version="4.0.0-beta-22703" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
   <package id="System.Text.Encoding.CodePages" version="4.0.0-beta-22703" />
+  <package id="System.Threading" version="4.0.10-beta-22703" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
   <package id="System.Threading.Thread" version="4.0.0-beta-22703" />
   <package id="System.Threading.ThreadPool" version="4.0.10-beta-22703" />


### PR DESCRIPTION
This test has been failing intermittently because the Assert can happen before the other threads are able to finish reading what was in stdout.