### PR TITLE
Fix anonymous memory maps on Unix to support multiple views sharing data

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -6,6 +6,7 @@ internal static partial class Interop
     private static partial class Libraries
     {
         internal const string Libc = "libc";             // C library
+        internal const string LibRt = "librt";           // POSIX Realtime Extensions library
         internal const string LibCoreClr = "libcoreclr"; // CoreCLR runtime
         internal const string LibCrypto = "libcrypto";   // OpenSSL crypto library
     }

--- a/src/Common/src/Interop/Unix/libc/Interop.OpenFlags.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.OpenFlags.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [Flags]
+        internal enum OpenFlags
+        {
+            O_RDONLY    = 0x0,
+            O_WRONLY    = 0x1,
+            O_RDWR      = 0x2,
+            O_CREAT     = 0x40,
+            O_EXCL      = 0x80,
+            O_TRUNC     = 0x200,
+            O_SYNC      = 0x1000,
+            O_ASYNC     = 0x2000,
+            O_LARGEFILE = 0x8000,
+            O_CLOEXEC   = 0x80000,
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libc/Interop.ftruncate.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.ftruncate.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Runtime.InteropServices;
 
-using off64_t = System.Int64;
+using off_t = System.Int64; // Assuming either 64-bit machine or _FILE_OFFSET_BITS == 64
 
 internal static partial class Interop
 {
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern off64_t ftruncate64(int fd, off64_t length);
+        internal static extern int ftruncate(int fd, off_t length);
     }
 }

--- a/src/Common/src/Interop/Unix/librt/Interop.shm_open.cs
+++ b/src/Common/src/Interop/Unix/librt/Interop.shm_open.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 
 using mode_t  = System.Int32;
@@ -10,7 +9,10 @@ internal static partial class Interop
 {
     internal static partial class libc
     {
-        [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern int open(string filename, OpenFlags flags, mode_t mode);
+        [DllImport(Libraries.LibRt, SetLastError = true)]
+        internal static extern int shm_open(string name, OpenFlags flags, mode_t mode);
+
+        [DllImport(Libraries.LibRt, SetLastError = true)]
+        internal static extern int shm_unlink(string name);
     }
 }

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -117,6 +117,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
       <Link>Common\Interop\Unix\Interop.open.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.read.cs">
       <Link>Common\Interop\Unix\Interop.read.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -68,6 +68,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
       <Link>Common\Interop\Unix\libc\Interop.open.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
       <Link>Common\Interop\Unix\libc\Interop.strerror.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -254,8 +254,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.fsync.cs">
       <Link>Common\Interop\Unix\Interop.fsync.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.ftruncate64.cs">
-      <Link>Common\Interop\Unix\Interop.ftruncate64.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.ftruncate.cs">
+      <Link>Common\Interop\Unix\Interop.ftruncate.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.getegid.cs">
       <Link>Common\Interop\Unix\Interop.getegid.cs</Link>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -239,9 +239,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.close.cs">
       <Link>Common\Interop\Unix\Interop.close.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.opendir.cs">
-      <Link>Common\Interop\Unix\Interop.opendir.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.closedir.cs">
       <Link>Common\Interop\Unix\Interop.closedir.cs</Link>
     </Compile>
@@ -271,6 +268,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
       <Link>Common\Interop\Unix\Interop.open.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.opendir.cs">
+      <Link>Common\Interop\Unix\Interop.opendir.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.lseek.cs">
       <Link>Common\Interop\Unix\Interop.lseek64.cs</Link>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -581,7 +581,7 @@ namespace System.IO
                 SeekCore(value, SeekOrigin.Begin);
             }
 
-            SysCall<long, int>((fd, length, _) => Interop.libc.ftruncate64(fd, length), value);
+            SysCall<long, int>((fd, length, _) => Interop.libc.ftruncate(fd, length), value);
 
             // Return file pointer to where it was before setting length
             if (origPos != value)

--- a/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -15,8 +15,15 @@ namespace Microsoft.Win32.SafeHandles
         /// <summary>Counter used to produce a unique handle value.</summary>
         private static long s_counter = 0;
 
