### PR TITLE
Remove Console.WriteLines from FileSystem tests

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Ansichars.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Ansichars.cs
@@ -36,11 +36,7 @@ public class Directory_AnsiChars
             Console.WriteLine("unexpected exception occured... Exception message:" + e.ToString());
         }
 
-        if (bTestPassed)
-        {
-            Console.WriteLine("Test PASSED");
-        }
-        else
+        if (!bTestPassed)
         {
             Console.WriteLine("Test FAILED");
         }

--- a/src/System.IO.FileSystem/tests/PortedCommon/EnumerableUtils.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/EnumerableUtils.cs
@@ -25,18 +25,10 @@ namespace EnumerableTests
         {
             _totalCount++;
 
-            Console.WriteLine();
-            Console.WriteLine("--------------------------------");
-            Console.WriteLine("Running Inner Test: {0} ({1})", methodName, testName);
-
-            if (failCount == 0)
-            {
-                Console.WriteLine("---- Inner Test PASSED ---------");
-            }
-            else
+            if (failCount != 0)
             {
                 _totalFailCount++;
-                Console.WriteLine("---- Inner Test FAILED ---------");
+                Console.WriteLine("---- Inner Test FAILED: {0} ({1}) ----", methodName, testName);
             }
         }
 


### PR DESCRIPTION
A few Console.WriteLine calls in the FileSystem tests are resulting in lots of unnecessary output while running tests.  Removing them.