### PR TITLE
Fix Issue#1211

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -29,7 +29,7 @@ namespace System.Diagnostics.ProcessTests
         public void Dispose()
         {
             _process.Kill();
-            _process.WaitForExit(WaitInMS);
+            Assert.True(_process.WaitForExit(WaitInMS));
 
             // Also ensure that there are no open processes with the same name as ProcessName
             foreach (Process p in Process.GetProcessesByName(ProcessName))
@@ -37,7 +37,7 @@ namespace System.Diagnostics.ProcessTests
                 if (!p.HasExited)
                 {
                     p.Kill();
-                    p.WaitForExit(WaitInMS);
+                    Assert.True(p.WaitForExit(WaitInMS));
                 }
             }
         }
@@ -105,7 +105,7 @@ namespace System.Diagnostics.ProcessTests
             p.Start();
             Sleep();
             p.Kill();
-            p.WaitForExit(WaitInMS);
+            Assert.True(p.WaitForExit(WaitInMS));
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace System.Diagnostics.ProcessTests
             {
                 Process p = CreateProcess();
                 p.Start();
-                p.WaitForExit(WaitInMS);
+                Assert.True(p.WaitForExit(WaitInMS));
                 Assert.Equal(p.ExitCode, 100);
             }
 
@@ -184,7 +184,7 @@ namespace System.Diagnostics.ProcessTests
             {
                 Process p = CreateProcess();
                 p.Start();
-                p.WaitForExit(WaitInMS);
+                Assert.True(p.WaitForExit(WaitInMS));
                 Assert.True(p.HasExited, "Process_HasExited001 failed");
             }
 
@@ -198,7 +198,7 @@ namespace System.Diagnostics.ProcessTests
                 finally
                 {
                     p.Kill();
-                    p.WaitForExit(WaitInMS);
+                    Assert.True(p.WaitForExit(WaitInMS));
                 }
 
                 Assert.True(p.HasExited, "Process_HasExited003 failed");

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_EncodingTest.cs
@@ -47,7 +47,7 @@ namespace System.Diagnostics.ProcessTests
                     Assert.Equal(p.StandardError.CurrentEncoding.CodePage, Encoding.UTF8.CodePage);
 
                     p.Kill();
-                    p.WaitForExit(WaitInMS);
+                    Assert.True(p.WaitForExit(WaitInMS));
                 }
 
                 {
@@ -67,7 +67,7 @@ namespace System.Diagnostics.ProcessTests
                     Assert.Equal(p.StandardError.CurrentEncoding.CodePage, s_ConsoleEncoding);
 
                     p.Kill();
-                    p.WaitForExit(WaitInMS);
+                    Assert.True(p.WaitForExit(WaitInMS));
                 }
             }
             finally

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics.ProcessTests
             p.StartInfo.RedirectStandardError = true;
             p.Start();
             Assert.Equal(p.StandardError.ReadToEnd(), "ProcessTest_ConsoleApp.exe error stream\r\n");
-            p.WaitForExit(WaitInMS);
+            Assert.True(p.WaitForExit(WaitInMS));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace System.Diagnostics.ProcessTests
             p.StartInfo.RedirectStandardOutput = true;
             p.Start();
             string s = p.StandardOutput.ReadToEnd();
-            p.WaitForExit(WaitInMS);
+            Assert.True(p.WaitForExit(WaitInMS));
             Assert.Equal(s, "ProcessTest_ConsoleApp.exe started\r\nProcessTest_ConsoleApp.exe closed\r\n");
         }
 
@@ -106,6 +106,7 @@ namespace System.Diagnostics.ProcessTests
                 string str = "This string should come as output";
                 writer.WriteLine(str);
             }
+            Assert.True(p.WaitForExit(WaitInMS));
         }
     }
 }


### PR DESCRIPTION
Process test always calls WaitForExit with a timeout but
do not assert in case the process fails to exit in the given time.
Updating the tests to add this behavior.