### PR TITLE
Remove unused regex resource strings

### DIFF
--- a/src/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -123,12 +123,6 @@
   <data name="AlternationCantHaveComment" xml:space="preserve">
     <value>Alternation conditions cannot be comments.</value>
   </data>
-  <data name="Arg_InvalidArrayType" xml:space="preserve">
-    <value>Target array type is not compatible with the type of items in the collection.</value>
-  </data>
-  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
-    <value>Only single dimensional arrays are supported for the requested action.</value>
-  </data>
   <data name="BadClassInCharRange" xml:space="preserve">
     <value>Cannot include class \\{0} in character range.</value>
   </data>


### PR DESCRIPTION
The regex `Arg_InvalidArrayType` and `Arg_RankMultiDimNotSupported` resource strings are no longer used in corefx. These resources were removed from corefx as part of #317, but were added back by commit 3ad583086b7b5eebfaca535fea861b871776cc3d (not sure why, but I'm guessing these strings are still used in the full framework).

Do these unused resources need to be kept around even though they aren't used in corefx?