### PR TITLE
Integrate perf build into corefx build.

### DIFF
--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -25,5 +25,6 @@
     <GenerateCodeCoverageReportForAll>true</GenerateCodeCoverageReportForAll>
   </PropertyGroup>
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
+  <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets')" />
 
 </Project>


### PR DESCRIPTION
Import PerfTesting.targets to enable a consumptive metrics perf build;
this build is enabled by setting msbuild property TestConsumptiveMetrics
to true.  E.g. "build.cmd /p:TestConsumptiveMetrics=true".  This will
generate an XML file in the test run directory.  Note that this
implementation is a prototype and will likely change in the future.