### PR TITLE
Lots of FileSystem test fixes for Unix

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Ansichars.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Ansichars.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 public class Directory_AnsiChars
 {
-    [Fact]
+    [ActiveIssue(847)]
     public static void runTest()
     {
         bool bTestPassed = false;

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -418,7 +418,7 @@ public class Directory_CreateDirectory
 
             foreach (var component in components)
             {
-                string path = IOServices.AddTrailingSlashIfNeeded(directory.Path + "\\" + component);
+                string path = IOServices.AddTrailingSlashIfNeeded(Path.Combine(directory.Path, component));
 
                 DirectoryInfo result = Directory.CreateDirectory(path);
 
@@ -437,7 +437,7 @@ public class Directory_CreateDirectory
 
             foreach (var component in components)
             {
-                string path = directory.Path + @"\" + component;
+                string path = directory.Path + Path.DirectorySeparatorChar + component;
 
                 DirectoryInfo result = Directory.CreateDirectory(path);
 

--- a/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
@@ -48,7 +48,7 @@ public class Directory_Delete_MountVolume
                 if (FileSystemDebugInfo.IsCurrentDriveNTFS() && otherDriveInMachine != null)
                 {
                     Console.WriteLine(scenarioDescription);
-                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), MountPrefixName));
 
                     try
                     {
@@ -136,7 +136,7 @@ public class Directory_Delete_MountVolume
                 if (FileSystemDebugInfo.IsCurrentDriveNTFS())
                 {
                     File.AppendAllText(debugFileName, String.Format("{0}{1}", scenarioDescription, Environment.NewLine));
-                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), MountPrefixName));
                     try
                     {
                         Directory.CreateDirectory(mountedDirName);

--- a/src/System.IO.FileSystem/tests/Directory/Delete_str_bool.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_str_bool.cs
@@ -125,9 +125,9 @@ public class Directory_Co5663Delete_str_bool
         // [] String should be case insensitive
         //-----------------------------------------------------------------
         string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_withFiles");
-        Directory.CreateDirectory(dirName + "\\Test1");
-        Directory.CreateDirectory(dirName + "\\Test2");
-        new FileStream(dirName + "\\Test1\\Hello.tmp", FileMode.Create).Dispose();
+        Directory.CreateDirectory(Path.Combine(dirName, "Test1"));
+        Directory.CreateDirectory(Path.Combine(dirName, "Test2"));
+        new FileStream(Path.Combine(dirName, "Test1", "Hello.tmp"), FileMode.Create).Dispose();
 
         DirectoryInfo dir2 = new DirectoryInfo(dirName);
         try
@@ -159,17 +159,17 @@ public class Directory_Co5663Delete_str_bool
     {
         // [] Directory with subdirectories should fail when passed false and pass when true
         string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_withSubDirs");
-        Directory.CreateDirectory(dirName + "\\Test1");
-        DirectoryInfo dir2 = Directory.CreateDirectory(dirName + "\\Test2");
+        Directory.CreateDirectory(Path.Combine(dirName, "Test1"));
+        DirectoryInfo dir2 = Directory.CreateDirectory(Path.Combine(dirName, "Test2"));
         Directory.Delete(dir2.FullName.ToUpper(), false);
-        if (Directory.Exists(dirName + "\\Test2"))
+        if (Directory.Exists(Path.Combine(dirName, "Test2")))
         {
             printerr("Error_49928! Directory not deleted");
             Assert.True(false, "Directory not deleted");
         }
 
         // Trying to delete one with subdirs
-        Directory.CreateDirectory(dirName + "\\Test2");
+        Directory.CreateDirectory(Path.Combine(dirName, "Test2"));
         dir2 = new DirectoryInfo(dirName);
         try
         {

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str.cs
@@ -190,7 +190,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             // [] SearchString ending with '*'
 
             iCountTestcases++;
-            strArr = Directory.GetDirectories(".\\" + dirName, "TestDir*");
+            strArr = Directory.GetDirectories(Path.Combine(".", dirName), "TestDir*");
             iCountTestcases++;
             if (strArr.Length != 3)
             {
@@ -201,7 +201,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             String[] names = new String[strArr.Length];
             int i = 0;
             foreach (String d in strArr)
-                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(d);
 
             iCountTestcases++;
             if (Array.IndexOf(names, "TestDir1") < 0)
@@ -226,7 +226,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             // [] SearchString is '*'
             strLoc = "Loc_249yv";
 
-            strArr = Directory.GetDirectories(Directory.GetCurrentDirectory() + "\\" + dirName, "*");
+            strArr = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), dirName), "*");
             iCountTestcases++;
             if (strArr.Length != 5)
             {
@@ -236,7 +236,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             names = new String[strArr.Length];
             i = 0;
             foreach (String d in strArr)
-                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(d);
 
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1Dir1") < 0)
@@ -272,7 +272,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             // [] SearchString starting with '*'
             strLoc = "Loc_20v99";
 
-            strArr = Directory.GetDirectories(Directory.GetCurrentDirectory() + "\\" + dirName, "*Dir2");
+            strArr = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), dirName), "*Dir2");
             iCountTestcases++;
             if (strArr.Length != 2)
             {
@@ -282,7 +282,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             names = new String[strArr.Length];
             i = 0;
             foreach (String d in strArr)
-                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(d);
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1Dir2") < 0)
             {
@@ -302,7 +302,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             dir2.CreateSubdirectory("AAABB");
             dir2.CreateSubdirectory("aaabbcc");
 
-            strArr = Directory.GetDirectories(".\\" + dirName, "*BB*");
+            strArr = Directory.GetDirectories(Path.Combine(".", dirName), "*BB*");
             iCountTestcases++;
             if (strArr.Length != 2)
             {
@@ -312,7 +312,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             names = new String[strArr.Length];
             i = 0;
             foreach (String d in strArr)
-                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(d);
             iCountTestcases++;
             if (Array.IndexOf(names, "AAABB") < 0)
             {
@@ -329,7 +329,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             // [] Should not search on fullpath
             // [] No matches should return empty array
 
-            strArr = Directory.GetDirectories(".\\" + dirName, "Directory");
+            strArr = Directory.GetDirectories(Path.Combine(".", dirName), "Directory");
             iCountTestcases++;
             if (strArr.Length != 0)
             {
@@ -339,7 +339,7 @@ public class Directory_Co5674GetDirectories_Str_Str
 
             //Code coverage
             //Search pattern could have subdirectories
-            strArr = Directory.GetDirectories(".", String.Format("{0}\\TestDir*", dirName));
+            strArr = Directory.GetDirectories(".", Path.Combine(dirName, "TestDir*"));
             if (strArr.Length != 3)
             {
                 iCountErrors++;
@@ -349,7 +349,7 @@ public class Directory_Co5674GetDirectories_Str_Str
             names = new String[strArr.Length];
             i = 0;
             foreach (String d in strArr)
-                names[i++] = d.ToString().Substring(d.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(d);
 
             iCountTestcases++;
             if (Array.IndexOf(names, "TestDir1") < 0)

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str_so.cs
@@ -80,7 +80,7 @@ public class Directory_GetDirectories_str_str_so
             /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
             try
             {
-                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), ManageFileSystem.DirPrefixName);
                 using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
                 {
                     expectedDirs = fileManager.GetDirectories(1);
@@ -102,7 +102,7 @@ public class Directory_GetDirectories_str_str_so
                     }
                 }
                 //only 1 level
-                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), ManageFileSystem.DirPrefixName);
                 dirName = Path.GetFullPath(dirName);
                 using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
                 {
@@ -404,7 +404,7 @@ public class Directory_GetDirectories_str_str_so
             /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
             try
             {
-                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), ManageFileSystem.DirPrefixName);
                 using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
                 {
                     expectedDirs = fileManager.GetAllDirectories();
@@ -612,17 +612,14 @@ public class Directory_GetDirectories_str_str_so
             // Regression Test (DevDiv Bug927807): throw NotSupportException when there are whitespace before drive letter
             try
             {
-                string pathStr = @" C:\";
-                var fullPath = Path.GetFullPath(pathStr);
-                Eval(fullPath, "C:\\", "Wrong Full Path");
+                string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
-                pathStr = "  D:\\";
-                fullPath = Path.GetFullPath(pathStr);
-                Eval(fullPath, "D:\\", "Wrong Full Path");
+                var fullPath = Path.GetFullPath(" " + root);
+                Eval(fullPath, root, "Wrong Full Path");
 
-                pathStr = "   E:\\Test\\Test.cs  ";
-                fullPath = Path.GetFullPath(pathStr);
-                Eval(fullPath, @"E:\Test\Test.cs", "Wrong Full Path");
+                string pathStr = root + "test" + Path.DirectorySeparatorChar + "test.cs";
+                fullPath = Path.GetFullPath(" " + pathStr);
+                Eval(fullPath, pathStr, "Wrong Full Path");
             }
             catch (Exception ex)
             {

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot_str.cs
@@ -59,9 +59,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_49b78";
 
-            str2 = Directory.GetDirectoryRoot("C:\\");
+            str2 = Directory.GetDirectoryRoot(Path.GetPathRoot(Directory.GetCurrentDirectory()));
             iCountTestcases++;
-            if (!str2.Equals("C:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_69y7b! Unexpected parent==" + str2);
@@ -71,9 +71,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_98ygg";
 
-            str2 = Directory.GetDirectoryRoot("\\Machine\\Test");
+            str2 = Directory.GetDirectoryRoot(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test"));
             iCountTestcases++;
-            String root = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().IndexOf('\\') + 1);
+            String root = Path.GetPathRoot(Directory.GetCurrentDirectory());
             if (!str2.Equals(root))
             {
                 iCountErrors++;
@@ -84,9 +84,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_yg7bk";
 
-            str2 = Directory.GetDirectoryRoot("\\\\Machine\\Test");
+            str2 = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test"));
             iCountTestcases++;
-            if (!str2.Equals("\\\\Machine\\Test"))
+            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")))
             {
                 iCountErrors++;
                 printerr("Error_4y7gb! Unexpected parent==" + str2);
@@ -97,9 +97,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_9876b";
 
-            str2 = Directory.GetDirectoryRoot("X:\\a\\b\\c\\d\\");
+            str2 = Directory.GetDirectoryRoot(Path.Combine(Directory.GetCurrentDirectory(), "a", "b", "c", "d") + Path.DirectorySeparatorChar);
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_298yg! Unexpected parent==" + str2);
@@ -109,9 +109,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_75y7b";
 
-            str2 = Directory.GetDirectoryRoot("X:\\a\\b\\c");
+            str2 = Directory.GetDirectoryRoot(Path.Combine(Directory.GetCurrentDirectory(), "a", "b", "c"));
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory()))) 
             {
                 iCountErrors++;
                 printerr("Error_9887b! Unexpected parent==" + str2);
@@ -121,9 +121,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_y7t98";
 
-            str2 = Directory.GetDirectoryRoot("\\\\Machine\\Test1\\Test2\\Test3");
+            str2 = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2", "Test3"));
             iCountTestcases++;
-            if (!str2.Equals("\\\\Machine\\Test1"))
+            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
             {
                 iCountErrors++;
                 printerr("Error_69929! Unexpected parent==" + str2);
@@ -133,9 +133,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_2984y";
 
-            str2 = Directory.GetDirectoryRoot("C:\\Test\\..\\.\\Test\\Test");
+            str2 = Directory.GetDirectoryRoot(Path.Combine(Directory.GetCurrentDirectory(), "Test", "..", ".", "Test", "Test"));
             iCountTestcases++;
-            if (!str2.Equals("C:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_20928! Unexpected parent==" + str2);
@@ -146,9 +146,9 @@ public class Directory_GetDirectoryRoot_str
 
             strLoc = "Loc_8y76y";
 
-            str2 = Directory.GetDirectoryRoot("X:\\My Samples\\Hello To The World\\Test");
+            str2 = Directory.GetDirectoryRoot(Path.Combine(Directory.GetCurrentDirectory(), "My Samples", "Hello To The World", "Test"));
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_9019c! Unexpected parent==" + str2);

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -111,7 +111,7 @@ public class Directory_GetFileSystemEntries_str
             iCountTestcases++;
             try
             {
-                String strTempDir = "c:\\dls;d\\442349-0\\v443094(*)(+*$#$*\\\\\\";
+                String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 2);
                 Directory.GetFileSystemEntries(strTempDir);
                 iCountErrors++;
                 printerr("Error_1003! Expected exception not thrown");
@@ -129,7 +129,7 @@ public class Directory_GetFileSystemEntries_str
             iCountTestcases++;
             try
             {
-                String strTempDir = "c:\\\\\\\\\\";
+                String strTempDir = Directory.GetCurrentDirectory() + new string(Path.DirectorySeparatorChar, 5);
                 strArr = Directory.GetFileSystemEntries(strTempDir);
                 if (strArr == null || strArr.Length == 0)
                 {
@@ -179,10 +179,10 @@ public class Directory_GetFileSystemEntries_str
             dir2.CreateSubdirectory("TestDir1");
             dir2.CreateSubdirectory("TestDir2");
             dir2.CreateSubdirectory("TestDir3");
-            FileStream fs1 = new FileInfo(dir2.ToString() + "\\" + "TestFile1").Create();
-            FileStream fs2 = new FileInfo(dir2.ToString() + "\\" + "TestFile2").Create();
-            FileStream fs3 = new FileInfo(dir2.ToString() + "\\" + "Test.bat").Create();
-            FileStream fs4 = new FileInfo(dir2.ToString() + "\\" + "Test.exe").Create();
+            FileStream fs1 = new FileInfo(Path.Combine(dir2.ToString(), "TestFile1")).Create();
+            FileStream fs2 = new FileInfo(Path.Combine(dir2.ToString(), "TestFile2")).Create();
+            FileStream fs3 = new FileInfo(Path.Combine(dir2.ToString(), "Test.bat")).Create();
+            FileStream fs4 = new FileInfo(Path.Combine(dir2.ToString(), "Test.exe")).Create();
 
             iCountTestcases++;
             strArr = Directory.GetFileSystemEntries(dir2.Name);
@@ -194,7 +194,7 @@ public class Directory_GetFileSystemEntries_str
             }
 
             for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
-                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+                strArr[iLoop] = Path.GetFileName(strArr[iLoop]);
 
             iCountTestcases++;
             if (Array.IndexOf(strArr, "TestDir1") < 0)

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -89,7 +89,7 @@ public class Directory_GetFileSystemEntries_str_str
             iCountTestcases++;
             try
             {
-                String strTempDir = "c:\\dls;d\\442349-0\\v443094(*)(+*$#$*\\\\\\";
+                String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 3);
                 Directory.GetFileSystemEntries(strTempDir, "*");
                 iCountErrors++;
                 printerr("Error_1003! Expected exception not thrown");
@@ -164,7 +164,7 @@ public class Directory_GetFileSystemEntries_str_str
             iCountTestcases++;
             try
             {
-                String strTempDir = "c:\\dls;d\\442349-0\\v443094(*)(+*$#$*\\\\\\";
+                String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 3);
                 Directory.GetFileSystemEntries(dirName, strTempDir);
                 iCountErrors++;
                 printerr("Error_3003! Expected exception not thrown");
@@ -231,7 +231,7 @@ public class Directory_GetFileSystemEntries_str_str
             iCountTestcases++;
             try
             {
-                String strTempDir = "c:\\\\\\\\\\";
+                String strTempDir = Directory.GetCurrentDirectory() + new string(Path.DirectorySeparatorChar, 5);
                 strArr = Directory.GetFileSystemEntries(strTempDir, "*");
                 if (strArr == null || strArr.Length == 0)
                 {
@@ -281,10 +281,10 @@ public class Directory_GetFileSystemEntries_str_str
             dir2.CreateSubdirectory("TestDir1");
             dir2.CreateSubdirectory("TestDir2");
             dir2.CreateSubdirectory("TestDir3");
-            FileStream fs1 = new FileInfo(dir2.ToString() + "\\" + "TestFile1").Create();
-            FileStream fs2 = new FileInfo(dir2.ToString() + "\\" + "TestFile2").Create();
-            FileStream fs3 = new FileInfo(dir2.ToString() + "\\" + "Test1File2").Create();
-            FileStream fs4 = new FileInfo(dir2.ToString() + "\\" + "Test1Dir2").Create();
+            FileStream fs1 = new FileInfo(Path.Combine(dir2.ToString(), "TestFile1")).Create();
+            FileStream fs2 = new FileInfo(Path.Combine(dir2.ToString(), "TestFile2")).Create();
+            FileStream fs3 = new FileInfo(Path.Combine(dir2.ToString(), "Test1File2")).Create();
+            FileStream fs4 = new FileInfo(Path.Combine(dir2.ToString(), "Test1Dir2")).Create();
 
             //white spaces for search pattern
             strArr = Directory.GetFileSystemEntries(dirName, "           ");
@@ -314,7 +314,7 @@ public class Directory_GetFileSystemEntries_str_str
             }
 
             for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
-                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+                strArr[iLoop] = Path.GetFileName(strArr[iLoop]);
 
             iCountTestcases++;
             if (Array.IndexOf(strArr, "TestDir1") < 0)
@@ -375,7 +375,7 @@ public class Directory_GetFileSystemEntries_str_str
             }
 
             for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
-                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+                strArr[iLoop] = Path.GetFileName(strArr[iLoop]);
 
             iCountTestcases++;
             if (Array.IndexOf(strArr, "Test1Dir2") < 0)
@@ -410,7 +410,7 @@ public class Directory_GetFileSystemEntries_str_str
                 printerr("Error_948yv! Incorrect number of files==" + strArr.Length);
             }
             for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
-                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+                strArr[iLoop] = Path.GetFileName(strArr[iLoop]);
 
             iCountTestcases++;
             if (Array.IndexOf(strArr, "Test1Dir2") < 0)
@@ -427,8 +427,8 @@ public class Directory_GetFileSystemEntries_str_str
 
             // [] Search criteria Beginning and ending with '*'
 
-            new FileInfo(dir2.FullName + "\\" + "AAABB").Create();
-            Directory.CreateDirectory(dir2.FullName + "\\" + "aaabbcc");
+            new FileInfo(Path.Combine(dir2.FullName, "AAABB")).Create();
+            Directory.CreateDirectory(Path.Combine(dir2.FullName, "aaabbcc"));
 
             strArr = Directory.GetFileSystemEntries(dir2.Name, "*BB*");
 
@@ -439,7 +439,7 @@ public class Directory_GetFileSystemEntries_str_str
                 printerr("Error_4y190! Incorrect number of files==" + strArr.Length);
             }
             for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
-                strArr[iLoop] = strArr[iLoop].Substring(strArr[iLoop].IndexOf("\\") + 1);
+                strArr[iLoop] = Path.GetFileName(strArr[iLoop]);
 
             iCountTestcases++;
             if (Array.IndexOf(strArr, "aaabbcc") < 0)
@@ -458,9 +458,9 @@ public class Directory_GetFileSystemEntries_str_str
             // [] Search Criteria without match should return empty array
 
             strLoc = "Loc_2301";
-            FileInfo f = new FileInfo(dir2.Name + "\\" + "TestDir1\\Test.tmp");
+            FileInfo f = new FileInfo(Path.Combine(dir2.Name, "TestDir1", "Test.tmp"));
             FileStream fs6 = f.Create();
-            strArr = Directory.GetFileSystemEntries(dir2.Name, "TestDir1\\*");
+            strArr = Directory.GetFileSystemEntries(dir2.Name, Path.Combine("TestDir1", "*"));
             iCountTestcases++;
             if (strArr.Length != 1)
             {

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
@@ -138,11 +138,11 @@ public class Directory_GetFiles_str
             dir2.CreateSubdirectory("Test1Dir1");
             dir2.CreateSubdirectory("Test1Dir2");
 
-            new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
-            new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
-            new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
-            new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile3")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "Test1File1")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "Test1File2")).Create();
 
             // [] Searchstring ending with '*'
 

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str_Str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str_Str.cs
@@ -170,7 +170,7 @@ public class Directory_GetFiles_str_str
             strLoc = "Loc_4y982";
 
             dir2 = Directory.CreateDirectory(dirName);
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "*");
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), "*");
             iCountTestcases++;
             if (strArr.Length != 0)
             {
@@ -189,16 +189,16 @@ public class Directory_GetFiles_str_str
             dir2.CreateSubdirectory("TestDir3");
             dir2.CreateSubdirectory("Test1Dir1");
             dir2.CreateSubdirectory("Test1Dir2");
-            new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
-            new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
-            new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
-            new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile3")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "Test1File1")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "Test1File2")).Create();
 
             // [] SearchString ending with '*'
 
             iCountTestcases++;
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "TestFile*");
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), "TestFile*");
             iCountTestcases++;
             if (strArr.Length != 3)
             {
@@ -209,7 +209,7 @@ public class Directory_GetFiles_str_str
             String[] names = new String[strArr.Length];
             int i = 0;
             foreach (String f in strArr)
-                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f);
 
             iCountTestcases++;
             if (Array.IndexOf(names, "TestFile1") < 0)
@@ -234,7 +234,7 @@ public class Directory_GetFiles_str_str
             // Search string is '*'
             strLoc = "Loc_4y7gb";
 
-            strArr = Directory.GetFiles(".\\" + dirName, "*");
+            strArr = Directory.GetFiles(Path.Combine(".", dirName), "*");
             iCountTestcases++;
             if (strArr.Length != 5)
             {
@@ -244,7 +244,7 @@ public class Directory_GetFiles_str_str
             names = new String[strArr.Length];
             i = 0;
             foreach (String f in strArr)
-                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f);
 
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1File1") < 0)
@@ -279,7 +279,7 @@ public class Directory_GetFiles_str_str
 
             strLoc = "Loc_4yg7b";
 
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "*File2");
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), "*File2");
             iCountTestcases++;
             if (strArr.Length != 2)
             {
@@ -289,7 +289,7 @@ public class Directory_GetFiles_str_str
             names = new String[strArr.Length];
             i = 0;
             foreach (String f in strArr)
-                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f);
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1File2") < 0)
             {
@@ -308,10 +308,10 @@ public class Directory_GetFiles_str_str
             // [] Search should be case insensitive.
             strLoc = "Loc_767b7";
 
-            new FileInfo(dir2.FullName + "\\" + "AAABB").Create();
-            new FileInfo(dir2.FullName + "\\" + "aaabbcc").Create();
+            new FileInfo(Path.Combine(dir2.FullName, "AAABB")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "aaabbcc")).Create();
 
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "*BB*");
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), "*BB*");
             iCountTestcases++;
             if (strArr.Length != 2)
             {
@@ -321,7 +321,7 @@ public class Directory_GetFiles_str_str
             names = new String[strArr.Length];
             i = 0;
             foreach (String f in strArr)
-                names[i++] = f.Substring(f.ToString().LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f);
             iCountTestcases++;
             if (Array.IndexOf(names, "AAABB") < 0)
             {
@@ -339,7 +339,7 @@ public class Directory_GetFiles_str_str
 
             strLoc = "Loc_38yf8";
 
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "AAABB");
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), "AAABB");
             iCountTestcases++;
             if (strArr.Length != 1)
             {
@@ -357,7 +357,7 @@ public class Directory_GetFiles_str_str
             // [] No match returns zero length array
             strLoc = "Loc_yg78b";
 
-            strArr = Directory.GetFiles(".\\" + dirName, "Directory");
+            strArr = Directory.GetFiles(Path.Combine(".", dirName), "Directory");
             iCountTestcases++;
             if (strArr.Length != 0)
             {
@@ -365,8 +365,8 @@ public class Directory_GetFiles_str_str
                 printerr("Error_209v7! Incorrect number of files==" + strArr.Length);
             }
 
-            new FileInfo(dir2.FullName + "\\" + "TestDir1\\Test.tmp").Create();
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName, "TestDir1\\*");
+            new FileInfo(Path.Combine(dir2.FullName, Path.Combine("TestDir1", "Test.tmp"))).Create();
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), Path.Combine("TestDir1", "*"));
             iCountTestcases++;
             if (strArr.Length != 1)
             {

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str_str_so.cs
@@ -86,7 +86,7 @@ public class Directory_GetFiles_str_str_so
             /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
             try
             {
-                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), ManageFileSystem.DirPrefixName);
                 using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
                 {
                     expectedFiles = fileManager.GetFiles(dirName, 0);
@@ -107,7 +107,7 @@ public class Directory_GetFiles_str_str_so
                     }
                 }
                 //only 1 level
