### PR TITLE
Fix Issue#566 and unblock PR#1201.

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/Helpers.cs
+++ b/src/Microsoft.Win32.Registry/tests/Helpers.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    internal static class Helpers
+    {
+        [DllImport("api-ms-win-core-registry-l2-1-0.dll", CharSet = CharSet.Unicode, EntryPoint = "RegSetValueW", SetLastError = true)]
+        private static extern int RegSetValue(SafeRegistryHandle handle, string value, int regType, string sb, int sizeIgnored);
+
+        internal const string _DefaultValue = "default";
+
+        internal static bool SetDefaultValue(this RegistryKey key)
+        {
+            const int REG_SZ = 1;
+            return RegSetValue(key.Handle, null, REG_SZ, _DefaultValue, 0) == 0;
+        }
+
+        [DllImport("api-ms-win-core-registry-l1-1-0.dll", CharSet = CharSet.Unicode, EntryPoint = "RegQueryValueExW", SetLastError = true)]
+        private static extern int RegQueryValueEx(SafeRegistryHandle handle, string valueName, int[] reserved, IntPtr regType, [Out] byte[] value, ref int size);
+
+        internal static bool IsDefaultValueSet(this RegistryKey key)
+        {
+            const int ERROR_FILE_NOT_FOUND = 2;
+            byte[] b = new byte[4];
+            int size = 4;
+            return RegQueryValueEx(key.Handle, null, null, IntPtr.Zero, b, ref size) != ERROR_FILE_NOT_FOUND;
+        }
+    }
+
+}

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Registry\Registry_Getvalue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj_valuekind.cs" />
+    <Compile Include="Helpers.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Win32.RegistryTests
                 _rk1.DeleteSubKeyTree(_testKeyName);
             if (_rk1.GetValue(_testKeyName) != null)
                 _rk1.DeleteValue(_testKeyName);
+            _rk2 = _rk1.CreateSubKey(_testKeyName);
         }
 
         public RegistryKey_GetValue_str()
@@ -36,19 +37,9 @@ namespace Microsoft.Win32.RegistryTests
         [Fact]
         public void Test01()
         {
-            // [] Passing in null should return null
-            //Update: we now return the default value here
-
-            _rk1 = Microsoft.Win32.Registry.CurrentUser;
-
-            try
-            {
-                Object ol = _rk1.GetValue(null);
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, "Err_2121 Unexpected exception :: " + e.Message);
-            }
+            Assert.True(_rk2.SetDefaultValue());
+            Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(null));
+            Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(String.Empty));
         }
 
         [Fact]
@@ -67,8 +58,6 @@ namespace Microsoft.Win32.RegistryTests
         public void Test03()
         {
             // [] Vanilla case , add a  bunch different objects, then get them
-
-            _rk2 = _rk1.CreateSubKey(_testKeyName);
 
             Random rand = new Random(-55);
 
@@ -111,8 +100,6 @@ namespace Microsoft.Win32.RegistryTests
         {
             // [] Getting back a string
 
-            _rk2 = _rk1.CreateSubKey(_testKeyName);
-
             String str = "Here is a little test string";
             _rk2.SetValue(_testStringName, str);
             if (!_rk2.GetValue(_testStringName).Equals(str))
@@ -130,8 +117,6 @@ namespace Microsoft.Win32.RegistryTests
             ubArr[0] = 1;
             ubArr[1] = 2;
             ubArr[2] = 3;
-
-            _rk2 = _rk1.CreateSubKey(_testKeyName);
 
             // [] Getting byte array
             _rk2.SetValue("UBArr", ubArr);
@@ -159,8 +144,6 @@ namespace Microsoft.Win32.RegistryTests
         public void RegistryKeySetValueMultiStringRoundTrips()
         {
             // [] Getting a string array
-
-            _rk2 = _rk1.CreateSubKey(_testKeyName);
 
             String[] strArr = new String[3];
             strArr[0] = "Her kommer nissen";

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Win32.RegistryTests
                 _rk1.DeleteSubKeyTree(_testKeyName);
             if (_rk1.GetValue(_testKeyName) != null)
                 _rk1.DeleteValue(_testKeyName);
+            _rk2 = _rk1.CreateSubKey(_testKeyName);
         }
 
         public RegistryKey_GetValue_str_obj()
@@ -34,12 +35,15 @@ namespace Microsoft.Win32.RegistryTests
         [Fact]
         public void Test01()
         {
-            // [] Null arguments should be ignored
+            if (!_rk2.IsDefaultValueSet())
+            {
+                Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(null, Helpers._DefaultValue));
+                Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(string.Empty, Helpers._DefaultValue));
+            }
 
-            _rk1 = Microsoft.Win32.Registry.CurrentUser;
-            Action a = () => { _rk1.GetValue(null, null); };
-            try { a(); }
-            catch (Exception ex) { Assert.False(true, string.Format("Test threw {0} exception", ex.GetType().Name)); }
+            Assert.True(_rk2.SetDefaultValue());
+            Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(null, null));
+            Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(string.Empty, null));
         }
 
         [Fact]
