### PR TITLE
Adding more tests to System.Linq.

### DIFF
--- a/src/System.Linq/tests/AggregateTests.cs
+++ b/src/System.Linq/tests/AggregateTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Linq;
+
+namespace Test
+{
+    public class AggregateTests
+    {
+        //
+        // Aggregate
+        //
+        [Fact]
+        public static void RunAggregationTests()
+        {
+            RunAggregationTest1_Sum1(1024);
+            RunAggregationTest1_Sum2(1024);
+            RunAggregationTest1_Sum3(1024);
+            RunAggregationTest2(16);
+        }
+
+        private static void RunAggregationTest1_Sum1(int count)
+        {
+            int expectSum = 0;
+            int[] ints = new int[count];
+            for (int i = 0; i < ints.Length; i++)
+            {
+                ints[i] = i;
+                expectSum += i;
+            }
+
+            int realSum = ints.Aggregate<int>(
+                delegate (int x, int y) { return x + y; });
+            if (realSum != expectSum)
+                Assert.True(false, string.Format("RunAggregationTest1_Sum1: FAILED. (count: {2}):  FAIL  > Expect: {0}, real: {1}", expectSum, realSum, count));
+        }
+
+        private static void RunAggregationTest1_Sum2(int count)
+        {
+            int expectSum = 0;
+            int[] ints = new int[count];
+            for (int i = 0; i < ints.Length; i++)
+            {
+                ints[i] = i;
+                expectSum += i;
+            }
+
+            int realSum = ints.Aggregate<int, int>(
+                0, delegate (int x, int y) { return x + y; });
+
+            if (realSum != expectSum)
+                Assert.True(false, string.Format("RunAggregationTest1_Sum2(count={2}):  FAIL.  > Expect: {0}, real: {1}", expectSum, realSum, count));
+        }
+
+        private static void RunAggregationTest1_Sum3(int count)
+        {
+            int expectSum = 0;
+            int[] ints = new int[count];
+            for (int i = 0; i < ints.Length; i++)
+            {
+                ints[i] = i;
+                expectSum += i;
+            }
+
+            int realSum = ints.Aggregate<int, int, int>(
+                0, delegate (int x, int y) { return x + y; }, delegate (int x) { return x; });
+
+            if (realSum != expectSum)
+                Assert.True(false, string.Format("RunAggregationTest1_Sum3(count={2}): FAILED.  > Expect: {0}, real: {1}", expectSum, realSum, count));
+        }
+
+        private static void RunAggregationTest2(int count)
+        {
+            int[] arr = new int[count];
+            int count1 = arr.Select(x => x).Aggregate<int, int>(0, (acc, x) => acc + 1);
+            int count2 = arr.Select(x => x).Aggregate<int, int, int>(0, (acc, x) => acc + 1, res => res);
+
+            if (count1 != arr.Length)
+            {
+                Assert.True(false, string.Format("RunAggregationTest2(count={2}): FAILED.  > Count1 expect: {0}, real: {1}", arr.Length, count1, count));
+            }
+
+            if (count2 != arr.Length)
+            {
+                Assert.True(false, string.Format("RunAggregationTest2(count={2}): FAILED.  > Count2 expect: {0}, real: {1}", arr.Length, count2, count));
+            }
+        }
+    }
+}

