### PR TITLE
Fix interop for directory enumeration on Unix

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.readdir.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.readdir.cs
@@ -14,14 +14,37 @@ internal static partial class Interop
         [DllImport(Libraries.Libc, SetLastError = true)]
         internal static extern IntPtr readdir(IntPtr dirp);
 
+        internal static unsafe DType GetDirEntType(IntPtr dirEnt)
+        {
+            return ((dirent*)dirEnt)->d_type;
+        }
+
+        internal static unsafe string GetDirEntName(IntPtr dirEnt)
+        {
+            return Marshal.PtrToStringAnsi((IntPtr)((dirent*)dirEnt)->d_name);
+        }
+
+        internal enum DType : byte
+        {
+            DT_UNKNOWN = 0,
+            DT_FIFO = 1,
+            DT_CHR = 2,
+            DT_DIR = 4,
+            DT_BLK = 6,
+            DT_REG = 8,
+            DT_LNK = 10,
+            DT_SOCK = 12,
+            DT_WHT = 14
+        }
+
         #pragma warning disable 0649 // fields are assigned by P/Invoke call 
-        internal unsafe struct dirent 
+        private unsafe struct dirent 
         { 
             internal ino_t d_ino; 
             internal off_t d_off; 
             internal short d_reclen; 
-            internal byte d_type; 
-            internal fixed byte d_name[256]; 
+            internal DType d_type; 
+            internal fixed byte d_name[256];
         } 
         #pragma warning restore 0649 
     }

--- a/src/Common/src/Interop/OSX/libc/Interop.readdir.cs
+++ b/src/Common/src/Interop/OSX/libc/Interop.readdir.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [DllImport(Libraries.Libc, EntryPoint = "readdir$INODE64", SetLastError = true)]
+        internal static extern IntPtr readdir(IntPtr dirp);
+
+        internal static unsafe DType GetDirEntType(IntPtr dirEnt)
+        {
+            return ((dirent*)dirEnt)->d_type;
+        }
+
+        internal static unsafe string GetDirEntName(IntPtr dirEnt)
+        {
+            dirent* curEntryPtr = (dirent*)dirEnt;
+            return Marshal.PtrToStringAnsi((IntPtr)curEntryPtr->d_name, curEntryPtr->d_namelen);
+        }
+
+        internal enum DType : byte
+        {
+            DT_UNKNOWN = 0,
+            DT_FIFO = 1,
+            DT_CHR = 2,
+            DT_DIR = 4,
+            DT_BLK = 6,
+            DT_REG = 8,
+            DT_LNK = 10,
+            DT_SOCK = 12,
+            DT_WHT = 14
+        }
+
+        private const int __DARWIN_MAXPATHLEN = 1024;
+
+        #pragma warning disable 0649 // fields are assigned by P/Invoke call 
+        private unsafe struct dirent 
+        { 
+            internal ulong d_ino; 
+            internal ulong d_off; 
+            internal ushort d_reclen;
+            internal ushort d_namelen;
+            internal DType d_type; 
+            internal fixed byte d_name[__DARWIN_MAXPATHLEN]; 
+        }
+        #pragma warning restore 0649
+    }
+}

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -290,9 +290,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.read.cs">
       <Link>Common\Interop\Unix\Interop.read.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.readdir.cs">
-      <Link>Common\Interop\Unix\Interop.readdir.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.rename.cs">
       <Link>Common\Interop\Unix\Interop.rename.cs</Link>
     </Compile>
@@ -313,6 +310,18 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
       <Link>Common\Interop\Unix\Interop.GetInformation.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Linux -->
+  <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.readdir.cs">
+      <Link>Common\Interop\Linux\Interop.readdir.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- OSX -->
+  <ItemGroup Condition="'$(TargetsOSX)' == 'true'">
+    <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.readdir.cs">
+      <Link>Common\Interop\OSX\Interop.readdir.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Two fixes:
1) Avoid unnecessary stat usage when we know whether the file is a directory/file based on the results of readdir
2) Use the right export name of readdir and layout of struct dirent on OSX