### PR TITLE
Fix some Path tests not to assume Windows

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.cs
@@ -16,8 +16,8 @@ public static class PathTests
     [Fact]
     public static void GetDirectoryName()
     {
-        Assert.Equal("dir", Path.GetDirectoryName(@"dir\baz"));
-        Assert.Equal(null, Path.GetDirectoryName(@"c:\"));
+        Assert.Equal("dir", Path.GetDirectoryName(Path.Combine("dir", "baz")));
+        Assert.Equal(null, Path.GetDirectoryName(Path.GetPathRoot(Directory.GetCurrentDirectory())));
     }
 
     [Fact]
@@ -32,22 +32,23 @@ public static class PathTests
     [Fact]
     public static void GetFileName()
     {
-        Assert.Equal("file.exe", Path.GetFileName(@"c:\bar\baz\file.exe"));
-        Assert.Equal(string.Empty, Path.GetFileName(@"c:\bar\baz\"));
+        Assert.Equal("file.exe", Path.GetFileName(Path.Combine("bar", "baz", "file.exe")));
+        Assert.Equal(string.Empty, Path.GetFileName(Path.Combine("bar", "baz") + Path.DirectorySeparatorChar));
     }
 
     [Fact]
     public static void GetFileNameWithoutExtension()
     {
-        Assert.Equal("file", Path.GetFileNameWithoutExtension(@"c:\bar\baz\file.exe"));
-        Assert.Equal(string.Empty, Path.GetFileNameWithoutExtension(@"c:\bar\baz\"));
+        Assert.Equal("file", Path.GetFileNameWithoutExtension(Path.Combine("bar","baz","file.exe")));
+        Assert.Equal(string.Empty, Path.GetFileNameWithoutExtension(Path.Combine("bar","baz") + Path.DirectorySeparatorChar));
     }
 
     [Fact]
     public static void GetPathRoot()
     {
-        Assert.Equal(@"c:\", Path.GetPathRoot(@"c:\x\y\z\"));
-        Assert.True(Path.IsPathRooted(@"c:\x\y\z\"));
+        string cwd = Directory.GetCurrentDirectory();
+        Assert.Equal(cwd.Substring(0, cwd.IndexOf(Path.DirectorySeparatorChar) + 1), Path.GetPathRoot(cwd));
+        Assert.True(Path.IsPathRooted(cwd));
         Assert.Equal(string.Empty, Path.GetPathRoot(@"file.exe"));
         Assert.False(Path.IsPathRooted("file.exe"));
     }

--- a/src/System.Runtime.Extensions/tests/packages.config
+++ b/src/System.Runtime.Extensions/tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.IO.FileSystem" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Globalization" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime" version="4.0.20-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />


### PR DESCRIPTION
Several tests for Path in System.Runtime.Extensions.Tests are assuming Windows paths.  This fixes them.  After this, 6 of the 436 tests are still failing due to reliance on Win32-specific things (e.g. P/Invoking to set an environment variable) and will need to be disabled for Unix.