### PR TITLE
Tweak an immutable collections test

### DIFF
--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -105,14 +105,14 @@ namespace System.Collections.Immutable.Test
         [Fact]
         public void GetEnumeratorTest()
         {
-            var builder = ImmutableSortedSet.Create("a", "B").ToBuilder();
+            var builder = ImmutableSortedSet.Create("a", "B").WithComparer(StringComparer.Ordinal).ToBuilder();
             IEnumerable<string> enumerable = builder;
             using (var enumerator = enumerable.GetEnumerator())
             {
                 Assert.True(enumerator.MoveNext());
-                Assert.Equal("a", enumerator.Current);
-                Assert.True(enumerator.MoveNext());
                 Assert.Equal("B", enumerator.Current);
+                Assert.True(enumerator.MoveNext());
+                Assert.Equal("a", enumerator.Current);
                 Assert.False(enumerator.MoveNext());
             }
         }


### PR DESCRIPTION
Out of the 611 immutable collections tests, one was failing on Unix.  The test is verifying that an ImmutableSortedSet.Builder's enumerator returns values in the right sorted order.  The problem is that it's using a default comparer based on the current culture, and we've not yet implemented that support on Unix, instead defaulting all such comparers to use ordinal... this results in a different sort order, and the test fails.

Since the actual comparer used is immaterial to what the test is verifying, I've simple tweaked the test to use an ordinal comparer.  This then passes on both Windows and Unix.