### PR TITLE
Add serialization support for XmlDocument and XmlElement in XmlSerializer

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/packages.config
+++ b/src/System.Runtime.Serialization.Json/tests/packages.config
@@ -22,6 +22,7 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22405" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22605" />
+  <package id="System.Xml.XmlDocument" version="4.0.0-beta-22605" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 using System.ComponentModel;
+using System.Xml;
 
 namespace SerializationTypes
 {
@@ -2091,4 +2092,15 @@ public class TestableDerivedException : System.Exception
     { }
 
     public string TestProperty { get; set; }
+}
+
+public class TypeWithXmlElementProperty
+{
+    [XmlAnyElement]
+    public XmlElement[] Elements;
+}
+
+public class TypeWithXmlDocumentProperty
+{
+    public XmlDocument Document;
 }

--- a/src/System.Runtime.Serialization.Xml/tests/packages.config
+++ b/src/System.Runtime.Serialization.Xml/tests/packages.config
@@ -22,6 +22,7 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22405" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22605" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22605" />
+  <package id="System.Xml.XmlDocument" version="4.0.0-beta-22605" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />

--- a/src/System.Xml.XmlSerializer/src/Resources/Strings.resx
+++ b/src/System.Xml.XmlSerializer/src/Resources/Strings.resx
@@ -678,4 +678,16 @@
   <data name="IsNotAssignableFrom" xml:space="preserve">
     <value>{0} is not assignable from {1}.</value>
   </data>
+  <data name="XmlElementNameMismatch" xml:space="preserve">
+    <value>This element was named '{0}' from namespace '{1}' but should have been named '{2}' from namespace '{3}'.</value>
+  </data>
+  <data name="XmlNeedAttributeHere" xml:space="preserve">
+    <value>The node must be either type XmlAttribute or a derived type.</value>
+  </data>
+  <data name="XmlNoAttributeHere" xml:space="preserve">
+    <value>Cannot write a node of type XmlAttribute as an element value. Use XmlAnyAttributeAttribute with an array of XmlNode or XmlAttribute to write the node as an attribute.</value>
+  </data>
+  <data name="XmlInvalidArrayTypeSyntax" xml:space="preserve">
+    <value>Invalid wsd:arrayType syntax: '{0}'.</value>
+  </data>
 </root>

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -1560,7 +1560,7 @@ namespace System.Xml.Serialization
                     for (int i = 0; i < a.XmlElements.Count; i++)
                     {
                         XmlElementAttribute xmlElement = a.XmlElements[i];
-                        Type targetType = xmlElement.Type == null ? arrayElementType : xmlElement.Type;
+                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlNode).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlElement);
                         TypeDesc targetTypeDesc = _typeScope.GetTypeDesc(targetType);
                         TypeModel typeModel = _modelScope.GetTypeModel(targetType);
                         ElementAccessor element = new ElementAccessor();
@@ -1601,7 +1601,7 @@ namespace System.Xml.Serialization
                     for (int i = 0; i < a.XmlAnyElements.Count; i++)
                     {
                         XmlAnyElementAttribute xmlAnyElement = a.XmlAnyElements[i];
-                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(object);
+                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlNode).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlElement);
                         if (!arrayElementType.IsAssignableFrom(targetType))
                             throw new InvalidOperationException(SR.Format(SR.XmlIllegalAnyElement, arrayElementType.FullName));
                         string anyName = xmlAnyElement.Name.Length == 0 ? xmlAnyElement.Name : XmlConvert.EncodeLocalName(xmlAnyElement.Name);
