### PR TITLE
Backslash on Unix is a valid path character- need to fix up separators b...

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,23 +2,23 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00026</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00029</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
-    <SourceDir>$(ProjectDir)src\</SourceDir>
+    <SourceDir>$(ProjectDir)src/</SourceDir>
 
     <!-- Output directories -->
-    <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin\</BinDir>
-    <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj\</ObjDir>
-    <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests\</TestWorkingDir>
-    <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages\</PackagesOutDir>
+    <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
+    <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
+    <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
+    <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
     
     <!-- Input Directories -->
-    <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir)packages\</PackagesDir>
-    <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
+    <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir)packages/</PackagesDir>
+    <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)/lib/</ToolsDir>
   </PropertyGroup>
 
   <!-- Common nuget properties -->

--- a/dir.targets
+++ b/dir.targets
@@ -50,9 +50,13 @@
                   Address="https://www.nuget.org/nuget.exe"
                   Condition="!Exists('$(NuGetToolPath)')" />
 
+    <PropertyGroup>
+      <_RestoreBuildToolsCommand>$(NugetRestoreCommand) "$(SourceDir).nuget/packages.config"</_RestoreBuildToolsCommand>
+    </PropertyGroup>
+
     <!-- Restore build tools -->
-    <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget\packages.config&quot;" StandardOutputImportance="Low" />
-    
+    <Exec Command="$(_RestoreBuildToolsCommand)" StandardOutputImportance="Low" />
+
     <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
 

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00026" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00029" />
 </packages>


### PR DESCRIPTION
Backslash on Unix is a valid path character- need to fix up separators before invoking.