### PR TITLE
Add System.Reflection.DispatchProxy library

### DIFF
--- a/src/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.sln
+++ b/src/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.DispatchProxy", "src\System.Reflection.DispatchProxy.csproj", "{1E689C1B-690C-4799-BDE9-6E7990585894}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{20F85A9C-FC0B-4220-B11F-38205E6F67F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.DispatchProxy.Tests", "tests\System.Reflection.DispatchProxy.Tests.csproj", "{089444FE-8FF5-4D8F-A51B-32D026425F6B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.Build.0 = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B} = {20F85A9C-FC0B-4220-B11F-38205E6F67F8}
+	EndGlobalSection
+EndGlobal

--- a/src/System.Reflection.DispatchProxy/src/Resources/Strings.resx
+++ b/src/System.Reflection.DispatchProxy/src/Resources/Strings.resx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BaseType_Cannot_Be_Sealed" xml:space="preserve">
+    <value>The base type '{0}' cannot be sealed.</value>
+  </data>
+  <data name="BaseType_Must_Have_Default_Ctor" xml:space="preserve">
+    <value>The base type '{0}' must have a public parameterless constructor.</value>
+  </data>
+  <data name="InterfaceType_Must_Be_Interface" xml:space="preserve">
+    <value>The type '{0}' must be an interface, not a class.</value>
+  </data>
+ <data name="BaseType_Cannot_Be_Abstract" xml:space="preserve">
+    <value>The base type '{0}' cannot be abstract.</value>
+  </data>
+</root>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <ProjectGuid>{1E689C1B-690C-4799-BDE9-6E7990585894}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Reflection.DispatchProxy</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <!-- References are resolved from packages.config -->
+  <ItemGroup>
+    <Compile Include="System\Reflection\DispatchProxy.cs" />
+    <Compile Include="System\Reflection\DispatchProxyGenerator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxy.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxy.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// DispatchProxy provides a mechanism for the instantiation of proxy objects and handling of
+    /// their method dispatch.
+    /// </summary>
+    public abstract class DispatchProxy
+    {
+        protected DispatchProxy()
+        {
+        }
+
+        /// <summary>
+        /// Whenever any method on the generated proxy type is called, this method
+        /// will be invoked to dispatch control.
+        /// </summary>
+        /// <param name="targetMethod">The method the caller invoked</param>
+        /// <param name="args">The arguments the caller passed to the method</param>
+        /// <returns>The object to return to the caller, or <c>null</c> for void methods</returns>
+        protected abstract object Invoke(MethodInfo targetMethod, object[] args);
+
+        /// <summary>
+        /// Creates an object instance that derives from class <typeparamref name="TProxy"/>
+        /// and implements interface <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The interface the proxy should implement.</typeparam>
+        /// <typeparam name="TProxy">The base class to use for the proxy class.</typeparam>
+        /// <returns>An object instance that implements <typeparamref name="T"/>.</returns>
+        /// <exception cref="System.ArgumentException"><typeparamref name="T"/> is a class, 
+        /// or <typeparamref name="TProxy"/> is sealed or does not have a parameterless constructor</exception>
+        public static T Create<T, TProxy>()
+            where TProxy : DispatchProxy
+        {
+            return (T)DispatchProxyGenerator.CreateProxyInstance(typeof(TProxy), typeof(T));
+        }
+    }
+}

