### PR TITLE
Fix race condition in GC KeepAlive test

### DIFF
--- a/src/System.Runtime/tests/System/GC.cs
+++ b/src/System.Runtime/tests/System/GC.cs
@@ -91,19 +91,16 @@ public class GCTests
     {
         public static void Run()
         {
-            RunWorker();
-            Assert.False(KeepAliveObject.Finalized);
-            Assert.True(DoNotKeepAliveObject.Finalized);
-        }
-
-        private static void RunWorker()
-        {
             var keepAlive = new KeepAliveObject();
-            var doNotKeepAlive = new DoNotKeepAliveObject();
 
+            var doNotKeepAlive = new DoNotKeepAliveObject();
             doNotKeepAlive = null;
+
             GC.Collect();
             GC.WaitForPendingFinalizers();
+
+            Assert.True(DoNotKeepAliveObject.Finalized);
+            Assert.False(KeepAliveObject.Finalized);
 
             GC.KeepAlive(keepAlive);
         }
@@ -170,12 +167,8 @@ public class GCTests
     {
         public static void Run()
         {
-            var obj = new TestObject();
             int recursionCount = 0;
-
-            RunWorker(obj, ref recursionCount);
-
-            Assert.False(TestObject.Finalized);
+            RunWorker(new TestObject(), ref recursionCount);
         }
 
         private static void RunWorker(object obj, ref int recursionCount)
@@ -188,6 +181,7 @@ public class GCTests
 
             RunWorker(obj, ref recursionCount);
 
+            Assert.False(TestObject.Finalized);
             GC.KeepAlive(obj);
         }
 


### PR DESCRIPTION
A few tests for GC.KeepAlive have a race condition where they use KeepAlive to prevent an object from being finalized and then assert that it hasn't.  But the object can get finalized after the call to KeepAlive and before the check, causing the test to randomly fail.

Fixes #1230 