-                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), ManageFileSystem.DirPrefixName);
                 dirName = Path.GetFullPath(dirName);
                 using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 1, 10))
                 {
@@ -349,7 +349,7 @@ public class Directory_GetFiles_str_str_so
                     }
                 }
                 //path too long
-                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(String.Format("{0}\\{1}", new String('a', 100), new String('b', 200)), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_927gs! wrong exception thrown"));
+                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(Path.Combine(new String('a', 100), new String('b', 200)), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_927gs! wrong exception thrown"));
                 CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(new String('a', 100), new String('b', 200), SearchOption.TopDirectoryOnly); }, String.Format("Err_213aka! wrong exception thrown"));
             }
             catch (Exception ex)
@@ -420,7 +420,7 @@ public class Directory_GetFiles_str_str_so
             /* Scenario disabled when porting because it modifies the filesystem outside of the test's working directory
             try
             {
-                dirName = ManageFileSystem.GetNonExistingDir(@"\", ManageFileSystem.DirPrefixName);
+                dirName = ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), ManageFileSystem.DirPrefixName);
                 using (ManageFileSystem fileManager = new ManageFileSystem(dirName, 3, 100))
                 {
                     expectedFiles = fileManager.GetAllFiles();

--- a/src/System.IO.FileSystem/tests/Directory/Modify_FailSafe.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Modify_FailSafe.cs
@@ -98,7 +98,7 @@ public class Directory_Modify_FailSafe
 
 
         // Test DirectoryInfo.Name on something like "c:\bar\"
-        DirectoryInfo subDir = new DirectoryInfo(Path.Combine(di.Name, "bar\\"));
+        DirectoryInfo subDir = new DirectoryInfo(Path.Combine(di.Name, "bar") + Path.DirectorySeparatorChar);
         if (!subDir.Name.Equals("bar"))
             throw new Exception("Subdirectory name was wrong.  Expected bar, Got: " + subDir.Name);
 
@@ -112,14 +112,15 @@ public class Directory_Modify_FailSafe
         if (!rootName.Equals(root.Name))
             throw new Exception(String.Format("Root directory name was wrong!  rootName: {0}  DI.Root.Name: {1}", rootName, root.Name));
 
-        // Test DirectoryInfo behavior for "c:\"
-        DirectoryInfo c = new DirectoryInfo("c:\\");
-        if (!"c:\\".Equals(c.Name))
-            throw new Exception("DirectoryInfo name for c:\\ was wrong!  got: " + c.Name);
-        if (!"c:\\".Equals(c.FullName))
-            throw new Exception("DirectoryInfo FullName for c:\\ was wrong!  got: " + c.FullName);
+        // Test DirectoryInfo behavior for the root
+        string rootPath = root.FullName;
+        DirectoryInfo c = new DirectoryInfo(rootPath);
+        if (!rootPath.Equals(c.Name))
+            throw new Exception("DirectoryInfo name for root was wrong!  got: " + c.Name);
+        if (!rootPath.Equals(c.FullName))
+            throw new Exception("DirectoryInfo FullName for root was wrong!  got: " + c.FullName);
         if (null != c.Parent)
-            throw new Exception("DirectoryInfo::Parent for c:\\ is not null!");
+            throw new Exception("DirectoryInfo::Parent for root is not null!");
 
         FailSafeDirectoryOperations.DeleteDirectoryInfo(di, true);
         di.Refresh();
@@ -228,7 +229,7 @@ public class Directory_Modify_FailSafe
             throw new Exception("Found[0] wasn't files[2] when listing c*!  got: " + found[0]);
 
         // Copy then delete a file to make sure it's gone.
-        File.Copy(dir + "\\" + s_files[0], dir.FullName + "\\newfile.new");
+        File.Copy(Path.Combine(dir.ToString(), s_files[0]), Path.Combine(dir.FullName, "newfile.new"));
         found = dir.GetFiles("new*.new");
         if (found.Length != 1)
             throw new Exception("Didn't find copied file!");
@@ -242,7 +243,7 @@ public class Directory_Modify_FailSafe
         String curDir = Directory.GetCurrentDirectory();
         if (curDir == null)
             throw new Exception("Ack! got null string from get current directory");
-        String newDir = Path.Combine(curDir, dirName); //curDir+'\\'+dirName;
+        String newDir = Path.Combine(curDir, dirName);
         Directory.SetCurrentDirectory(newDir);
         if (!newDir.Equals(Directory.GetCurrentDirectory()))
             throw new Exception("Ack!  new directory didn't equal getcwd!  " + Directory.GetCurrentDirectory());
@@ -408,7 +409,7 @@ public class Directory_Modify_FailSafe
     public static void GetSubdirectoriesTest()
     {
         String testDir = "GetSubdirectoriesTempDir";
-        if (Directory.Exists("." + Path.DirectorySeparatorChar + testDir))
+        if (Directory.Exists(Path.Combine(".", testDir)))
         {
             Console.WriteLine("Test didn't clean up right, trying to delete directory \"" + testDir + "\"");
             try

--- a/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
@@ -182,7 +182,7 @@ public class Directory_Move_str_str
             //-----------------------------------------------------------------
 
             Directory.CreateDirectory(dirName);
-            Directory.Move(dirName + "\\", tempDirName + "\\");
+            Directory.Move(dirName + Path.DirectorySeparatorChar, tempDirName + Path.DirectorySeparatorChar);
             iCountTestcases++;
             if (Directory.Exists(dirName))
             {
@@ -231,7 +231,7 @@ public class Directory_Move_str_str
             strLoc = "Loc_00028";
 
             dir2 = Directory.CreateDirectory(dirName);
-            dir2.CreateSubdirectory("SubDir\\SubSubDir");
+            dir2.CreateSubdirectory(Path.Combine("SubDir", "SubSubDir"));
             FailSafeDirectoryOperations.MoveDirectory(dirName, tempDirName);
             //			Directory.Move(dirName, tempDirName);
             iCountTestcases++;
@@ -248,7 +248,7 @@ public class Directory_Move_str_str
                 printerr("Error_00030! Destination directory missing");
             }
             iCountTestcases++;
-            if (!Directory.Exists(dir2.FullName + "\\SubDir\\SubSubDir"))
+            if (!Directory.Exists(Path.Combine(dir2.FullName, "SubDir", "SubSubDir")))
             {
                 iCountErrors++;
                 printerr("Error_00031! Subdirectories not moved");

--- a/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
@@ -47,7 +47,7 @@ public class Directory_ReparsePoints_MountVolume
                 string otherDriveInMachine = IOServices.GetNtfsDriveOtherThanCurrent();
                 if (FileSystemDebugInfo.IsCurrentDriveNTFS() && otherDriveInMachine != null)
                 {
-                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), MountPrefixName));
                     try
                     {
                         Console.WriteLine("Creating directory " + mountedDirName);
@@ -201,7 +201,7 @@ public class Directory_ReparsePoints_MountVolume
             {
                 if (FileSystemDebugInfo.IsCurrentDriveNTFS())
                 {
-                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(@"\", MountPrefixName));
+                    mountedDirName = Path.GetFullPath(ManageFileSystem.GetNonExistingDir(Path.DirectorySeparatorChar.ToString(), MountPrefixName));
                     try
                     {
                         Directory.CreateDirectory(mountedDirName);

--- a/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
@@ -89,8 +89,9 @@ public class Directory_Co5736SetCurrentDirectory_dir
 
             strLoc = "Loc_9t8gt";
 
-            dir = new DirectoryInfo("c:\\");
-            Directory.SetCurrentDirectory("c:\\");
+            string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+            dir = new DirectoryInfo(root);
+            Directory.SetCurrentDirectory(root);
             iCountTestcases++;
             if (!Directory.GetCurrentDirectory().Equals(dir.FullName))
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -22,7 +22,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void CreateCurrentDirectoryWithRelativeTraversal()
         {
-            DirectoryInfo dir = new DirectoryInfo(Path.Combine(TestDirectory, "abc\\xyz\\..\\.."));
+            DirectoryInfo dir = new DirectoryInfo(Path.Combine(TestDirectory, "abc", "xyz", "..", ".."));
             dir.Create();
             Assert.Equal(dir.FullName, TestDirectory);
         }
@@ -67,7 +67,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void PathJustTooLong()
         {
-            StringBuilder sb = new StringBuilder(TestDirectory + "\\");
+            StringBuilder sb = new StringBuilder(TestDirectory + Path.DirectorySeparatorChar);
             while (sb.Length < 248)
             {
                 sb.Append("a");
@@ -81,7 +81,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void PathJustShortEnough()
         {
-            StringBuilder sb = new StringBuilder(TestDirectory + "\\");
+            StringBuilder sb = new StringBuilder(TestDirectory + Path.DirectorySeparatorChar);
             while (sb.Length < 247)
             {
                 sb.Append("a");

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
@@ -107,7 +107,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void MultipleNewDirectories()
         {
-            string subdirName = "Test\\Test\\Test";
+            string subdirName = Path.Combine("Test", "Test", "Test");
 
             DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(subdirName);
 
@@ -128,7 +128,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void NetworkName()
         {
-            Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory("\\\\contoso\\amusement\\device"));
+            Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("contoso", "amusement", "device")));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Delete.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Delete.cs
@@ -41,7 +41,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void DeleteRoot()
         {
-            Assert.Throws<IOException>(() => new DirectoryInfo("C:\\").Delete());
+            Assert.Throws<IOException>(() => new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory())).Delete());
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -134,7 +134,7 @@ namespace System.IO.FileSystem.Tests
         public void FalseForFile()
         {
             string fileName = GetTestFilePath();
-            File.Create(fileName);
+            File.Create(fileName).Dispose();
             DirectoryInfo di = new DirectoryInfo(fileName);
             Assert.False(di.Exists);
         }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories.cs
@@ -94,8 +94,8 @@ public class DirectoryInfo_GetDirectories
                 printerr("Error_879by! Incorrect name==" + dirArr[2].Name);
             }
 
-            Directory.Delete(dirName + "\\TestDir3");
-            Directory.Delete(dirName + "\\TestDir2");
+            Directory.Delete(Path.Combine(dirName, "TestDir3"));
+            Directory.Delete(Path.Combine(dirName, "TestDir2"));
 
             dirArr = dir2.GetDirectories();
             iCountTestcases++;
@@ -141,7 +141,7 @@ C:\wd\bar\abc
             int dirSuffixNo = 0;
             while (Directory.Exists(String.Format("{0}{1}", rootTempDir, dirSuffixNo++))) ;
             rootTempDir = String.Format("{0}{1}", rootTempDir, (dirSuffixNo - 1));
-            String tempFullName = String.Format(@"{0}\laks1\laks2", rootTempDir);
+            String tempFullName = Path.Combine(rootTempDir, "laks1", "laks2");
             Directory.CreateDirectory(tempFullName);
             DirectoryInfo dir = new DirectoryInfo(rootTempDir);
             AddFolders(dir);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str.cs
@@ -160,8 +160,8 @@ public class DirectoryInfo_GetDirectories_str
             dir2.CreateSubdirectory("Test1Dir1");
             dir2.CreateSubdirectory("Test1Dir2");
             FileStream[] fs = new FileStream[2];
-            fs[0] = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            fs[1] = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
+            fs[0] = new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            fs[1] = new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
             for (int iLoop = 0; iLoop < 2; iLoop++)
                 fs[iLoop].Dispose();
 
@@ -179,7 +179,7 @@ public class DirectoryInfo_GetDirectories_str
             String[] names = new String[dirA.Length];
             int i = 0;
             foreach (DirectoryInfo f in dirA)
-                names[i++] = f.FullName.Substring(f.FullName.LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f.FullName);
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1Dir1") < 0)
             {
@@ -211,8 +211,8 @@ public class DirectoryInfo_GetDirectories_str
                 printerr("Error_190vh! Incorrect name==" + dirA[4].ToString());
             }
 
-            Directory.Delete(dirName + "\\TestDir2");
-            Directory.Delete(dirName + "\\TestDir3");
+            Directory.Delete(Path.Combine(dirName, "TestDir2"));
+            Directory.Delete(Path.Combine(dirName, "TestDir3"));
 
             dirA = dir2.GetDirectories("*");
             iCountTestcases++;
@@ -224,7 +224,7 @@ public class DirectoryInfo_GetDirectories_str
             names = new String[dirA.Length];
             i = 0;
             foreach (DirectoryInfo f in dirA)
-                names[i++] = f.FullName.Substring(f.FullName.LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f.FullName);
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1Dir1") < 0)
             {
@@ -246,7 +246,7 @@ public class DirectoryInfo_GetDirectories_str
 
             dir1 = new DirectoryInfo(".");
 
-            dirA = dir1.GetDirectories(String.Format("{0}\\*", dirName));
+            dirA = dir1.GetDirectories(Path.Combine(dirName, "*"));
 
             if (dirA.Length != 3)
             {
@@ -256,7 +256,7 @@ public class DirectoryInfo_GetDirectories_str
             names = new String[dirA.Length];
             i = 0;
             foreach (DirectoryInfo f in dirA)
-                names[i++] = f.FullName.Substring(f.FullName.LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f.FullName);
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1Dir1") < 0)
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
@@ -66,10 +66,10 @@ public class DirectoryInfo_GetFileSystemInfos
             new FileInfo(dir2.ToString() + "Test.exe");
 
             FileStream[] fs = new FileStream[4];
-            fs[0] = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            fs[1] = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
-            fs[2] = new FileInfo(dir2.FullName + "\\" + "Test.bat").Create();
-            fs[3] = new FileInfo(dir2.FullName + "\\" + "Test.exe").Create();
+            fs[0] = new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            fs[1] = new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
+            fs[2] = new FileInfo(Path.Combine(dir2.FullName, "Test.bat")).Create();
+            fs[3] = new FileInfo(Path.Combine(dir2.FullName, "Test.exe")).Create();
             for (int iLoop = 0; iLoop < 4; iLoop++)
                 fs[iLoop].Dispose();
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
@@ -133,11 +133,11 @@ public class DirectoryInfo_GetFileSystemInfos_str
             dir2.CreateSubdirectory("TestDir3");
             dir2.CreateSubdirectory("Test1Dir1");
             dir2.CreateSubdirectory("Test1Dir2");
-            new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
-            new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
-            new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
-            new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "TestFile3")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "Test1File1")).Create();
+            new FileInfo(Path.Combine(dir2.FullName, "Test1File2")).Create();
 
             // [] Search criteria ending with '*'
 
@@ -313,8 +313,8 @@ public class DirectoryInfo_GetFileSystemInfos_str
 
             // [] Search criteria Beginning and ending with '*'
 
-            new FileInfo(dir2.FullName + "\\" + "AAABB").Create();
-            Directory.CreateDirectory(dir2.FullName + "\\" + "aaabbcc");
+            new FileInfo(Path.Combine(dir2.FullName, "AAABB")).Create();
+            Directory.CreateDirectory(Path.Combine(dir2.FullName, "aaabbcc"));
 
             fsArr = dir2.GetFileSystemInfos("*BB*");
             iCountTestcases++;
@@ -357,8 +357,8 @@ public class DirectoryInfo_GetFileSystemInfos_str
                 printerr("Error_209v7! Incorrect number of files==" + fsArr.Length);
             }
 
-            new FileInfo(dir2.FullName + "\\" + "TestDir1\\Test.tmp").Create();
-            fsArr = dir2.GetFileSystemInfos("TestDir1\\*");
+            new FileInfo(Path.Combine(dir2.FullName, "TestDir1", "Test.tmp")).Create();
+            fsArr = dir2.GetFileSystemInfos(Path.Combine("TestDir1", "*"));
             iCountTestcases++;
             if (fsArr.Length != 1)
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
@@ -60,10 +60,10 @@ public class DirectoryInfo_GetFiles
             dir2.CreateSubdirectory("TestDir1");
             dir2.CreateSubdirectory("TestDir2");
             dir2.CreateSubdirectory("TestDir3");
-            FileStream fs1 = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            FileStream fs2 = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
-            FileStream fs3 = new FileInfo(dir2.FullName + "\\" + "Test.bat").Create();
-            FileStream fs4 = new FileInfo(dir2.FullName + "\\" + "Test.exe").Create();
+            FileStream fs1 = new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            FileStream fs2 = new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
+            FileStream fs3 = new FileInfo(Path.Combine(dir2.FullName, "Test.bat")).Create();
+            FileStream fs4 = new FileInfo(Path.Combine(dir2.FullName, "Test.exe")).Create();
             fs1.Dispose();
             fs2.Dispose();
             fs3.Dispose();
@@ -107,8 +107,8 @@ public class DirectoryInfo_GetFiles
                 printerr("Error_29894! Incorrect name==" + filArr[3].Name);
             }
 
-            File.Delete(dirName + "\\TestFile1");
-            File.Delete(dirName + "\\TestFile2");
+            File.Delete(Path.Combine(dirName, "TestFile1"));
+            File.Delete(Path.Combine(dirName, "TestFile2"));
 
             filArr = dir2.GetFiles();
             iCountTestcases++;

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str.cs
@@ -117,7 +117,7 @@ public class DirectoryInfo_GetFiles_str
             strLoc = "Loc_4y982";
 
             dir2 = Directory.CreateDirectory(dirName);
-            strArr = Directory.GetFiles(Directory.GetCurrentDirectory() + "\\" + dirName);
+            strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName));
             iCountTestcases++;
             if (strArr.Length != 0)
             {
@@ -136,18 +136,18 @@ public class DirectoryInfo_GetFiles_str
             dir2.CreateSubdirectory("TestDir3");
             dir2.CreateSubdirectory("Test1Dir1");
             dir2.CreateSubdirectory("Test1Dir2");
-            fs[0] = new FileInfo(dir2.FullName + "\\" + "TestFile1").Create();
-            fs[1] = new FileInfo(dir2.FullName + "\\" + "TestFile2").Create();
-            fs[2] = new FileInfo(dir2.FullName + "\\" + "TestFile3").Create();
-            fs[3] = new FileInfo(dir2.FullName + "\\" + "Test1File1").Create();
-            fs[4] = new FileInfo(dir2.FullName + "\\" + "Test1File2").Create();
+            fs[0] = new FileInfo(Path.Combine(dir2.FullName, "TestFile1")).Create();
+            fs[1] = new FileInfo(Path.Combine(dir2.FullName, "TestFile2")).Create();
+            fs[2] = new FileInfo(Path.Combine(dir2.FullName, "TestFile3")).Create();
+            fs[3] = new FileInfo(Path.Combine(dir2.FullName, "Test1File1")).Create();
+            fs[4] = new FileInfo(Path.Combine(dir2.FullName, "Test1File2")).Create();
             for (int iLoop = 0; iLoop < 5; iLoop++)
                 fs[iLoop].Dispose();
 
             // Get all files
             strLoc = "Loc_4y7gb";
 
-            strArr = Directory.GetFiles(".\\" + dirName);
+            strArr = Directory.GetFiles("." + Path.DirectorySeparatorChar + dirName);
             iCountTestcases++;
             if (strArr.Length != 5)
             {
@@ -158,7 +158,7 @@ public class DirectoryInfo_GetFiles_str
             int i = 0;
             foreach (String f in strArr)
             {
-                names[i++] = f.Substring(f.LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f);
             }
 
             iCountTestcases++;
@@ -193,11 +193,11 @@ public class DirectoryInfo_GetFiles_str
             }
 
             strLoc = "Loc_45500";
-            File.Delete(dirName + "\\TestFile1");
-            File.Delete(dirName + "\\Test1File1");
+            File.Delete(Path.Combine(dirName, "TestFile1"));
+            File.Delete(Path.Combine(dirName, "Test1File1"));
 
             iCountTestcases++;
-            strArr = Directory.GetFiles(".\\" + dirName);
+            strArr = Directory.GetFiles(Path.Combine(".", dirName));
             if (strArr.Length != 3)
             {
                 iCountErrors++;
@@ -206,7 +206,7 @@ public class DirectoryInfo_GetFiles_str
             names = new String[strArr.Length];
             i = 0;
             foreach (String f in strArr)
-                names[i++] = f.Substring(f.LastIndexOf("\\") + 1);
+                names[i++] = Path.GetFileName(f);
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1File2") < 0)
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
@@ -324,7 +324,7 @@ public class DirectoryInfo_Move_str
             iCountTestcases++;
             try
             {
-                dir2.MoveTo(Path.Combine(testDir, "Test\\Test\\Test"));
+                dir2.MoveTo(Path.Combine(testDir, "Test", "Test", "Test"));
                 iCountErrors++;
                 printerr("Error_1039s! Expected exception not thrown");
                 fil2.Delete();
@@ -401,7 +401,7 @@ public class DirectoryInfo_Move_str
             iCountTestcases++;
             try
             {
-                subdir = new DirectoryInfo(Path.Combine(TestInfo.CurrentDirectory, "NewTest5525\\Test5525"));
+                subdir = new DirectoryInfo(Path.Combine(TestInfo.CurrentDirectory, "NewTest5525", "Test5525"));
             }
             catch (Exception exc)
             {
@@ -430,7 +430,7 @@ public class DirectoryInfo_Move_str
             {
                 dir2 = new DirectoryInfo(subDir);
                 dir2.Create();
-                dir2.MoveTo(TestInfo.CurrentDirectory + "\\" + value);
+                dir2.MoveTo(Path.Combine(TestInfo.CurrentDirectory, value));
                 if (!dir2.FullName.Equals(moveDir))
                 {
                     Console.WriteLine("moveDir: <{0}>", moveDir);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -50,9 +50,9 @@ public class DirectoryInfo_ToString
 
             strLoc = "Loc_20u9x";
 
-            dir = new DirectoryInfo("c:\\");
+            dir = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory()));
             iCountTestcases++;
-            if (!dir.ToString().Equals("c:\\"))
+            if (!dir.ToString().Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_2098x! Incorrect dir returned==" + dir.ToString());
@@ -109,7 +109,7 @@ public class DirectoryInfo_ToString
 
             dir = new DirectoryInfo("..");
             iCountTestcases++;
-            if (!dir.FullName.Equals(Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().LastIndexOf("\\"))))
+            if (!dir.FullName.Equals(Path.GetDirectoryName(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_298xy! Incorrect dir returned, dir==" + dir.ToString());

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
@@ -36,9 +36,9 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        public void CDrive()
+        public void RootOath()
         {
-            string dirName = "c:\\";
+            string dirName = Path.GetPathRoot(Directory.GetCurrentDirectory());
             DirectoryInfo dir = new DirectoryInfo(dirName);
             Assert.Equal(dir.FullName, dirName);
         }
@@ -73,15 +73,15 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void NetworkShare()
         {
-            string dirName = "\\\\contoso\\amusement\\device";
+            string dirName = new string(Path.DirectorySeparatorChar, 2) + Path.Combine("contoso", "amusement", "device");
             Assert.Equal(new DirectoryInfo(dirName).FullName, dirName);
         }
 
         [Fact]
         public void TrailingSlash()
         {
-            DirectoryInfo dir1 = new DirectoryInfo("C:\\hello");
-            DirectoryInfo dir2 = new DirectoryInfo("C:\\hello\\");
+            DirectoryInfo dir1 = new DirectoryInfo(Directory.GetCurrentDirectory());
+            DirectoryInfo dir2 = new DirectoryInfo(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar);
 
             Assert.Equal(dir1.Name, dir2.Name);
             Assert.Equal(dir1.Parent.FullName, dir2.Parent.FullName);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_CreationTime.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_CreationTime.cs
@@ -82,7 +82,7 @@ public class DirectoryInfo_get_CreationTime
             dir.Delete(true);
 
             //See VSWhidbey # 92050
-            String path = TestInfo.CurrentDirectory + "\\";
+            String path = TestInfo.CurrentDirectory + Path.DirectorySeparatorChar;
             String tempPath;
             int count = 0;
             while (true)

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_FullName.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_FullName.cs
@@ -66,7 +66,7 @@ public class DirectoryInfo_Co5511get_FullName
 
             iCountTestcases++;
             dir = new DirectoryInfo("This directory does not exist");
-            if (!dir.FullName.Equals(Directory.GetCurrentDirectory() + "\\This directory does not exist"))
+            if (!dir.FullName.Equals(Path.Combine(Directory.GetCurrentDirectory(), "This directory does not exist")))
             {
                 iCountErrors++;
                 printerr("Error_109z9! Incorrect directory name, dir==" + dir.ToString());
@@ -77,9 +77,9 @@ public class DirectoryInfo_Co5511get_FullName
 
             strLoc = "Loc_20u9x";
 
-            dir = new DirectoryInfo("c:\\");
+            dir = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory()));
             iCountTestcases++;
-            if (!dir.FullName.Equals("c:\\"))
+            if (!dir.FullName.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_2098x! Incorrect dir returned==" + dir.FullName);
@@ -89,8 +89,8 @@ public class DirectoryInfo_Co5511get_FullName
 
             strLoc = "Loc_099s8";
 
-            dir = new DirectoryInfo("C:\\");
-            DirectoryInfo dir2 = new DirectoryInfo("C:\\");
+            dir = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory()).ToUpper());
+            DirectoryInfo dir2 = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory()).ToUpper());
 
             iCountTestcases++;
             if (!dir.FullName.Equals(dir2.FullName))
@@ -147,9 +147,9 @@ public class DirectoryInfo_Co5511get_FullName
 
             dir = new DirectoryInfo("..");
             iCountTestcases++;
-            String strParent = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().LastIndexOf("\\"));
-            if (strParent.IndexOf("\\") == -1 && strParent.IndexOf("/") == -1)
-                strParent = strParent + "\\";
+            String strParent = Path.GetDirectoryName(Directory.GetCurrentDirectory());
+            if (strParent.IndexOf(Path.DirectorySeparatorChar) == -1 && strParent.IndexOf(Path.AltDirectorySeparatorChar) == -1)
+                strParent = strParent + Path.DirectorySeparatorChar;
             if (!dir.FullName.Equals(strParent))
             {
                 iCountErrors++;

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Name.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Name.cs
@@ -40,7 +40,7 @@ public class DirectoryInfo_get_Name
 
             iCountTestcases++;
             dir2 = new DirectoryInfo(".");
-            if (!dir2.Name.Equals(Directory.GetCurrentDirectory().Substring(Directory.GetCurrentDirectory().LastIndexOf("\\") + 1)))
+            if (!dir2.Name.Equals(Path.GetFileName(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_69v8j! Incorrect Name on directory, dir2.Name==" + dir2.Name);
@@ -48,7 +48,7 @@ public class DirectoryInfo_get_Name
 
             iCountTestcases++;
             dir2 = new DirectoryInfo(Directory.GetCurrentDirectory());
-            if (!dir2.Name.Equals(Directory.GetCurrentDirectory().Substring(Directory.GetCurrentDirectory().LastIndexOf("\\") + 1)))
+            if (!dir2.Name.Equals(Path.GetFileName(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_97t67! Incorrect Name on directory, dir2.Name==" + dir2.Name);
@@ -61,7 +61,7 @@ public class DirectoryInfo_get_Name
             //-----------------------------------------------------------------
             strLoc = "Loc_99084";
 
-            dir2 = new DirectoryInfo("\\\\contoso\\amusement\\device");
+            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("contoso", "amusement", "device"));
             if (!dir2.Name.Equals("device"))
             {
                 iCountErrors++;
@@ -71,9 +71,9 @@ public class DirectoryInfo_get_Name
             // [] Root directory
 
             iCountTestcases++;
-            dir2 = new DirectoryInfo("C:\\");
+            dir2 = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory()));
 
-            if (!dir2.Name.Equals("C:\\"))
+            if (!dir2.Name.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_50210! Incorrect name==" + dir2.Name);
@@ -87,7 +87,7 @@ public class DirectoryInfo_get_Name
             string currentDir = Directory.GetCurrentDirectory();
             dir2 = new DirectoryInfo(currentDir.ToUpper());
             iCountTestcases++;
-            if (!dir2.Name.Equals(currentDir.Substring(currentDir.LastIndexOf("\\") + 1).ToUpper()))
+            if (!dir2.Name.Equals(Path.GetFileName(currentDir).ToUpper()))
             {
                 iCountErrors++;
                 Console.WriteLine(dir2.Name);
@@ -96,7 +96,7 @@ public class DirectoryInfo_get_Name
 
             dir2 = new DirectoryInfo(currentDir.ToLower());
             iCountTestcases++;
-            if (!dir2.Name.Equals(currentDir.Substring(currentDir.LastIndexOf("\\") + 1).ToLower()))
+            if (!dir2.Name.Equals(Path.GetFileName(currentDir).ToLower()))
             {
                 iCountErrors++;
                 Console.WriteLine(dir2.Name);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Parent.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Parent.cs
@@ -42,7 +42,7 @@ public class DirectoryInfo_get_Parent
 
             strLoc = "Loc_49b78";
 
-            dir2 = new DirectoryInfo("C:\\").Parent;
+            dir2 = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory())).Parent;
             iCountTestcases++;
             if (dir2 != null)
             {
@@ -54,7 +54,7 @@ public class DirectoryInfo_get_Parent
 
             strLoc = "Loc_98ygg";
 
-            dir2 = new DirectoryInfo("\\Machine\\Test").Parent;
+            dir2 = new DirectoryInfo(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test")).Parent;
             str2 = dir2.Name;
             iCountTestcases++;
             if (!str2.Equals("Machine"))
@@ -67,7 +67,7 @@ public class DirectoryInfo_get_Parent
 
             strLoc = "Loc_yg7bk";
 
-            dir2 = new DirectoryInfo("\\\\Machine\\Test").Parent;
+            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")).Parent;
             iCountTestcases++;
             if (dir2 != null)
             {
@@ -79,10 +79,10 @@ public class DirectoryInfo_get_Parent
             // [] Get parent of directory string ending with \
 
             strLoc = "Loc_9876b";
-            dir2 = new DirectoryInfo("X:\\a\\b\\c\\d").Parent;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "a") + Path.DirectorySeparatorChar).Parent;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\a\\b\\c"))
+            if (!str2.Equals(Directory.GetCurrentDirectory()))
             {
                 iCountErrors++;
                 printerr("Error_298yg! Unexpected parent==" + str2);
@@ -91,11 +91,11 @@ public class DirectoryInfo_get_Parent
             // [] Get parent of nested directories
 
             strLoc = "Loc_75y7b";
-            dir2 = new DirectoryInfo("X:\\a\\b\\c").Parent;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "a")).Parent;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\a\\b"))
-            {
+            if (!str2.Equals(Directory.GetCurrentDirectory()))
+                {
                 iCountErrors++;
                 printerr("Error_9887b! Unexpected parent==" + str2);
             }
@@ -104,10 +104,10 @@ public class DirectoryInfo_get_Parent
 
             strLoc = "Loc_y7t98";
 
-            dir2 = new DirectoryInfo("\\\\Machine\\Test1\\Test2").Parent;
+            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2")).Parent;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("\\\\Machine\\Test1"))
+            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
             {
                 iCountErrors++;
                 printerr("Error_69929! Unexpected parent==" + str2);
@@ -117,10 +117,10 @@ public class DirectoryInfo_get_Parent
 
             strLoc = "Loc_2984y";
 
-            dir2 = new DirectoryInfo("X:\\Test\\..\\.\\Test").Parent;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "Test", "..", ".", "Test")).Parent;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Directory.GetCurrentDirectory()))
             {
                 iCountErrors++;
                 printerr("Error_20928! Unexpected parent==" + str2);
@@ -130,10 +130,10 @@ public class DirectoryInfo_get_Parent
 
             strLoc = "Loc_8y76y";
 
-            dir2 = new DirectoryInfo("X:\\My Samples\\Hello To The World\\Test").Parent;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "My Samples", "Hello To The World", "Test")).Parent;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\My Samples\\Hello To The World"))
+            if (!str2.Equals(Path.Combine(Directory.GetCurrentDirectory(), "My Samples", "Hello To The World")))
             {
                 iCountErrors++;
                 printerr("Error_9019c! Unexpected parent==" + str2);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Root.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Root.cs
@@ -42,10 +42,10 @@ public class DirectoryInfo_get_Root
 
             strLoc = "Loc_49b78";
 
-            dir2 = new DirectoryInfo("C:\\").Root;
+            dir2 = new DirectoryInfo(Path.GetPathRoot(Directory.GetCurrentDirectory())).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("C:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_69y7b! Unexpected parent==" + dir2.FullName);
@@ -55,10 +55,10 @@ public class DirectoryInfo_get_Root
 
             strLoc = "Loc_98ygg";
 
-            dir2 = new DirectoryInfo("\\Machine\\Test").Root;
+            dir2 = new DirectoryInfo(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test")).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            String root = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().IndexOf('\\') + 1);
+            String root = Path.GetPathRoot(Directory.GetCurrentDirectory());
             if (!str2.Equals(root))
             {
                 iCountErrors++;
@@ -69,22 +69,22 @@ public class DirectoryInfo_get_Root
 
             strLoc = "Loc_yg7bk";
 
-            dir2 = new DirectoryInfo("\\\\Machine\\Test").Root;
+            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("\\\\Machine\\Test"))
+            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")))
             {
                 iCountErrors++;
                 printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
             }
 
-            // [] get root of subdirectories endning with \
+            // [] get root of subdirectories ending with \
 
             strLoc = "Loc_9876b";
-            dir2 = new DirectoryInfo("X:\\a\\b\\c\\d\\").Root;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "a") + Path.DirectorySeparatorChar).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_298yg! Unexpected parent==" + str2);
@@ -93,10 +93,10 @@ public class DirectoryInfo_get_Root
             // [] get root of subdirectories
 
             strLoc = "Loc_75y7b";
-            dir2 = new DirectoryInfo("X:\\a\\b\\c").Root;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "a")).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_9887b! Unexpected parent==" + str2);
@@ -107,10 +107,10 @@ public class DirectoryInfo_get_Root
 
             strLoc = "Loc_y7t98";
 
-            dir2 = new DirectoryInfo("\\\\Machine\\Test1\\Test2\\Test3").Root;
+            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2", "Test3")).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("\\\\Machine\\Test1"))
+            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
             {
                 iCountErrors++;
                 printerr("Error_69929! Unexpected parent==" + str2);
@@ -120,10 +120,10 @@ public class DirectoryInfo_get_Root
 
             strLoc = "Loc_2984y";
 
-            dir2 = new DirectoryInfo("X:\\Test\\..\\.\\Test\\Test").Root;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "Test", "..", ".", "Test", "Test")).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_20928! Unexpected parent==" + str2);
@@ -134,10 +134,10 @@ public class DirectoryInfo_get_Root
 
             strLoc = "Loc_8y76y";
 
-            dir2 = new DirectoryInfo("X:\\My Samples\\Hello To The World\\Test").Root;
+            dir2 = new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), "My Samples", "Hello To The World", "Test")).Root;
             str2 = dir2.FullName;
             iCountTestcases++;
-            if (!str2.Equals("X:\\"))
+            if (!str2.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_9019c! Unexpected parent==" + str2);

--- a/src/System.IO.FileSystem/tests/File/Create_str_i.cs
+++ b/src/System.IO.FileSystem/tests/File/Create_str_i.cs
@@ -191,7 +191,7 @@ public class File_Create_str_i
             strLoc = "loc_89tbh_1";
 
             //see VSWhidbey bug 103341
-            filName = String.Format(@"{0}\{1}", TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            filName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
             if (File.Exists(filName))
                 File.Delete(filName);
             fs2 = File.Create(String.Format(" {0}", filName), 100);
@@ -206,7 +206,7 @@ public class File_Create_str_i
             strLoc = "loc_89tbh_3";
 
             //see VSWhidbey bug 103341
-            filName = String.Format(@" {0}\ {1}", TestInfo.CurrentDirectory, Path.GetRandomFileName());
+            filName = Path.Combine(" " + TestInfo.CurrentDirectory, " " + Path.GetRandomFileName());
             if (File.Exists(filName))
                 File.Delete(filName);
             fs2 = File.Create(filName, 100);
@@ -229,7 +229,7 @@ public class File_Create_str_i
                 File.Delete(filName);
             fs2 = File.Create(filName, 100);
             iCountTestcases++;
-            filName = String.Format(@"{0}\{1}", Directory.GetCurrentDirectory(), filName);
+            filName = Path.Combine(Directory.GetCurrentDirectory(), filName);
             if (!File.Exists(filName))
             {
                 iCountErrors++;

--- a/src/System.IO.FileSystem/tests/File/GetAttributes_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetAttributes_str.cs
@@ -73,7 +73,7 @@ public class File_GetAttributes_str
             strLoc = "loc_0015";
 
             iCountTestcases++;
-            String[] paths = { @"\Foo8235378\Bar", "Bar2342385", "c:\\this is a invalid testing directory\\test\\test\\" };
+            String[] paths = { Path.Combine("Foo8235378", "Bar"), "Bar2342385", Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "this is a invalid testing directory", "test", "test") };
             foreach (String path in paths)
             {
                 if (Directory.Exists(path))

--- a/src/System.IO.FileSystem/tests/File/SetAttributes_str_attrs.cs
+++ b/src/System.IO.FileSystem/tests/File/SetAttributes_str_attrs.cs
@@ -74,7 +74,7 @@ public class File_SetAttributes_str_attrs
             iCountTestcases++;
             try
             {
-                File.SetAttributes("c:\\this is a invalid testing directory\\test\\test", FileAttributes.Hidden);
+                File.SetAttributes(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "this is a invalid testing directory", "test", "test"), FileAttributes.Hidden);
                 iCountErrors++;
                 printerr("Error_0006! Expected exception not thrown");
             }

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.IO;
 using System.Collections;
@@ -276,7 +277,7 @@ public class FileInfo_CopyTo_str
             fs2.Dispose();
             fil2 = new FileInfo(filName);
             File.Delete(testFilName);
-            fil1 = fil2.CopyTo(Path.GetDirectoryName(testFilName) + "\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\" + Path.GetFileName(testFilName));
+            fil1 = fil2.CopyTo(Path.GetDirectoryName(testFilName) + string.Concat(Enumerable.Repeat(Path.DirectorySeparatorChar + ".", 90).ToArray()) + Path.DirectorySeparatorChar + Path.GetFileName(testFilName));
             iCountTestcases++;
             if (!fil1.FullName.Equals(testFilName))
             {

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str_b.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str_b.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.IO;
 using System.Collections;
@@ -273,7 +274,7 @@ public class FileInfo_CopyTo_str_b
             fs2 = new FileStream(filName, FileMode.Create);
             fs2.Dispose();
             fil2 = new FileInfo(filName);
-            fil1 = fil2.CopyTo(Path.GetDirectoryName(testFilName) + "\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\" + Path.GetFileName(testFilName), false);
+            fil1 = fil2.CopyTo(Path.GetDirectoryName(testFilName) + string.Concat(Enumerable.Repeat(Path.DirectorySeparatorChar + ".", 90).ToArray()) + Path.DirectorySeparatorChar + Path.GetFileName(testFilName), false);
             iCountTestcases++;
             if (!fil1.FullName.Equals(testFilName))
             {

--- a/src/System.IO.FileSystem/tests/FileInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create.cs
@@ -107,7 +107,7 @@ public class FileInfo_Create
             strLoc = "Loc_09t83";
 
             iCountTestcases++;
-            fileName = Path.Combine(TestInfo.CurrentDirectory, "abc\\..", Path.GetRandomFileName());
+            fileName = Path.Combine(TestInfo.CurrentDirectory, "abc", "..", Path.GetRandomFileName());
             file2 = new FileInfo(fileName);
             try
             {

--- a/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
@@ -110,7 +110,7 @@ public class FileInfo_Create_str
             strLoc = "Loc_09t83";
 
             iCountTestcases++;
-            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "abc\\..\\Test.txt"));
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "abc", "..", "Test.txt"));
             try
             {
                 FileStream fs = file2.Create();
@@ -179,11 +179,11 @@ public class FileInfo_Create_str
             strLoc = "Loc_209ud";
 
             iCountTestcases++;
-            file2 = new FileInfo(TestInfo.CurrentDirectory + "\\" + "Test\\Test\\Test\\test.cs");
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "Test", "Test", "Test", "test.cs"));
             try
             {
                 file2.Create();
-                if (file2.FullName.IndexOf("Test\\Test\\Test") == -1)
+                if (file2.FullName.IndexOf(Path.Combine("Test", "Test", "Test")) == -1)
                 {
                     iCountErrors++;
                     printerr("Error_0010! Unexpected File name :: " + file2.FullName);
@@ -227,7 +227,7 @@ public class FileInfo_Create_str
             strLoc = "Loc_098gt";
 
             iCountTestcases++;
-            file2 = new FileInfo(TestInfo.CurrentDirectory + "abc\\xyz\\..\\..\\test.txt");
+            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory, "abc", "xyz", "..", "..", "test.txt"));
             try
             {
                 FileStream fs = file2.Create();

--- a/src/System.IO.FileSystem/tests/FileInfo/FullName.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/FullName.cs
@@ -32,17 +32,17 @@ public class FileInfo_FullName
             //-----------------------------------------------------------------
             s_strLoc = "Loc_2723d";
 
-            strFileName = "Hello\\file.tmp";
+            strFileName = Path.Combine("Hello", "file.tmp");
             fil2 = new FileInfo(strFileName);
             s_iCountTestcases++;
-            if (!fil2.FullName.Equals(s_strTFPath + "\\" + strFileName))
+            if (!fil2.FullName.Equals(Path.Combine(s_strTFPath, strFileName)))
             {
                 s_iCountErrors++;
                 printerr("Error_5yb87! Incorrect name==" + fil2.FullName);
             }
 
             // [] \Directory\File
-            strFileName = "\\Directory\\File";
+            strFileName = Path.DirectorySeparatorChar + Path.Combine("Directory", "File");
             fil2 = new FileInfo(strFileName);
             s_iCountTestcases++;
             if (fil2.FullName.IndexOf(strFileName) != 2)
@@ -52,7 +52,7 @@ public class FileInfo_FullName
             }
 
             // [] UNC share
-            strFileName = "\\\\Machine\\Directory\\File";
+            strFileName =  new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File");
             fil2 = new FileInfo(strFileName);
             s_iCountTestcases++;
             if (!fil2.FullName.Equals(strFileName))
@@ -62,7 +62,7 @@ public class FileInfo_FullName
             }
 
             // [] Multiple spaces and dots in filename
-            strFileName = "C:\\File.tmp hello.blah";
+            strFileName = Path.Combine(Directory.GetCurrentDirectory(), "File.tmp hello.blah");
             fil2 = new FileInfo(strFileName);
             s_iCountTestcases++;
             if (!fil2.FullName.Equals(strFileName))
@@ -71,11 +71,11 @@ public class FileInfo_FullName
                 printerr("Error_2987b! Incorrect name==" + fil2.FullName);
             }
 
-            strFileName = "C://Directory//File";
+            strFileName = Path.Combine(Directory.GetCurrentDirectory(), "Directory", "File").Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             fil2 = new FileInfo(strFileName);
             s_iCountTestcases++;
 
-            if (!fil2.FullName.Equals("C:\\Directory\\File"))
+            if (!fil2.FullName.Equals(Path.Combine(Directory.GetCurrentDirectory(), "Directory", "File")))
             {
                 s_iCountErrors++;
                 Console.WriteLine("strFileName: " + strFileName);

--- a/src/System.IO.FileSystem/tests/FileInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/ToString.cs
@@ -35,41 +35,41 @@ public class FileInfo_ToString
             //-----------------------------------------------------------------
             s_strLoc = "Loc_2723d";
 
-            fil2 = new FileInfo("Hello\\file.tmp");
+            fil2 = new FileInfo(Path.Combine("Hello", "file.tmp"));
             s_iCountTestcases++;
-            if (!fil2.ToString().Equals("Hello\\file.tmp"))
+            if (!fil2.ToString().Equals(Path.Combine("Hello", "file.tmp")))
             {
                 s_iCountErrors++;
                 printerr("Error_5yb87! Incorrect name==" + fil2.ToString());
             }
 
 
-            fil2 = new FileInfo("\\Directory\\File");
+            fil2 = new FileInfo(Path.DirectorySeparatorChar + Path.Combine("Directory", "File"));
             s_iCountTestcases++;
-            if (!fil2.ToString().Equals("\\Directory\\File"))
+            if (!fil2.ToString().Equals(Path.DirectorySeparatorChar + Path.Combine("Directory", "File")))
             {
                 s_iCountErrors++;
                 printerr("Error_78288! Incorrect name==" + fil2.ToString());
             }
 
-            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
             s_iCountTestcases++;
-            if (!fil2.ToString().Equals("\\\\Machine\\Directory\\File"))
+            if (!fil2.ToString().Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File")))
             {
                 s_iCountErrors++;
                 printerr("Error_67y8b! Incorrect name==" + fil2.ToString());
             }
 
-            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "File.tmp hello.blah"));
             s_iCountTestcases++;
-            if (!fil2.ToString().Equals("C:\\File.tmp hello.blah"))
+            if (!fil2.ToString().Equals(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "File.tmp hello.blah")))
             {
                 s_iCountErrors++;
                 printerr("Error_2987b! Incorrect name==" + fil2.ToString());
             }
-            fil2 = new FileInfo("C://Directory//File");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Directory", "File").Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             s_iCountTestcases++;
-            if (!fil2.ToString().Equals("C://Directory//File"))
+            if (!fil2.ToString().Equals(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Directory", "File").Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)))
             {
                 s_iCountErrors++;
                 printerr("Error_2y78d! Incorrect name==" + fil2.ToString());

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Directory.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Directory.cs
@@ -40,50 +40,50 @@ public class FileInfo_get_Directory
             //-----------------------------------------------------------------
             strLoc = "Loc_2723d";
 
-            fil2 = new FileInfo("Hello\\file.tmp");
+            fil2 = new FileInfo(Path.Combine("Hello", "file.tmp"));
             dir2 = fil2.Directory;
             iCountTestcases++;
-            if (!dir2.FullName.Equals(Directory.GetCurrentDirectory() + "\\Hello"))
+            if (!dir2.FullName.Equals(Path.Combine(Directory.GetCurrentDirectory(), "Hello")))
             {
                 iCountErrors++;
                 printerr("Error_5yb87! Incorrect name==" + dir2.FullName);
             }
 
             // [] Directory string starting with \
-            fil2 = new FileInfo("\\Directory\\File");
+            fil2 = new FileInfo(Path.Combine("Directory", "File"));
             dir2 = fil2.Directory;
             iCountTestcases++;
-            if (!dir2.FullName.Equals(Directory.GetCurrentDirectory().Substring(0, 2) + "\\Directory"))
+            if (!dir2.FullName.Equals(Path.Combine(Directory.GetCurrentDirectory(), "Directory")))
             {
                 iCountErrors++;
                 printerr("Error_78288! Incorrect name==" + dir2.FullName);
             }
 
             // [] UNC share
-            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
             dir2 = fil2.Directory;
             iCountTestcases++;
-            if (!dir2.FullName.Equals("\\\\Machine\\Directory"))
+            if (!dir2.FullName.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory")))
             {
                 iCountErrors++;
                 printerr("Error_67y8b! Incorrect name==" + dir2.FullName);
             }
 
             // [] 
-            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "File.tmp hello.blah"));
             dir2 = fil2.Directory;
             iCountTestcases++;
-            if (!dir2.FullName.Equals("C:\\"))
+            if (!dir2.FullName.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_2987b! Incorrect name==" + dir2.FullName);
             }
 
             // [] C:/Directory/File
-            fil2 = new FileInfo("C:/Directory/File");
+            fil2 = new FileInfo(Path.Combine(Directory.GetCurrentDirectory(), "File").Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             dir2 = fil2.Directory;
             iCountTestcases++;
-            if (!dir2.FullName.Equals("C:\\Directory"))
+            if (!dir2.FullName.Equals(Directory.GetCurrentDirectory()))
             {
                 iCountErrors++;
                 printerr("Error_2y78d! Incorrect name==" + dir2.FullName);
@@ -91,10 +91,10 @@ public class FileInfo_get_Directory
 
 
             // [] Multiple subdireactories
-            fil2 = new FileInfo("C:\\Dir1\\Dir2\\Dir3\\Dir4\\File1");
+            fil2 = new FileInfo(Path.Combine(Directory.GetCurrentDirectory(), "Dir1", "Dir2", "Dir3", "Dir4", "File1"));
             dir2 = fil2.Directory;
             iCountTestcases++;
-            if (!dir2.FullName.Equals("C:\\Dir1\\Dir2\\Dir3\\Dir4"))
+            if (!dir2.FullName.Equals(Path.Combine(Directory.GetCurrentDirectory(), "Dir1", "Dir2", "Dir3", "Dir4")))
             {
                 iCountErrors++;
                 printerr("Error_283fy! Incorrect name==" + dir2.FullName);

--- a/src/System.IO.FileSystem/tests/FileInfo/get_DirectoryName.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_DirectoryName.cs
@@ -40,45 +40,45 @@ public class FileInfo_get_DirectoryName
             //-----------------------------------------------------------------
             strLoc = "Loc_2723d";
 
-            fil2 = new FileInfo("Hello\\file.tmp");
+            fil2 = new FileInfo(Path.Combine("Hello", "file.tmp"));
             iCountTestcases++;
-            if (!fil2.DirectoryName.Equals(Directory.GetCurrentDirectory() + "\\Hello"))
+            if (!fil2.DirectoryName.Equals(Path.Combine(Directory.GetCurrentDirectory(), "Hello")))
             {
                 iCountErrors++;
                 printerr("Error_5yb87! Incorrect name==" + fil2.DirectoryName);
             }
 
             // [] \Directory\File
-            fil2 = new FileInfo("\\Directory\\File");
+            fil2 = new FileInfo(Path.DirectorySeparatorChar + Path.Combine("Directory", "File"));
             iCountTestcases++;
-            if (!fil2.DirectoryName.Equals(Directory.GetCurrentDirectory().Substring(0, 2) + "\\Directory"))
+            if (!fil2.DirectoryName.Equals(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Directory")))
             {
                 iCountErrors++;
                 printerr("Error_78288! Incorrect name==" + fil2.DirectoryName);
             }
 
             // [] UNC share
-            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
             iCountTestcases++;
-            if (!fil2.DirectoryName.Equals("\\\\Machine\\Directory"))
+            if (!fil2.DirectoryName.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory")))
             {
                 iCountErrors++;
                 printerr("Error_67y8b! Incorrect name==" + fil2.DirectoryName);
             }
 
             // [] Names with spaces
-            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "File.tmp hello.blah"));
             iCountTestcases++;
-            if (!fil2.DirectoryName.Equals("C:\\"))
+            if (!fil2.DirectoryName.Equals(Path.GetPathRoot(Directory.GetCurrentDirectory())))
             {
                 iCountErrors++;
                 printerr("Error_2987b! Incorrect name==" + fil2.DirectoryName);
             }
 
             // [] C:/Directory/File
-            fil2 = new FileInfo("C:/Directory/File");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Directory", "File").Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             iCountTestcases++;
-            if (!fil2.DirectoryName.Equals("C:\\Directory"))
+            if (!fil2.DirectoryName.Equals(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Directory")))
             {
                 iCountErrors++;
                 printerr("Error_2y78d! Incorrect name==" + fil2.DirectoryName);
@@ -94,9 +94,9 @@ public class FileInfo_get_DirectoryName
             */
 
             // [] Multiple Subdirectories