--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -1,0 +1,697 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace System.Reflection
+{
+    // Helper class to handle the IL EMIT for the generation of proxies.
+    // Much of this code was taken directly from the Silverlight proxy generation in
+    // ndp\fx\src\wcf\System\ServiceModel\Channels\RealProxy.cs
+    // Differences beteen this and the Silverlight version are:
+    //  1. This version is based on DispatchProxy from NetNative and CoreCLR, not RealProxy in Silverlight ServiceModel.
+    //     There are several notable differences between them.
+    //  2. Both DispatchProxy and RealProxy permit the caller to ask for a proxy specifying a pair of types:
+    //     the interface type to implement, and a base type.  But they behave slightly differently:
+    //       - RealProxy generates a proxy type that derives from Object and *implements" all the base type's
+    //         interfaces plus all the interface type's interfaces.
+    //       - DispatchProxy generates a proxy type that *derives* from the base type and implements all
+    //         the interface type's interfaces.  This is true for both the CLR version in Project N and this
+    //         version in ProjectK.
+    //  3. DispatchProxy and RealProxy use different type hierarchies for the generated proxies:
+    //       - RealProxy type hierarchy is:
+    //             proxyType : proxyBaseType : object
+    //         Presumably the 'proxyBaseType' in the middle is to allow it to implement the base type's interfaces
+    //         explicitly, preventing collision for same name methods on the base and interface types.
+    //       - DispatchProxy hierarchy is:
+    //             proxyType : baseType (where baseType : DispatchProxy)
+    //         The generated DispatchProxy proxy type does not need to generate implementation methods
+    //         for the base type's interfaces, because the base type already must have implemented them.
+    //  4. RealProxy required a proxy instance to hold a backpointer to the RealProxy instance to mirror
+    //     the .Net Remoting design that required the proxy and RealProxy to be separate instances.
+    //     But the DispatchProxy design encourages the proxy type to *be* an DispatchProxy.  Therefore,
+    //     the proxy's 'this' becomes the equivalent of RealProxy's backpointer to RealProxy, so we were
+    //     able to remove an extraneous field and ctor arg from the DispatchProxy proxies.
+    //
+    internal static class DispatchProxyGenerator
+    {
+        // Generated proxies have a private Action field that all generated methods
+        // invoke.  It is the first field in the class and the first ctor parameter.
+        private const int InvokeActionFieldAndCtorParameterIndex = 0;
+
+        // Proxies are requested for a pair of types: base type and interface type.
+        // The generated proxy will subclass the given base type and implement the interface type.
+        // We maintain a cache keyed by 'base type' containing a dictionary keyed by interface type,
+        // containing the generated proxy type for that pair.   There are likely to be few (maybe only 1)
+        // base type in use for many interface types.
+        // Note: this differs from Silverlight's RealProxy implementation which keys strictly off the
+        // interface type.  But this does not allow the same interface type to be used with more than a
+        // single base type.  The implementation here permits multiple interface types to be used with
+        // multiple base types, and the generated proxy types will be unique.
+        // This cache of generated types grows unbounded, one element per unique T/ProxyT pair.
+        // This approach is used to prevent regenerating identical proxy types for identical T/Proxy pairs,
+        // which would ultimately be a more expensive leak.
+        // Proxy instances are not cached.  Their lifetime is entirely owned by the caller of DispatchProxy.Create.
+        private static readonly Dictionary<Type, Dictionary<Type, Type>> s_baseTypeAndInterfaceToGeneratedProxyType = new Dictionary<Type, Dictionary<Type, Type>>();
+        private static readonly ProxyAssembly s_proxyAssembly = new ProxyAssembly();
+        private static readonly MethodInfo s_dispatchProxyInvokeMethod = typeof(DispatchProxy).GetTypeInfo().GetDeclaredMethod("Invoke");
+
+        // Returns a new instance of a proxy the derives from 'baseType' and implements 'interfaceType'
+        internal static object CreateProxyInstance(Type baseType, Type interfaceType)
+        {
+            Debug.Assert(baseType != null);
+            Debug.Assert(interfaceType != null);
+
+            Type proxiedType = GetProxyType(baseType, interfaceType);
+            return Activator.CreateInstance(proxiedType, (Action<object[]>)DispatchProxyGenerator.Invoke);
+        }
+
+        private static Type GetProxyType(Type baseType, Type interfaceType)
+        {
+            lock (s_baseTypeAndInterfaceToGeneratedProxyType)
+            {
+                Dictionary<Type, Type> interfaceToProxy = null;
+                if (!s_baseTypeAndInterfaceToGeneratedProxyType.TryGetValue(baseType, out interfaceToProxy))
+                {
+                    interfaceToProxy = new Dictionary<Type, Type>();
+                    s_baseTypeAndInterfaceToGeneratedProxyType[baseType] = interfaceToProxy;
+                }
+
+                Type generatedProxy = null;
+                if (!interfaceToProxy.TryGetValue(interfaceType, out generatedProxy))
+                {
+                    generatedProxy = GenerateProxyType(baseType, interfaceType);
+                    interfaceToProxy[interfaceType] = generatedProxy;
+                }
+
+                return generatedProxy;
+            }
+        }
+
+        // Unconditionally generates a new proxy type derived from 'baseType' and implements 'interfaceType'
+        private static Type GenerateProxyType(Type baseType, Type interfaceType)
+        {
+            // Parameter validation is deferred until the point we need to create the proxy.
+            // This prevents unnecessary overhead revalidating cached proxy types.
+            TypeInfo baseTypeInfo = baseType.GetTypeInfo();
+
+            // The interface type must be an interface, not a class
+            if (!interfaceType.GetTypeInfo().IsInterface)
+            {
+                // "T" is the generic parameter seen via the public contract
+                throw new ArgumentException(String.Format(SR.InterfaceType_Must_Be_Interface, interfaceType.FullName), "T");
+            }
+
+            // The base type cannot be sealed because the proxy needs to subclass it.
+            if (baseTypeInfo.IsSealed)
+            {
+                // "TProxy" is the generic parameter seen via the public contract
+                throw new ArgumentException(String.Format(SR.BaseType_Cannot_Be_Sealed, baseTypeInfo.FullName), "TProxy");
+            }
+
+            // The base type cannot be abstract
+            if (baseTypeInfo.IsAbstract)
+            {
+                throw new ArgumentException(String.Format(SR.BaseType_Cannot_Be_Abstract, baseType.FullName), "TProxy");
+            }
+
+            // The base type must have a public default ctor
+            if (!baseTypeInfo.DeclaredConstructors.Any(c => c.IsPublic && c.GetParameters().Length == 0))
+            {
+                throw new ArgumentException(String.Format(SR.BaseType_Must_Have_Default_Ctor, baseType.FullName), "TProxy");
+            }
+
+            // Create a type that derives from 'baseType' provided by caller
+            ProxyBuilder pb = s_proxyAssembly.CreateProxy("generatedProxy", baseType);
+
+            foreach (Type t in interfaceType.GetTypeInfo().ImplementedInterfaces)
+                pb.AddInterfaceImpl(t);
+
+            pb.AddInterfaceImpl(interfaceType);
+
+            Type generatedProxyType = pb.CreateType();
+            return generatedProxyType;
+        }
+
+        // All generated proxy methods call this static helper method to dispatch.
+        // Its job is to unpack the arguments and the 'this' instance and to dispatch directly
+        // to the (abstract) DispatchProxy.Invoke() method.
+        private static void Invoke(object[] args)
+        {
+            PackedArgs packed = new PackedArgs(args);
+            MethodBase method = s_proxyAssembly.ResolveMethodToken(packed.DeclaringType, packed.MethodToken);
+            if (method.IsGenericMethodDefinition)
+                method = ((MethodInfo)method).MakeGenericMethod(packed.GenericTypes);
+
+            // Call (protected method) DispatchProxy.Invoke()
+            try
+            {
+                Debug.Assert(s_dispatchProxyInvokeMethod != null);
+                object returnValue = s_dispatchProxyInvokeMethod.Invoke(packed.DispatchProxy,
+                                                                       new object[] { method, packed.Args });
+                packed.ReturnValue = returnValue;
+            }
+            catch (TargetInvocationException tie)
+            {
+                ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            }
+        }
+
+        private class PackedArgs
+        {
+            internal const int DispatchProxyPosition = 0;
+            internal const int DeclaringTypePosition = 1;
+            internal const int MethodTokenPosition = 2;
+            internal const int ArgsPosition = 3;
+            internal const int GenericTypesPosition = 4;
+            internal const int ReturnValuePosition = 5;
+
+            internal static readonly Type[] PackedTypes = new Type[] { typeof(object), typeof(Type), typeof(int), typeof(object[]), typeof(Type[]), typeof(object) };
+
+            private object[] _args;
+            internal PackedArgs() : this(new object[PackedTypes.Length]) { }
+            internal PackedArgs(object[] args) { _args = args; }
+
+            internal DispatchProxy DispatchProxy { get { return (DispatchProxy)_args[DispatchProxyPosition]; } }
+            internal Type DeclaringType { get { return (Type)_args[DeclaringTypePosition]; } }
+            internal int MethodToken { get { return (int)_args[MethodTokenPosition]; } }
+            internal object[] Args { get { return (object[])_args[ArgsPosition]; } }
+            internal Type[] GenericTypes { get { return (Type[])_args[GenericTypesPosition]; } }
+            internal object ReturnValue { /*get { return args[ReturnValuePosition]; }*/ set { _args[ReturnValuePosition] = value; } }
+        }
+
+        private class ProxyAssembly
+        {
+            private AssemblyBuilder _ab;
+            private ModuleBuilder _mb;
+            private int _typeId = 0;
+
+            // Maintain a MethodBase-->int, int-->MethodBase mapping to permit generated code
+            // to pass methods by token
+            private Dictionary<MethodBase, int> _methodToToken = new Dictionary<MethodBase, int>();
+            private List<MethodBase> _methodsByToken = new List<MethodBase>();
+
+            public ProxyAssembly()
+            {
+                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("ProxyBuilder"), AssemblyBuilderAccess.Run);
+                _mb = _ab.DefineDynamicModule("testmod");
+            }
+
+            public ProxyBuilder CreateProxy(string name, Type proxyBaseType)
+            {
+                int nextId = Interlocked.Increment(ref _typeId);
+                TypeBuilder tb = _mb.DefineType(name + "_" + nextId, TypeAttributes.Public, proxyBaseType);
+                return new ProxyBuilder(this, tb, proxyBaseType);
+            }
+
+            internal void GetTokenForMethod(MethodBase method, out Type type, out int token)
+            {
+                type = method.DeclaringType;
+                token = 0;
+                if (!_methodToToken.TryGetValue(method, out token))
+                {
+                    _methodsByToken.Add(method);
+                    token = _methodsByToken.Count - 1;
+                    _methodToToken[method] = token;
+                }
+            }
+
+            internal MethodBase ResolveMethodToken(Type type, int token)
+            {
+                Debug.Assert(token >= 0 && token < _methodsByToken.Count);
+                return _methodsByToken[token];
+            }
+        }
+
+        private class ProxyBuilder
+        {
+            private static readonly MethodInfo s_delegateInvoke = typeof(Action<object[]>).GetTypeInfo().GetDeclaredMethod("Invoke");
+
+            private ProxyAssembly _assembly;
+            private TypeBuilder _tb;
+            private Type _proxyBaseType;
+            private List<FieldBuilder> _fields;
+
+            internal ProxyBuilder(ProxyAssembly assembly, TypeBuilder tb, Type proxyBaseType)
+            {
+                _assembly = assembly;
+                _tb = tb;
+                _proxyBaseType = proxyBaseType;
+
+                _fields = new List<FieldBuilder>();
+                _fields.Add(tb.DefineField("invoke", typeof(Action<object[]>), FieldAttributes.Private));
+            }
+
+            private void Complete()
+            {
+                Type[] args = new Type[_fields.Count];
+                for (int i = 0; i < args.Length; i++)
+                {
+                    args[i] = _fields[i].FieldType;
+                }
+
+                ConstructorBuilder cb = _tb.DefineConstructor(MethodAttributes.Public, CallingConventions.HasThis, args);
+                ILGenerator il = cb.GetILGenerator();
+
+                // chained ctor call
+                ConstructorInfo baseCtor = _proxyBaseType.GetTypeInfo().DeclaredConstructors.SingleOrDefault(c => c.IsPublic && c.GetParameters().Length == 0);
+                Debug.Assert(baseCtor != null);
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Call, baseCtor);
+
+                // store all the fields
+                for (int i = 0; i < args.Length; i++)
+                {
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldarg, i + 1);
+                    il.Emit(OpCodes.Stfld, _fields[i]);
+                }
+
+                il.Emit(OpCodes.Ret);
+            }
+
+            internal Type CreateType()
+            {
+                this.Complete();
+                return _tb.CreateTypeInfo().AsType();
+            }
+
+            internal void AddInterfaceImpl(Type iface)
+            {
+                _tb.AddInterfaceImplementation(iface);
+                foreach (MethodInfo mi in iface.GetRuntimeMethods())
+                {
+                    AddMethodImpl(mi);
+                }
+            }
+
+            private void AddMethodImpl(MethodInfo mi)
+            {
+                ParameterInfo[] parameters = mi.GetParameters();
+                Type[] paramTypes = ParamTypes(parameters, false);
+
+                MethodBuilder mdb = _tb.DefineMethod(mi.Name, MethodAttributes.Public | MethodAttributes.Virtual, mi.ReturnType, paramTypes);
+                if (mi.ContainsGenericParameters)
+                {
+                    Type[] ts = mi.GetGenericArguments();
+                    string[] ss = new string[ts.Length];
+                    for (int i = 0; i < ts.Length; i++)
+                    {
+                        ss[i] = ts[i].Name;
+                    }
+                    GenericTypeParameterBuilder[] genericParameters = mdb.DefineGenericParameters(ss);
+                    for (int i = 0; i < genericParameters.Length; i++)
+                    {
+                        genericParameters[i].SetGenericParameterAttributes(ts[i].GetTypeInfo().GenericParameterAttributes);
+                    }
+                }
+                ILGenerator il = mdb.GetILGenerator();
+
+                ParametersArray args = new ParametersArray(il, paramTypes);
+
+                // object[] args = new object[paramCount];
+                il.Emit(OpCodes.Nop);
+                GenericArray<object> argsArr = new GenericArray<object>(il, ParamTypes(parameters, true).Length);
+
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    // args[i] = argi;
+                    if (!parameters[i].IsOut)
+                    {
+                        argsArr.BeginSet(i);
+                        args.Get(i);
+                        argsArr.EndSet(parameters[i].ParameterType);
+                    }
+                }
+
+                // object[] packed = new object[PackedArgs.PackedTypes.Length];
+                GenericArray<object> packedArr = new GenericArray<object>(il, PackedArgs.PackedTypes.Length);
+
+                // packed[PackedArgs.DispatchProxyPosition] = this;
+                packedArr.BeginSet(PackedArgs.DispatchProxyPosition);
+                il.Emit(OpCodes.Ldarg_0);
+                packedArr.EndSet(typeof(DispatchProxy));
+
+                // packed[PackedArgs.DeclaringTypePosition] = typeof(iface);
+                MethodInfo Type_GetTypeFromHandle = typeof(Type).GetRuntimeMethod("GetTypeFromHandle", new Type[] { typeof(RuntimeTypeHandle) });
+                int methodToken;
+                Type declaringType;
+                _assembly.GetTokenForMethod(mi, out declaringType, out methodToken);
+                packedArr.BeginSet(PackedArgs.DeclaringTypePosition);
+                il.Emit(OpCodes.Ldtoken, declaringType);
+                il.Emit(OpCodes.Call, Type_GetTypeFromHandle);
+                packedArr.EndSet(typeof(object));
+
+                // packed[PackedArgs.MethodTokenPosition] = iface method token;
+                packedArr.BeginSet(PackedArgs.MethodTokenPosition);
+                il.Emit(OpCodes.Ldc_I4, methodToken);
+                packedArr.EndSet(typeof(Int32));
+
+                // packed[PackedArgs.ArgsPosition] = args;
+                packedArr.BeginSet(PackedArgs.ArgsPosition);
+                argsArr.Load();
+                packedArr.EndSet(typeof(object[]));
+
+                // packed[PackedArgs.GenericTypesPosition] = mi.GetGenericArguments();
+                if (mi.ContainsGenericParameters)
+                {
+                    packedArr.BeginSet(PackedArgs.GenericTypesPosition);
+                    Type[] genericTypes = mi.GetGenericArguments();
+                    GenericArray<Type> typeArr = new GenericArray<Type>(il, genericTypes.Length);
+                    for (int i = 0; i < genericTypes.Length; ++i)
+                    {
+                        typeArr.BeginSet(i);
+                        il.Emit(OpCodes.Ldtoken, genericTypes[i]);
+                        il.Emit(OpCodes.Call, Type_GetTypeFromHandle);
+                        typeArr.EndSet(typeof(Type));
+                    }
+                    typeArr.Load();
+                    packedArr.EndSet(typeof(Type[]));
+                }
+
+                // Call static DispatchProxyHelper.Invoke(object[])
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, _fields[InvokeActionFieldAndCtorParameterIndex]); // delegate
+                packedArr.Load();
+                il.Emit(OpCodes.Call, s_delegateInvoke);
+
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    if (parameters[i].ParameterType.IsByRef)
+                    {
+                        args.BeginSet(i);
+                        argsArr.Get(i);
+                        args.EndSet(i, typeof(object));
+                    }
+                }
+
+                if (mi.ReturnType != typeof(void))
+                {
+                    packedArr.Get(PackedArgs.ReturnValuePosition);
+                    Convert(il, typeof(object), mi.ReturnType, false);
+                }
+
+                il.Emit(OpCodes.Ret);
+
+                _tb.DefineMethodOverride(mdb, mi);
+            }
+
+            private static Type[] ParamTypes(ParameterInfo[] parms, bool noByRef)
+            {
+                Type[] types = new Type[parms.Length];
+                for (int i = 0; i < parms.Length; i++)
+                {
+                    types[i] = parms[i].ParameterType;
+                    if (noByRef && types[i].IsByRef)
+                        types[i] = types[i].GetElementType();
+                }
+                return types;
+            }
+
+            // TypeCode does not exist in ProjectK or ProjectN.
+            // This lookup method was copied from PortableLibraryThunks\Internal\PortableLibraryThunks\System\TypeThunks.cs
+            // but returns the integer value equivalent to its TypeCode enum.
+            private static int GetTypeCode(Type type)
+            {
+                if (type == null)
+                    return 0;   // TypeCode.Empty;
+
+                if (type == typeof(Boolean))
+                    return 3;   // TypeCode.Boolean;
+
+                if (type == typeof(Char))
+                    return 4;   // TypeCode.Char;
+
+                if (type == typeof(SByte))
+                    return 5;   // TypeCode.SByte;
+
+                if (type == typeof(Byte))
+                    return 6;   // TypeCode.Byte;
+
+                if (type == typeof(Int16))
+                    return 7;   // TypeCode.Int16;
+
+                if (type == typeof(UInt16))
+                    return 8;   // TypeCode.UInt16;
+
+                if (type == typeof(Int32))
+                    return 9;   // TypeCode.Int32;
+
+                if (type == typeof(UInt32))
+                    return 10;  // TypeCode.UInt32;
+
+                if (type == typeof(Int64))
+                    return 11;  // TypeCode.Int64;
+
+                if (type == typeof(UInt64))
+                    return 12;  // TypeCode.UInt64;
+
+                if (type == typeof(Single))
+                    return 13;  // TypeCode.Single;
+
+                if (type == typeof(Double))
+                    return 14;  // TypeCode.Double;
+
+                if (type == typeof(Decimal))
+                    return 15;  // TypeCode.Decimal;
+
+                if (type == typeof(DateTime))
+                    return 16;  // TypeCode.DateTime;
+
+                if (type == typeof(String))
+                    return 18;  // TypeCode.String;
+
+                if (type.GetTypeInfo().IsEnum)
+                    return GetTypeCode(Enum.GetUnderlyingType(type));
+
+                return 1;   // TypeCode.Object;
+            }
+
+            private static OpCode[] s_convOpCodes = new OpCode[] {
+                OpCodes.Nop,//Empty = 0,
+                OpCodes.Nop,//Object = 1,
+                OpCodes.Nop,//DBNull = 2,
+                OpCodes.Conv_I1,//Boolean = 3,
+                OpCodes.Conv_I2,//Char = 4,
+                OpCodes.Conv_I1,//SByte = 5,
+                OpCodes.Conv_U1,//Byte = 6,
+                OpCodes.Conv_I2,//Int16 = 7,
+                OpCodes.Conv_U2,//UInt16 = 8,
+                OpCodes.Conv_I4,//Int32 = 9,
+                OpCodes.Conv_U4,//UInt32 = 10,
+                OpCodes.Conv_I8,//Int64 = 11,
+                OpCodes.Conv_U8,//UInt64 = 12,
+                OpCodes.Conv_R4,//Single = 13,
+                OpCodes.Conv_R8,//Double = 14,
+                OpCodes.Nop,//Decimal = 15,
+                OpCodes.Nop,//DateTime = 16,
+                OpCodes.Nop,//17
+                OpCodes.Nop,//String = 18,
+            };
+
+            private static OpCode[] s_ldindOpCodes = new OpCode[] {
+                OpCodes.Nop,//Empty = 0,
+                OpCodes.Nop,//Object = 1,
+                OpCodes.Nop,//DBNull = 2,
+                OpCodes.Ldind_I1,//Boolean = 3,
+                OpCodes.Ldind_I2,//Char = 4,
+                OpCodes.Ldind_I1,//SByte = 5,
+                OpCodes.Ldind_U1,//Byte = 6,
+                OpCodes.Ldind_I2,//Int16 = 7,
+                OpCodes.Ldind_U2,//UInt16 = 8,
+                OpCodes.Ldind_I4,//Int32 = 9,
+                OpCodes.Ldind_U4,//UInt32 = 10,
+                OpCodes.Ldind_I8,//Int64 = 11,
+                OpCodes.Ldind_I8,//UInt64 = 12,
+                OpCodes.Ldind_R4,//Single = 13,
+                OpCodes.Ldind_R8,//Double = 14,
+                OpCodes.Nop,//Decimal = 15,
+                OpCodes.Nop,//DateTime = 16,
+                OpCodes.Nop,//17
+                OpCodes.Ldind_Ref,//String = 18,
+            };
+
+            private static OpCode[] s_stindOpCodes = new OpCode[] {
+                OpCodes.Nop,//Empty = 0,
+                OpCodes.Nop,//Object = 1,
+                OpCodes.Nop,//DBNull = 2,
+                OpCodes.Stind_I1,//Boolean = 3,
+                OpCodes.Stind_I2,//Char = 4,
+                OpCodes.Stind_I1,//SByte = 5,
+                OpCodes.Stind_I1,//Byte = 6,
+                OpCodes.Stind_I2,//Int16 = 7,
+                OpCodes.Stind_I2,//UInt16 = 8,
+                OpCodes.Stind_I4,//Int32 = 9,
+                OpCodes.Stind_I4,//UInt32 = 10,
+                OpCodes.Stind_I8,//Int64 = 11,
+                OpCodes.Stind_I8,//UInt64 = 12,
+                OpCodes.Stind_R4,//Single = 13,
+                OpCodes.Stind_R8,//Double = 14,
+                OpCodes.Nop,//Decimal = 15,
+                OpCodes.Nop,//DateTime = 16,
+                OpCodes.Nop,//17
+                OpCodes.Stind_Ref,//String = 18,
+            };
+
+            private static void Convert(ILGenerator il, Type source, Type target, bool isAddress)
+            {
+                Debug.Assert(!target.IsByRef);
+                if (target == source)
+                    return;
+
+                TypeInfo sourceTypeInfo = source.GetTypeInfo();
+                TypeInfo targetTypeInfo = target.GetTypeInfo();
+
+                if (source.IsByRef)
+                {
+                    Debug.Assert(!isAddress);
+                    Type argType = source.GetElementType();
+                    Ldind(il, argType);
+                    Convert(il, argType, target, isAddress);
+                    return;
+                }
+                if (targetTypeInfo.IsValueType)
+                {
+                    if (sourceTypeInfo.IsValueType)
+                    {
+                        OpCode opCode = s_convOpCodes[GetTypeCode(target)];
+                        Debug.Assert(!opCode.Equals(OpCodes.Nop));
+                        il.Emit(opCode);
+                    }
+                    else
+                    {
+                        Debug.Assert(sourceTypeInfo.IsAssignableFrom(targetTypeInfo));
+                        il.Emit(OpCodes.Unbox, target);
+                        if (!isAddress)
+                            Ldind(il, target);
+                    }
+                }
+                else if (targetTypeInfo.IsAssignableFrom(sourceTypeInfo))
+                {
+                    if (sourceTypeInfo.IsValueType)
+                    {
+                        if (isAddress)
+                            Ldind(il, source);
+                        il.Emit(OpCodes.Box, source);
+                    }
+                }
+                else
+                {
+                    Debug.Assert(sourceTypeInfo.IsAssignableFrom(targetTypeInfo) || targetTypeInfo.IsInterface || sourceTypeInfo.IsInterface);
+                    if (target.IsGenericParameter)
+                    {
+                        // T GetProperty<T>() where T : class;
+                        Debug.Assert(targetTypeInfo.GenericParameterAttributes == GenericParameterAttributes.ReferenceTypeConstraint);
+                        il.Emit(OpCodes.Unbox_Any, target);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Castclass, target);
+                    }
+                }
+            }
+
+            private static void Ldind(ILGenerator il, Type type)
+            {
+                OpCode opCode = s_ldindOpCodes[GetTypeCode(type)];
+                if (!opCode.Equals(OpCodes.Nop))
+                {
+                    il.Emit(opCode);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldobj, type);
+                }
+            }
+
+            private static void Stind(ILGenerator il, Type type)
+            {
+                OpCode opCode = s_stindOpCodes[GetTypeCode(type)];
+                if (!opCode.Equals(OpCodes.Nop))
+                {
+                    il.Emit(opCode);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Stobj, type);
+                }
+            }
+
+            private class ParametersArray
+            {
+                private ILGenerator _il;
+                private Type[] _paramTypes;
+                internal ParametersArray(ILGenerator il, Type[] paramTypes)
+                {
+                    _il = il;
+                    _paramTypes = paramTypes;
+                }
+
+                internal void Get(int i)
+                {
+                    _il.Emit(OpCodes.Ldarg, i + 1);
+                }
+
+                internal void BeginSet(int i)
+                {
+                    _il.Emit(OpCodes.Ldarg, i + 1);
+                }
+
+                internal void EndSet(int i, Type stackType)
+                {
+                    Debug.Assert(_paramTypes[i].IsByRef);
+                    Type argType = _paramTypes[i].GetElementType();
+                    Convert(_il, stackType, argType, false);
+                    Stind(_il, argType);
+                }
+            }
+
+            private class GenericArray<T>
+            {
+                private ILGenerator _il;
+                private LocalBuilder _lb;
+                internal GenericArray(ILGenerator il, int len)
+                {
+                    _il = il;
+                    _lb = il.DeclareLocal(typeof(T[]));
+
+                    il.Emit(OpCodes.Ldc_I4, len);
+                    il.Emit(OpCodes.Newarr, typeof(T));
+                    il.Emit(OpCodes.Stloc, _lb);
+                }
+
+                internal void Load()
+                {
+                    _il.Emit(OpCodes.Ldloc, _lb);
+                }
+
+                internal void Get(int i)
+                {
+                    _il.Emit(OpCodes.Ldloc, _lb);
+                    _il.Emit(OpCodes.Ldc_I4, i);
+                    _il.Emit(OpCodes.Ldelem_Ref);
+                }
+
+                internal void BeginSet(int i)
+                {
+                    _il.Emit(OpCodes.Ldloc, _lb);
+                    _il.Emit(OpCodes.Ldc_I4, i);
+                }
+
+                internal void EndSet(Type stackType)
+                {
+                    Convert(_il, stackType, typeof(T), false);
+                    _il.Emit(OpCodes.Stelem_Ref);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Reflection.DispatchProxy/src/packages.config
+++ b/src/System.Reflection.DispatchProxy/src/packages.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Collections" version="4.0.10-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
+  <package id="System.Reflection.Emit" version="4.0.0-beta-22703" />
+  <package id="System.Reflection.Emit.ILGeneration" version="4.0.0-beta-22703" />
+  <package id="System.Reflection.Extensions" version="4.0.0-beta-22703" />
+  <package id="System.Reflection.Primitives" version="4.0.0-beta-22703" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Threading" version="4.0.10-beta-22703" />
+</packages>

--- a/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -1,0 +1,447 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DispatchProxyTests
+{
+    public static class DispatchProxyTests
+    {
+        [Fact]
+        public static void Create_Proxy_Derives_From_DispatchProxy_BaseType()
+        {
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+
+            Assert.NotNull(proxy);
+            Assert.True(typeof(TestDispatchProxy).GetTypeInfo().IsAssignableFrom(proxy.GetType().GetTypeInfo()),
+                        String.Format("Proxy type {0} did not derive from {1}", proxy.GetType().Name, typeof(TestDispatchProxy).Name));
+        }
+
+        [Fact]
+        public static void Create_Proxy_Implements_All_Interfaces()
+        {
+            TestType_IHelloAndGoodbyeService proxy = DispatchProxy.Create<TestType_IHelloAndGoodbyeService, TestDispatchProxy>();
+
+            Assert.NotNull(proxy);
+            Type[] implementedInterfaces = typeof(TestType_IHelloAndGoodbyeService).GetTypeInfo().ImplementedInterfaces.ToArray();
+            foreach (Type t in implementedInterfaces)
+            {
+                Assert.True(t.GetTypeInfo().IsAssignableFrom(proxy.GetType().GetTypeInfo()),
+                            String.Format("Proxy type {0} did not derive from {1}", proxy.GetType().Name, t.Name));
+            }
+        }
+
+        [Fact]
+        public static void Create_Same_Proxy_Type_And_Base_Type_Reuses_Same_Generated_Type()
+        {
+            TestType_IHelloService proxy1 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            TestType_IHelloService proxy2 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+
+            Assert.NotNull(proxy1);
+            Assert.NotNull(proxy2);
+            Assert.True(proxy1.GetType() == proxy2.GetType(),
+                        String.Format("First instance of proxy type was {0} but second was {1}", proxy1.GetType().Name, proxy2.GetType().Name));
+        }
+
+        [Fact]
+        public static void Create_Proxy_Instances_Of_Same_Proxy_And_Base_Type_Are_Unique()
+        {
+            TestType_IHelloService proxy1 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            TestType_IHelloService proxy2 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+
+            Assert.NotNull(proxy1);
+            Assert.NotNull(proxy2);
+            Assert.False(object.ReferenceEquals(proxy1, proxy2),
+                        String.Format("First and second instance of proxy type {0} were the same instance", proxy1.GetType().Name));
+        }
+
+
+        [Fact]
+        public static void Create_Same_Proxy_Type_With_Different_BaseType_Uses_Different_Generated_Type()
+        {
+            TestType_IHelloService proxy1 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            TestType_IHelloService proxy2 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy2>();
+
+            Assert.NotNull(proxy1);
+            Assert.NotNull(proxy2);
+            Assert.False(proxy1.GetType() == proxy2.GetType(),
+                        String.Format("Proxy generated for base type {0} used same for base type {1}", typeof(TestDispatchProxy).Name, typeof(TestDispatchProxy).Name));
+        }
+
+        [Fact]
+        public static void Created_Proxy_With_Different_Proxy_Type_Use_Different_Generated_Type()
+        {
+            TestType_IHelloService proxy1 = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            TestType_IGoodbyeService proxy2 = DispatchProxy.Create<TestType_IGoodbyeService, TestDispatchProxy>();
+
+            Assert.NotNull(proxy1);
+            Assert.NotNull(proxy2);
+            Assert.False(proxy1.GetType() == proxy2.GetType(),
+                        String.Format("Proxy generated for type {0} used same for type {1}", typeof(TestType_IHelloService).Name, typeof(TestType_IGoodbyeService).Name));
+        }
+
+        [Fact]
+        public static void Create_Using_Concrete_Proxy_Type_Throws_ArgumentException()
+        {
+            ArgumentException caughtException = null;
+
+            try
+            {
+                TestType_ConcreteClass proxy = DispatchProxy.Create<TestType_ConcreteClass, TestDispatchProxy>();
+            }
+            catch (ArgumentException ex)
+            {
+                caughtException = ex;
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, String.Format("Caught unexpected exception {0}", e.ToString()));
+            }
+
+            Assert.True(caughtException != null, "Expected ArgumentException to be thrown");
+            Assert.True(String.Equals(caughtException.ParamName, "T"),
+                        String.Format("Expected paramName 'T' but received '{0}'", caughtException.ParamName));
+        }
+
+        [Fact]
+        public static void Create_Using_Sealed_BaseType_Throws_ArgumentException()
+        {
+            ArgumentException caughtException = null;
+
+            try
+            {
+                TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, Sealed_TestDispatchProxy>();
+            }
+            catch (ArgumentException ex)
+            {
+                caughtException = ex;
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, String.Format("Caught unexpected exception {0}", e.ToString()));
+            }
+
+            Assert.True(caughtException != null, "Expected ArgumentException to be thrown");
+            Assert.True(String.Equals(caughtException.ParamName, "TProxy"),
+                        String.Format("Expected paramName 'TProxy' but received '{0}'", caughtException.ParamName));
+        }
+
+        [Fact]
+        public static void Create_Using_Abstract_BaseType_Throws_ArgumentException()
+        {
+            ArgumentException caughtException = null;
+
+            try
+            {
+                TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, Abstract_TestDispatchProxy>();
+            }
+            catch (ArgumentException ex)
+            {
+                caughtException = ex;
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, String.Format("Caught unexpected exception {0}", e.ToString()));
+            }
+
+            Assert.True(caughtException != null, "Expected ArgumentException to be thrown");
+            Assert.True(String.Equals(caughtException.ParamName, "TProxy"),
+                        String.Format("Expected paramName 'TProxy' but received '{0}'", caughtException.ParamName));
+        }
+
+        [Fact]
+        public static void Create_Using_BaseType_Without_Default_Ctor_Throws_ArgumentException()
+        {
+            ArgumentException caughtException = null;
+
+            try
+            {
+                TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, NoDefaultCtor_TestDispatchProxy>();
+            }
+            catch (ArgumentException ex)
+            {
+                caughtException = ex;
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, String.Format("Caught unexpected exception {0}", e.ToString()));
+            }
+
+            Assert.True(caughtException != null, "Expected ArgumentException to be thrown");
+            Assert.True(String.Equals(caughtException.ParamName, "TProxy"),
+                        String.Format("Expected paramName 'TProxy' but received '{0}'", caughtException.ParamName));
+        }
+
+        [Fact]
+        public static void Invoke_Receives_Correct_MethodInfo_And_Arguments()
+        {
+            bool wasInvoked = false;
+            StringBuilder errorBuilder = new StringBuilder();
+
+            // This Func is called whenever we call a method on the proxy.
+            // This is where we validate it received the correct arguments and methods
+            Func<MethodInfo, object[], object> invokeCallback = (method, args) =>
+            {
+                wasInvoked = true;
+
+                if (method == null)
+                {
+                    string error = String.Format("Proxy for {0} was called with null method", typeof(TestType_IHelloService).Name);
+                    errorBuilder.AppendLine(error);
+                    return null;
+                }
+                else
+                {
+                    MethodInfo expectedMethod = typeof(TestType_IHelloService).GetTypeInfo().GetDeclaredMethod("Hello");
+                    if (expectedMethod != method)
+                    {
+                        string error = String.Format("Proxy for {0} was called with incorrect method.  Expected = {1}, Actual = {2}",
+                                                    typeof(TestType_IHelloService).Name, expectedMethod, method);
+                        errorBuilder.AppendLine(error);
+                        return null;
+                    }
+                }
+
+                return "success";
+            };
+
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            Assert.NotNull(proxy);
+
+            TestDispatchProxy dispatchProxy = proxy as TestDispatchProxy;
+            Assert.NotNull(dispatchProxy);
+
+            // Redirect Invoke to our own Func above
+            dispatchProxy.CallOnInvoke = invokeCallback;
+
+            // Calling this method now will invoke the Func above which validates correct method
+            proxy.Hello("testInput");
+
+            Assert.True(wasInvoked, "The invoke method was not called");
+            Assert.True(errorBuilder.Length == 0, errorBuilder.ToString());
+        }
+
+        [Fact]
+        public static void Invoke_Receives_Correct_MethodInfo()
+        {
+            MethodInfo invokedMethod = null;
+
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                invokedMethod = method;
+                return String.Empty;
+            };
+
+            proxy.Hello("testInput");
+
+            MethodInfo expectedMethod = typeof(TestType_IHelloService).GetTypeInfo().GetDeclaredMethod("Hello");
+            Assert.True(invokedMethod != null && expectedMethod == invokedMethod, String.Format("Invoke expected method {0} but actual was {1}", expectedMethod, invokedMethod));
+        }
+
+        [Fact]
+        public static void Invoke_Receives_Correct_Arguments()
+        {
+            object[] actualArgs = null;
+
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                actualArgs = args;
+                return String.Empty;
+            };
+
+            proxy.Hello("testInput");
+
+            object[] expectedArgs = new object[] { "testInput" };
+            Assert.True(actualArgs != null && actualArgs.Length == expectedArgs.Length,
+                String.Format("Invoked expected object[] of length {0} but actual was {1}",
+                                expectedArgs.Length, (actualArgs == null ? "null" : actualArgs.Length.ToString())));
+            for (int i = 0; i < expectedArgs.Length; ++i)
+            {
+                Assert.True(expectedArgs[i].Equals(actualArgs[i]),
+                    String.Format("Expected arg[{0}] = '{1}' but actual was '{2}'",
+                    i, expectedArgs[i], actualArgs[i]));
+            }
+        }
+
+        [Fact]
+        public static void Invoke_Returns_Correct_Value()
+        {
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                return "testReturn";
+            };
+
+            string expectedResult = "testReturn";
+            string actualResult = proxy.Hello(expectedResult);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public static void Invoke_Multiple_Parameters_Receives_Correct_Arguments()
+        {
+            object[] invokedArgs = null;
+            object[] expectedArgs = new object[] { (int)42, "testString", (double)5.0 };
+
+            TestType_IMultipleParameterService proxy = DispatchProxy.Create<TestType_IMultipleParameterService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                invokedArgs = args;
+                return 0.0;
+            };
+
+            proxy.TestMethod((int)expectedArgs[0], (string)expectedArgs[1], (double)expectedArgs[2]);
+
+            Assert.True(invokedArgs != null && invokedArgs.Length == expectedArgs.Length,
+                        String.Format("Expected {0} arguments but actual was {1}",
+                        expectedArgs.Length, invokedArgs == null ? "null" : invokedArgs.Length.ToString()));
+
+            for (int i = 0; i < expectedArgs.Length; ++i)
+            {
+                Assert.True(expectedArgs[i].Equals(invokedArgs[i]),
+                    String.Format("Expected arg[{0}] = '{1}' but actual was '{2}'",
+                    i, expectedArgs[i], invokedArgs[i]));
+            }
+        }
+
+        [Fact]
+        public static void Invoke_Multiple_Parameters_Via_Params_Receives_Correct_Arguments()
+        {
+            object[] actualArgs = null;
+            object[] invokedArgs = null;
+            object[] expectedArgs = new object[] { 42, "testString", 5.0 };
+
+            TestType_IMultipleParameterService proxy = DispatchProxy.Create<TestType_IMultipleParameterService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                invokedArgs = args;
+                return String.Empty;
+            };
+
+            proxy.ParamsMethod((int)expectedArgs[0], (string)expectedArgs[1], (double)expectedArgs[2]);
+
+            // All separate params should have become a single object[1] array
+            Assert.True(invokedArgs != null && invokedArgs.Length == 1,
+                        String.Format("Expected single element object[] but actual was {0}",
+                        invokedArgs == null ? "null" : invokedArgs.Length.ToString()));
+
+            // That object[1] should contain an object[3] containing the args
+            actualArgs = invokedArgs[0] as object[];
+            Assert.True(actualArgs != null && actualArgs.Length == expectedArgs.Length,
+                String.Format("Invoked expected object[] of length {0} but actual was {1}",
+                                expectedArgs.Length, (actualArgs == null ? "null" : actualArgs.Length.ToString())));
+            for (int i = 0; i < expectedArgs.Length; ++i)
+            {
+                Assert.True(expectedArgs[i].Equals(actualArgs[i]),
+                    String.Format("Expected arg[{0}] = '{1}' but actual was '{2}'",
+                    i, expectedArgs[i], actualArgs[i]));
+            }
+        }
+
+        [Fact]
+        public static void Invoke_Void_Returning_Method_Accepts_Null_Return()
+        {
+            MethodInfo invokedMethod = null;
+
+            TestType_IOneWay proxy = DispatchProxy.Create<TestType_IOneWay, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                invokedMethod = method;
+                return null;
+            };
+
+            proxy.OneWay();
+
+            MethodInfo expectedMethod = typeof(TestType_IOneWay).GetTypeInfo().GetDeclaredMethod("OneWay");
+            Assert.True(invokedMethod != null && expectedMethod == invokedMethod, String.Format("Invoke expected method {0} but actual was {1}", expectedMethod, invokedMethod));
+        }
+
+        [Fact]
+        public static void Invoke_Same_Method_Multiple_Interfaces_Calls_Correct_Method()
+        {
+            List<MethodInfo> invokedMethods = new List<MethodInfo>();
+
+            TestType_IHelloService1And2 proxy = DispatchProxy.Create<TestType_IHelloService1And2, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                invokedMethods.Add(method);
+                return null;
+            };
+
+            ((TestType_IHelloService)proxy).Hello("calling 1");
+            ((TestType_IHelloService2)proxy).Hello("calling 2");
+
+            Assert.True(invokedMethods.Count == 2, String.Format("Expected 2 method invocations but received {0}", invokedMethods.Count));
+
+            MethodInfo expectedMethod = typeof(TestType_IHelloService).GetTypeInfo().GetDeclaredMethod("Hello");
+            Assert.True(invokedMethods[0] != null && expectedMethod == invokedMethods[0], String.Format("First invoke should have been TestType_IHelloService.Hello but actual was {0}", invokedMethods[0]));
+
+            expectedMethod = typeof(TestType_IHelloService2).GetTypeInfo().GetDeclaredMethod("Hello");
+            Assert.True(invokedMethods[1] != null && expectedMethod == invokedMethods[1], String.Format("Second invoke should have been TestType_IHelloService2.Hello but actual was {0}", invokedMethods[1]));
+        }
+
+        [Fact]
+        public static void Invoke_Thrown_Exception_Rethrown_To_Caller()
+        {
+            Exception actualException = null;
+            InvalidOperationException expectedException = new InvalidOperationException("testException");
+
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                throw expectedException;
+            };
+
+            try
+            {
+                proxy.Hello("testCall");
+            }
+            catch (Exception e)
+            {
+                actualException = e;
+            }
+
+            Assert.Equal(expectedException, actualException);
+        }
+
+        [Fact]
+        public static void Invoke_Property_Setter_And_Getter_Invokes_Correct_Methods()
+        {
+            List<MethodInfo> invokedMethods = new List<MethodInfo>();
+
+            TestType_IPropertyService proxy = DispatchProxy.Create<TestType_IPropertyService, TestDispatchProxy>();
+            ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
+            {
+                invokedMethods.Add(method);
+                return null;
+            };
+
+
+            proxy.ReadWrite = "testValue";
+            string actualValue = proxy.ReadWrite;
+
+            Assert.True(invokedMethods.Count == 2, String.Format("Expected 2 method invocations but received {0}", invokedMethods.Count));
+
+            PropertyInfo propertyInfo = typeof(TestType_IPropertyService).GetTypeInfo().GetDeclaredProperty("ReadWrite");
+            Assert.NotNull(propertyInfo);
+
+            MethodInfo expectedMethod = propertyInfo.SetMethod;
+            Assert.True(invokedMethods[0] != null && expectedMethod == invokedMethods[0], String.Format("First invoke should have been {0} but actual was {1}",
+                            expectedMethod.Name, invokedMethods[0]));
+
+            expectedMethod = propertyInfo.GetMethod;
+            Assert.True(invokedMethods[1] != null && expectedMethod == invokedMethods[1], String.Format("First invoke should have been {0} but actual was {1}",
+                            expectedMethod.Name, invokedMethods[1]));
+
+            Assert.Null(actualValue);
+        }
+    }
+}

