### PR TITLE
Bump buildtools version

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,7 +2,7 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00021</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00023</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00021" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00023" />
 </packages>


### PR DESCRIPTION
Pulls in newer version which references newer version of xunit (containing fixes for Linux execution)

@stephentoub 