-            fil2 = new FileInfo("C:\\Dir1\\Dir2\\Dir3\\Dir4\\File1");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Dir1", "Dir2", "Dir3", "Dir4", "File1"));
             iCountTestcases++;
-            if (!fil2.DirectoryName.Equals("C:\\Dir1\\Dir2\\Dir3\\Dir4"))
+            if (!fil2.DirectoryName.Equals(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "Dir1", "Dir2", "Dir3", "Dir4")))
             {
                 iCountErrors++;
                 printerr("Error_283fy! Incorrect name==" + fil2.DirectoryName);

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Name.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Name.cs
@@ -35,7 +35,7 @@ public class FileInfo_get_Name
             //-----------------------------------------------------------------
             s_strLoc = "Loc_2723d";
 
-            fil2 = new FileInfo("Hello\\file.tmp");
+            fil2 = new FileInfo(Path.Combine("Hello", "file.tmp"));
             s_iCountTestcases++;
             if (!fil2.Name.Equals("file.tmp"))
             {
@@ -45,7 +45,7 @@ public class FileInfo_get_Name
 
 
             // [] \Directory\File
-            fil2 = new FileInfo("\\Directory\\File");
+            fil2 = new FileInfo(Path.DirectorySeparatorChar + Path.Combine("Directory", "File"));
             s_iCountTestcases++;
             if (!fil2.Name.Equals("File"))
             {
@@ -55,7 +55,7 @@ public class FileInfo_get_Name
 
 
             // [] UNC share
-            fil2 = new FileInfo("\\\\Machine\\Directory\\File");
+            fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
             s_iCountTestcases++;
             if (!fil2.Name.Equals("File"))
             {
@@ -64,7 +64,7 @@ public class FileInfo_get_Name
             }
 
             // [] Multiple spaces and dots in filename
-            fil2 = new FileInfo("C:\\File.tmp hello.blah");
+            fil2 = new FileInfo(Path.Combine(Path.GetPathRoot(Directory.GetCurrentDirectory()), "File.tmp hello.blah"));
             s_iCountTestcases++;
             if (!fil2.Name.Equals("File.tmp hello.blah"))
             {

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -23,7 +23,7 @@ internal static class IOInputs
     {
         yield return Path.GetRandomFileName();
         yield return "!@#$%^&";
-        yield return "\x65e5\x672c\x8a9e";
+        // yield return "\x65e5\x672c\x8a9e"; // TODO: Issue #846
         yield return "A";
         yield return " A";
         yield return "  A";
@@ -59,50 +59,31 @@ internal static class IOInputs
 
     public static IEnumerable<string> GetUncPathsWithoutShareName()
     {
-        yield return @"\\";
-        yield return @"\\ ";
-        yield return @"\\\\\\\\\\\\";
-        yield return @"\\S";
-        yield return @"\\S ";
-        yield return @"\\Server";
-        yield return @"\\Server \";
-        yield return @"\\Server \\";
-        yield return @"\\Server\ ";
-        yield return @"\\Server\\ ";
-
-        // check alt dir seperator character as well
-        yield return @"//";
-        yield return @"// ";
-        yield return @"////////////";
-        yield return @"//S";
-        yield return @"//S ";
-        yield return @"//Server";
-        yield return @"//Server /";
-        yield return @"//Server //";
-        yield return @"//Server/ ";
-        yield return @"//Server// ";
+        foreach (char slash in new[] { Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar })
+        {
+            string slashes = new string(slash, 2);
+            yield return slashes;
+            yield return slashes + " ";
+            yield return slashes + new string(slash, 5);
+            yield return slashes + "S";
+            yield return slashes + "S ";
+            yield return slashes + "Server";
+            yield return slashes + "Server " + slash;
+            yield return slashes + "Server " + new string(slash, 2);
+            yield return slashes + "Server" + slash + " ";
+            yield return slashes + "Server" + slash + slash + " ";
+        }
     }
 
     public static IEnumerable<string> GetPathsWithReservedDeviceNames()
     {
+        string root = Path.GetPathRoot(Directory.GetCurrentDirectory());
         foreach (string deviceName in GetReservedDeviceNames())
         {
             yield return deviceName;
-        }
-
-        foreach (string deviceName in GetReservedDeviceNames())
-        {
-            yield return @"C:\" + deviceName;
-        }
-
-        foreach (string deviceName in GetReservedDeviceNames())
-        {
-            yield return @"C:\Directory\" + deviceName;
-        }
-
-        foreach (string deviceName in GetReservedDeviceNames())
-        {
-            yield return @"\\Server\" + deviceName;
+            yield return Path.Combine(root, deviceName);
+            yield return Path.Combine(root, "Directory", deviceName);
+            yield return Path.Combine(new string(Path.DirectorySeparatorChar, 2), "Server", deviceName);
         }
     }
 

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -102,14 +102,14 @@ internal class IOServices
     public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent = IOInputs.MaxComponent)
     {
         List<string> paths = new List<string>();
-        rootPath = rootPath.TrimEnd('\\', '/');
+        rootPath = rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         StringBuilder path = new StringBuilder(characterCount);
         path.Append(rootPath);
 
         while (path.Length < characterCount)
         {
-            path.Append('\\');
+            path.Append(Path.DirectorySeparatorChar);
             if (path.Length == characterCount)
                 break;
 


### PR DESCRIPTION
The FileSystem tests are a mess, especially on Unix.  Before the File/Directory/etc. tests got checked in, the FileSystem tests (which then were really only for FileStream and were fairly clean) could run on Unix, with 25 of the 360 tests failing due primarily to lack of support for FileShare options.  Now, with ~575 tests, when run on Unix more than 300 fail, runtime assertions occur in multiple places (due to globalization issues), and worst, all of the files in the working directory end up getting deleted.

This commit has a first set of fixes, primarily involving ensuring that paths are specified appropriately, with hundreds of changes to ensure that the right path separator is used, that particular roots aren't assumed, etc.  After this commit, on Unix we're down from > 300 failures to 114 failures, and the suite is able to finish running without deleting the working directory.

There's still more work to be done after this, but I wanted to get these fixes committed before continuing on.