### PR TITLE
Fixing race condition in Process tests.

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -44,7 +44,10 @@ namespace System.Diagnostics.ProcessTests
             p.ErrorDataReceived += (s, e) => { sb.Append(e.Data); };
             p.Start();
             p.BeginErrorReadLine();
-            p.WaitForExit(WaitInMS);
+
+            if (p.WaitForExit(WaitInMS))
+                p.WaitForExit(); // This ensures async event handlers are finished processing.
+            
             Assert.Equal("ProcessTest_ConsoleApp.exe error stream", sb.ToString());
         }
 
@@ -69,7 +72,9 @@ namespace System.Diagnostics.ProcessTests
                 p.OutputDataReceived += (s, e) => sb.Append(e.Data);
                 p.Start();
                 p.BeginOutputReadLine();
-                p.WaitForExit(WaitInMS);
+                if (p.WaitForExit(WaitInMS))
+                    p.WaitForExit(); // This ensures async event handlers are finished processing.
+
                 Assert.Equal(sb.ToString(), "ProcessTest_ConsoleApp.exe startedProcessTest_ConsoleApp.exe closed");
             }
 
@@ -81,7 +86,9 @@ namespace System.Diagnostics.ProcessTests
                 p.OutputDataReceived += (s, e) => { sb.Append(e.Data); ((Process)s).CancelOutputRead(); };
                 p.Start();
                 p.BeginOutputReadLine();
-                p.WaitForExit(WaitInMS);
+                if (p.WaitForExit(WaitInMS))
+                    p.WaitForExit(); // This ensures async event handlers are finished processing.
+
                 Assert.Equal(sb.ToString(), "ProcessTest_ConsoleApp.exe started");
             }
         }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/System.Diagnostics.Process.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="Process_UseShellExecute.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\System.Diagnostics.Process.csproj">
       <Project>{63634289-90d7-4947-8bf3-dbbe98d76c85}</Project>
       <Name>System.Diagnostics.Process</Name>


### PR DESCRIPTION
According to the [docs](https://msdn.microsoft.com/en-us/library/vstudio/ty0d8k56(v=vs.100).aspx) it looks like the guidance in this case is to call WaitForExit() after getting true from WaitForExit(timeout). 

"When standard output has been redirected to asynchronous event handlers, it is possible that output processing will not have completed when this method returns. To ensure that asynchronous event handling has been completed, call the WaitForExit() overload that takes no parameter after receiving a true from this overload." 
