### PR TITLE
Restrict input properties to the build

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -45,6 +45,19 @@
   debug configurations, and to Release for any of the release configurations.
   -->
 
+  <ItemGroup>
+    <AllowableOSs Include="Windows_NT" />
+    <AllowableOSs Include="Linux" />
+    <AllowableOSs Include="OSX" />
+  </ItemGroup>
+  <ItemGroup>
+    <AllowableConfigurations Include="Debug" />
+    <AllowableConfigurations Include="Release" />
+  </ItemGroup>
+  <ItemGroup>
+    <AllowablePlatforms Include="AnyCPU" />
+  </ItemGroup>
+  
   <!-- Set default Configuration and Platform -->
   <PropertyGroup>
     <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>

--- a/dir.targets
+++ b/dir.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" InitialTargets="_RestoreBuildToolsWrapper" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" InitialTargets="_RestoreBuildToolsWrapper;CheckProperties" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
   <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
@@ -69,5 +69,20 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
 
   <Target Name="Test" />
+  
+  <Target Name="CheckProperties">
+    <ItemGroup>
+        <MatchedOSs Include="%(AllowableOSs.Identity)" Condition="'%(AllowableOSs.Identity)' == '$(OS)'" />
+    </ItemGroup>
+    <ItemGroup>
+        <MatchedConfigurations Include="%(AllowableConfigurations.Identity)" Condition="'%(AllowableConfigurations.Identity)' == '$(Configuration)'" />
+    </ItemGroup>
+    <ItemGroup>
+        <MatchedPlatforms Include="%(AllowablePlatforms.Identity)" Condition="'%(AllowablePlatforms.Identity)' == '$(Platform)'" />
+    </ItemGroup>
+    <Error Condition="'@(MatchedOSs)' == ''" Text="OS=$(OS) not allowed, valid values are: @(AllowableOSs)" />
+    <Error Condition="'@(MatchedConfigurations)' == ''" Text="Configuration=$(Configuration) not allowed, valid values are: @(AllowableConfigurations)" />
+    <Error Condition="'@(MatchedPlatforms)' == ''" Text="Platform=$(Platform) not allowed, valid values are: @(AllowablePlatforms)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
We should restrict the OS, Configuration, and Platform input properties based on allowable values to avoid user error (example, passing OS=Unix vs. OS=Linux).

Addresses #1243 
cc @richlander 