### PR TITLE
Disable flakey FileSystemWatcher test for internalbuffer size.

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
@@ -9,6 +9,7 @@ using Xunit;
 public partial class FileSystemWatcher_4000_Tests
 {
     [Fact]
+    [ActiveIssue(1165)]
     public static void FileSystemWatcher_InternalBufferSize_File()
     {
         using (var file = Utility.CreateTestFile())

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -38,6 +38,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj"> 
+      <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project> 
+      <Name>XunitTraitsDiscoverers</Name> 
+    </ProjectReference> 
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
FileSystemWatcher test for internalbuffer size has been a bit flakey due to losing its file handle.  Disable until we can re-implement this test.