-        /// <summary>The underlying SafeFileHandle.  May be null to use anonymous backing storage.</summary>
+        /// <summary>The underlying SafeFileHandle.  May be null.</summary>
         internal readonly SafeFileHandle _fileHandle;
+
+        /// <summary>
+        /// The name of the map, currently used to give internal names to anonymous,
+        /// memory-backed maps.  This will be null if the map is file-backed or in
+        /// some corner cases of memory-backed maps, e.g. read-only.
+        /// </summary>
+        internal readonly string _mapName;
 
         /// <summary>The inheritability of the memory-mapped file.</summary>
         internal readonly HandleInheritability _inheritability;
@@ -31,18 +38,21 @@ namespace Microsoft.Win32.SafeHandles
         internal readonly long _capacity;
 
         /// <summary>Initializes the memory-mapped file handle.</summary>
-        /// <param name="fileHandle">The underlying file handle; this may be null in the case of a page-file backed memory-mapped file.</param>
+        /// <param name="mapName">The name of the map; may be null.</param>
+        /// <param name="fileHandle">The underlying file handle; may be null.</param>
         /// <param name="inheritability">The inheritability of the memory-mapped file.</param>
         /// <param name="access">The access for the memory-mapped file.</param>
         /// <param name="options">The options for the memory-mapped file.</param>
         /// <param name="capacity">The capacity of the memory-mapped file.</param>
         internal SafeMemoryMappedFileHandle(
+            string mapName,
             SafeFileHandle fileHandle, HandleInheritability inheritability,
             MemoryMappedFileAccess access, MemoryMappedFileOptions options,
             long capacity)
             : base(new IntPtr(-1), ownsHandle: true)
         {
             // Store the arguments.  We'll actually open the map when the view is created.
+            _mapName = mapName;
             _fileHandle = fileHandle;
             _inheritability = inheritability;
             _access = access;
@@ -54,10 +64,21 @@ namespace Microsoft.Win32.SafeHandles
             SetHandle(new IntPtr(nextHandleValue));
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && _mapName != null && _fileHandle != null)
+            {
+                // with a non-null name, the file handle is a shared memory object we created; no one else references it
+                _fileHandle.Dispose(); 
+            }
+            base.Dispose(disposing);
+        }
+
         protected override unsafe bool ReleaseHandle()
         {
-            // The actual handle we're holding in the SafeHandle is fake, so nothing to do.
-            return true;
+            return _mapName != null ?
+                Interop.libc.shm_unlink(_mapName) == 0 :
+                true; // if no mapName, nothing to release
         }
 
         public override bool IsInvalid

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -123,6 +123,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.ftruncate.cs">
+      <Link>Common\Interop\Unix\Interop.ftruncate.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
       <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
     </Compile>
@@ -138,11 +141,20 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.msync.cs">
       <Link>Common\Interop\Unix\Interop.msync.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
+      <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
       <Link>Common\Interop\Unix\Interop.strerror.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.sysconf.cs">
       <Link>Common\Interop\Unix\Interop.sysconf.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\librt\Interop.shm_open.cs">
+      <Link>Common\Interop\Unix\Interop.shm_open.cs</Link>
     </Compile>
     <Compile Include="Microsoft\Win32\SafeMemoryMappedFileHandle.Unix.cs" />
     <Compile Include="Microsoft\Win32\SafeMemoryMappedViewHandle.Unix.cs" />

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -22,21 +22,45 @@ namespace System.IO.MemoryMappedFiles
             if (mapName != null)
             {
                 // TODO: We currently do not support named maps.  We could possibly support 
-                // named maps in the future by using shm_open / shm_unlink.
+                // named maps in the future by using shm_open / shm_unlink, as we do for
+                // giving internal names to anonymous maps.  Issues to work through will include 
+                // dealing with permissions, passing information from the creator of the 
+                // map to another opener of it, etc.
                 throw CreateNamedMapsNotSupportedException();
             }
 
             SafeFileHandle fileHandle = null;
             if (fileStream != null)
             {
+                // This map is backed by a file.  Make sure the file's size is increased to be
+                // at least as big as the requested capacity of the map.
                 fileHandle = fileStream.SafeFileHandle;
                 if (fileStream.Length < capacity)
                 {
                     fileStream.SetLength(capacity);
                 }
             }