@@ -59,8 +63,6 @@ namespace Microsoft.Win32.RegistryTests
         public void Test03()
         {
             // [] Vanilla case , add a  bunch different objects (sampling all value types)
-
-            _rk2 = _rk1.CreateSubKey(_testKeyName);
 
             Random rand = new Random(-55);
 

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj_b.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj_b.cs
@@ -24,8 +24,7 @@ namespace Microsoft.Win32.RegistryTests
             var counter = Interlocked.Increment(ref s_keyCount);
             _testKeyName2 += counter.ToString();
             _rk1 = Microsoft.Win32.Registry.CurrentUser;
-            //Make sure we don't have registry key that we create and test here
-            CleanRegistryKeys();
+            _rk2 = _rk1.CreateSubKey(_testKeyName2);
         }
 
         public RegistryKey_GetValue_str_obj_b()
@@ -36,21 +35,15 @@ namespace Microsoft.Win32.RegistryTests
         [Fact]
         public void Test01()
         {
-            // [] Null arguments should be ignored
-            try
+            if (!_rk2.IsDefaultValueSet())
             {
-#pragma warning disable  0618
-                Object obj = _rk1.GetValue(null, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
-#pragma warning restore  0618
-                if (obj != null)
-                {
-                    Assert.False(true, "Error Key value is incorrect...");
-                }
+                Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(null, Helpers._DefaultValue, RegistryValueOptions.DoNotExpandEnvironmentNames));
+                Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(string.Empty, Helpers._DefaultValue, RegistryValueOptions.DoNotExpandEnvironmentNames));
             }
-            catch (Exception e)
-            {
-                Assert.False(true, "Error Unexpected exception occured , got exc==" + e.ToString());
-            }
+
+            Assert.True(_rk2.SetDefaultValue());
+            Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(null, null, RegistryValueOptions.DoNotExpandEnvironmentNames));
+            Assert.Equal(Helpers._DefaultValue, _rk2.GetValue(string.Empty, null, RegistryValueOptions.DoNotExpandEnvironmentNames));
         }
 
         [Fact]
@@ -73,30 +66,9 @@ namespace Microsoft.Win32.RegistryTests
         }
 
         [Fact]
