### PR TITLE
Convert ProcessTest_ConsoleApp to .NET Core

### DIFF
--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/App.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-  </startup>
-</configuration>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/System.Diagnostics.Process.TestConsoleApp.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/System.Diagnostics.Process.TestConsoleApp.csproj
@@ -6,23 +6,16 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>System.Diagnostics.ProcessTests</RootNamespace>
     <AssemblyName>System.Diagnostics.Process.TestConsoleApp</AssemblyName>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-  </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="TestConsoleApp.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Console" version="4.0.0-beta-22703" />
+  <package id="System.IO" version="4.0.10-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
+</packages>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -1,24 +1,23 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.IO;
-using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Win32.SafeHandles;
 using Xunit;
-using System.Text;
 
 namespace System.Diagnostics.ProcessTests
 {
     public partial class ProcessTest : IDisposable
     {
-        private const int WaitInMS = 100 * 1000;
-        private const string ProcessName = "System.Diagnostics.Process.TestConsoleApp.exe";
+        private const int WaitInMS = 100 * 1000; 
+        private const string CoreRunName = "corerun";
+        private const string TestExeName = "System.Diagnostics.Process.TestConsoleApp.exe";
+
         private Process _process;
+        private List<Process> _processes = new List<Process>();
 
         public ProcessTest()
         {
@@ -28,15 +27,17 @@ namespace System.Diagnostics.ProcessTests
 
         public void Dispose()
         {
-            _process.Kill();
-            Assert.True(_process.WaitForExit(WaitInMS));
-
-            // Also ensure that there are no open processes with the same name as ProcessName
-            foreach (Process p in Process.GetProcessesByName(ProcessName))
+            // Ensure that there are no open processes with the same name as ProcessName
+            foreach (Process p in _processes)
             {
                 if (!p.HasExited)
                 {
+                    try
+                    {
                     p.Kill();
+                    }
+                    catch (InvalidOperationException) { } // in case it was never started
+
                     Assert.True(p.WaitForExit(WaitInMS));
                 }
             }
@@ -45,8 +46,12 @@ namespace System.Diagnostics.ProcessTests
         Process CreateProcess(string optionalArgument = ""/*String.Empty is not a constant*/)
         {
             Process p = new Process();
-            p.StartInfo.FileName = ProcessName;
-            p.StartInfo.Arguments = optionalArgument;
+            _processes.Add(p);
+
+            p.StartInfo.FileName = CoreRunName;
+            p.StartInfo.Arguments = string.IsNullOrWhiteSpace(optionalArgument) ? 
+                TestExeName : 
+                TestExeName + " " + optionalArgument;
 
             // Profilers / code coverage tools doing coverage of the test process set environment
             // variables to tell the targeted process what profiler to load.  We don't want the child process 
@@ -218,13 +223,13 @@ namespace System.Diagnostics.ProcessTests
         {
             // Get MainModule property from a Process object
             string moduleName = _process.MainModule.ModuleName;
-            Assert.Equal(ProcessName, moduleName);
+            Assert.Equal(CoreRunName, moduleName);
 
             // Check that the mainModule is present in the modules list.
             bool foundMainModule = false;
             foreach (ProcessModule pModule in _process.Modules)
             {
-                if (String.Equals(moduleName, ProcessName, StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(moduleName, CoreRunName, StringComparison.OrdinalIgnoreCase))
                 {
                     foundMainModule = true;
                     break;
@@ -416,7 +421,7 @@ namespace System.Diagnostics.ProcessTests
         [Fact]
         public void ProcessProcessName()
         {
-            Assert.Equal(_process.ProcessName, Path.ChangeExtension(ProcessName, null));
+            Assert.Equal(_process.ProcessName, CoreRunName, StringComparer.OrdinalIgnoreCase);
         }
 
 
@@ -646,7 +651,7 @@ namespace System.Diagnostics.ProcessTests
                 Process process = CreateProcessInfinite();
                 process.Start();
 
-                Assert.Equal(ProcessName, process.StartInfo.FileName);
+                Assert.Equal(CoreRunName, process.StartInfo.FileName);
 
                 process.Kill();
                 Assert.True(process.WaitForExit(WaitInMS));
@@ -664,8 +669,8 @@ namespace System.Diagnostics.ProcessTests
 
             {
                 Process process = new Process();
-                process.StartInfo = new ProcessStartInfo(ProcessName);
-                Assert.Equal(ProcessName, process.StartInfo.FileName);
+                process.StartInfo = new ProcessStartInfo(TestExeName);
+                Assert.Equal(TestExeName, process.StartInfo.FileName);
             }
 
             {

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics.ProcessTests
             Process p = CreateProcessError();
             p.StartInfo.RedirectStandardError = true;
             p.Start();
-            Assert.Equal(p.StandardError.ReadToEnd(), ProcessName + " error stream\r\n");
+            Assert.Equal(p.StandardError.ReadToEnd(), TestExeName + " error stream\r\n");
             Assert.True(p.WaitForExit(WaitInMS));
         }
 
@@ -47,7 +47,7 @@ namespace System.Diagnostics.ProcessTests
             if (p.WaitForExit(WaitInMS))
                 p.WaitForExit(); // This ensures async event handlers are finished processing.
 
-            Assert.Equal(ProcessName + " error stream", sb.ToString());
+            Assert.Equal(TestExeName + " error stream", sb.ToString());
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace System.Diagnostics.ProcessTests
             p.Start();
             string s = p.StandardOutput.ReadToEnd();
             Assert.True(p.WaitForExit(WaitInMS));
-            Assert.Equal(s, ProcessName + " started\r\n" + ProcessName + " closed\r\n");
+            Assert.Equal(s, TestExeName + " started" + Environment.NewLine + TestExeName + " closed" + Environment.NewLine);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace System.Diagnostics.ProcessTests
                 if (p.WaitForExit(WaitInMS))
                     p.WaitForExit(); // This ensures async event handlers are finished processing.
 
-                Assert.Equal(sb.ToString(), ProcessName + " started" + ProcessName + " closed");
+                Assert.Equal(sb.ToString(), TestExeName + " started" + TestExeName + " closed");
             }
 
             {
@@ -88,7 +88,7 @@ namespace System.Diagnostics.ProcessTests
                 if (p.WaitForExit(WaitInMS))
                     p.WaitForExit(); // This ensures async event handlers are finished processing.
 
-                Assert.Equal(sb.ToString(), ProcessName + " started");
+                Assert.Equal(sb.ToString(), TestExeName + " started");
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Win32.Primitives" version="4.0.0-beta-22703" />
+  <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Console" version="4.0.0-beta-22703" />
   <package id="System.IO" version="4.0.10-beta-22703" />
   <package id="System.Linq" version="4.0.0-beta-22703" />


### PR DESCRIPTION
For ProcessTest_ConsoleApp to be runnable on Unix, it needs to first be on .NET Core.