### PR TITLE
Fix Process src/test issues on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.waitpid.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.waitpid.cs
@@ -28,7 +28,13 @@ internal static partial class Interop
         {
             return WTERMSIG(status) == 0;
         }
-        private static int WTERMSIG(int status)
+
+        internal static bool WIFSIGNALED(int status)
+        {
+            return ((sbyte)(((status) & 0x7f) + 1) >> 1) > 0;
+        }
+
+        internal static int WTERMSIG(int status)
         {
             return status & 0x7F;
         }

--- a/src/Common/src/System/IO/StringParser.cs
+++ b/src/Common/src/System/IO/StringParser.cs
@@ -159,14 +159,16 @@ namespace System.IO
             return result;
         }
 
+        internal delegate T ParseRawFunc<T>(string buffer, ref int startIndex, ref int endIndex);
+
         /// <summary>
         /// Moves to the next component and hands the raw buffer and indexing data to a selector function
         /// that can validate and return the appropriate data from the component.
         /// </summary>
-        internal T ParseRaw<T>(Func<string, int, int, T> selector)
+        internal T ParseRaw<T>(ParseRawFunc<T> selector)
         {
             MoveNextOrFail();
-            return selector(_buffer, _startIndex, _endIndex);
+            return selector(_buffer, ref _startIndex, ref _endIndex);
         }
 
         /// <summary>Throws unconditionally for invalid data.</summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -88,7 +88,7 @@ namespace System.Diagnostics
                 int maxCpu = IntPtr.Size == 4 ? 32 : 64;
                 for (int cpu = 0; cpu < maxCpu; cpu++)
                 {
-                    if ((bits & (cpu << 1)) != 0)
+                    if ((bits & (1u << cpu)) != 0)
                         Interop.libc.CPU_SET(cpu, &set);
                 }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -191,7 +191,7 @@ namespace System.Diagnostics
             Debug.Assert(Monitor.IsEntered(_gate));
 
             _exited = true;
-            _exitTime = DateTime.UtcNow; // TODO: Should be DateTime.Now, but that's currently asserting in the JIT in time zone code
+            _exitTime = DateTime.Now;
             if (_exitedEvent != null)
             {
                 _exitedEvent.Set();
@@ -296,6 +296,11 @@ namespace System.Diagnostics
                     if (Interop.libc.WIFEXITED(status))
                     {
                         _exitCode = Interop.libc.WEXITSTATUS(status);
+                    }
+                    else if (Interop.libc.WIFSIGNALED(status))
+                    {
+                        const int ExitCodeSignalOffset = 128;
+                        _exitCode = ExitCodeSignalOffset + Interop.libc.WTERMSIG(status);
                     }
                     SetExited();
                     return;
@@ -509,7 +514,7 @@ namespace System.Diagnostics
         /// <summary>Gets a current time stamp.</summary>
         private static long GetTimestamp()
         {
-            return DateTime.UtcNow.Ticks; // TODO: Change to use Stopwatch.GetTimestamp() once it's available
+            return Stopwatch.GetTimestamp();
         }
 
     }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -34,7 +34,7 @@ namespace System.Diagnostics.ProcessTests
                 {
                     try
                     {
-                    p.Kill();
+                        p.Kill();
                     }
                     catch (InvalidOperationException) { } // in case it was never started
 
@@ -163,7 +163,7 @@ namespace System.Diagnostics.ProcessTests
             {
                 Process p = CreateProcessInfinite();
                 StartAndKillProcessWithDelay(p);
-                Assert.True(p.ExitCode < 0, String.Format("Process_ExitCode: Unexpected Exit code {0}", p.ExitCode));
+                Assert.NotEqual(0, p.ExitCode);
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics.ProcessTests
             Process p = CreateProcessError();
             p.StartInfo.RedirectStandardError = true;
             p.Start();
-            Assert.Equal(p.StandardError.ReadToEnd(), TestExeName + " error stream\r\n");
+            Assert.Equal(p.StandardError.ReadToEnd(), TestExeName + " error stream" + Environment.NewLine);
             Assert.True(p.WaitForExit(WaitInMS));
         }
 


### PR DESCRIPTION
With these product fixes and test changes, all of the System.Diagnostics.Process tests that aren't Win32-specific (e.g. expecting Win32-specific values, P/Invoking to Win32 functions, etc.) pass on Linux.