### PR TITLE
Allow null strings to Debug.Write on Unix

### DIFF
--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Unix.cs
@@ -26,6 +26,8 @@ namespace System.Diagnostics
 
             public void WriteCore(string message)
             {
+                Assert(message != null);
+
                 WriteToSyslog(message);
                 WriteToFile(Interop.Devices.stderr, message);
             }

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Windows.cs
@@ -51,6 +51,8 @@ namespace System.Diagnostics
 
             public void WriteCore(string message)
             {
+                Assert(message != null);
+
                 // really huge messages mess up both VS and dbmon, so we chop it up into 
                 // reasonable chunks if it's too big. This is the number of characters 
                 // that OutputDebugstring chunks at.
@@ -59,7 +61,7 @@ namespace System.Diagnostics
                 // We don't want output from multiple threads to be interleaved.
                 lock (s_ForLock)
                 {
-                    if (message == null || message.Length <= WriteChunkLength)
+                    if (message.Length <= WriteChunkLength)
                     {
                         WriteToDebugger(message);
                     }
@@ -78,7 +80,7 @@ namespace System.Diagnostics
             [System.Security.SecuritySafeCritical]
             private static void WriteToDebugger(string message)
             {
-                Interop.mincore.OutputDebugString(message ?? string.Empty);
+                Interop.mincore.OutputDebugString(message);
             }
 
             private static bool IsRTLResources

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.cs
@@ -83,7 +83,7 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Write(string message)
         {
-            s_logger.WriteCore(message);
+            s_logger.WriteCore(message ?? string.Empty);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/src/System.Diagnostics.Debug/tests/DebugTests.cs
+++ b/src/System.Diagnostics.Debug/tests/DebugTests.cs
@@ -32,6 +32,7 @@ namespace System.Diagnostics.Tests
         public void Write()
         {
             VerifyLogged(() => { Debug.Write(5); }, "5");
+            VerifyLogged(() => { Debug.Write((string)null); }, "");
             VerifyLogged(() => { Debug.Write((object)null); }, "");
             VerifyLogged(() => { Debug.Write(5, "category"); }, "category:5");
             VerifyLogged(() => { Debug.Write((object)null, "category"); }, "category:");
@@ -47,6 +48,7 @@ namespace System.Diagnostics.Tests
         public void WriteLine()
         {
             VerifyLogged(() => { Debug.WriteLine(5); }, "5" + Environment.NewLine);
+            VerifyLogged(() => { Debug.WriteLine((string)null); }, Environment.NewLine);
             VerifyLogged(() => { Debug.WriteLine((object)null); }, Environment.NewLine);
             VerifyLogged(() => { Debug.WriteLine(5, "category"); }, "category:5" + Environment.NewLine);
             VerifyLogged(() => { Debug.WriteLine((object)null, "category"); }, "category:" + Environment.NewLine);
@@ -176,6 +178,7 @@ namespace System.Diagnostics.Tests
 
             public void WriteCore(string message)
             {
+                Assert.NotNull(message);
                 LoggedOutput += message;
             }
         }


### PR DESCRIPTION
The Windows implementation allows null strings to Debug.Write, treating them as string.Empty.  The Unix implementation should, too.