### PR TITLE
[Issue#606] Process.MainModule can throw NullReferenceException

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -125,7 +125,7 @@ namespace System.Diagnostics
                 // On NT, the first module is the main module.
                 EnsureState(State.HaveId | State.IsLocal);
                 ModuleInfo module = NtProcessManager.GetFirstModuleInfo(_processId);
-                return new ProcessModule(module);
+                return (module != null ? new ProcessModule(module) : null);
             }
         }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -309,8 +309,6 @@ namespace System.Diagnostics
 
         private static ModuleInfo[] GetModuleInfos(int processId, bool firstModuleOnly)
         {
-            Contract.Ensures(Contract.Result<ModuleInfo[]>().Length >= 1);
-
             // preserving Everett behavior.    
             if (processId == SystemProcessID || processId == IdleProcessID)
             {

--- a/src/System.Diagnostics.Process/src/packages.config
+++ b/src/System.Diagnostics.Process/src/packages.config
@@ -17,7 +17,6 @@
   <package id="System.Globalization" version="4.0.10-beta-22703" />
   <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
-  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
   <package id="System.Reflection" version="4.0.10-beta-22703" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
   <package id="System.Collections" version="4.0.10-beta-22703" />

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/ProcessTest.cs
@@ -218,24 +218,30 @@ namespace System.Diagnostics.ProcessTests
         }
 
         [Fact]
-        [ActiveIssue(606)]
         public void Process_MainModule()
         {
             // Get MainModule property from a Process object
-            string moduleName = _process.MainModule.ModuleName;
-            Assert.Equal(CoreRunName, moduleName);
-
-            // Check that the mainModule is present in the modules list.
-            bool foundMainModule = false;
-            foreach (ProcessModule pModule in _process.Modules)
+            ProcessModule mainModule = _process.MainModule;
+            if (mainModule != null)
             {
-                if (String.Equals(moduleName, CoreRunName, StringComparison.OrdinalIgnoreCase))
+                Assert.Equal(CoreRunName, Path.GetFileNameWithoutExtension(mainModule.ModuleName));
+
+                // Check that the mainModule is present in the modules list.
+                bool foundMainModule = false;
+                if (_process.Modules != null)
                 {
-                    foundMainModule = true;
-                    break;
+                    foreach (ProcessModule pModule in _process.Modules)
+                    {
+                        if (String.Equals(Path.GetFileNameWithoutExtension(mainModule.ModuleName), CoreRunName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            foundMainModule = true;
+                            break;
+                        }
+                    }
+
+                    Assert.True(foundMainModule, "Could not found Module " + mainModule.ModuleName);
                 }
             }
-            Assert.True(foundMainModule, "Could not found Module " + moduleName);
         }
 
         [Fact]


### PR DESCRIPTION

Process library uses psapi!EnumProcessModules to get the complete module list and then uses the first module in the list to get the MainModule. This API has certain limitations and our implementation tries to idenitfy/work-around all these limitations by giving exceptions, calling the native API multiple times etc. However the API can still return null which is then wrapped in a ProcessModule causing NullReferenceException on usage.

As per msdn [EnumProcessModules](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682631(v=vs.85).aspx) is not always guranteed to give a correct behavior.

    If the module list in the target process is corrupted or not yet initialized, or if
    the module list changes during the function call as a result of DLLs being loaded or unloaded,
    EnumProcessModules may fail or return incorrect information.

And so, it is not possible for us to always give the MainModule. As a result I have updated the implementation of Process.MainModule to return null (instead of wrapping the null in a ProcessModule). This pushes the onus on the callsite to check for this possibility. This is essentially a breaking change however it will break only those apps which earlier would have caused NullReferenceException anyway. And the developer could guard against this scenario with a simple null reference check code pattern. In fact in .Net 1.1 Process.MainModule did return null. The behavior got changed at some point between 1.1 and 2.0.

I also considered the following options
- Throw an exception - Since the behavior is caused due to things outside of developer control, the developer can't do anything to prevent this exception. It is unclear what type of exception should be thrown? And overall it seemed like an overkill to guard against a scenario, you could easily do with a Null check.
- Wrap the null but make all the properties return default values - This is the least breaking option, however this behavior is difficult to identify and in my opinion incorrect!

Interestingly I did not find any hits for the same behavior on desktop. I also tried running our open src test in loop for a day and the only time I could repro this was through ctrl+c. 