@@ -1842,7 +1842,7 @@ namespace System.Xml.Serialization
                     for (int i = 0; i < a.XmlAnyElements.Count; i++)
                     {
                         XmlAnyElementAttribute xmlAnyElement = a.XmlAnyElements[i];
-                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(accessorType) ? accessorType : typeof(object);
+                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(accessorType) ? accessorType : typeof(XmlNode).IsAssignableFrom(accessorType) ? accessorType : typeof(XmlElement);
                         if (!accessorType.IsAssignableFrom(targetType))
                             throw new InvalidOperationException(SR.Format(SR.XmlIllegalAnyElement, accessorType.FullName));
 
@@ -2011,6 +2011,11 @@ namespace System.Xml.Serialization
                         choiceTypes.Add(type, false);
                     }
                 }
+            }
+            if (choiceTypes.Contains(typeof(XmlElement)) && a.XmlAnyElements.Count > 0)
+            {
+                // You need to add {0} to the '{1}'.
+                throw new InvalidOperationException(SR.Format(SR.XmlChoiceIdentiferMissing, typeof(XmlChoiceIdentifierAttribute).Name, accessorName));
             }
 
             XmlArrayItemAttributes items = a.XmlArrayItems;

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -33,6 +33,7 @@ namespace System.Xml.Serialization
     public abstract class XmlSerializationReader : XmlSerializationGeneratedCode
     {
         private XmlReader _r;
+        private XmlDocument _d;
         private XmlDeserializationEvents _events;
         private bool _soap12;
         private bool _isReturnValue;
@@ -168,6 +169,19 @@ namespace System.Xml.Serialization
             }
         }
 
+        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.Document"]/*' />
+        protected XmlDocument Document
+        {
+            get
+            {
+                if (_d == null)
+                {
+                    _d = new XmlDocument(_r.NameTable);
+                }
+                return _d;
+            }
+        }
+
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReaderCount"]/*' />
         protected int ReaderCount
         {
@@ -176,8 +190,6 @@ namespace System.Xml.Serialization
                 return 0;
             }
         }
-
-
 
         private void InitPrimitiveIDs()
         {
@@ -619,6 +631,24 @@ namespace System.Xml.Serialization
             return name[5] == ':';
         }
 
+        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsArrayTypeAttribute"]/*' />
+        protected void ParseWsdlArrayType(XmlAttribute attr)
+        {
+            if ((object)attr.LocalName == (object)_wsdlArrayTypeID && (object)attr.NamespaceURI == (object)_wsdlNsID)
+            {
+                int colon = attr.Value.LastIndexOf(':');
+                if (colon < 0)
+                {
+                    attr.Value = _r.LookupNamespace("") + ":" + attr.Value;
+                }
+                else
+                {
+                    attr.Value = _r.LookupNamespace(attr.Value.Substring(0, colon)) + ":" +
+                                 attr.Value.Substring(colon + 1);
+                }
+            }
+            return;
+        }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsReturnValue"]/*' />
         protected bool IsReturnValue
@@ -699,6 +729,16 @@ namespace System.Xml.Serialization
             return qname;
         }
 
+        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadXmlDocument"]/*' />
+        protected XmlDocument ReadXmlDocument(bool wrapped)
+        {
+            XmlNode n = ReadXmlNode(wrapped);
+            if (n == null)
+                return null;
+            XmlDocument doc = new XmlDocument();
+            doc.AppendChild(doc.ImportNode(n, true));
+            return doc;
+        }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CollapseWhitespace"]/*' />
         protected string CollapseWhitespace(string value)
@@ -708,6 +748,31 @@ namespace System.Xml.Serialization
             return value.Trim();
         }
 
+        protected XmlNode ReadXmlNode(bool wrapped)
+        {
+            XmlNode node = null;
+            if (wrapped)
+            {
+                if (ReadNull()) return null;
+                _r.ReadStartElement();
+                _r.MoveToContent();
+                if (_r.NodeType != XmlNodeType.EndElement)
+                    node = Document.ReadNode(_r);
+                int whileIterations = 0;
+                int readerCount = ReaderCount;
+                while (_r.NodeType != XmlNodeType.EndElement)
+                {
+                    UnknownNode(null);
+                    CheckReaderCount(ref whileIterations, ref readerCount);
+                }
+                _r.ReadEndElement();
+            }
+            else
+            {
+                node = Document.ReadNode(_r);
+            }
+            return node;
+        }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToByteArrayBase64"]/*' />
         protected static byte[] ToByteArrayBase64(string value)