+            else
+            {
+                // This map is backed by memory-only.  With files, multiple views over the same map
+                // will end up being able to share data through the same file-based backing store;
+                // for anonymous maps, we need a similar backing store, or else multiple views would logically 
+                // each be their own map and wouldn't share any data.  To achieve this, we create a POSIX shared 
+                // memory object and use its file descriptor as the file handle.  However, we only do this when the 
+                // permission is more than read-only.  We can't ftruncate to increase the size of a shared memory 
+                // object that has read-only permissions, but we also don't need to worry about sharing
+                // views over a read-only, anonymous, memory-backed map, because the data will never change, so all views
+                // will always see zero and can't change that.  In that case, we just use the built-in anonymous support of
+                // the map by leaving fileHandle as null.
+                Interop.libc.MemoryMappedProtections protections = MemoryMappedView.GetProtections(access, forVerification: false);
+                if ((protections & Interop.libc.MemoryMappedProtections.PROT_WRITE) != 0 && capacity > 0)
+                {
+                    mapName = "/AnonCoreFxMemMap_" + Guid.NewGuid().ToString("N"); // unique name must start with "/" and be < NAME_MAX length
+                    fileHandle = CreateNewSharedMemoryObject(mapName, protections, capacity);
+                }
+            }
 
-            return new SafeMemoryMappedFileHandle(fileHandle, inheritability, access, options, capacity);
+            return new SafeMemoryMappedFileHandle(mapName, fileHandle, inheritability, access, options, capacity);
         }
 
         /// <summary>
@@ -86,5 +110,39 @@ namespace System.IO.MemoryMappedFiles
         {
             return new PlatformNotSupportedException(SR.PlatformNotSupported_NamedMaps);
         }
+
+        private static SafeFileHandle CreateNewSharedMemoryObject(
+            string mapName, Interop.libc.MemoryMappedProtections protections, long capacity)
+        {
+            // Determine the flags to use when creating the shared memory object
+            Interop.libc.OpenFlags flags = (protections & Interop.libc.MemoryMappedProtections.PROT_WRITE) != 0 ?
+                Interop.libc.OpenFlags.O_RDWR :
+                Interop.libc.OpenFlags.O_RDONLY;
+            flags |= Interop.libc.OpenFlags.O_CREAT | Interop.libc.OpenFlags.O_EXCL; // CreateNew
+
+            // Create the shared memory object
+            int fd;
+            Interop.CheckIo(fd = Interop.libc.shm_open(mapName, flags, (int)Interop.libc.Permissions.S_IRWXU), mapName);
+            SafeFileHandle fileHandle = new SafeFileHandle((IntPtr)fd, ownsHandle: true);
+
+            // Then enlarge it to the requested capacity
+            bool gotFd = false;
+            fileHandle.DangerousAddRef(ref gotFd);
+            try
+            {
+                while (Interop.CheckIo(Interop.libc.ftruncate((int)fileHandle.DangerousGetHandle(), capacity), mapName)) ;
+            }
+            finally
+            {
+                if (gotFd)
+                {
+                    fileHandle.DangerousRelease();
+                }
+            }
+
+            // Return the fd for the object
+            return fileHandle;
+        }
+
     }
 }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