--- a/src/System.Reflection.DispatchProxy/tests/System.Reflection.DispatchProxy.Tests.csproj
+++ b/src/System.Reflection.DispatchProxy/tests/System.Reflection.DispatchProxy.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{089444FE-8FF5-4D8F-A51B-32D026425F6B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Reflection.DispatchProxy.Tests</AssemblyName>
+    <RootNamespace>System.Reflection.DispatchProxy.Tests</RootNamespace>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DispatchProxyTests.cs" />
+    <Compile Include="TestTypes.cs" />
+  </ItemGroup>
+  <!-- References are resolved from packages.config -->
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Reflection.DispatchProxy.csproj">
+      <Project>{1e689c1b-690c-4799-bde9-6e7990585894}</Project>
+      <Name>System.Reflection.DispatchProxy</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.DispatchProxy/tests/TestTypes.cs
+++ b/src/System.Reflection.DispatchProxy/tests/TestTypes.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+
+// Test types used to make proxies.
+public interface TestType_IHelloService
+{
+    string Hello(string message);
+}
+
+public interface TestType_IGoodbyeService
+{
+    string Goodbye(string message);
+}
+
+// Demonstrates interface implementing multiple other interfaces
+public interface TestType_IHelloAndGoodbyeService : TestType_IHelloService, TestType_IGoodbyeService
+{
+}
+
+// Deliberately contains method with same signature of TestType_IHelloService (see TestType_IHelloService1And2).
+public interface TestType_IHelloService2
+{
+    string Hello(string message);
+}
+
+// Demonstrates 2 interfaces containing same method name dispatches to the right one
+public interface TestType_IHelloService1And2 : TestType_IHelloService, TestType_IHelloService2
+{
+}
+
+// Demonstrates methods taking multiple parameters as well as a params parameter
+public interface TestType_IMultipleParameterService
+{
+    double TestMethod(int i, string s, double d);
+    object ParamsMethod(params object[] parameters);
+}
+
+// Demonstrate a void-returning method and parameterless method
+public interface TestType_IOneWay
+{
+    void OneWay();
+}
+
+// Demonstrates proxies can be made for properties.
+public interface TestType_IPropertyService
+{
+    string ReadWrite { get; set; }
+}
+
+// Negative -- demonstrates trying to use a class for the interface type for the proxy
+public class TestType_ConcreteClass
+{
+    public string Echo(string s) { return null; }
+}
+
+// Negative -- demonstrates base type that is sealed and should generate exception
+public sealed class Sealed_TestDispatchProxy : DispatchProxy
+{
+    protected override object Invoke(MethodInfo targetMethod, object[] args)
+    {
+        throw new InvalidOperationException();
+    }
+}
+
+// This test double creates a proxy instance for the requested 'ProxyT' type.
+// When methods are invoked on that proxy, it will call a registered callback.
+public class TestDispatchProxy : DispatchProxy
+{
+    // Gets or sets the Action to invoke when clients call methods on the proxy.
+    public Func<MethodInfo, object[], object> CallOnInvoke { get; set; }
+
+    // Gets the proxy itself (which is always 'this')
+    public object GetProxy()
+    {
+        return this;
+    }
+
+    // Implementation of DispatchProxy.Invoke() just calls back to given Action
+    protected override object Invoke(MethodInfo targetMethod, object[] args)
+    {
+        return CallOnInvoke(targetMethod, args);
+    }
+}
+
+public class TestDispatchProxy2 : TestDispatchProxy
+{
+}
+
+// Negative test -- demonstrates base type that is abstract
+public abstract class Abstract_TestDispatchProxy : DispatchProxy
+{
+    protected override object Invoke(MethodInfo targetMethod, object[] args)
+    {
+        throw new InvalidOperationException();
+    }
+}
+
+// Negative -- demonstrates base type that has no public default ctor
+public class NoDefaultCtor_TestDispatchProxy : DispatchProxy
+{
+    private NoDefaultCtor_TestDispatchProxy()
+    {
+    }
+    protected override object Invoke(MethodInfo targetMethod, object[] args)
+    {
+        throw new InvalidOperationException();
+    }
+}
+

--- a/src/System.Reflection.DispatchProxy/tests/packages.config
+++ b/src/System.Reflection.DispatchProxy/tests/packages.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Collections" version="4.0.10-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Linq" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
+  <package id="System.Reflection.Emit" version="4.0.0-beta-22703" />
+  <package id="System.Reflection.Emit.ILGeneration" version="4.0.0-beta-22703" />
+  <package id="System.Reflection.Extensions" version="4.0.0-beta-22703" />
+  <package id="System.Reflection.Primitives" version="4.0.0-beta-22703" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Threading" version="4.0.10-beta-22703" />
+  <package id="xunit" version="2.0.0-beta5-build2785" />
+  <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.assert" version="2.0.0-beta5-build2785" />
+  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+</packages>


### PR DESCRIPTION
Initial commit of System.Reflection.DispatchProxy src and tests.
DispatchProxy provides a mechanism to dynamcially create proxy types
that implement a specified interface and derive from a specified
DispatchProxy type.  Method invocations on the generated proxy
instance are dispatched to that DispatchProxy base type.

An API review for DispatchProxy was done with the fxdc team, and the original code was ported verbatim from the code they reviewed.  The only changes in the CoreFx repo are conformance to the directory and project structures