@@ -852,16 +917,31 @@ namespace System.Xml.Serialization
             {
                 return;
             }
-            else
+            if (_r.NodeType == XmlNodeType.Element)
             {
                 _r.Skip();
                 return;
             }
+            UnknownNode(Document.ReadNode(_r), o, qnames);
         }
 
+        private void UnknownNode(XmlNode unknownNode, object o, string qnames)
+        {
+            if (unknownNode == null)
+                return;
+        }
 
-
-
+        private void GetCurrentPosition(out int lineNumber, out int linePosition)
+        {
+            if (Reader is IXmlLineInfo)
+            {
+                IXmlLineInfo lineInfo = (IXmlLineInfo)Reader;
+                lineNumber = lineInfo.LineNumber;
+                linePosition = lineInfo.LinePosition;
+            }
+            else
+                lineNumber = linePosition = -1;
+        }
 
         private string CurrentTag()
         {
@@ -1062,11 +1142,25 @@ namespace System.Xml.Serialization
 
         private object ReadXmlNodes(bool elementCanBeType)
         {
+            ArrayList xmlNodeList = new ArrayList();
             string elemLocalName = Reader.LocalName;
             string elemNs = Reader.NamespaceURI;
+            string elemName = Reader.Name;
             string xsiTypeName = null;
             string xsiTypeNs = null;
             int skippableNodeCount = 0;
+            int lineNumber = -1, linePosition = -1;
+            XmlNode unknownNode = null;
+            if (Reader.NodeType == XmlNodeType.Attribute)
+            {
+                XmlAttribute attr = Document.CreateAttribute(elemName, elemNs);
+                attr.Value = Reader.Value;
+                unknownNode = attr;
+            }
+            else
+                unknownNode = Document.CreateElement(elemName, elemNs);
+            GetCurrentPosition(out lineNumber, out linePosition);
+            XmlElement unknownElement = unknownNode as XmlElement;
 
             while (Reader.MoveToNextAttribute())
             {
@@ -1084,9 +1178,9 @@ namespace System.Xml.Serialization
                     xsiTypeName = (colon >= 0) ? value.Substring(colon + 1) : value;
                     xsiTypeNs = Reader.LookupNamespace((colon >= 0) ? value.Substring(0, colon) : "");
                 }
-                // To support new Object().
-                // <anyType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                skippableNodeCount--;
+                XmlAttribute xmlAttribute = (XmlAttribute)Document.ReadNode(_r);
+                xmlNodeList.Add(xmlAttribute);
+                if (unknownElement != null) unknownElement.SetAttributeNode(xmlAttribute);
             }
 
             // If the node is referenced (or in case of paramStyle = bare) and if xsi:type is not
@@ -1096,7 +1190,9 @@ namespace System.Xml.Serialization
             {
                 xsiTypeName = elemLocalName;
                 xsiTypeNs = elemNs;
-                skippableNodeCount--;
+                XmlAttribute xsiTypeAttribute = Document.CreateAttribute(_typeID, _instanceNsID);
+                xsiTypeAttribute.Value = elemName;
+                xmlNodeList.Add(xsiTypeAttribute);
             }
             if (xsiTypeName == Soap.UrType &&
                 ((object)xsiTypeNs == (object)_schemaNsID ||
@@ -1114,14 +1210,29 @@ namespace System.Xml.Serialization
             }
             else
             {
-                throw CodeGenerator.NotSupported("XLinq");
+                Reader.ReadStartElement();
+                Reader.MoveToContent();
+                int whileIterations = 0;
+                int readerCount = ReaderCount;
+                while (Reader.NodeType != System.Xml.XmlNodeType.EndElement)
+                {
+                    XmlNode xmlNode = Document.ReadNode(_r);
+                    xmlNodeList.Add(xmlNode);
+                    if (unknownElement != null) unknownElement.AppendChild(xmlNode);
+                    Reader.MoveToContent();
+                    CheckReaderCount(ref whileIterations, ref readerCount);
+                }
+                ReadEndElement();
             }
 
 
-            if (skippableNodeCount >= 0)
+            if (xmlNodeList.Count <= skippableNodeCount)
                 return new object();
 
-            throw CodeGenerator.NotSupported("XLinq");
+            XmlNode[] childNodes = (XmlNode[])xmlNodeList.ToArray(typeof(XmlNode));
+
+            UnknownNode(unknownNode, null, null);
+            return childNodes;
         }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CheckReaderCount"]/*' />

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -674,6 +674,58 @@ public class XmlSerializerTests
         Assert.StrictEqual(value.TestProperty, actual.TestProperty);
     }
 