@@ -56,7 +56,8 @@ namespace System.IO.MemoryMappedFiles
             try
             {
                 // Determine whether to create the pages as private or as shared; the former is used for copy-on-write.
-                Interop.libc.MemoryMappedFlags flags = (memMappedFileHandle._access == MemoryMappedFileAccess.CopyOnWrite) ?
+                Interop.libc.MemoryMappedFlags flags = 
+                    (memMappedFileHandle._access == MemoryMappedFileAccess.CopyOnWrite || access == MemoryMappedFileAccess.CopyOnWrite) ?
                     Interop.libc.MemoryMappedFlags.MAP_PRIVATE :
                     Interop.libc.MemoryMappedFlags.MAP_SHARED;
 
@@ -86,7 +87,7 @@ namespace System.IO.MemoryMappedFiles
                 Interop.libc.MemoryMappedProtections mapProtForVerification = GetProtections(memMappedFileHandle._access, forVerification: true);
                 if ((viewProtForVerification & mapProtForVerification) != viewProtForVerification)
                 {
-                    throw new UnauthorizedAccessException(viewProtForVerification + " <> " + mapProtForVerification);
+                    throw new UnauthorizedAccessException();
                 }
 
                 // Create the map
@@ -163,7 +164,7 @@ namespace System.IO.MemoryMappedFiles
         private const long MaxProcessAddressSpace = 8192L * 1000 * 1000 * 1000;
 
         /// <summary>Maps a MemoryMappedFileAccess to the associated MemoryMappedProtections.</summary>
-        private static Interop.libc.MemoryMappedProtections GetProtections(
+        internal static Interop.libc.MemoryMappedProtections GetProtections(
             MemoryMappedFileAccess access, bool forVerification)
         {
             switch (access)

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/Dispose.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile/Dispose.cs
@@ -40,8 +40,7 @@ public class MMF_Dispose
             // Dispose()
             ////////////////////////////////////////////////////////////////////////
 
-            string tempPath = Path.GetTempFileName();
-            MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(tempPath, FileMode.Open, null, 100);
+            MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, 100);
             MemoryMappedViewStream viewStream = mmf.CreateViewStream();
             MemoryMappedViewAccessor viewAccessor = mmf.CreateViewAccessor();
             mmf.Dispose();
@@ -116,7 +115,6 @@ public class MMF_Dispose
 
             viewStream.Dispose();
             viewAccessor.Dispose();
-            File.Delete(tempPath);
 
             /// END TEST CASES
 

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/ReadX.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/ReadX.cs
@@ -48,8 +48,7 @@ public class MMVA_ReadX : TestBase
 
         try
         {
-            using (FileStream fs = new FileStream(Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite, 0x1000, FileOptions.DeleteOnClose))
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, null, pageSize * 10, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, pageSize * 10))
             {
                 // Default ViewAccessor size - whole MMF
                 using (MemoryMappedViewAccessor view = mmf.CreateViewAccessor())

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/WriteX.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor/WriteX.cs
@@ -49,8 +49,7 @@ public class MMVA_WriteX : TestBase
 
         try
         {
-            using (FileStream fs = new FileStream(Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite, 0x1000, FileOptions.DeleteOnClose))
-            using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, null, _pageSize * 10, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
+            using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, _pageSize * 10))
             {
                 // Default ViewAccessor size - whole MMF
                 using (MemoryMappedViewAccessor view = mmf.CreateViewAccessor())

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -185,6 +185,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.open.cs">
       <Link>Common\Interop\Unix\Interop.open.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
     </Compile>


### PR DESCRIPTION
In our current implementation of anonymous (no mapName specified), non-persisted (no file provided) memory-mapped files, each time a view is created we call mmap with the anonymous option.  This effectively results in every view of the same MemoryMappedFile actually being distinct and not sharing any data with any other view on the same map.

This commit fixes the implementation so that anonymous, non-persisted memory-mapped files are instead backed by POSIX shared memory objects.  This makes it so that multiple views/streams over the same anonymous map correctly share data as expected.  (In the future, we should be able to extend this to provide support for named, non-persisted maps.)

I'd previously modified our tests to avoid exercising this unsupported path on Unix.  Now that it's supported, I've put the few tests back to the way they were so that we test multiple views/streams over the same map correctly sharing data with each other.

In doing this, I also discovered two additional issues that I've fixed:
- We were using ftruncate64 in FileStream when setting its length, but ftruncate64 isn't available on OSX; changed it to use ftruncate instead.
- We were incorrectly handling CopyOnWrite views, having them use shared rather than private memory; fixed by checking the view's requested access in addition to the map's.