### PR TITLE
Fix TestCtorCharPtr test in System.Runtime.Tests

### DIFF
--- a/src/System.Runtime/tests/System/String.cs
+++ b/src/System.Runtime/tests/System/String.cs
@@ -37,7 +37,7 @@ public static unsafe class StringTests
     [Fact]
     public static void TestCtorCharPtr()
     {
-        char[] c = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
+        char[] c = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '\0' };
         fixed (char* pc = c)
         {
             String s = new String(pc);
@@ -52,7 +52,7 @@ public static unsafe class StringTests
     public static void TestCtorCharPtrIntInt()
     {
         String s;
-        char[] c = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
+        char[] c = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '\0' };
         fixed (char* pc = c)
         {
             s = new String(pc, 2, 3);


### PR DESCRIPTION
The TestCtorCharPtr test is passing a char* to String's ctor.  This char* needs to be null-teriminated, but it's not currently, causing random failures.  I've simply added a null terminator. (I also added one to another case in the same file, though technically that's not required as those tests use indices that prevent the test from walking off the end of the array.)