### PR TITLE
Fix cross-plat issues in XmlResolver tests

### DIFF
--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/System.Xml.RW.XmlSystemPathResolver.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/System.Xml.RW.XmlSystemPathResolver.Tests.csproj
@@ -19,11 +19,6 @@
     <Compile Include="XmlSystemPathResolverTests.cs" />
   </ItemGroup>
   <ItemGroup>
-	<Content Include="Empty.xml">
-	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</Content>
-  </ItemGroup>
-  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/packages.config
@@ -5,6 +5,8 @@
   <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.IO" version="4.0.10-beta-22703" />
+  <package id="System.IO.FileSystem" version="4.0.0-beta-22703" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
   <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
   <package id="xunit" version="2.0.0-beta5-build2785" />


### PR DESCRIPTION
The System.Xml.RW.XmlSystemPathResolver tests were using P/Invokes to Win32 for things that could have been done with existing .NET APIs.  This commit replaces those so that the tests can run on Unix.

The tests were also relying on an Empty.xml file which would need to be deployed with the tests.  Now that the tests are able to use System.IO.FileSystem, the commit removes that Empty.xml file and just generates a temporary empty file at run time.