### PR TITLE
Fix newline handling in an XDocument test

### DIFF
--- a/src/System.Xml.XDocument/tests/SDMSample/SDMDocument.cs
+++ b/src/System.Xml.XDocument/tests/SDMSample/SDMDocument.cs
@@ -158,8 +158,8 @@ namespace CoreXml.Test.XLinq
                     {
                         doc.Add("");
                         Validate.String(doc.ToString(SaveOptions.DisableFormatting), "");
-                        doc.Add(" \t\r\n");
-                        Validate.String(doc.ToString(SaveOptions.DisableFormatting), " \t\r\n");
+                        doc.Add(" \t" + Environment.NewLine);
+                        Validate.String(doc.ToString(SaveOptions.DisableFormatting), " \t" + Environment.NewLine);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
The DocumentAddString XDocument test is failing on Unix.  By default, XmlWriter normalizes newlines to be Environment.NewLine, but the test is expecting that a string containing "\r\n" will roundtrip as "\r\n" rather than as "\n".