+    [Fact]
+    public static void Xml_XmlElementAsRoot()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml("<html></html>");
+        XmlElement expected = xDoc.CreateElement("Element");
+        expected.InnerText = "Element innertext";
+        var actual = SerializeAndDeserialize(expected, @"<?xml version=""1.0"" encoding=""utf-8""?><Element>Element innertext</Element>");
+        Assert.NotNull(actual);
+        Assert.StrictEqual(expected.InnerText, actual.InnerText);
+    }
+
+    [Fact]
+    public static void Xml_TypeWithXmlElementProperty()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml("<html></html>");
+        XmlElement productElement = xDoc.CreateElement("Product");
+        productElement.InnerText = "Product innertext";
+        XmlElement categoryElement = xDoc.CreateElement("Category");
+        categoryElement.InnerText = "Category innertext";
+        var expected = new TypeWithXmlElementProperty() { Elements = new[] { productElement, categoryElement } };
+        var actual = SerializeAndDeserialize(expected, @"<?xml version=""1.0"" encoding=""utf-8""?><TypeWithXmlElementProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Product>Product innertext</Product><Category>Category innertext</Category></TypeWithXmlElementProperty>");
+        Assert.StrictEqual(expected.Elements.Length, actual.Elements.Length);
+        for (int i = 0; i < expected.Elements.Length; ++i)
+        {
+            Assert.StrictEqual(expected.Elements[i].InnerText, actual.Elements[i].InnerText);
+        }
+    }
+
+    [Fact]
+    public static void Xml_XmlDocumentAsRoot()
+    {
+        XmlDocument expected = new XmlDocument();
+        expected.LoadXml("<html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
+        var actual = SerializeAndDeserialize(expected, @"<?xml version=""1.0"" encoding=""utf-8""?><html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
+        Assert.NotNull(actual);
+        Assert.StrictEqual(expected.OuterXml, actual.OuterXml);
+    }
+
+    [Fact]
+    public static void Xml_TypeWithXmlDocumentProperty()
+    {
+        XmlDocument xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml("<html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
+        var expected = new TypeWithXmlDocumentProperty() {Document = xmlDoc};
+        var actual = SerializeAndDeserialize(expected, @"<TypeWithXmlDocumentProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Document><html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html></Document></TypeWithXmlDocumentProperty>");
+        Assert.NotNull(actual);
+        Assert.NotNull(actual.Document);
+        Assert.StrictEqual(expected.Document.OuterXml, actual.Document.OuterXml);
+    }
+
     private static System.Reflection.ConstructorInfo FindDefaultConstructor(System.Reflection.TypeInfo ti)
     {
         foreach (System.Reflection.ConstructorInfo ci in ti.DeclaredConstructors)


### PR DESCRIPTION
Add back the code that was removed when moving serialization to .NET Core. Issue #1256.