### PR TITLE
Fix Console tests on Linux

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Win32.SafeHandles
         private SafeFileHandle(bool ownsHandle)
             : base(s_invalidHandle, ownsHandle)
         {
-            handle = s_invalidHandle; // TODO: remove this once base implementation correctly sets it
         }
 
         /// <summary>Opens the specified file with the requested flags and mode.</summary>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -376,6 +376,15 @@ namespace System
                     }
                 }
             }
+
+            public override void Flush()
+            {
+                if (_handle.IsClosed)
+                {
+                    throw __Error.GetFileNotOpen();
+                }
+                base.Flush();
+            }
         }
 
         /// <summary>Provides access to and processing of the terminfo database.</summary>


### PR DESCRIPTION
Two System.Console tests were failing on Linux because the ConsoleStream's Flush method wasn't throwing an ObjectDisposedException if the stream had already been closed.  Now all of the System.Console tests pass on Linux.