### PR TITLE
Fix input data format in unit tests depending on culture

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -5,6 +5,7 @@ using Xunit;
 using SerializationTypes;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
@@ -101,9 +102,9 @@ public static class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_DecimalAsRoot()
     {
-        foreach (decimal value in new decimal[] { (decimal)-1.2, (decimal)0, (decimal)2.3, decimal.MinValue, decimal.MaxValue })
+        foreach (decimal value in new decimal[] { -1.2m, 0.0m, 2.3m, decimal.MinValue, decimal.MaxValue })
         {
-            Assert.StrictEqual(SerializeAndDeserialize<decimal>(value, value.ToString()), value);
+            Assert.StrictEqual(SerializeAndDeserialize<decimal>(value, value.ToString(CultureInfo.InvariantCulture)), value);
         }
     }
 

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using SerializationTypes;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
-using System.Xml;
 using System.Text;
-using System.Diagnostics;
-using System.Collections;
-using Xunit;
+using System.Xml;
 using System.Xml.Linq;
 
+using SerializationTypes;
+
+using Xunit;
 
 public static class DataContractSerializerTests
 {
@@ -95,9 +96,10 @@ public static class DataContractSerializerTests
     [Fact]
     public static void DCS_DecimalAsRoot()
     {
-        foreach (decimal value in new decimal[] { (decimal)-1.2, (decimal)0, (decimal)2.3, decimal.MinValue, decimal.MaxValue })
+        foreach (decimal value in new decimal[] { -1.2m, 0.0m, 2.3m, decimal.MinValue, decimal.MaxValue })
         {
-            Assert.StrictEqual(SerializeAndDeserialize<decimal>(value, string.Format("<decimal xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">{0}</decimal>", value.ToString())), value);
+            var baseline = string.Format("<decimal xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">{0}</decimal>", value.ToString(CultureInfo.InvariantCulture));
+            Assert.StrictEqual(SerializeAndDeserialize<decimal>(value, baseline), value);
         }
     }
 

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using SerializationTypes;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -64,9 +65,10 @@ public class XmlSerializerTests
     [Fact]
     public static void Xml_DecimalAsRoot()
     {
-        foreach (decimal value in new decimal[] { (decimal)-1.2, (decimal)0, (decimal)2.3, decimal.MinValue, decimal.MaxValue })
+        foreach (decimal value in new decimal[] { -1.2m, 0.0m, 2.3m, decimal.MinValue, decimal.MaxValue })
         {
-            Assert.StrictEqual(SerializeAndDeserialize<decimal>(value, string.Format("<?xml version=\"1.0\"?>\r\n<decimal>{0}</decimal>", value.ToString())), value);
+            var baseline = string.Format("<?xml version=\"1.0\"?>\r\n<decimal>{0}</decimal>", value.ToString(CultureInfo.InvariantCulture));
+            Assert.StrictEqual(SerializeAndDeserialize<decimal>(value, baseline), value);
         }
     }
 


### PR DESCRIPTION
This commit fixes tests that fails on machine where decimal symbol different from "." (dot).