### PR TITLE
Update the Apisets for some native calls to make them work on Win7.

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -17,7 +17,8 @@ internal static partial class Interop
         internal const string Kernel32_L1 = "api-ms-win-core-kernel32-legacy-l1-1-1.dll";
         internal const string Kernel32_L2 = "api-ms-win-core-kernel32-legacy-l1-1-0.dll";
         internal const string Localization = "api-ms-win-core-localization-l1-2-0.dll";
-        internal const string Memory = "api-ms-win-core-memory-l1-1-1.dll";
+        internal const string Memory_L1_0 = "api-ms-win-core-memory-l1-1-0.dll";
+        internal const string Memory_L1_1 = "api-ms-win-core-memory-l1-1-1.dll";
         internal const string NtDll = "ntdll.dll";
         internal const string Pipe = "api-ms-win-core-namedpipe-l1-1-0.dll";
         internal const string ProcessEnvironment = "api-ms-win-core-processenvironment-l1-1-0.dll";

--- a/src/Common/src/Interop/Windows/mincore/Interop.CreateFileMapping.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CreateFileMapping.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_0, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern SafeMemoryMappedFileHandle CreateFileMapping(
             SafeFileHandle hFile,
             ref SECURITY_ATTRIBUTES lpFileMappingAttributes,
@@ -18,7 +18,7 @@ internal partial class Interop
             int dwMaximumSizeLow,
             string lpName);
 
-        [DllImport(Libraries.Memory, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_0, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern SafeMemoryMappedFileHandle CreateFileMapping(
             IntPtr hFile,
             ref SECURITY_ATTRIBUTES lpFileMappingAttributes,

--- a/src/Common/src/Interop/Windows/mincore/Interop.FlushViewOfFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.FlushViewOfFile.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory)]
+        [DllImport(Libraries.Memory_L1_0)]
         internal extern static int FlushViewOfFile(IntPtr lpBaseAddress, UIntPtr dwNumberOfBytesToFlush);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetProcessWorkingSetSizeEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetProcessWorkingSetSizeEx.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_1, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool GetProcessWorkingSetSizeEx(SafeProcessHandle handle, out IntPtr min, out IntPtr max, out int flags);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.MapViewOfFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MapViewOfFile.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, EntryPoint = "MapViewOfFile", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_0, EntryPoint = "MapViewOfFile", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern SafeMemoryMappedViewHandle MapViewOfFile(
             SafeMemoryMappedFileHandle hFileMappingObject,
             int dwDesiredAccess,

--- a/src/Common/src/Interop/Windows/mincore/Interop.OpenFileMapping.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.OpenFileMapping.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, EntryPoint = "OpenFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_0, EntryPoint = "OpenFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern SafeMemoryMappedFileHandle OpenFileMapping(int dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, string lpName);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.SetProcessWorkingSetSizeEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.SetProcessWorkingSetSizeEx.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_1, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool SetProcessWorkingSetSizeEx(SafeProcessHandle handle, IntPtr min, IntPtr max, int flags);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.UnmapViewOfFile.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.UnmapViewOfFile.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory)]
+        [DllImport(Libraries.Memory_L1_0)]
         internal extern static int UnmapViewOfFile(IntPtr lpBaseAddress);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.VirtualAlloc.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.VirtualAlloc.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, EntryPoint = "VirtualAlloc", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_0, EntryPoint = "VirtualAlloc", CharSet = CharSet.Unicode, SetLastError = true)]
         internal extern static IntPtr VirtualAlloc(SafeHandle lpAddress, UIntPtr dwSize, int flAllocationType, int flProtect);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.VirtualQuery.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.VirtualQuery.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport(Libraries.Memory, EntryPoint = "VirtualQuery", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Memory_L1_0, EntryPoint = "VirtualQuery", CharSet = CharSet.Unicode, SetLastError = true)]
         internal extern static UIntPtr VirtualQuery(SafeMemoryMappedViewHandle lpAddress, ref MEMORY_BASIC_INFORMATION lpBuffer, UIntPtr dwLength);
     }
 }


### PR DESCRIPTION
While consolidating the interop calls I accidently merged the apisets used by the Process class and the FileSystem class. This should be fixed now.

I also validated the pinvokes for all src libraries to ensure they will work down level. As part of this testing I found System.Reflection.Metadata.dll uses some pinvokes well hidden in its sources :) that won't work on Win7. I will create a separate issue to clean that up.