### PR TITLE
`ParallelQuery<float?>.Sum()` add up all elements.

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/DoubleSumAggregationOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/DoubleSumAggregationOperator.cs
@@ -46,10 +46,7 @@ namespace System.Linq.Parallel
                 double sum = 0.0;
                 while (enumerator.MoveNext())
                 {
-                    checked
-                    {
-                        sum += enumerator.Current;
-                    }
+                    sum += enumerator.Current;
                 }
 
                 return sum;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/FloatSumAggregationOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/FloatSumAggregationOperator.cs
@@ -46,10 +46,7 @@ namespace System.Linq.Parallel
                 double sum = 0.0;
                 while (enumerator.MoveNext())
                 {
-                    checked
-                    {
-                        sum += enumerator.Current;
-                    }
+                    sum += enumerator.Current;
                 }
 
                 return (float)sum;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/NullableFloatSumAggregationOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/NullableFloatSumAggregationOperator.cs
@@ -98,7 +98,7 @@ namespace System.Linq.Parallel
                 if (source.MoveNext(ref element, ref keyUnused))
                 {
                     // We just scroll through the enumerator and accumulate the sum.
-                    float tempSum = 0.0f;
+                    double tempSum = 0.0f;
                     int i = 0;
                     do
                     {
@@ -110,7 +110,7 @@ namespace System.Linq.Parallel
                     while (source.MoveNext(ref element, ref keyUnused));
 
                     // The sum has been calculated. Now just return.
-                    currentElement = new double?(tempSum);
+                    currentElement = tempSum;
                     return true;
                 }
 

--- a/src/System.Linq.Parallel/tests/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/SumTests.cs
@@ -45,6 +45,14 @@ namespace Test
             }
         }
 
+        [Fact]
+        public static void FloatLimitationTest()
+        {
+            float[] elements = new[] { 16777220F, 1F, 1F, 1F, 1F, 1F, 1F, };
+            Assert.Equal(16777226F, elements.AsParallel().Sum());
+            Assert.Equal((float?)16777226F, elements.AsParallel().Sum(x => (float?)x));
+        }
+
         private static void RunSumTest1<T>(int count)
         {
             if (typeof(T) == typeof(int))


### PR DESCRIPTION
`ParallelQuery<float?>.Sum()` doesn't add up all elements, even when the final result would round to a different value.

For instance, `16777220F + 3F + 3F` should yield `16777230` (the next representation).

The non-nullable summation already yields the expected result, by adding the individual elements together as doubles, and then casting for the final result, but the nullable version performs everything as simple floats.  This change makes the nullable version behave like the non-nullable version, by adding the elements together as doubles first.  It also removes `checked` for these operations, as it's ignored for these types (would yield `Infinity` instead).

This behavior also appears in the current consumer release.  I don't know if an effort should be made to fix that separately from general adoption of corefx.

(side note: I'm doing the PR for this issue separate from the rest of my work on the PLINQ tests, as I'm not done with the rest yet, and somebody might care about this problem...)