--- a/src/System.Linq/tests/AllAnyTests.cs
+++ b/src/System.Linq/tests/AllAnyTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test
+{
+    public class AllAnyTests
+    {
+        //
+        // Any and All
+        //
+
+        [Fact]
+        public static void RunAnyTests()
+        {
+            RunAnyTest_AllFalse(1024);
+            RunAnyTest_AllTrue(1024);
+            RunAnyTest_OneTrue(1024, 512);
+            RunAnyTest_OneTrue(1024, 0);
+            RunAnyTest_OneTrue(1024, 1023);
+            RunAnyTest_OneTrue(1024 * 1024, 1024 * 512);
+        }
+
+        [Fact]
+        public static void RunAllTests()
+        {
+            RunAllTest_AllFalse(1024);
+            RunAllTest_AllTrue(1024);
+            RunAllTest_OneFalse(1024, 512);
+            RunAllTest_OneFalse(1024, 0);
+            RunAllTest_OneFalse(1024, 1023);
+            RunAllTest_OneFalse(1024 * 1024, 1024 * 512);
+        }
+
+        private static void RunAnyTest_AllFalse(int size)
+        {
+            bool[] bools = new bool[size];
+            for (int i = 0; i < size; i++) bools[i] = false;
+
+            bool expect = false;
+            bool result = bools.Any(delegate (bool b) { return b; });
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunAnyTest_AllFalse(size={2}):  FAILED.  > Expect: {0}, real: {1}", expect, result, size));
+        }
+
+        private static void RunAnyTest_AllTrue(int size)
+        {
+            bool[] bools = new bool[size];
+            for (int i = 0; i < size; i++) bools[i] = true;
+
+            bool expect = true;
+            bool result = bools.Any(delegate (bool b) { return b; });
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunAnyTest_AllTrue(size={2}  > Expect: {0}, real: {1}", expect, result, size));
+        }
+
+        private static void RunAnyTest_OneTrue(int size, int truePosition)
+        {
+            bool[] bools = new bool[size];
+            for (int i = 0; i < size; i++) bools[i] = false;
+            bools[truePosition] = true;
+
+            bool expect = true;
+            bool result = bools.Any(delegate (bool b) { return b; });
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunAnyTest_OneTrue(size={2}, truePosition={3}):  FAILED.  > Expect: {0}, real: {1}", expect, result, size, truePosition));
+        }
+
+        // Commenting this out because the method InfiniteEnumerable() is causing the
+        // following compiler error. Apparently it is because of the use of the yield
+        // keyword, as the error disappears when I stop using it:
+        // Error	1	Missing compiler required member 'System.Environment.get_CurrentManagedThreadId'
+
+        /*//
+        // Tests the Any() operator applied to infinite enumerables
+        //
+        [Fact]
+        public static void RunAnyTest_Infinite()
+        {
+            if (!InfiniteEnumerable().Select(x => -x).Any())
+            {
+                Assert.True(false, string.Format("RunAnyTest_Infinite:  FAILED.  > Expected true return value."));
+            }
+
+            if (!InfiniteEnumerable().Select(x => -x).Any(x => true))
+            {
+                Assert.True(false, string.Format("RunAnyTest_Infinite:  FAILED.  > Expected true return value."));
+            }
+        }*/
+
+        private static void RunAllTest_AllFalse(int size)
+        {
+            bool[] bools = new bool[size];
+            for (int i = 0; i < size; i++) bools[i] = false;
+
+            bool expect = false;
+            bool result = bools.All(delegate (bool b) { return b; });
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunAllTest_AllFalse(size={2}):  FAILED.  > Expect: {0}, real: {1}", expect, result, size));
+        }
+
+        private static void RunAllTest_AllTrue(int size)
+        {
+            bool[] bools = new bool[size];
+            for (int i = 0; i < size; i++) bools[i] = true;
+
+            bool expect = true;
+            bool result = bools.All(delegate (bool b) { return b; });
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunAllTest_AllTrue(size={2}):  FAILED.  > Expect: {0}, real: {1}", expect, result, size));
+        }
+
+        private static void RunAllTest_OneFalse(int size, int falsePosition)
+        {
+            bool[] bools = new bool[size];
+            for (int i = 0; i < size; i++) bools[i] = true;
+            bools[falsePosition] = false;
+
+            bool expect = false;
+            bool result = bools.All(delegate (bool b) { return b; });
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunAllTest_OneFalse(size={2}, falsePosition={3}): FAILED.  > Expect: {0}, real: {1}", expect, result, size, falsePosition));
+        }
+
+        /*private static IEnumerable<int> InfiniteEnumerable()
+        {
+            while (true) yield return 0;
+        }*/
+    }
+}

--- a/src/System.Linq/tests/ContainsTests.cs
+++ b/src/System.Linq/tests/ContainsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Linq;
+
+namespace Test
+{
+    public class ContainsTests
+    {
+        //
+        // Contains
+        //
+        [Fact]
+        public static void RunContainsTests()
+        {
+            RunContainsTest_NoMatching(1024);
+            RunContainsTest_AllMatching(1024);
+            RunContainsTest_OneMatching(1024, 512);
+            RunContainsTest_OneMatching(1024, 0);
+            RunContainsTest_OneMatching(1024, 1023);
+            RunContainsTest_OneMatching(1024 * 1024, 1024 * 512);
+        }
+
+        private static void RunContainsTest_NoMatching(int size)
+        {
+            int toFind = 103372;
+            //Random r = new Random(33);
+            int[] data = new int[size];
+            for (int i = 0; i < size; i++)
+            {
+                data[i] = i;
+                if (data[i] == toFind)
+                    data[i] += 1;
+            }
+
+            bool expect = false;
+            bool result = data.Contains(toFind);
+
+            if (result != expect)
+                Assert.True(false, string.Format("RunContainsTest_NoMatching(size={2}):  FAILED.  > Expect: {0}, real: {1}", expect, result, size));
+        }
+
+        private static void RunContainsTest_AllMatching(int size)
+        {
+            int toFind = 103372;
+            int[] data = new int[size];
+            for (int i = 0; i < size; i++)
+                data[i] = 103372;
+
+            bool expect = true;
+            bool result = data.Contains(toFind);
+            if (result != expect)
+                Assert.True(false, string.Format("RunContainsTest_AllMatching(size={2}):  FAILED.  > Expect: {0}, real: {1}", expect, result, size));
+        }
+
+        private static void RunContainsTest_OneMatching(int size, int matchPosition)
+        {
+            int toFind = 103372;
+            //Random r = new Random(33);
+            int[] data = new int[size];
+            for (int i = 0; i < size; i++)
+            {
+                data[i] = i;
+                if (data[i] == toFind)
+                    data[i] += 1;
+            }
+            data[matchPosition] = toFind;
+
+            bool expect = true;
+            bool result = data.Contains(toFind);
+
+            if (result != expect)
+                Assert.True(false,
+                    string.Format("RunContainsTest_OneMatching(size={2}, matchPosition={3}):  FAILED.  > Expect: {0}, real: {1}",
+                    expect, result, size, matchPosition));
+        }
+    }
+}

--- a/src/System.Linq/tests/CountTests.cs
+++ b/src/System.Linq/tests/CountTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Linq;
+
+namespace Test
+{
+    public class CountTests
+    {
+        //
+        // LongCount
+        //
+        [Fact]
+        public static void RunLongCountTests()
+        {
+            RunLongCountTest1(0);
+            RunLongCountTest1(1);
+            RunLongCountTest1(1024);
+            RunLongCountTest1(1024 * 1024);
+            /*RunLongCountTest2(0);
+            RunLongCountTest2(1);
+            RunLongCountTest2(1024);
+            RunLongCountTest2(1024 * 1024);*/
+        }
+
+        private static void RunLongCountTest1(long count)
+        {
+            int[] ints = new int[count];
+            long returnedCount = ints.LongCount();
+
+            if (!count.Equals(returnedCount))
+                Assert.True(false, string.Format("RRunLongCountTest1:  FAILED.   >Expected {0}, actual {1}", count, returnedCount));
+        }
+
+        // Commenting this out because it is causing the following exception:
+        // Error	1	The type 'System.Threading.Tasks.Task' is defined in an assembly that is not referenced.
+        // You must add a reference to assembly 'System.Threading.Tasks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+
+        /*
+        private static void RunLongCountTest2(long count)
+        {
+            int[] ints = new int[count];
+            long returnedCount = ints.LongCount(i => i == 0);
+
+            if (!count.Equals(returnedCount))
+                Assert.True(false, string.Format("RRunLongCountTest2:  FAILED.   >Expected {0}, actual {1}", count, returnedCount));
+
+            Assert.Throws<ArgumentNullException>(() => ints.LongCount(null));
+        }
+         * */
+    }
+}

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -18,7 +18,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AggregateTests.cs" />
+    <Compile Include="AllAnyTests.cs" />
     <Compile Include="CachedEnumerator.cs" />
+    <Compile Include="ContainsTests.cs" />
+    <Compile Include="CountTests.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="EmptyEnumerable.cs" />
   </ItemGroup>


### PR DESCRIPTION
This time I copied some files from System.Linq.Parallel, because, looking at them, they seem to fit very well with System.Linq after removing the AsParallel() keyword. If I get a positive feedback about this from the community, then I will go ahead with copying the rest of files from System.Linq (of course on the condition that they fit) and hopefully this will improve the code coverage of System.Linq considerably.

#1143