### PR TITLE
Fix FileSystemWatcher src/tests on Linux

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -663,7 +663,7 @@ namespace System.IO
                 //         uint32_t len;
                 //         char     name[]; // length determined by len; at least 1 for required null termination
                 //     };
-                Debug.Assert((_bufferPos + (c_INotifyEventSize + 1)) <= _bufferAvailable);
+                Debug.Assert(_bufferPos + c_INotifyEventSize <= _bufferAvailable);
                 NotifyEvent readEvent;
                 readEvent.wd = BitConverter.ToInt32(_buffer, _bufferPos);
                 readEvent.mask = BitConverter.ToUInt32(_buffer, _bufferPos + 4);       // +4  to get past wd

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.NotifyFilter.cs
@@ -22,7 +22,7 @@ public partial class FileSystemWatcher_4000_Tests
             watcher.EnableRaisingEvents = true;
 
             var attributes = File.GetAttributes(file.Path);
-            attributes |= FileAttributes.Temporary;
+            attributes |= FileAttributes.ReadOnly;
 
             File.SetAttributes(file.Path, attributes);
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -383,7 +383,11 @@ public partial class FileSystemWatcher_4000_Tests
         Assert.Equal(currentDir, watcher.Path);
 
         // expect a change for same "full-path" but different string path, FSW does not normalize
-        string currentDirRelative = currentDir + @"\.\.\.\.";
+        string currentDirRelative = currentDir +
+            Path.DirectorySeparatorChar + "." +
+            Path.DirectorySeparatorChar + "." +
+            Path.DirectorySeparatorChar + "." +
+            Path.DirectorySeparatorChar + ".";
         watcher.Path = currentDirRelative;
         Assert.Equal(currentDirRelative, watcher.Path);
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -371,7 +371,7 @@ public partial class FileSystemWatcher_4000_Tests
         watcher.Path = "..";
         Assert.Equal("..", watcher.Path);
 
-        string currentDir = Path.GetFullPath(".").Trim('.', Path.DirectorySeparatorChar);
+        string currentDir = Path.GetFullPath(".").TrimEnd('.', Path.DirectorySeparatorChar);
         watcher.Path = currentDir;
         Assert.Equal(currentDir, watcher.Path);
 


### PR DESCRIPTION
This commit fixes issues highlighted when running the System.IO.FileSystem.Watcher tests on Linux.  There are 49 tests that pass on Windows; after these product and test fixes, only 7 of those fail on Linux, all due to Windows-specific tests that will need to be tweaked based on target system or disabled entirely on Linux:
- 2 are P/Invoking to Win32 functions related to security
- 3 are trying to overflow the event buffer but not doing so on Linux
- 2 are expecting case-insensitive file paths