-        public void Test03()
-        {
-            // [] Pass name=string.Empty
-            try
-            {
-#pragma warning disable  0618
-                Object obj1 = _rk1.GetValue(String.Empty, _strTest, RegistryValueOptions.DoNotExpandEnvironmentNames);
-#pragma warning restore  0618
-                if (obj1.ToString() != _strTest)
-                {
-                    Assert.False(true, "Error null return expected");
-                }
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, "Error Unexpected exception occured.... exception message...:" + e.ToString());
-            }
-        }
-
-        [Fact]
         public void Test04()
         {
             // [] Pass name=Existing key, default value = null 
-            _rk2 = _rk1.CreateSubKey(_testKeyName2);
             try
             {
                 string strKey = "MyTestKey";
@@ -116,37 +88,12 @@ namespace Microsoft.Win32.RegistryTests
         }
 
         [Fact]
-        public void Test05()
-        {
-            // [] Pass name=null, default value = some value 
-            _rk2 = _rk1.CreateSubKey(_testKeyName2);
-            string strKey = "MyTestKey";
-
-            try
-            {
-                _rk2.SetValue(strKey, _strTest, RegistryValueKind.ExpandString);
-#pragma warning disable  0618
-                Object obj1 = _rk2.GetValue(null, _strTest, RegistryValueOptions.DoNotExpandEnvironmentNames);
-#pragma warning restore  0618
-                if (obj1.ToString() != _strTest)
-                {
-                    Assert.False(true, "Error null return expected");
-                }
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, "Error Unexpected exception occured.... exception message...:" + e.ToString());
-            }
-        }
-
-        [Fact]
         public void Test06()
         {
             // [] Make sure NoExpand = false works with some valid values.
             string[] strTestValues = new string[] { @"%Systemroot%\mydrive\mydirectory\myfile.xxx", @"%tmp%\gfdhghdfgk\fsdfds\dsd.yyy", @"%path%\rwerew.zzz", @"%Systemroot%\mydrive\%path%\myfile.xxx" };
             string[] strExpectedTestValues = new string[] { Environment.ExpandEnvironmentVariables("%Systemroot%") + @"\mydrive\mydirectory\myfile.xxx", Environment.ExpandEnvironmentVariables("%tmp%") + @"\gfdhghdfgk\fsdfds\dsd.yyy", Environment.ExpandEnvironmentVariables("%path%") + @"\rwerew.zzz", Environment.ExpandEnvironmentVariables("%Systemroot%") + @"\mydrive\" + Environment.ExpandEnvironmentVariables("%path%") + @"\myfile.xxx" };
 
-            _rk2 = _rk1.CreateSubKey(_testKeyName2);
             try
             {
                 for (int iLoop = 0; iLoop < strTestValues.Length; iLoop++)
@@ -171,7 +118,6 @@ namespace Microsoft.Win32.RegistryTests
         [Fact]
         public void Test07()
         {
-            _rk2 = _rk1.CreateSubKey(_testKeyName2);
             //Set some new environment variables and make sure the
             string[] strMyNewEnvVariables = new string[] { "MyEnv", "PathPath", "Name", "blah", "TestKEyyyyyyyyyyyyyy" };
             try
@@ -228,7 +174,6 @@ namespace Microsoft.Win32.RegistryTests
             al.Add(@"%Systemroot%\myblah\%username%\mydrive\mydirectory\myfile.xxx");
             al.Add(@"%path%\mydrive\%tmp%\myfile.xxx");
 
-            _rk2 = _rk1.CreateSubKey(_testKeyName2);
             try
             {
                 IDictionary strEnvVariables = Environment.GetEnvironmentVariables();

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj_regvalopt.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj_regvalopt.cs
@@ -32,24 +32,6 @@ namespace Microsoft.Win32.RegistryTests
         }
 
         [Fact]
-        public void Test01()
-        {
-            // [] Null arguments should be ignored
-            try
-            {
-                Object obj = _rk1.GetValue(null, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
-                if (obj != null)
-                {
-                    Assert.False(true, "Error Key value is incorrect...");
-                }
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, "Error Unexpected exception occured , got exc==" + e.ToString());
-            }
-        }
-
-        [Fact]
         public void Test02()
         {
             //passing negative value for the enum should throw
@@ -82,25 +64,6 @@ namespace Microsoft.Win32.RegistryTests
         }
 
         [Fact]
-        public void Test05()
-        {
-            // [] Pass name=string.Empty 
-            String strTest = "This is a test string";
-            try
-            {
-                Object obj1 = _rk1.GetValue(String.Empty, strTest, RegistryValueOptions.DoNotExpandEnvironmentNames);
-                if (obj1.ToString() != strTest)
-                {
-                    Assert.False(true, "Error null return expected");
-                }
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, "Error Unexpected exception occured.... exception message...:" + e.ToString());
-            }
-        }
-
-        [Fact]
         public void Test06()
         {
             // [] Pass name=Existing key, default value = null 
@@ -111,20 +74,6 @@ namespace Microsoft.Win32.RegistryTests
                 string strKey = "MyTestKey";
                 _rk2.SetValue(strKey, strTest, RegistryValueKind.ExpandString);
                 Object obj1 = _rk2.GetValue(strKey, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
-                if (obj1.ToString() != strTest)
-                {
-                    Assert.False(true, "Error null return expected");
-                }
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, "Error Unexpected exception occured.... exception message...:" + e.ToString());
-            }
-
-            // [] Pass name=null, default value = some value 
-            try
-            {
-                Object obj1 = _rk2.GetValue(null, strTest, RegistryValueOptions.DoNotExpandEnvironmentNames);
                 if (obj1.ToString() != strTest)
                 {
                     Assert.False(true, "Error null return expected");


### PR DESCRIPTION
Microsoft.Win32.Registry test made incorrect assumptions about the Registry's unnamed value's default value. Updated the tests to remove the assumption.