### PR TITLE
Fix Debug.WriteToFile's buffer manipulation on Unix

### DIFF
--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
@@ -63,12 +63,13 @@ namespace System.Diagnostics
                                 }
                             }
 
+                            int totalBytesWritten = 0;
                             while (bufCount > 0)
                             {
                                 int bytesWritten;
-                                while (Interop.CheckIo(bytesWritten = (int)Interop.libc.write((int)fileHandle.DangerousGetHandle(), buf, new IntPtr(bufCount)))) ;
+                                while (Interop.CheckIo(bytesWritten = (int)Interop.libc.write((int)fileHandle.DangerousGetHandle(), buf + totalBytesWritten, new IntPtr(bufCount)))) ;
                                 bufCount -= bytesWritten;
-                                buf += bytesWritten;
+                                totalBytesWritten += bytesWritten;
                             }
                         }
                     }


### PR DESCRIPTION
The Debug type's implementation to write to a file maintains a buffer on the stack that it copies chunks of ASCII data to before writing out each chunk.  The code to actually write the chunk out is moving the buffer pointer, but it's never moved back; if we then need to loop around to handle a subsequent chunk, we end up potentially writing off the end of the buffer on the stack and scribbling over other memory.