### PR TITLE
Initial commit of linux/osx cross testing script

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Runs tests on linux/mac that don't have native build support"
+    echo "usage: run-test [options]"
+    echo
+    echo "Input sources:"
+    echo "    --coreclr-bins <location>     Location of root of the binaries directory"
+    echo "                                  containing the linux/mac coreclr build"
+    echo "                                  default: <repo_root>\binaries"
+    echo "    --mscorlib-bins <location>    Location of the root binaries directory containing"
+    echo "                                  the linux/mac mscorlib.dll"
+    echo "                                  default: <repo_root>\binaries"
+    echo "    --corefx-tests <location>     Location of the root binaries location containing"
+    echo "                                  the windows tests"
+    echo "                                  default: bin"
+    echo "    --corefx-bins <location>      Location of the linux/mac corefx binaries"
+    echo "                                  default: bin"
+    echo
+    echo "Flavor/OS options:"
+    echo "    --configuration <config>      Configuration to run (Debug/Release)"
+    echo "                                  default: Debug"
+    echo "    --os <os>                     OS to run (OSX/Linux)"
+    echo "                                  default: detect current OS"
+    echo
+    echo "Execution options:"
+    echo "    --restrict-proj <regex>       Run test projects that match regex"
+    echo "                                  default: .* (all projects)"
+    echo
+    exit 1
+}
+
+ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Location parameters
+CoreClrBinRoot="$ProjectRoot/binaries"
+MscorlibBinRoot="$ProjectRoot/binaries"
+CoreFxTestsRoot="$ProjectRoot/bin"
+CoreFxBinRoot="$ProjectRoot/bin"
+# OS/Configuration defaults
+Configuration="Debug"
+OSName=$(uname -s)
+case $OSName in
+    Linux)
+        OS=Linux
+        ;;
+
+    Darwin)
+        OS=OSX
+        ;;
+
+    *)
+        echo "Unsupported OS $OSName detected, configuring as if for Linux"
+        OS=Linux
+        ;;
+esac
+# Misc defaults
+TestHostVersion="0.0.1-prerelease"
+OverlayDir="$ProjectRoot/bin/tests/$OS.AnyCPU.$Configuration/TestOverlay/"
+TestSelection=".*"
+TestsFailed=0
+
+create_test_overlay()
+{
+  # Creates the test overlay that will be copied on top of
+  # Each of the test directories.
+
+  local packageName="Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost.$TestHostVersion.nupkg"
+  local packageDir="packages/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost.$TestHostVersion"
+  rm -rf $packageDir
+  mkdir -p $packageDir
+  pushd $packageDir > /dev/null
+  # Pull down the testhost package and unzip it.
+  echo "Pulling down $packageName"
+  wget -q https://www.myget.org/F/dotnet-buildtools/api/v2/package/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost/$TestHostVersion -O $packageName
+  echo "Unzipping to $packageDir"
+  unzip -q -o $packageName
+  popd > /dev/null
+
+  # Make the overlay
+
+  rm -rf $OverlayDir
+  mkdir -p $OverlayDir
+  
+  local LowerOS="$(echo $OS | awk '{print tolower($OS)}')"
+  local LowerConfiguration="$(echo $Configuration | awk '{print tolower($Configuration)}')"
+
+  # First the temporary test host binaries
+  local packageLibDir="$packageDir/lib"
+  local coreClrDir="$CoreClrBinRoot/Product/$LowerOS.x64.$LowerConfiguration"
+  local mscorlibLocation="$MscorlibBinRoot/Product/Unix.x64.$LowerConfiguration/mscorlib.dll"
+  local coreFxDir="$CoreFxBinRoot/$OS.AnyCPU.$Configuration"
+  
+  if [ ! -d $packageLibDir ]
+  then
+	echo "Package not laid out as expected"
+	exit 1
+  fi
+  cp $packageLibDir/* $OverlayDir
+  
+  # Then the CoreCLR native binaries
+  if [ ! -d $coreClrDir ]
+  then
+	echo "Coreclr $OS binaries not found at $coreClrDir"
+	exit 1
+  fi
+  cp -r $coreClrDir/* $OverlayDir
+  
+  # Then the mscorlib from the upstream build.
+  # TODO When the mscorlib flavors get properly changed then 
+  if [ ! -f $mscorlibLocation ]
+  then
+	echo "Mscorlib not found at $mscorlibLocation"
+	exit 1
+  fi
+  cp -r $mscorlibLocation $OverlayDir
+  
+  # Then the binaries from the linux build of corefx
+  if [ ! -d $coreFxDir ]
+  then
+	echo "Mscorlib not found at $mscorlibLocation"
+	exit 1
+  fi
+  cp -n -r $coreFxDir/**/System*.dll $OverlayDir
+}
+
+copy_test_overlay()
+{
+  testDir=$1
+
+  cp -r $OverlayDir/* $testDir/
+}
+
+
+# $1 is the name of the test project
+runtest()
+{
+  testProject=$1
+
+  # Check here to see whether we should run this project
+
+  if grep "UnsupportedOperatingSystems.*$OS.*" $1
+  then
+    echo "Test project file $1 indicates this test is not supported on $OS, skipping"
+    return
+  fi
+  
+  # Check for project restrictions
+  
+  if [[ ! $testProject =~ $TestSelection ]]; then
+    echo "Skipping $testProject"
+    return
+  fi
+
+  # Grab the directory name that would correspond to this test
+
+  fileName="${file##*/}"
+  fileNameWithoutExtension="${fileName%.*}"
+  testDllName="$fileNameWithoutExtension.dll"
+
+  dirName="$CoreFxTestsRoot/tests/Windows_NT.AnyCPU.$Configuration/$fileNameWithoutExtension/aspnetcore50"
+
+  if [ ! -d "$dirName" ] || [ ! -f "$dirName/$testDllName" ]
+  then
+    echo "Did not find corresponding test dll for $testProject at $dirName/$testDllName"
+    return
+  fi
+
+  copy_test_overlay $dirName
+
+  # Invoke xunit
+
+  pushd $dirName > /dev/null
+  echo
+  echo "Running tests in $dirName"
+  echo "./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop"
+  echo
+  ./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop
+  if [ $? ]
+  then
+    TestsFailed=1
+  fi
+  popd > /dev/null
+}
+
+# Parse arguments
+
+while [[ $# > 0 ]]
+do
+    opt="$1"
+    case $opt in
+        -h|--help)
+        usage
+        ;;
+        --coreclr-bins)
+        CoreClrBinRoot=$2
+        ;;
+        --mscorlib-bins)
+        MscorlibBinRoot=$2
+        ;;
+        --corefx-tests)
+        CoreFxTestsRoot=$2
+        ;;
+        --corefx-bins)
+        CoreFxBinRoot=$2
+        ;;
+        --restrict-proj)
+        TestSelection=$2
+        ;;
+        --configuration)
+        Configuration=$2
+        ;;
+        --os)
+        OS=$2
+        ;;
+        *)
+        ;;
+    esac
+    shift
+done
+
+# Check parameters up front for valid values:
+
+if [ ! "$Configuration" == "Debug" ] && [ ! "$Configuration" == "Release" ]
+then
+    echo "Configuration should be Debug or Release"
+    exit 1
+fi
+
+if [ ! "$OS" == "OSX" ] && [ ! "$OS" == "Linux" ]
+then
+    echo "OS should be Linux or OSX"
+    exit 1
+fi
+
+create_test_overlay
+
+# Walk the directory tree rooted at src bin/tests/Windows_NT.AnyCPU.$Configuration/
+
+for file in src/**/tests/*.Tests.csproj
+do
+  runtest $file
+done
+
+exit $TestsFailed

--- a/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
+++ b/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Win32.Primitives.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Win32.Registry.Tests</RootNamespace>
     <AssemblyName>Microsoft.Win32.Registry.Tests</AssemblyName>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Tests</AssemblyName>
     <RootNamespace>System.Collections.Tests</RootNamespace>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -12,6 +12,7 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{30CAB353-089E-4294-B23B-F2DD1D945654}</ProjectGuid>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Utils.cs" />
@@ -28,7 +29,7 @@
       <Project>{6B4C1660-D158-4820-BE1C-D7A29CEBEC9B}</Project>
       <Name>System.Private.DataContractSerialization</Name>
     </ProjectReference>
-	<ProjectReference Include="..\..\System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj">
+    <ProjectReference Include="..\..\System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj">
       <Project>{CDF0ACB5-1361-4E48-8ECB-22E8022F5F01}</Project>
       <Name>System.Runtime.Serialization.Primitives</Name>
     </ProjectReference>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RestorePackages>true</RestorePackages>
     <NoWarn>1718</NoWarn>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This script allows for cross testing of Linux/OSX, where we don't have the ability to compile the tests natively.  Linux specifically lacks enough msbuild (or a stable enough coreclr) to be able to build the tests and corefx libraries.

The script assumes that the public bits for the dependent repositories are available locally (can be specified by parameter).  It then builds an overlay directory that can be copied over the test directory for each of the compiled Windows test directories prior to execution.

There is some rudimentary control over what gets executed.  It looks for a string in the test's csproj file "NotSupportedOperatingSystems.*OS.* which disables the project for the OS.  In addition, a switch can be used to specify a pattern of tests to run (this is useful to run a single directory).