### PR TITLE
Regex collection cleanup

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Text.RegularExpressions
 {
@@ -15,38 +16,16 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public class GroupCollection : ICollection
     {
-        internal Match _match;
-        internal Dictionary<Int32, Int32> _captureMap;
+        private readonly Match _match;
+        private readonly Dictionary<int, int> _captureMap;
 
         // cache of Group objects fed to the user
-        internal Group[] _groups;
+        private Group[] _groups;
 
-        /*
-         * Nonpublic constructor
-         */
-        internal GroupCollection(Match match, Dictionary<Int32, Int32> caps)
+        internal GroupCollection(Match match, Dictionary<int, int> caps)
         {
             _match = match;
             _captureMap = caps;
-        }
-
-        /// <summary>
-        /// The object on which to synchronize
-        /// </summary>
-        Object ICollection.SyncRoot
-        {
-            get
-            {
-                return _match;
-            }
-        }
-
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
         }
 
         /// <summary>
@@ -54,21 +33,15 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public int Count
         {
-            get
-            {
-                return _match._matchcount.Length;
-            }
+            get { return _match._matchcount.Length; }
         }
 
         public Group this[int groupnum]
         {
-            get
-            {
-                return GetGroup(groupnum);
-            }
+            get { return GetGroup(groupnum); }
         }
 
-        public Group this[String groupname]
+        public Group this[string groupname]
         {
             get
             {
@@ -79,7 +52,15 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        internal Group GetGroup(int groupnum)
+        /// <summary>
+        /// Provides an enumerator in the same order as Item[].
+        /// </summary>
+        public IEnumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        private Group GetGroup(int groupnum)
         {
             if (_captureMap != null)
             {
@@ -97,11 +78,10 @@ namespace System.Text.RegularExpressions
             return Group._emptygroup;
         }
 
-
-        /*
-         * Caches the group objects
-         */
-        internal Group GetGroupImpl(int groupnum)
+        /// <summary>
+        /// Caches the group objects
+        /// </summary>
+        private Group GetGroupImpl(int groupnum)
         {
             if (groupnum == 0)
                 return _match;
@@ -120,10 +100,16 @@ namespace System.Text.RegularExpressions
             return _groups[groupnum - 1];
         }
 
-        /// <summary>
-        /// Copies all the elements of the collection to the given array
-        /// beginning at the given index.
-        /// </summary>
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return _match; }
+        }
+
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
             if (array == null)
@@ -135,77 +121,51 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /// <summary>
-        /// Provides an enumerator in the same order as Item[].
-        /// </summary>
-        public IEnumerator GetEnumerator()
+        private class Enumerator : IEnumerator
         {
-            return new GroupEnumerator(this);
-        }
-    }
+            private readonly GroupCollection _collection;
+            private int _index;
 
-
-    /*
-     * This non-public enumerator lists all the captures
-     * Should it be public?
-     */
-    internal class GroupEnumerator : IEnumerator
-    {
-        internal GroupCollection _rgc;
-        internal int _curindex;
-
-        /*
-         * Nonpublic constructor
-         */
-        internal GroupEnumerator(GroupCollection rgc)
-        {
-            _curindex = -1;
-            _rgc = rgc;
-        }
-
-        /*
-         * As required by IEnumerator
-         */
-        public bool MoveNext()
-        {
-            int size = _rgc.Count;
-
-            if (_curindex >= size)
-                return false;
-
-            _curindex++;
-
-            return (_curindex < size);
-        }
-
-        /*
-         * As required by IEnumerator
-         */
-        public Object Current
-        {
-            get { return Capture; }
-        }
-
-        /*
-         * Returns the current capture
-         */
-        public Capture Capture
-        {
-            get
+            internal Enumerator(GroupCollection collection)
             {
-                if (_curindex < 0 || _curindex >= _rgc.Count)
-                    throw new InvalidOperationException(SR.EnumNotStarted);
+                Debug.Assert(collection != null, "collection cannot be null.");
 
-                return _rgc[_curindex];
+                _collection = collection;
+                _index = -1;
             }
-        }
 
-        /*
-         * Reset to before the first item
-         */
-        public void Reset()
-        {
-            _curindex = -1;
+            public bool MoveNext()
+            {
+                int size = _collection.Count;
+
+                if (_index >= size)
+                    return false;
+
+                _index++;
+
+                return _index < size;
+            }
+
+            public Group Current
+            {
+                get
+                {
+                    if (_index < 0 || _index >= _collection.Count)
+                        throw new InvalidOperationException(SR.EnumNotStarted);
+
+                    return _collection[_index];
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            void IEnumerator.Reset()
+            {
+                _index = -1;
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -12,9 +13,9 @@ namespace Test
         [Fact]
         public static void EnumeratorTest1()
         {
-            var regex = new Regex("e");
-            var collection = regex.Matches("dotnet");
-            var enumerator = collection.GetEnumerator();
+            Regex regex = new Regex("e");
+            MatchCollection collection = regex.Matches("dotnet");
+            IEnumerator enumerator = collection.GetEnumerator();
 
             Assert.Throws<InvalidOperationException>(() => enumerator.Current);
             Assert.True(enumerator.MoveNext());
@@ -37,9 +38,9 @@ namespace Test
         [Fact]
         public static void EnumeratorTest2()
         {
-            var regex = new Regex("t");
-            var collection = regex.Matches("dotnet");
-            var enumerator = collection.GetEnumerator();
+            Regex regex = new Regex("t");
+            MatchCollection collection = regex.Matches("dotnet");
+            IEnumerator enumerator = collection.GetEnumerator();
 
             for (int i = 0; i < collection.Count; i++)
             {

--- a/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Test
+{
+    public class MatchCollectionTests
+    {
+        [Fact]
+        public static void EnumeratorTest1()
+        {
+            var regex = new Regex("e");
+            var collection = regex.Matches("dotnet");
+            var enumerator = collection.GetEnumerator();
+
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.IsAssignableFrom<Match>(enumerator.Current);
+            Assert.Equal(4, ((Match)enumerator.Current).Index);
+            Assert.Equal("e", ((Match)enumerator.Current).Value);
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            enumerator.Reset();
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.IsAssignableFrom<Match>(enumerator.Current);
+            Assert.Equal(4, ((Match)enumerator.Current).Index);
+            Assert.Equal("e", ((Match)enumerator.Current).Value);
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+        }
+
+        [Fact]
+        public static void EnumeratorTest2()
+        {
+            var regex = new Regex("t");
+            var collection = regex.Matches("dotnet");
+            var enumerator = collection.GetEnumerator();
+
+            for (int i = 0; i < collection.Count; i++)
+            {
+                enumerator.MoveNext();
+
+                Assert.Equal(enumerator.Current, collection[i]);
+            }
+
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            enumerator.Reset();
+
+            for (int i = 0; i < collection.Count; i++)
+            {
+                enumerator.MoveNext();
+
+                Assert.Equal(enumerator.Current, collection[i]);
+            }
+
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="EscapeUnescapeTests.cs" />
     <Compile Include="GroupNamesAndNumbers.cs" />
     <Compile Include="IsMatchMatchSplitTests.cs" />
+    <Compile Include="MatchCollectionTests.cs" />
     <Compile Include="R2LGetGroupNamesMatchTests.cs" />
     <Compile Include="RegexComponentsSplitTests.cs" />
     <Compile Include="RegexConstructorTests.cs" />


### PR DESCRIPTION
As part of implementing #271 (Regex collections should implement generic collection interfaces), I cleaned up some of the internals of the Regex collections. Since #271 adds new APIs, it must go in the 'future' branch. Instead of doing all the changes in 'future', I split up the changes into two parts:

 1. (This PR) **Internal cleanup** (no new APIs) to be checked-in to 'master'
 2. **Implement generic collection interfaces** (new APIs) to be checked-in to 'future'

This PR is part 1. Once this PR has been reviewed, accepted, and merged into 'master', please merge 'master' into 'future'. Then I'll submit another PR in 'future' that adds the generic interfaces, building on top of these changes.

### Summary of changes in this PR:
 - `MatchCollection` enumerator tests
 - Fields: internal -> private
 - Made enumerators private nested classes
 - Reduced the size of `MatchCollection`'s enumerator
 - Enumerator field naming improvements
 - Reorganized member order (prep for generic collection members)
 - Removed unnecessary static field (`s_infinite`) from `MatchCollection`
 - Use language keywords instead of BCL types