### PR TITLE
Add serialization support for XmlDocument and XmlElement in XmlSerializer

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.Serialization.Json
             {
                 DataMember member = dataContract.Members[i];
                 object currentMemberValue;
-                if (deserialzedValue.TryGetValue(XmlConvert.DecodeName(dataContract.Members[i].Name), out currentMemberValue) || 
+                if (deserialzedValue.TryGetValue(XmlConvert.DecodeName(dataContract.Members[i].Name), out currentMemberValue) ||
                     dataContract.IsKeyValuePairAdapter && deserialzedValue.TryGetValue(XmlConvert.DecodeName(dataContract.Members[i].Name.ToLowerInvariant()), out currentMemberValue))
                 {
                     if (member.MemberType.GetTypeInfo().IsPrimitive || currentMemberValue == null)

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -835,9 +835,9 @@ public static class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_SuspensionManager()
     {
-        var dict2 = new Dictionary<string, object> {{"Key2-0", "Value2-0"}};
-        var dict1 = new Dictionary<string, object> {{"Key1-0", "Value1-0"}, {"Key1-1", dict2}};
-        var dict0 = new Dictionary<string, object> {{"Key0", dict1}};
+        var dict2 = new Dictionary<string, object> { { "Key2-0", "Value2-0" } };
+        var dict1 = new Dictionary<string, object> { { "Key1-0", "Value1-0" }, { "Key1-1", dict2 } };
+        var dict0 = new Dictionary<string, object> { { "Key0", dict1 } };
 
         var y = SerializeAndDeserialize<Dictionary<string, object>>(dict0, "[{\"Key\":\"Key0\",\"Value\":[{\"__type\":\"KeyValuePairOfstringanyType:#System.Collections.Generic\",\"key\":\"Key1-0\",\"value\":\"Value1-0\"},{\"__type\":\"KeyValuePairOfstringanyType:#System.Collections.Generic\",\"key\":\"Key1-1\",\"value\":[{\"__type\":\"KeyValuePairOfstringanyType:#System.Collections.Generic\",\"key\":\"Key2-0\",\"value\":\"Value2-0\"}]}]}]");
         Assert.NotNull(y);

--- a/src/System.Runtime.Serialization.Json/tests/packages.config
+++ b/src/System.Runtime.Serialization.Json/tests/packages.config
@@ -22,6 +22,7 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22405" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22605" />
+  <package id="System.Xml.XmlDocument" version="4.0.0-beta-22605" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.Serialization;
@@ -289,23 +290,23 @@ namespace SerializationTypes
         }
     }
 
-    public class TypeWithIDictionaryPropertyInitWithConcreteType 
+    public class TypeWithIDictionaryPropertyInitWithConcreteType
     {
         private IDictionary<string, string> dictionaryProperty;
 
-        public IDictionary<string, string> DictionaryProperty 
+        public IDictionary<string, string> DictionaryProperty
         {
-            get 
+            get
             {
                 return this.dictionaryProperty;
             }
-            set 
+            set
             {
                 this.dictionaryProperty = value;
             }
         }
 
-        public TypeWithIDictionaryPropertyInitWithConcreteType() 
+        public TypeWithIDictionaryPropertyInitWithConcreteType()
         {
             dictionaryProperty = new Dictionary<string, string>();
         }
@@ -913,7 +914,7 @@ namespace SerializationTypes
     [KnownType(typeof(SimpleBaseDerived2))]
     public class GenericBase2<T, K>
         where T : new()
-        where K : new()
+    where K : new()
     {
         [DataMember]
         public T genericData1;
@@ -2091,4 +2092,16 @@ public class TestableDerivedException : System.Exception
     { }
 
     public string TestProperty { get; set; }
+}
+
+
+public class TypeWithXmlElementProperty
+{
+    [XmlAnyElement]
+    public XmlElement[] Elements;
+}
+
+public class TypeWithXmlDocumentProperty
+{
+    public XmlDocument Document;
 }

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -292,23 +292,23 @@ namespace SerializationTypes
 
     public class TypeWithIDictionaryPropertyInitWithConcreteType
     {
-        private IDictionary<string, string> dictionaryProperty;
+        private IDictionary<string, string> _dictionaryProperty;
 
         public IDictionary<string, string> DictionaryProperty
         {
             get
             {
-                return this.dictionaryProperty;
+                return _dictionaryProperty;
             }
             set
             {
-                this.dictionaryProperty = value;
+                _dictionaryProperty = value;
             }
         }
 
         public TypeWithIDictionaryPropertyInitWithConcreteType()
         {
-            dictionaryProperty = new Dictionary<string, string>();
+            _dictionaryProperty = new Dictionary<string, string>();
         }
     }
 
@@ -914,7 +914,7 @@ namespace SerializationTypes
     [KnownType(typeof(SimpleBaseDerived2))]
     public class GenericBase2<T, K>
         where T : new()
-    where K : new()
+        where K : new()
     {
         [DataMember]
         public T genericData1;
@@ -1822,29 +1822,33 @@ namespace SerializationTypes
 
     public class TypeWithNonPublicDefaultConstructor
     {
-        static string prefix;
+        private static string s_prefix;
         static TypeWithNonPublicDefaultConstructor()
         {
-            prefix = "Mr. ";
+            s_prefix = "Mr. ";
         }
 
         private TypeWithNonPublicDefaultConstructor()
         {
-            Name = prefix + "FooName";
+            Name = s_prefix + "FooName";
         }
         public string Name { get; set; }
     }
 
     [XmlRoot("RootElement")]
-    public class TypeWithMismatchBetweenAttributeAndPropertyType {
+    public class TypeWithMismatchBetweenAttributeAndPropertyType
+    {
         private int _intValue = 120;
 
         [DefaultValue(true), XmlAttribute("IntValue")]
-        public int IntValue {
-            get {
+        public int IntValue
+        {
+            get
+            {
                 return _intValue;
             }
-            set {
+            set
+            {
                 _intValue = value;
             }
         }
@@ -1876,19 +1880,19 @@ namespace SerializationTypes
 
         public ArticleBase(string title, string category)
         {
-            this.title = title;
-            this.category = category;
+            _title = title;
+            _category = category;
         }
 
-        string title;
+        private string _title;
 
         [DataMember]
-        public string Title { get { return title; } set { title = value; } }
+        public string Title { get { return _title; } set { _title = value; } }
 
-        string category;
+        private string _category;
 
         [DataMember]
-        public string Category { get { return category; } set { category = value; } }
+        public string Category { get { return _category; } set { _category = value; } }
 
         public override string ToString()
         {
@@ -1935,58 +1939,58 @@ namespace SerializationTypes
 
     public class MyGenericList<T> : IList<T>
     {
-        List<T> internalList = new List<T>();
+        private List<T> _internalList = new List<T>();
 
         public int IndexOf(T item)
         {
-            return internalList.IndexOf(item);
+            return _internalList.IndexOf(item);
         }
 
         public void Insert(int index, T item)
         {
-            internalList.Insert(index, item);
+            _internalList.Insert(index, item);
         }
 
         public void RemoveAt(int index)
         {
-            internalList.RemoveAt(index);
+            _internalList.RemoveAt(index);
         }
 
         public T this[int index]
         {
             get
             {
-                return internalList[index];
+                return _internalList[index];
             }
             set
             {
-                internalList[index] = value;
+                _internalList[index] = value;
             }
         }
 
         public void Add(T item)
         {
-            internalList.Add(item);
+            _internalList.Add(item);
         }
 
         public void Clear()
         {
-            internalList.Clear();
+            _internalList.Clear();
         }
 
         public bool Contains(T item)
         {
-            return internalList.Contains(item);
+            return _internalList.Contains(item);
         }
 
         public void CopyTo(T[] array, int arrayIndex)
         {
-            internalList.CopyTo(array, arrayIndex);
+            _internalList.CopyTo(array, arrayIndex);
         }
 
         public int Count
         {
-            get { return internalList.Count; }
+            get { return _internalList.Count; }
         }
 
         public bool IsReadOnly
@@ -1996,23 +2000,23 @@ namespace SerializationTypes
 
         public bool Remove(T item)
         {
-            return internalList.Remove(item);
+            return _internalList.Remove(item);
         }
 
         public IEnumerator<T> GetEnumerator()
         {
-            return internalList.GetEnumerator();
+            return _internalList.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return internalList.GetEnumerator();
+            return _internalList.GetEnumerator();
         }
     }
 
     public class TypeWithListPropertiesWithoutPublicSetters
     {
-        List<string> anotherStringList = new List<string>();
+        private List<string> _anotherStringList = new List<string>();
 
         public TypeWithListPropertiesWithoutPublicSetters()
         {
@@ -2021,7 +2025,7 @@ namespace SerializationTypes
         }
         public MyGenericList<int> IntList { get; private set; }
         public List<string> StringList { get; private set; }
-        public List<string> AnotherStringList { get { return anotherStringList; } }
+        public List<string> AnotherStringList { get { return _anotherStringList; } }
     }
 
     public abstract class HighScoreManager<T> where T : HighScoreManager<T>.HighScoreBase

--- a/src/System.Runtime.Serialization.Xml/tests/packages.config
+++ b/src/System.Runtime.Serialization.Xml/tests/packages.config
@@ -22,6 +22,7 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22405" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22605" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22605" />
+  <package id="System.Xml.XmlDocument" version="4.0.0-beta-22605" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />

--- a/src/System.Xml.XmlSerializer/src/Resources/Strings.resx
+++ b/src/System.Xml.XmlSerializer/src/Resources/Strings.resx
@@ -678,4 +678,16 @@
   <data name="IsNotAssignableFrom" xml:space="preserve">
     <value>{0} is not assignable from {1}.</value>
   </data>
+  <data name="XmlElementNameMismatch" xml:space="preserve">
+    <value>This element was named '{0}' from namespace '{1}' but should have been named '{2}' from namespace '{3}'.</value>
+  </data>
+  <data name="XmlNeedAttributeHere" xml:space="preserve">
+    <value>The node must be either type XmlAttribute or a derived type.</value>
+  </data>
+  <data name="XmlNoAttributeHere" xml:space="preserve">
+    <value>Cannot write a node of type XmlAttribute as an element value. Use XmlAnyAttributeAttribute with an array of XmlNode or XmlAttribute to write the node as an attribute.</value>
+  </data>
+  <data name="XmlInvalidArrayTypeSyntax" xml:space="preserve">
+    <value>Invalid wsd:arrayType syntax: '{0}'.</value>
+  </data>
 </root>

--- a/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.Forwards.cs
+++ b/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.Forwards.cs
@@ -4,5 +4,5 @@
 using System.Runtime.CompilerServices;
 
 
-[assembly:TypeForwardedTo(typeof(System.Xml.Serialization.IXmlSerializable))]
-[assembly:TypeForwardedTo(typeof(System.Xml.Serialization.XmlSchemaProviderAttribute))]
+[assembly: TypeForwardedTo(typeof(System.Xml.Serialization.IXmlSerializable))]
+[assembly: TypeForwardedTo(typeof(System.Xml.Serialization.XmlSchemaProviderAttribute))]

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlChoiceIdentifierAttribute.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlChoiceIdentifierAttribute.cs
@@ -11,7 +11,6 @@ using System.Reflection;
 
 namespace System.Xml.Serialization
 {
-
     /// <include file='doc\XmlChoiceIdentifierAttribute.uex' path='docs/doc[@for="XmlChoiceIdentifierAttribute"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -1560,7 +1560,7 @@ namespace System.Xml.Serialization
                     for (int i = 0; i < a.XmlElements.Count; i++)
                     {
                         XmlElementAttribute xmlElement = a.XmlElements[i];
-                        Type targetType = xmlElement.Type == null ? arrayElementType : xmlElement.Type;
+                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlNode).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlElement);
                         TypeDesc targetTypeDesc = _typeScope.GetTypeDesc(targetType);
                         TypeModel typeModel = _modelScope.GetTypeModel(targetType);
                         ElementAccessor element = new ElementAccessor();
@@ -1601,7 +1601,7 @@ namespace System.Xml.Serialization
                     for (int i = 0; i < a.XmlAnyElements.Count; i++)
                     {
                         XmlAnyElementAttribute xmlAnyElement = a.XmlAnyElements[i];
-                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(object);
+                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlNode).IsAssignableFrom(arrayElementType) ? arrayElementType : typeof(XmlElement);
                         if (!arrayElementType.IsAssignableFrom(targetType))
                             throw new InvalidOperationException(SR.Format(SR.XmlIllegalAnyElement, arrayElementType.FullName));
                         string anyName = xmlAnyElement.Name.Length == 0 ? xmlAnyElement.Name : XmlConvert.EncodeLocalName(xmlAnyElement.Name);
@@ -1842,7 +1842,7 @@ namespace System.Xml.Serialization
                     for (int i = 0; i < a.XmlAnyElements.Count; i++)
                     {
                         XmlAnyElementAttribute xmlAnyElement = a.XmlAnyElements[i];
-                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(accessorType) ? accessorType : typeof(object);
+                        Type targetType = typeof(IXmlSerializable).IsAssignableFrom(accessorType) ? accessorType : typeof(XmlNode).IsAssignableFrom(accessorType) ? accessorType : typeof(XmlElement);
                         if (!accessorType.IsAssignableFrom(targetType))
                             throw new InvalidOperationException(SR.Format(SR.XmlIllegalAnyElement, accessorType.FullName));
 
@@ -2011,6 +2011,11 @@ namespace System.Xml.Serialization
                         choiceTypes.Add(type, false);
                     }
                 }
+            }
+            if (choiceTypes.Contains(typeof(XmlElement)) && a.XmlAnyElements.Count > 0)
+            {
+                // You need to add {0} to the '{1}'.
+                throw new InvalidOperationException(SR.Format(SR.XmlChoiceIdentiferMissing, typeof(XmlChoiceIdentifierAttribute).Name, accessorName));
             }
 
             XmlArrayItemAttributes items = a.XmlArrayItems;

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -33,6 +33,7 @@ namespace System.Xml.Serialization
     public abstract class XmlSerializationReader : XmlSerializationGeneratedCode
     {
         private XmlReader _r;
+        private XmlDocument _d;
         private XmlDeserializationEvents _events;
         private bool _soap12;
         private bool _isReturnValue;
@@ -168,6 +169,19 @@ namespace System.Xml.Serialization
             }
         }
 
+        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.Document"]/*' />
+        protected XmlDocument Document
+        {
+            get
+            {
+                if (_d == null)
+                {
+                    _d = new XmlDocument(_r.NameTable);
+                }
+                return _d;
+            }
+        }
+
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReaderCount"]/*' />
         protected int ReaderCount
         {
@@ -176,8 +190,6 @@ namespace System.Xml.Serialization
                 return 0;
             }
         }
-
-
 
         private void InitPrimitiveIDs()
         {
@@ -619,6 +631,24 @@ namespace System.Xml.Serialization
             return name[5] == ':';
         }
 
+        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsArrayTypeAttribute"]/*' />
+        protected void ParseWsdlArrayType(XmlAttribute attr)
+        {
+            if ((object)attr.LocalName == (object)_wsdlArrayTypeID && (object)attr.NamespaceURI == (object)_wsdlNsID)
+            {
+                int colon = attr.Value.LastIndexOf(':');
+                if (colon < 0)
+                {
+                    attr.Value = _r.LookupNamespace("") + ":" + attr.Value;
+                }
+                else
+                {
+                    attr.Value = _r.LookupNamespace(attr.Value.Substring(0, colon)) + ":" +
+                                 attr.Value.Substring(colon + 1);
+                }
+            }
+            return;
+        }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.IsReturnValue"]/*' />
         protected bool IsReturnValue
@@ -699,6 +729,16 @@ namespace System.Xml.Serialization
             return qname;
         }
 
+        /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ReadXmlDocument"]/*' />
+        protected XmlDocument ReadXmlDocument(bool wrapped)
+        {
+            XmlNode n = ReadXmlNode(wrapped);
+            if (n == null)
+                return null;
+            XmlDocument doc = new XmlDocument();
+            doc.AppendChild(doc.ImportNode(n, true));
+            return doc;
+        }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CollapseWhitespace"]/*' />
         protected string CollapseWhitespace(string value)
@@ -708,6 +748,31 @@ namespace System.Xml.Serialization
             return value.Trim();
         }
 
+        protected XmlNode ReadXmlNode(bool wrapped)
+        {
+            XmlNode node = null;
+            if (wrapped)
+            {
+                if (ReadNull()) return null;
+                _r.ReadStartElement();
+                _r.MoveToContent();
+                if (_r.NodeType != XmlNodeType.EndElement)
+                    node = Document.ReadNode(_r);
+                int whileIterations = 0;
+                int readerCount = ReaderCount;
+                while (_r.NodeType != XmlNodeType.EndElement)
+                {
+                    UnknownNode(null);
+                    CheckReaderCount(ref whileIterations, ref readerCount);
+                }
+                _r.ReadEndElement();
+            }
+            else
+            {
+                node = Document.ReadNode(_r);
+            }
+            return node;
+        }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.ToByteArrayBase64"]/*' />
         protected static byte[] ToByteArrayBase64(string value)
@@ -852,16 +917,31 @@ namespace System.Xml.Serialization
             {
                 return;
             }
-            else
+            if (_r.NodeType == XmlNodeType.Element)
             {
                 _r.Skip();
                 return;
             }
+            UnknownNode(Document.ReadNode(_r), o, qnames);
         }
 
+        private void UnknownNode(XmlNode unknownNode, object o, string qnames)
+        {
+            if (unknownNode == null)
+                return;
+        }
 
-
-
+        private void GetCurrentPosition(out int lineNumber, out int linePosition)
+        {
+            if (Reader is IXmlLineInfo)
+            {
+                IXmlLineInfo lineInfo = (IXmlLineInfo)Reader;
+                lineNumber = lineInfo.LineNumber;
+                linePosition = lineInfo.LinePosition;
+            }
+            else
+                lineNumber = linePosition = -1;
+        }
 
         private string CurrentTag()
         {
@@ -1062,11 +1142,25 @@ namespace System.Xml.Serialization
 
         private object ReadXmlNodes(bool elementCanBeType)
         {
+            ArrayList xmlNodeList = new ArrayList();
             string elemLocalName = Reader.LocalName;
             string elemNs = Reader.NamespaceURI;
+            string elemName = Reader.Name;
             string xsiTypeName = null;
             string xsiTypeNs = null;
             int skippableNodeCount = 0;
+            int lineNumber = -1, linePosition = -1;
+            XmlNode unknownNode = null;
+            if (Reader.NodeType == XmlNodeType.Attribute)
+            {
+                XmlAttribute attr = Document.CreateAttribute(elemName, elemNs);
+                attr.Value = Reader.Value;
+                unknownNode = attr;
+            }
+            else
+                unknownNode = Document.CreateElement(elemName, elemNs);
+            GetCurrentPosition(out lineNumber, out linePosition);
+            XmlElement unknownElement = unknownNode as XmlElement;
 
             while (Reader.MoveToNextAttribute())
             {
@@ -1084,9 +1178,9 @@ namespace System.Xml.Serialization
                     xsiTypeName = (colon >= 0) ? value.Substring(colon + 1) : value;
                     xsiTypeNs = Reader.LookupNamespace((colon >= 0) ? value.Substring(0, colon) : "");
                 }
-                // To support new Object().
-                // <anyType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                skippableNodeCount--;
+                XmlAttribute xmlAttribute = (XmlAttribute)Document.ReadNode(_r);
+                xmlNodeList.Add(xmlAttribute);
+                if (unknownElement != null) unknownElement.SetAttributeNode(xmlAttribute);
             }
 
             // If the node is referenced (or in case of paramStyle = bare) and if xsi:type is not
@@ -1096,7 +1190,9 @@ namespace System.Xml.Serialization
             {
                 xsiTypeName = elemLocalName;
                 xsiTypeNs = elemNs;
-                skippableNodeCount--;
+                XmlAttribute xsiTypeAttribute = Document.CreateAttribute(_typeID, _instanceNsID);
+                xsiTypeAttribute.Value = elemName;
+                xmlNodeList.Add(xsiTypeAttribute);
             }
             if (xsiTypeName == Soap.UrType &&
                 ((object)xsiTypeNs == (object)_schemaNsID ||
@@ -1114,14 +1210,29 @@ namespace System.Xml.Serialization
             }
             else
             {
-                throw CodeGenerator.NotSupported("XLinq");
+                Reader.ReadStartElement();
+                Reader.MoveToContent();
+                int whileIterations = 0;
+                int readerCount = ReaderCount;
+                while (Reader.NodeType != System.Xml.XmlNodeType.EndElement)
+                {
+                    XmlNode xmlNode = Document.ReadNode(_r);
+                    xmlNodeList.Add(xmlNode);
+                    if (unknownElement != null) unknownElement.AppendChild(xmlNode);
+                    Reader.MoveToContent();
+                    CheckReaderCount(ref whileIterations, ref readerCount);
+                }
+                ReadEndElement();
             }
 
 
-            if (skippableNodeCount >= 0)
+            if (xmlNodeList.Count <= skippableNodeCount)
                 return new object();
 
-            throw CodeGenerator.NotSupported("XLinq");
+            XmlNode[] childNodes = (XmlNode[])xmlNodeList.ToArray(typeof(XmlNode));
+
+            UnknownNode(unknownNode, null, null);
+            return childNodes;
         }
 
         /// <include file='doc\XmlSerializationReader.uex' path='docs/doc[@for="XmlSerializationReader.CheckReaderCount"]/*' />

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -973,6 +973,58 @@ public class XmlSerializerTests
         Assert.StrictEqual(value.TestProperty, actual.TestProperty);
     }
 
+    [Fact]
+    public static void Xml_XmlElementAsRoot()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml("<html></html>");
+        XmlElement expected = xDoc.CreateElement("Element");
+        expected.InnerText = "Element innertext";
+        var actual = SerializeAndDeserialize(expected, @"<?xml version=""1.0"" encoding=""utf-8""?><Element>Element innertext</Element>");
+        Assert.NotNull(actual);
+        Assert.StrictEqual(expected.InnerText, actual.InnerText);
+    }
+
+    [Fact]
+    public static void Xml_TypeWithXmlElementProperty()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml("<html></html>");
+        XmlElement productElement = xDoc.CreateElement("Product");
+        productElement.InnerText = "Product innertext";
+        XmlElement categoryElement = xDoc.CreateElement("Category");
+        categoryElement.InnerText = "Category innertext";
+        var expected = new TypeWithXmlElementProperty() { Elements = new[] { productElement, categoryElement } };
+        var actual = SerializeAndDeserialize(expected, @"<?xml version=""1.0"" encoding=""utf-8""?><TypeWithXmlElementProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Product>Product innertext</Product><Category>Category innertext</Category></TypeWithXmlElementProperty>");
+        Assert.StrictEqual(expected.Elements.Length, actual.Elements.Length);
+        for (int i = 0; i < expected.Elements.Length; ++i)
+        {
+            Assert.StrictEqual(expected.Elements[i].InnerText, actual.Elements[i].InnerText);
+        }
+    }
+
+    [Fact]
+    public static void Xml_XmlDocumentAsRoot()
+    {
+        XmlDocument expected = new XmlDocument();
+        expected.LoadXml("<html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
+        var actual = SerializeAndDeserialize(expected, @"<?xml version=""1.0"" encoding=""utf-8""?><html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
+        Assert.NotNull(actual);
+        Assert.StrictEqual(expected.OuterXml, actual.OuterXml);
+    }
+
+    [Fact]
+    public static void Xml_TypeWithXmlDocumentProperty()
+    {
+        XmlDocument xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml("<html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
+        var expected = new TypeWithXmlDocumentProperty() {Document = xmlDoc};
+        var actual = SerializeAndDeserialize(expected, @"<TypeWithXmlDocumentProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Document><html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html></Document></TypeWithXmlDocumentProperty>");
+        Assert.NotNull(actual);
+        Assert.NotNull(actual.Document);
+        Assert.StrictEqual(expected.Document.OuterXml, actual.Document.OuterXml);
+    }
+
     private static System.Reflection.ConstructorInfo FindDefaultConstructor(System.Reflection.TypeInfo ti)
     {
         foreach (System.Reflection.ConstructorInfo ci in ti.DeclaredConstructors)

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -195,17 +195,17 @@ public class XmlSerializerTests
     public static void Xml_ArrayAsRoot()
     {
         SimpleType[] x = new SimpleType[] { new SimpleType { P1 = "abc", P2 = 11 }, new SimpleType { P1 = "def", P2 = 12 } };
-        SimpleType[] y = SerializeAndDeserialize<SimpleType[]>(x, 
-            "<?xml version=\"1.0\"?>" + Environment.NewLine + 
-            "<ArrayOfSimpleType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine + 
+        SimpleType[] y = SerializeAndDeserialize<SimpleType[]>(x,
+            "<?xml version=\"1.0\"?>" + Environment.NewLine +
+            "<ArrayOfSimpleType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <SimpleType>" + Environment.NewLine +
             "    <P1>abc</P1>" + Environment.NewLine +
-            "    <P2>11</P2>" + Environment.NewLine + 
-            "  </SimpleType>" + Environment.NewLine + 
-            "  <SimpleType>" + Environment.NewLine + 
-            "    <P1>def</P1>" + Environment.NewLine + 
-            "    <P2>12</P2>" + Environment.NewLine + 
-            "  </SimpleType>" + Environment.NewLine + 
+            "    <P2>11</P2>" + Environment.NewLine +
+            "  </SimpleType>" + Environment.NewLine +
+            "  <SimpleType>" + Environment.NewLine +
+            "    <P1>def</P1>" + Environment.NewLine +
+            "    <P2>12</P2>" + Environment.NewLine +
+            "  </SimpleType>" + Environment.NewLine +
             "</ArrayOfSimpleType>");
 
         Utils.Equal(x, y, (a, b) => { return SimpleType.AreEqual(a, b); });
@@ -221,26 +221,26 @@ public class XmlSerializerTests
             P1 = new SimpleType[] { new SimpleType { P1 = "ef", P2 = 5 }, new SimpleType { P1 = "gh", P2 = 7 } },
             P2 = new int[] { 11, 12 }
         };
-        TypeWithGetSetArrayMembers y = SerializeAndDeserialize<TypeWithGetSetArrayMembers>(x, 
-            "<?xml version=\"1.0\"?>" + Environment.NewLine + 
-            "<TypeWithGetSetArrayMembers xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine + 
-            "  <F1>" + Environment.NewLine + 
-            "    <SimpleType>" + Environment.NewLine + 
-            "      <P1>ab</P1>" + Environment.NewLine + 
-            "      <P2>1</P2>" + Environment.NewLine + 
-            "    </SimpleType>" + Environment.NewLine + 
-            "    <SimpleType>" + Environment.NewLine + 
-            "      <P1>cd</P1>" + Environment.NewLine + 
-            "      <P2>2</P2>" + Environment.NewLine + 
-            "    </SimpleType>" + Environment.NewLine + 
-            "  </F1>" + Environment.NewLine + 
-            "  <F2>" + Environment.NewLine + 
-            "    <int>-1</int>" + Environment.NewLine + 
-            "    <int>3</int>" + Environment.NewLine + 
-            "  </F2>" + Environment.NewLine + 
-            "  <P1>" + Environment.NewLine + 
-            "    <SimpleType>" + Environment.NewLine + 
-            "      <P1>ef</P1>" + Environment.NewLine + 
+        TypeWithGetSetArrayMembers y = SerializeAndDeserialize<TypeWithGetSetArrayMembers>(x,
+            "<?xml version=\"1.0\"?>" + Environment.NewLine +
+            "<TypeWithGetSetArrayMembers xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
+            "  <F1>" + Environment.NewLine +
+            "    <SimpleType>" + Environment.NewLine +
+            "      <P1>ab</P1>" + Environment.NewLine +
+            "      <P2>1</P2>" + Environment.NewLine +
+            "    </SimpleType>" + Environment.NewLine +
+            "    <SimpleType>" + Environment.NewLine +
+            "      <P1>cd</P1>" + Environment.NewLine +
+            "      <P2>2</P2>" + Environment.NewLine +
+            "    </SimpleType>" + Environment.NewLine +
+            "  </F1>" + Environment.NewLine +
+            "  <F2>" + Environment.NewLine +
+            "    <int>-1</int>" + Environment.NewLine +
+            "    <int>3</int>" + Environment.NewLine +
+            "  </F2>" + Environment.NewLine +
+            "  <P1>" + Environment.NewLine +
+            "    <SimpleType>" + Environment.NewLine +
+            "      <P1>ef</P1>" + Environment.NewLine +
             "      <P2>5</P2>" + Environment.NewLine +
             "    </SimpleType>" + Environment.NewLine +
             "    <SimpleType>" + Environment.NewLine +
@@ -250,8 +250,8 @@ public class XmlSerializerTests
             "  </P1>" + Environment.NewLine +
             "  <P2>" + Environment.NewLine +
             "    <int>11</int>" + Environment.NewLine +
-            "    <int>12</int>" + Environment.NewLine + 
-            "  </P2>" + Environment.NewLine + 
+            "    <int>12</int>" + Environment.NewLine +
+            "  </P2>" + Environment.NewLine +
             "</TypeWithGetSetArrayMembers>");
 
         Assert.NotNull(y);
@@ -284,11 +284,11 @@ public class XmlSerializerTests
         x.Add("zero");
         x.Add("one");
 
-        List<string> y = SerializeAndDeserialize<List<string>>(x, 
+        List<string> y = SerializeAndDeserialize<List<string>>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfString xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <string>zero</string>" + Environment.NewLine + 
-            "  <string>one</string>" + Environment.NewLine + 
+            "  <string>zero</string>" + Environment.NewLine +
+            "  <string>one</string>" + Environment.NewLine +
             "</ArrayOfString>");
 
         Assert.NotNull(y);
@@ -301,11 +301,11 @@ public class XmlSerializerTests
     public static void Xml_CollectionGenericRoot()
     {
         MyCollection<string> x = new MyCollection<string>("a1", "a2");
-        MyCollection<string> y = SerializeAndDeserialize<MyCollection<string>>(x, 
+        MyCollection<string> y = SerializeAndDeserialize<MyCollection<string>>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfString xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <string>a1</string>" + Environment.NewLine + 
-            "  <string>a2</string>" + Environment.NewLine + 
+            "  <string>a1</string>" + Environment.NewLine +
+            "  <string>a2</string>" + Environment.NewLine +
             "</ArrayOfString>");
 
         Assert.NotNull(y);
@@ -320,11 +320,11 @@ public class XmlSerializerTests
     public static void Xml_ListRoot()
     {
         MyList x = new MyList("a1", "a2");
-        MyList y = SerializeAndDeserialize<MyList>(x, 
+        MyList y = SerializeAndDeserialize<MyList>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfAnyType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <anyType xsi:type=\"xsd:string\">a1</anyType>" + Environment.NewLine + 
-            "  <anyType xsi:type=\"xsd:string\">a2</anyType>" + Environment.NewLine + 
+            "  <anyType xsi:type=\"xsd:string\">a1</anyType>" + Environment.NewLine +
+            "  <anyType xsi:type=\"xsd:string\">a2</anyType>" + Environment.NewLine +
             "</ArrayOfAnyType>");
 
         Assert.NotNull(y);
@@ -337,11 +337,11 @@ public class XmlSerializerTests
     public static void Xml_EnumerableGenericRoot()
     {
         MyEnumerable<string> x = new MyEnumerable<string>("a1", "a2");
-        MyEnumerable<string> y = SerializeAndDeserialize<MyEnumerable<string>>(x, 
+        MyEnumerable<string> y = SerializeAndDeserialize<MyEnumerable<string>>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfString xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <string>a1</string>" + Environment.NewLine + 
-            "  <string>a2</string>" + Environment.NewLine + 
+            "  <string>a1</string>" + Environment.NewLine +
+            "  <string>a2</string>" + Environment.NewLine +
             "</ArrayOfString>");
 
         Assert.NotNull(y);
@@ -355,11 +355,11 @@ public class XmlSerializerTests
     public static void Xml_CollectionRoot()
     {
         MyCollection x = new MyCollection('a', 45);
-        MyCollection y = SerializeAndDeserialize<MyCollection>(x, 
+        MyCollection y = SerializeAndDeserialize<MyCollection>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfAnyType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <anyType xmlns:q1=\"http://microsoft.com/wsdl/types/\" xsi:type=\"q1:char\">97</anyType>" + Environment.NewLine + 
-            "  <anyType xsi:type=\"xsd:int\">45</anyType>" + Environment.NewLine + 
+            "  <anyType xmlns:q1=\"http://microsoft.com/wsdl/types/\" xsi:type=\"q1:char\">97</anyType>" + Environment.NewLine +
+            "  <anyType xsi:type=\"xsd:int\">45</anyType>" + Environment.NewLine +
             "</ArrayOfAnyType>");
 
         Assert.NotNull(y);
@@ -372,11 +372,11 @@ public class XmlSerializerTests
     public static void Xml_EnumerableRoot()
     {
         MyEnumerable x = new MyEnumerable("abc", 3);
-        MyEnumerable y = SerializeAndDeserialize<MyEnumerable>(x, 
+        MyEnumerable y = SerializeAndDeserialize<MyEnumerable>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfAnyType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <anyType xsi:type=\"xsd:string\">abc</anyType>" + Environment.NewLine + 
-            "  <anyType xsi:type=\"xsd:int\">3</anyType>" + Environment.NewLine + 
+            "  <anyType xsi:type=\"xsd:string\">abc</anyType>" + Environment.NewLine +
+            "  <anyType xsi:type=\"xsd:int\">3</anyType>" + Environment.NewLine +
             "</ArrayOfAnyType>");
 
         Assert.NotNull(y);
@@ -402,11 +402,11 @@ public class XmlSerializerTests
     public static void Xml_EnumAsMember()
     {
         TypeWithEnumMembers x = new TypeWithEnumMembers { F1 = MyEnum.Three, P1 = MyEnum.Two };
-        TypeWithEnumMembers y = SerializeAndDeserialize<TypeWithEnumMembers>(x, 
+        TypeWithEnumMembers y = SerializeAndDeserialize<TypeWithEnumMembers>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<TypeWithEnumMembers xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <F1>Three</F1>" + Environment.NewLine + 
-            "  <P1>Two</P1>" + Environment.NewLine + 
+            "  <F1>Three</F1>" + Environment.NewLine +
+            "  <P1>Two</P1>" + Environment.NewLine +
             "</TypeWithEnumMembers>");
 
         Assert.NotNull(y);
@@ -418,13 +418,13 @@ public class XmlSerializerTests
     public static void Xml_DCClassWithEnumAndStruct()
     {
         DCClassWithEnumAndStruct value = new DCClassWithEnumAndStruct(true);
-        DCClassWithEnumAndStruct actual = SerializeAndDeserialize<DCClassWithEnumAndStruct>(value, 
-            "<?xml version=\"1.0\"?>" + Environment.NewLine + 
+        DCClassWithEnumAndStruct actual = SerializeAndDeserialize<DCClassWithEnumAndStruct>(value,
+            "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<DCClassWithEnumAndStruct xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <MyStruct>" + Environment.NewLine +
             "    <Data>Data</Data>" + Environment.NewLine +
-            "  </MyStruct>" + Environment.NewLine + 
-            "  <MyEnum1>One</MyEnum1>" + Environment.NewLine + 
+            "  </MyStruct>" + Environment.NewLine +
+            "  <MyEnum1>One</MyEnum1>" + Environment.NewLine +
             "</DCClassWithEnumAndStruct>");
 
         Assert.StrictEqual(value.MyEnum1, actual.MyEnum1);
@@ -438,10 +438,10 @@ public class XmlSerializerTests
         {
             ByteArray = new byte[] { 1, 2 }
         };
-        BuiltInTypes y = SerializeAndDeserialize<BuiltInTypes>(x, 
+        BuiltInTypes y = SerializeAndDeserialize<BuiltInTypes>(x,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
-            "<BuiltInTypes xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine + 
-            "  <ByteArray>AQI=</ByteArray>" + Environment.NewLine + 
+            "<BuiltInTypes xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
+            "  <ByteArray>AQI=</ByteArray>" + Environment.NewLine +
             "</BuiltInTypes>");
 
         Assert.NotNull(y);
@@ -451,7 +451,7 @@ public class XmlSerializerTests
     [Fact]
     public static void Xml_GenericBase()
     {
-        SerializeAndDeserialize<GenericBase2<SimpleBaseDerived, SimpleBaseDerived2>>(new GenericBase2<SimpleBaseDerived, SimpleBaseDerived2>(true), 
+        SerializeAndDeserialize<GenericBase2<SimpleBaseDerived, SimpleBaseDerived2>>(new GenericBase2<SimpleBaseDerived, SimpleBaseDerived2>(true),
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<GenericBase2OfSimpleBaseDerivedSimpleBaseDerived2 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <genericData1>" + Environment.NewLine +
@@ -460,16 +460,16 @@ public class XmlSerializerTests
             "  </genericData1>" + Environment.NewLine +
             "  <genericData2>" + Environment.NewLine +
             "    <BaseData />" + Environment.NewLine +
-            "    <DerivedData />" + Environment.NewLine + 
-            "  </genericData2>" + Environment.NewLine + 
+            "    <DerivedData />" + Environment.NewLine +
+            "  </genericData2>" + Environment.NewLine +
             "</GenericBase2OfSimpleBaseDerivedSimpleBaseDerived2>");
     }
 
     [Fact]
     public static void Xml_TypesWithArrayOfOtherTypes()
     {
-        SerializeAndDeserialize<TypeHasArrayOfASerializedAsB>(new TypeHasArrayOfASerializedAsB(true), 
-            "<?xml version=\"1.0\"?>" + Environment.NewLine + 
+        SerializeAndDeserialize<TypeHasArrayOfASerializedAsB>(new TypeHasArrayOfASerializedAsB(true),
+            "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<TypeHasArrayOfASerializedAsB xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <Items>" + Environment.NewLine +
             "    <TypeA>" + Environment.NewLine +
@@ -477,8 +477,8 @@ public class XmlSerializerTests
             "    </TypeA>" + Environment.NewLine +
             "    <TypeA>" + Environment.NewLine +
             "      <Name>typeBValue</Name>" + Environment.NewLine +
-            "    </TypeA>" + Environment.NewLine + 
-            "  </Items>" + Environment.NewLine + 
+            "    </TypeA>" + Environment.NewLine +
+            "  </Items>" + Environment.NewLine +
             "</TypeHasArrayOfASerializedAsB>");
     }
 
@@ -487,12 +487,12 @@ public class XmlSerializerTests
     public static void Xml_WithXElement()
     {
         var original = new WithXElement(true);
-        var actual = SerializeAndDeserialize<WithXElement>(original, 
+        var actual = SerializeAndDeserialize<WithXElement>(original,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithXElement xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <e>" + Environment.NewLine +
-            "    <ElementName1 Attribute1=\"AttributeValue1\">Value1</ElementName1>" + Environment.NewLine + 
-            "  </e>" + Environment.NewLine + 
+            "    <ElementName1 Attribute1=\"AttributeValue1\">Value1</ElementName1>" + Environment.NewLine +
+            "  </e>" + Environment.NewLine +
             "</WithXElement>");
 
         VerifyXElementObject(original.e, actual.e);
@@ -514,14 +514,14 @@ public class XmlSerializerTests
     public static void Xml_WithXElementWithNestedXElement()
     {
         var original = new WithXElementWithNestedXElement(true);
-        var actual = SerializeAndDeserialize<WithXElementWithNestedXElement>(original, 
+        var actual = SerializeAndDeserialize<WithXElementWithNestedXElement>(original,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithXElementWithNestedXElement xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <e1>" + Environment.NewLine +
             "    <ElementName1 Attribute1=\"AttributeValue1\">" + Environment.NewLine +
             "      <ElementName2 Attribute2=\"AttributeValue2\">Value2</ElementName2>" + Environment.NewLine +
-            "    </ElementName1>" + Environment.NewLine + 
-            "  </e1>" + Environment.NewLine + 
+            "    </ElementName1>" + Environment.NewLine +
+            "  </e1>" + Environment.NewLine +
             "</WithXElementWithNestedXElement>");
 
         VerifyXElementObject(original.e1, actual.e1);
@@ -533,7 +533,7 @@ public class XmlSerializerTests
     public static void Xml_WithArrayOfXElement()
     {
         var original = new WithArrayOfXElement(true);
-        var actual = SerializeAndDeserialize<WithArrayOfXElement>(original, 
+        var actual = SerializeAndDeserialize<WithArrayOfXElement>(original,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithArrayOfXElement xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <a>" + Environment.NewLine +
@@ -545,8 +545,8 @@ public class XmlSerializerTests
             "    </XElement>" + Environment.NewLine +
             "    <XElement>" + Environment.NewLine +
             "      <item xmlns=\"http://p.com/\">item2</item>" + Environment.NewLine +
-            "    </XElement>" + Environment.NewLine + 
-            "  </a>" + Environment.NewLine + 
+            "    </XElement>" + Environment.NewLine +
+            "  </a>" + Environment.NewLine +
             "</WithArrayOfXElement>");
 
         Assert.StrictEqual(original.a.Length, actual.a.Length);
@@ -560,7 +560,7 @@ public class XmlSerializerTests
     public static void Xml_WithListOfXElement()
     {
         var original = new WithListOfXElement(true);
-        var actual = SerializeAndDeserialize<WithListOfXElement>(original, 
+        var actual = SerializeAndDeserialize<WithListOfXElement>(original,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithListOfXElement xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <list>" + Environment.NewLine +
@@ -572,8 +572,8 @@ public class XmlSerializerTests
             "    </XElement>" + Environment.NewLine +
             "    <XElement>" + Environment.NewLine +
             "      <item xmlns=\"http://p.com/\">item2</item>" + Environment.NewLine +
-            "    </XElement>" + Environment.NewLine + 
-            "  </list>" + Environment.NewLine + 
+            "    </XElement>" + Environment.NewLine +
+            "  </list>" + Environment.NewLine +
             "</WithListOfXElement>");
 
         Assert.StrictEqual(original.list.Count, actual.list.Count);
@@ -585,10 +585,10 @@ public class XmlSerializerTests
     [Fact]
     public static void Xml_TypeNamesWithSpecialCharacters()
     {
-        SerializeAndDeserialize<__TypeNameWithSpecialCharacters漢ñ>(new __TypeNameWithSpecialCharacters漢ñ() { PropertyNameWithSpecialCharacters漢ñ = "Test" }, 
+        SerializeAndDeserialize<__TypeNameWithSpecialCharacters漢ñ>(new __TypeNameWithSpecialCharacters漢ñ() { PropertyNameWithSpecialCharacters漢ñ = "Test" },
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
-            "<__TypeNameWithSpecialCharacters漢ñ xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine + 
-            "  <PropertyNameWithSpecialCharacters漢ñ>Test</PropertyNameWithSpecialCharacters漢ñ>" + Environment.NewLine + 
+            "<__TypeNameWithSpecialCharacters漢ñ xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
+            "  <PropertyNameWithSpecialCharacters漢ñ>Test</PropertyNameWithSpecialCharacters漢ñ>" + Environment.NewLine +
             "</__TypeNameWithSpecialCharacters漢ñ>");
     }
 
@@ -596,8 +596,8 @@ public class XmlSerializerTests
     public static void Xml_JaggedArrayAsRoot()
     {
         int[][] jaggedIntegerArray = new int[][] { new int[] { 1, 3, 5, 7, 9 }, new int[] { 0, 2, 4, 6 }, new int[] { 11, 22 } };
-        int[][] actualJaggedIntegerArray = SerializeAndDeserialize<int[][]>(jaggedIntegerArray, 
-            "<?xml version=\"1.0\"?>" + Environment.NewLine + 
+        int[][] actualJaggedIntegerArray = SerializeAndDeserialize<int[][]>(jaggedIntegerArray,
+            "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <ArrayOfInt>" + Environment.NewLine +
             "    <int>1</int>" + Environment.NewLine +
@@ -614,8 +614,8 @@ public class XmlSerializerTests
             "  </ArrayOfInt>" + Environment.NewLine +
             "  <ArrayOfInt>" + Environment.NewLine +
             "    <int>11</int>" + Environment.NewLine +
-            "    <int>22</int>" + Environment.NewLine + 
-            "  </ArrayOfInt>" + Environment.NewLine + 
+            "    <int>22</int>" + Environment.NewLine +
+            "  </ArrayOfInt>" + Environment.NewLine +
             "</ArrayOfArrayOfInt>");
         Assert.Equal(jaggedIntegerArray[0], actualJaggedIntegerArray[0]);
         Assert.Equal(jaggedIntegerArray[1], actualJaggedIntegerArray[1]);
@@ -623,7 +623,7 @@ public class XmlSerializerTests
 
 
         string[][] jaggedStringArray = new string[][] { new string[] { "1", "3", "5", "7", "9" }, new string[] { "0", "2", "4", "6" }, new string[] { "11", "22" } };
-        string[][] actualJaggedStringArray = SerializeAndDeserialize<string[][]>(jaggedStringArray, 
+        string[][] actualJaggedStringArray = SerializeAndDeserialize<string[][]>(jaggedStringArray,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfArrayOfString xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <ArrayOfString>" + Environment.NewLine +
@@ -641,8 +641,8 @@ public class XmlSerializerTests
             "  </ArrayOfString>" + Environment.NewLine +
             "  <ArrayOfString>" + Environment.NewLine +
             "    <string>11</string>" + Environment.NewLine +
-            "    <string>22</string>" + Environment.NewLine + 
-            "  </ArrayOfString>" + Environment.NewLine + 
+            "    <string>22</string>" + Environment.NewLine +
+            "  </ArrayOfString>" + Environment.NewLine +
             "</ArrayOfArrayOfString>");
         Assert.Equal(jaggedStringArray[0], actualJaggedStringArray[0]);
         Assert.Equal(jaggedStringArray[1], actualJaggedStringArray[1]);
@@ -650,15 +650,15 @@ public class XmlSerializerTests
 
 
         object[] objectArray = new object[] { 1, 1.0F, 1.0, "string", Guid.Parse("2054fd3e-e118-476a-9962-1a882be51860"), new DateTime(2013, 1, 2) };
-        object[] actualObjectArray = SerializeAndDeserialize<object[]>(objectArray, 
+        object[] actualObjectArray = SerializeAndDeserialize<object[]>(objectArray,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfAnyType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <anyType xsi:type=\"xsd:int\">1</anyType>" + Environment.NewLine +
             "  <anyType xsi:type=\"xsd:float\">1</anyType>" + Environment.NewLine +
             "  <anyType xsi:type=\"xsd:double\">1</anyType>" + Environment.NewLine +
             "  <anyType xsi:type=\"xsd:string\">string</anyType>" + Environment.NewLine +
-            "  <anyType xmlns:q1=\"http://microsoft.com/wsdl/types/\" xsi:type=\"q1:guid\">2054fd3e-e118-476a-9962-1a882be51860</anyType>" + Environment.NewLine + 
-            "  <anyType xsi:type=\"xsd:dateTime\">2013-01-02T00:00:00</anyType>" + Environment.NewLine + 
+            "  <anyType xmlns:q1=\"http://microsoft.com/wsdl/types/\" xsi:type=\"q1:guid\">2054fd3e-e118-476a-9962-1a882be51860</anyType>" + Environment.NewLine +
+            "  <anyType xsi:type=\"xsd:dateTime\">2013-01-02T00:00:00</anyType>" + Environment.NewLine +
             "</ArrayOfAnyType>");
         Assert.True(1 == (int)actualObjectArray[0]);
         Assert.True(1.0F == (float)actualObjectArray[1]);
@@ -669,7 +669,7 @@ public class XmlSerializerTests
 
 
         int[][][] jaggedIntegerArray2 = new int[][][] { new int[][] { new int[] { 1 }, new int[] { 3 } }, new int[][] { new int[] { 0 } }, new int[][] { new int[] { } } };
-        int[][][] actualJaggedIntegerArray2 = SerializeAndDeserialize<int[][][]>(jaggedIntegerArray2, 
+        int[][][] actualJaggedIntegerArray2 = SerializeAndDeserialize<int[][][]>(jaggedIntegerArray2,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfArrayOfArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <ArrayOfArrayOfInt>" + Environment.NewLine +
@@ -686,8 +686,8 @@ public class XmlSerializerTests
             "    </ArrayOfInt>" + Environment.NewLine +
             "  </ArrayOfArrayOfInt>" + Environment.NewLine +
             "  <ArrayOfArrayOfInt>" + Environment.NewLine +
-            "    <ArrayOfInt />" + Environment.NewLine + 
-            "  </ArrayOfArrayOfInt>" + Environment.NewLine + 
+            "    <ArrayOfInt />" + Environment.NewLine +
+            "  </ArrayOfArrayOfInt>" + Environment.NewLine +
             "</ArrayOfArrayOfArrayOfInt>");
 
         Assert.True(actualJaggedIntegerArray2.Length == 3);
@@ -710,14 +710,14 @@ public class XmlSerializerTests
     public static void Xml_KnownTypesThroughConstructor()
     {
         KnownTypesThroughConstructor value = new KnownTypesThroughConstructor() { EnumValue = MyEnum.One, SimpleTypeValue = new SimpleKnownTypeValue() { StrProperty = "PropertyValue" } };
-        KnownTypesThroughConstructor actual = SerializeAndDeserialize<KnownTypesThroughConstructor>(value, 
+        KnownTypesThroughConstructor actual = SerializeAndDeserialize<KnownTypesThroughConstructor>(value,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<KnownTypesThroughConstructor xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <EnumValue xsi:type=\"MyEnum\">One</EnumValue>" + Environment.NewLine +
             "  <SimpleTypeValue xsi:type=\"SimpleKnownTypeValue\">" + Environment.NewLine +
-            "    <StrProperty>PropertyValue</StrProperty>" + Environment.NewLine + 
-            "  </SimpleTypeValue>" + Environment.NewLine + 
-            "</KnownTypesThroughConstructor>", 
+            "    <StrProperty>PropertyValue</StrProperty>" + Environment.NewLine +
+            "  </SimpleTypeValue>" + Environment.NewLine +
+            "</KnownTypesThroughConstructor>",
             () => { return new XmlSerializer(typeof(KnownTypesThroughConstructor), new Type[] { typeof(MyEnum), typeof(SimpleKnownTypeValue) }); });
 
         Assert.StrictEqual((MyEnum)value.EnumValue, (MyEnum)actual.EnumValue);
@@ -730,7 +730,7 @@ public class XmlSerializerTests
         DerivedClassWithSameProperty value = new DerivedClassWithSameProperty() { DateTimeProperty = new DateTime(100), IntProperty = 5, StringProperty = "TestString", ListProperty = new List<string>() };
         value.ListProperty.AddRange(new string[] { "one", "two", "three" });
 
-        DerivedClassWithSameProperty actual = SerializeAndDeserialize<DerivedClassWithSameProperty>(value, 
+        DerivedClassWithSameProperty actual = SerializeAndDeserialize<DerivedClassWithSameProperty>(value,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<DerivedClassWithSameProperty xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <StringProperty>TestString</StringProperty>" + Environment.NewLine +
@@ -739,8 +739,8 @@ public class XmlSerializerTests
             "  <ListProperty>" + Environment.NewLine +
             "    <string>one</string>" + Environment.NewLine +
             "    <string>two</string>" + Environment.NewLine +
-            "    <string>three</string>" + Environment.NewLine + 
-            "  </ListProperty>" + Environment.NewLine + 
+            "    <string>three</string>" + Environment.NewLine +
+            "  </ListProperty>" + Environment.NewLine +
             "</DerivedClassWithSameProperty>");
 
         Assert.StrictEqual(value.DateTimeProperty, actual.DateTimeProperty);
@@ -765,12 +765,12 @@ public class XmlSerializerTests
     public static void Xml_SimpleCollectionDataContract()
     {
         var value = new SimpleCDC(true);
-        var actual = SerializeAndDeserialize<SimpleCDC>(value, 
+        var actual = SerializeAndDeserialize<SimpleCDC>(value,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ArrayOfString xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <string>One</string>" + Environment.NewLine +
-            "  <string>Two</string>" + Environment.NewLine + 
-            "  <string>Three</string>" + Environment.NewLine + 
+            "  <string>Two</string>" + Environment.NewLine +
+            "  <string>Three</string>" + Environment.NewLine +
             "</ArrayOfString>");
 
         Assert.True(value.Count == actual.Count);
@@ -793,13 +793,13 @@ public class XmlSerializerTests
     public static void Xml_SerializeClassThatImplementsInteface()
     {
         ClassImplementsInterface value = new ClassImplementsInterface() { ClassID = "ClassID", DisplayName = "DisplayName", Id = "Id", IsLoaded = true };
-        ClassImplementsInterface actual = SerializeAndDeserialize<ClassImplementsInterface>(value, 
+        ClassImplementsInterface actual = SerializeAndDeserialize<ClassImplementsInterface>(value,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<ClassImplementsInterface xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <ClassID>ClassID</ClassID>" + Environment.NewLine +
             "  <DisplayName>DisplayName</DisplayName>" + Environment.NewLine +
-            "  <Id>Id</Id>" + Environment.NewLine + 
-            "  <IsLoaded>true</IsLoaded>" + Environment.NewLine + 
+            "  <Id>Id</Id>" + Environment.NewLine +
+            "  <IsLoaded>true</IsLoaded>" + Environment.NewLine +
             "</ClassImplementsInterface>");
 
         Assert.StrictEqual(value.ClassID, actual.ClassID);
@@ -813,7 +813,7 @@ public class XmlSerializerTests
     public static void Xml_XmlAttributesTest()
     {
         var value = new XmlSerializerAttributes();
-        var actual = SerializeAndDeserialize(value, 
+        var actual = SerializeAndDeserialize(value,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<AttributeTesting xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" XmlAttributeName=\"2\">" + Environment.NewLine +
             "  <Word>String choice value</Word>" + Environment.NewLine +
@@ -822,7 +822,7 @@ public class XmlSerializerTests
             "    <ItemChoiceType>DecimalNumber</ItemChoiceType>" + Environment.NewLine +
             "    <ItemChoiceType>Number</ItemChoiceType>" + Environment.NewLine +
             "    <ItemChoiceType>Word</ItemChoiceType>" + Environment.NewLine +
-            "    <ItemChoiceType>None</ItemChoiceType>" + Environment.NewLine + 
+            "    <ItemChoiceType>None</ItemChoiceType>" + Environment.NewLine +
             "  </XmlEnumProperty>&lt;xml&gt;Hello XML&lt;/xml&gt;<XmlNamespaceDeclarationsProperty>XmlNamespaceDeclarationsPropertyValue</XmlNamespaceDeclarationsProperty><XmlElementPropertyNode xmlns=\"http://element\">1</XmlElementPropertyNode><CustomXmlArrayProperty xmlns=\"http://mynamespace\"><string>one</string><string>two</string><string>three</string></CustomXmlArrayProperty></AttributeTesting>");
 
         Assert.StrictEqual(actual.EnumType, value.EnumType);
@@ -843,13 +843,13 @@ public class XmlSerializerTests
     public static void Xml_Struct()
     {
         var value = new WithStruct { Some = new SomeStruct { A = 1, B = 2 } };
-        var result = SerializeAndDeserialize(value, 
+        var result = SerializeAndDeserialize(value,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithStruct xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <Some>" + Environment.NewLine +
             "    <A>1</A>" + Environment.NewLine +
-            "    <B>2</B>" + Environment.NewLine + 
-            "  </Some>" + Environment.NewLine + 
+            "    <B>2</B>" + Environment.NewLine +
+            "  </Some>" + Environment.NewLine +
             "</WithStruct>");
 
         // Assert
@@ -861,11 +861,11 @@ public class XmlSerializerTests
     public static void Xml_Enums()
     {
         var item = new WithEnums() { Int = IntEnum.Option1, Short = ShortEnum.Option2 };
-        var actual = SerializeAndDeserialize(item, 
+        var actual = SerializeAndDeserialize(item,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithEnums xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
-            "  <Int>Option1</Int>" + Environment.NewLine + 
-            "  <Short>Option2</Short>" + Environment.NewLine + 
+            "  <Int>Option1</Int>" + Environment.NewLine +
+            "  <Short>Option2</Short>" + Environment.NewLine +
             "</WithEnums>");
         Assert.StrictEqual(item.Short, actual.Short);
         Assert.StrictEqual(item.Int, actual.Int);
@@ -875,7 +875,7 @@ public class XmlSerializerTests
     public static void Xml_Nullables()
     {
         var item = new WithNullables() { Optional = IntEnum.Option1, OptionalInt = 42, Struct1 = new SomeStruct { A = 1, B = 2 } };
-        var actual = SerializeAndDeserialize(item, 
+        var actual = SerializeAndDeserialize(item,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<WithNullables xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + Environment.NewLine +
             "  <Optional>Option1</Optional>" + Environment.NewLine +
@@ -885,8 +885,8 @@ public class XmlSerializerTests
             "  <Struct1>" + Environment.NewLine +
             "    <A>1</A>" + Environment.NewLine +
             "    <B>2</B>" + Environment.NewLine +
-            "  </Struct1>" + Environment.NewLine + 
-            "  <Struct2 xsi:nil=\"true\" />" + Environment.NewLine + 
+            "  </Struct1>" + Environment.NewLine +
+            "  <Struct2 xsi:nil=\"true\" />" + Environment.NewLine +
             "</WithNullables>");
         Assert.StrictEqual(item.OptionalInt, actual.OptionalInt);
         Assert.StrictEqual(item.Optional, actual.Optional);
@@ -944,11 +944,11 @@ public class XmlSerializerTests
     {
         var original = new TypeWithMemberWithXmlNamespaceDeclarationsAttribute() { header = "foo", body = "bar" };
 
-        var actual = SerializeAndDeserialize<TypeWithMemberWithXmlNamespaceDeclarationsAttribute>(original, 
+        var actual = SerializeAndDeserialize<TypeWithMemberWithXmlNamespaceDeclarationsAttribute>(original,
             "<?xml version=\"1.0\"?>" + Environment.NewLine +
             "<Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://www.w3.org/2003/05/soap-envelope\">" + Environment.NewLine +
-            "  <header>foo</header>" + Environment.NewLine + 
-            "  <body>bar</body>" + Environment.NewLine + 
+            "  <header>foo</header>" + Environment.NewLine +
+            "  <body>bar</body>" + Environment.NewLine +
             "</Envelope>");
         Assert.StrictEqual(original.header, actual.header);
         Assert.StrictEqual(original.body, actual.body);
@@ -1018,7 +1018,7 @@ public class XmlSerializerTests
     {
         XmlDocument xmlDoc = new XmlDocument();
         xmlDoc.LoadXml("<html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html>");
-        var expected = new TypeWithXmlDocumentProperty() {Document = xmlDoc};
+        var expected = new TypeWithXmlDocumentProperty() { Document = xmlDoc };
         var actual = SerializeAndDeserialize(expected, @"<TypeWithXmlDocumentProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Document><html><head>Head content</head><body><h1>Heading1</h1><div>Text in body</div></body></html></Document></TypeWithXmlDocumentProperty>");
         Assert.NotNull(actual);
         Assert.NotNull(actual.Document);


### PR DESCRIPTION
Add back the code that was removed when moving serialization to .NET Core. Issue #1256.