### PR TITLE
Add System.Security.SecureString library

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ The repo contains the following components. More libraries are coming soon. ['Wa
 
 * **Microsoft.Win32.Registry**. Provides support for accessing and modifying the Windows Registry.
 
+* **System.Security.SecureString**. Provides support for accessing and modifying text that should be kept confidential.
+
 * The overall list of items we currently plan to move onto GitHub is [here][typelist].
 
 [roslyn]: https://roslyn.codeplex.com/

--- a/src/Common/src/Interop/Windows/Crypt32/Interop.CryptProtectData.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.CryptProtectData.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class Crypt32
+    {
+        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptProtectData(
+                  [In] IntPtr pDataIn,
+                  [In] string szDataDescr,
+                  [In] IntPtr pOptionalEntropy,
+                  [In] IntPtr pvReserved,
+                  [In] IntPtr pPromptStruct,
+                  [In] uint dwFlags,
+                  [In, Out] IntPtr pDataOut);
+
+        private const uint CRYPTPROTECTMEMORY_SAME_PROCESS = 0x00;
+
+        internal static unsafe bool CryptProtectData(SafeBSTRHandle uncryptedBuffer, out SafeBSTRHandle cryptedBuffer)
+        {
+            byte* uncryptedBufferPtr = null;
+            DATA_BLOB pDataOut = default(DATA_BLOB);
+            try
+            {
+                uncryptedBuffer.AcquirePointer(ref uncryptedBufferPtr);
+                DATA_BLOB pDataIn = new DATA_BLOB((IntPtr)uncryptedBufferPtr, uncryptedBuffer.Length * 2);
+                if (CryptProtectData(new IntPtr(&pDataIn), String.Empty, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, CRYPTPROTECTMEMORY_SAME_PROCESS, new IntPtr(&pDataOut)))
+                {
+                    SafeBSTRHandle newHandle = SafeBSTRHandle.Allocate(pDataOut.pbData, pDataOut.cbData);
+                    cryptedBuffer = newHandle;
+                    return true;
+                }
+                else
+                {
+                    cryptedBuffer = SafeBSTRHandle.Allocate(null, 0);
+                    return false;
+                }
+            }
+            finally
+            {
+                if (uncryptedBufferPtr != null)
+                    uncryptedBuffer.ReleasePointer();
+
+                if (pDataOut.pbData != IntPtr.Zero)
+                {
+                    NtDll.ZeroMemory(pDataOut.pbData, (UIntPtr)pDataOut.cbData);
+                    Marshal.FreeHGlobal(pDataOut.pbData);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/Crypt32/Interop.CryptUnprotectData.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.CryptUnprotectData.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class Crypt32
+    {
+        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptUnprotectData(
+                  [In] IntPtr pDataIn,
+                  [In] IntPtr ppszDataDescr,
+                  [In] IntPtr pOptionalEntropy,
+                  [In] IntPtr pvReserved,
+                  [In] IntPtr pPromptStruct,
+                  [In] uint dwFlags,
+                  [In, Out] IntPtr pDataOut);
+
+        internal static unsafe bool CryptUnProtectData(SafeBSTRHandle cryptedBuffer, out SafeBSTRHandle uncryptedBuffer)
+        {
+            byte* cryptedBufferPtr = null;
+            DATA_BLOB pDataOut = default(DATA_BLOB);
+            try
+            {
+                cryptedBuffer.AcquirePointer(ref cryptedBufferPtr);
+                DATA_BLOB pDataIn = new DATA_BLOB((IntPtr)cryptedBufferPtr, cryptedBuffer.Length * 2);
+                if (CryptUnprotectData(new IntPtr(&pDataIn), IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, CRYPTPROTECTMEMORY_SAME_PROCESS, new IntPtr(&pDataOut)))
+                {
+                    SafeBSTRHandle newHandle = SafeBSTRHandle.Allocate(pDataOut.pbData, pDataOut.cbData);
+                    uncryptedBuffer = newHandle;
+                    return true;
+                }
+                else
+                {
+                    uncryptedBuffer = SafeBSTRHandle.Allocate(null, 0);
+                    return false;
+                }
+            }
+            finally
+            {
+                if (cryptedBufferPtr != null)
+                    cryptedBuffer.ReleasePointer();
+
+                if (pDataOut.pbData != IntPtr.Zero)
+                {
+                    NtDll.ZeroMemory(pDataOut.pbData, (UIntPtr)pDataOut.cbData);
+                    Marshal.FreeHGlobal(pDataOut.pbData);
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/Crypt32/Interop.DATA_BLOB.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.DATA_BLOB.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Crypt32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct DATA_BLOB
+        {
+            internal uint cbData;
+            internal IntPtr pbData;
+
+            internal DATA_BLOB(IntPtr handle, uint size)
+            {
+                cbData = size;
+                pbData = handle;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -9,8 +9,10 @@ internal static partial class Interop
         internal const string Console_L2 = "api-ms-win-core-console-l2-1-0.dll";
         internal const string CoreFile_L1 = "api-ms-win-core-file-l1-1-0.dll";
         internal const string CoreFile_L2 = "api-ms-win-core-file-l2-1-0.dll";
+        internal const string Crypt32 = "crypt32.dll";
         internal const string Debug = "api-ms-win-core-debug-l1-1-0.dll";
         internal const string Handle = "api-ms-win-core-handle-l1-1-0.dll";
+        internal const string Heap = "api-ms-win-core-heap-obsolete-l1-1-0.dll";
         internal const string ErrorHandling = "api-ms-win-core-errorhandling-l1-1-0.dll";
         internal const string IO = "api-ms-win-core-io-l1-1-0.dll";
         internal const string Kernel32 = "kernel32.dll";
@@ -20,6 +22,7 @@ internal static partial class Interop
         internal const string Memory_L1_0 = "api-ms-win-core-memory-l1-1-0.dll";
         internal const string Memory_L1_1 = "api-ms-win-core-memory-l1-1-1.dll";
         internal const string NtDll = "ntdll.dll";
+        internal const string OleAut32 = "oleaut32.dll";
         internal const string Pipe = "api-ms-win-core-namedpipe-l1-1-0.dll";
         internal const string ProcessEnvironment = "api-ms-win-core-processenvironment-l1-1-0.dll";
         internal const string ProcessThread_L1 = "api-ms-win-core-processthreads-l1-1-0.dll";

--- a/src/Common/src/Interop/Windows/NtDll/Interop.ZeroMemory.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.ZeroMemory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class NtDll
+    {
+        [DllImport(Libraries.NtDll, CharSet = CharSet.Unicode, EntryPoint = "RtlZeroMemory")]
+        internal static extern void ZeroMemory(SafeBSTRHandle address, uint length);
+
+        [DllImport(Libraries.NtDll, CharSet = CharSet.Unicode, EntryPoint = "RtlZeroMemory")]
+        internal static extern void ZeroMemory(IntPtr address, UIntPtr length);
+    }
+}

--- a/src/Common/src/Interop/Windows/oleaut32/Interop.SysAllocStringLen.cs
+++ b/src/Common/src/Interop/Windows/oleaut32/Interop.SysAllocStringLen.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class OleAut32
+    {
+        [DllImport(Libraries.OleAut32, CharSet = CharSet.Unicode)]
+        internal static extern SafeBSTRHandle SysAllocStringLen(string src, uint len);  // BSTR
+
+        [DllImport(Libraries.OleAut32, CharSet = CharSet.Unicode)]
+        internal static extern SafeBSTRHandle SysAllocStringLen(IntPtr src, uint len);  // BSTR
+    }
+}

--- a/src/Common/src/Interop/Windows/oleaut32/Interop.SysStringLen.cs
+++ b/src/Common/src/Interop/Windows/oleaut32/Interop.SysStringLen.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class OleAut32
+    {
+        [DllImport(Libraries.OleAut32)]
+        internal static extern uint SysStringLen(SafeBSTRHandle bstr);
+
+        [DllImport(Libraries.OleAut32)]
+        internal static extern uint SysStringLen(IntPtr bstr);
+
+        [DllImport(Libraries.OleAut32)]
+        internal static extern void SysFreeString(IntPtr bstr);
+    }
+}

--- a/src/System.Security.SecureString/System.Security.SecureString.sln
+++ b/src/System.Security.SecureString/System.Security.SecureString.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.SecureString", "src\System.Security.SecureString.csproj", "{A958BBDD-3238-4E58-AB7F-390AB6D88233}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FBCF7C99-4809-411D-BE8A-8E3E0DD17B7E}"
+	ProjectSection(SolutionItems) = preProject
+		..\.nuget\packages.config = ..\.nuget\packages.config
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.SecureString.Tests", "tests\System.Security.SecureString.Tests.csproj", "{69609238-62C7-479D-A8CE-709F41101D3C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Windows_Debug|Any CPU = Windows_Debug|Any CPU
+		Windows_Release|Any CPU = Windows_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Security.SecureString/src/Resources/Strings.resx
+++ b/src/System.Security.SecureString/src/Resources/Strings.resx
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Length" xml:space="preserve">
+    <value>The specified length exceeds maximum capacity of SecureString.</value>
+  </data>
+  <data name="ArgumentOutOfRange_IndexString" xml:space="preserve">
+    <value>Index was out of range. Must be non-negative and less than the length of the string.</value>
+  </data>
+  <data name="Arg_PlatformSecureString" xml:space="preserve">
+    <value>SecureString is only supported on Windows 2000 SP3 and higher platforms.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Capacity" xml:space="preserve">
+    <value>Capacity exceeds maximum capacity.</value>
+  </data>
+  <data name="InvalidOperation_ReadOnly" xml:space="preserve">
+    <value>Instance is read-only.</value>
+  </data>
+</root>

--- a/src/System.Security.SecureString/src/System.Security.SecureString.csproj
+++ b/src/System.Security.SecureString/src/System.Security.SecureString.csproj
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Windows_Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A958BBDD-3238-4E58-AB7F-390AB6D88233}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Security.SecureString</RootNamespace>
+    <AssemblyName>System.Security.SecureString</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
+  <!-- References are resolved from packages.config -->
+  <ItemGroup>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\crypt32\Interop.CryptProtectData.cs">
+      <Link>Common\Interop\Windows\Interop.CryptProtectData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\crypt32\Interop.CryptUnprotectData.cs">
+      <Link>Common\Interop\Windows\Interop.CryptUnprotectData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\crypt32\Interop.DATA_BLOB.cs">
+      <Link>Common\Interop\Windows\Interop.DATA_BLOB.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.ZeroMemory.cs">
+      <Link>Common\Interop\Windows\Interop.ZeroMemory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\OleAut32\Interop.SysAllocStringLen.cs">
+      <Link>Common\Interop\Windows\Interop.SysAllocStringLen.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\OleAut32\Interop.SysStringLen.cs">
+      <Link>Common\Interop\Windows\Interop.SysStringLen.cs</Link>
+    </Compile>
+    <Compile Include="System\Security\SecureString.cs" />
+    <Compile Include="System\Security\SafeBSTRHandle.cs" />
+    <Compile Include="System\Security\SecureStringMarshal.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
+++ b/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Security
+{
+    [System.Security.SecurityCritical]  // auto-generated
+    internal sealed class SafeBSTRHandle : SafeBuffer
+    {
+        internal SafeBSTRHandle() : base(true) { }
+
+        internal static SafeBSTRHandle Allocate(string src, uint len)
+        {
+            SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, len);
+            bstr.Initialize(len * sizeof(char));
+            return bstr;
+        }
+
+        internal static SafeBSTRHandle Allocate(IntPtr src, uint lenInBytes)
+        {
+            SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, lenInBytes / sizeof(char));
+            bstr.Initialize(lenInBytes);
+            return bstr;
+        }
+
+        [System.Security.SecurityCritical]
+        override protected bool ReleaseHandle()
+        {
+            Interop.NtDll.ZeroMemory(handle, (UIntPtr)(Interop.OleAut32.SysStringLen(handle) * 2));
+            Interop.OleAut32.SysFreeString(handle);
+            return true;
+        }
+
+        internal unsafe void ClearBuffer()
+        {
+            byte* bufferPtr = null;
+            try
+            {
+                AcquirePointer(ref bufferPtr);
+                Interop.NtDll.ZeroMemory((IntPtr)bufferPtr, (UIntPtr)(Interop.OleAut32.SysStringLen((IntPtr)bufferPtr) * 2));
+            }
+            finally
+            {
+                if (bufferPtr != null)
+                    ReleasePointer();
+            }
+        }
+
+        internal unsafe uint Length
+        {
+            get
+            {
+                return Interop.OleAut32.SysStringLen(this);
+            }
+        }
+
+        internal unsafe static void Copy(SafeBSTRHandle source, SafeBSTRHandle target)
+        {
+            byte* sourcePtr = null, targetPtr = null;
+            try
+            {
+                source.AcquirePointer(ref sourcePtr);
+                target.AcquirePointer(ref targetPtr);
+
+                Debug.Assert(Interop.OleAut32.SysStringLen((IntPtr)targetPtr) >= Interop.OleAut32.SysStringLen((IntPtr)sourcePtr), "Target buffer is not large enough!");
+                Buffer.MemoryCopy(sourcePtr, targetPtr, (int)Interop.OleAut32.SysStringLen((IntPtr)targetPtr) * sizeof(char), (int)Interop.OleAut32.SysStringLen((IntPtr)sourcePtr) * sizeof(char));
+            }
+            finally
+            {
+                if (sourcePtr != null)
+                    source.ReleasePointer();
+                if (targetPtr != null)
+                    target.ReleasePointer();
+            }
+        }
+    }
+}

--- a/src/System.Security.SecureString/src/System/Security/SecureString.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.cs
@@ -1,0 +1,446 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace System.Security
+{
+    public sealed class SecureString : IDisposable
+    {
+        [System.Security.SecurityCritical] // auto-generated
+        private SafeBSTRHandle _encryptedBuffer;
+
+        private int _decryptedLength;
+        private bool _readOnly;
+
+        private const int MaxLength = 65536;
+
+        private readonly object _methodLock = new object();
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        static SecureString()
+        {
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        internal SecureString(SecureString str)
+        {
+            AllocateBuffer(str.EncryptedBufferLength);
+            SafeBSTRHandle.Copy(str._encryptedBuffer, _encryptedBuffer);
+            _decryptedLength = str._decryptedLength;
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public SecureString()
+        {
+            AllocateBuffer(0);
+            _decryptedLength = 0;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private unsafe void InitializeSecureString(char* value, int length)
+        {
+            _encryptedBuffer = SafeBSTRHandle.Allocate(null, 0);
+            SafeBSTRHandle decryptedBuffer = SafeBSTRHandle.Allocate(null, (uint)length);
+            _decryptedLength = length;
+
+            byte* bufferPtr = null;
+            try
+            {
+                decryptedBuffer.AcquirePointer(ref bufferPtr);
+                Buffer.MemoryCopy((byte*)value, bufferPtr, decryptedBuffer.Length * sizeof(char), length * sizeof(char));
+            }
+            finally
+            {
+                if (bufferPtr != null)
+                    decryptedBuffer.ReleasePointer();
+            }
+
+            ProtectMemory(decryptedBuffer);
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        [CLSCompliant(false)]
+        public unsafe SecureString(char* value, int length)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException("length", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (length > MaxLength)
+            {
+                throw new ArgumentOutOfRangeException("length", SR.ArgumentOutOfRange_Length);
+            }
+
+            // Refactored since HandleProcessCorruptedStateExceptionsAttribute applies to methods only (yet).
+            InitializeSecureString(value, length);
+        }
+
+        public int Length
+        {
+            [System.Security.SecuritySafeCritical]  // auto-generated
+            get
+            {
+                lock (_methodLock)
+                {
+                    EnsureNotDisposed();
+                    return _decryptedLength;
+                }
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void AppendChar(char c)
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                EnsureNotReadOnly();
+
+                SafeBSTRHandle decryptedBuffer = null;
+                try
+                {
+                    decryptedBuffer = UnProtectMemory();
+                    EnsureCapacity(ref decryptedBuffer, _decryptedLength + 1);
+                    decryptedBuffer.Write<char>((uint)_decryptedLength * sizeof(char), c);
+                    _decryptedLength++;
+                }
+                finally
+                {
+                    ProtectMemory(decryptedBuffer);
+                }
+            }
+        }
+
+        // clears the current contents. Only available if writable
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void Clear()
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                EnsureNotReadOnly();
+
+                _decryptedLength = 0;
+                _encryptedBuffer.ClearBuffer();
+            }
+        }
+
+        // Do a deep-copy of the SecureString 
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public SecureString Copy()
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                return new SecureString(this);
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void Dispose()
+        {
+            lock (_methodLock)
+            {
+                if (_encryptedBuffer != null && !_encryptedBuffer.IsInvalid)
+                {
+                    _encryptedBuffer.Dispose();
+                    _encryptedBuffer = null;
+                }
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void InsertAt(int index, char c)
+        {
+            lock (_methodLock)
+            {
+                if (index < 0 || index > _decryptedLength)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
+                }
+
+                EnsureNotDisposed();
+                EnsureNotReadOnly();
+
+                unsafe
+                {
+                    byte* bufferPtr = null;
+                    SafeBSTRHandle decryptedBuffer = null;
+                    try
+                    {
+                        decryptedBuffer = UnProtectMemory();
+                        EnsureCapacity(ref decryptedBuffer, _decryptedLength + 1);
+
+                        decryptedBuffer.AcquirePointer(ref bufferPtr);
+                        char* pBuffer = (char*)bufferPtr;
+
+                        for (int i = _decryptedLength; i > index; i--)
+                        {
+                            pBuffer[i] = pBuffer[i - 1];
+                        }
+                        pBuffer[index] = c;
+                        ++_decryptedLength;
+                    }
+                    finally
+                    {
+                        ProtectMemory(decryptedBuffer);
+                        if (bufferPtr != null)
+                            decryptedBuffer.ReleasePointer();
+                    }
+                }
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public bool IsReadOnly()
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                return _readOnly;
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void MakeReadOnly()
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                _readOnly = true;
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void RemoveAt(int index)
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                EnsureNotReadOnly();
+
+                if (index < 0 || index >= _decryptedLength)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
+                }
+
+                unsafe
+                {
+                    byte* bufferPtr = null;
+                    SafeBSTRHandle decryptedBuffer = null;
+                    try
+                    {
+                        decryptedBuffer = UnProtectMemory();
+                        decryptedBuffer.AcquirePointer(ref bufferPtr);
+                        char* pBuffer = (char*)bufferPtr;
+
+                        for (int i = index; i < _decryptedLength - 1; i++)
+                        {
+                            pBuffer[i] = pBuffer[i + 1];
+                        }
+                        pBuffer[--_decryptedLength] = (char)0;
+                    }
+                    finally
+                    {
+                        ProtectMemory(decryptedBuffer);
+                        if (bufferPtr != null)
+                            decryptedBuffer.ReleasePointer();
+                    }
+                }
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public void SetAt(int index, char c)
+        {
+            lock (_methodLock)
+            {
+                if (index < 0 || index >= _decryptedLength)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
+                }
+                Debug.Assert(index <= Int32.MaxValue / sizeof(char));
+
+                EnsureNotDisposed();
+                EnsureNotReadOnly();
+
+                SafeBSTRHandle decryptedBuffer = null;
+                try
+                {
+                    decryptedBuffer = UnProtectMemory();
+                    decryptedBuffer.Write<char>((uint)index * sizeof(char), c);
+                }
+                finally
+                {
+                    ProtectMemory(decryptedBuffer);
+                }
+            }
+        }
+
+        private uint EncryptedBufferLength
+        {
+            [System.Security.SecurityCritical]  // auto-generated
+            get
+            {
+                Debug.Assert(_encryptedBuffer != null, "Buffer is not initialized!");
+                return _encryptedBuffer.Length;
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void AllocateBuffer(uint size)
+        {
+            _encryptedBuffer = SafeBSTRHandle.Allocate(null, size);
+            if (_encryptedBuffer.IsInvalid)
+            {
+                throw new OutOfMemoryException();
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void EnsureCapacity(ref SafeBSTRHandle decryptedBuffer, int capacity)
+        {
+            if (capacity > MaxLength)
+            {
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);
+            }
+
+            if (capacity <= _decryptedLength)
+            {
+                return;
+            }
+
+            SafeBSTRHandle newBuffer = SafeBSTRHandle.Allocate(null, (uint)capacity);
+
+            if (newBuffer.IsInvalid)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            SafeBSTRHandle.Copy(decryptedBuffer, newBuffer);
+            decryptedBuffer.Dispose();
+            decryptedBuffer = newBuffer;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void EnsureNotDisposed()
+        {
+            if (_encryptedBuffer == null)
+            {
+                throw new ObjectDisposedException(null);
+            }
+        }
+
+        private void EnsureNotReadOnly()
+        {
+            if (_readOnly)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void ProtectMemory(SafeBSTRHandle decryptedBuffer)
+        {
+            Debug.Assert(!decryptedBuffer.IsInvalid, "Invalid buffer!");
+
+            if (_decryptedLength == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                SafeBSTRHandle newEncryptedBuffer = null;
+                if (Interop.Crypt32.CryptProtectData(decryptedBuffer, out newEncryptedBuffer))
+                {
+                    _encryptedBuffer.Dispose();
+                    _encryptedBuffer = newEncryptedBuffer;
+                }
+                else
+                {
+                    throw new CryptographicException(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                decryptedBuffer.ClearBuffer();
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        internal unsafe IntPtr ToUniStr()
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                int length = _decryptedLength;
+                IntPtr ptr = IntPtr.Zero;
+                IntPtr result = IntPtr.Zero;
+                byte* bufferPtr = null;
+
+                SafeBSTRHandle decryptedBuffer = null;
+                try
+                {
+                    ptr = Marshal.AllocCoTaskMem((length + 1) * 2);
+
+                    if (ptr == IntPtr.Zero)
+                    {
+                        throw new OutOfMemoryException();
+                    }
+
+                    decryptedBuffer = UnProtectMemory();
+                    decryptedBuffer.AcquirePointer(ref bufferPtr);
+                    Buffer.MemoryCopy(bufferPtr, (byte*)ptr.ToPointer(), ((length + 1) * 2), length * 2);
+                    char* endptr = (char*)ptr.ToPointer();
+                    *(endptr + length) = '\0';
+                    result = ptr;
+                }
+                finally
+                {
+                    if (result == IntPtr.Zero)
+                    {
+                        // If we failed for any reason, free the new buffer
+                        if (ptr != IntPtr.Zero)
+                        {
+                            Interop.NtDll.ZeroMemory(ptr, (UIntPtr)(length * 2));
+                            Marshal.FreeCoTaskMem(ptr);
+                        }
+                    }
+
+                    if (bufferPtr != null)
+                        decryptedBuffer.ReleasePointer();
+                }
+                return result;
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private SafeBSTRHandle UnProtectMemory()
+        {
+            Debug.Assert(!_encryptedBuffer.IsInvalid, "Invalid buffer!");
+
+            SafeBSTRHandle decryptedBuffer = null;
+            if (_decryptedLength == 0)
+            {
+                return _encryptedBuffer;
+            }
+
+            if (!Interop.Crypt32.CryptUnProtectData(_encryptedBuffer, out decryptedBuffer))
+            {
+                throw new CryptographicException(Marshal.GetLastWin32Error());
+            }
+
+            return decryptedBuffer;
+        }
+    }
+}

--- a/src/System.Security.SecureString/src/System/Security/SecureStringMarshal.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureStringMarshal.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security
+{
+    public static class SecureStringMarshal
+    {
+        [System.Security.SecurityCritical]
+        public static IntPtr SecureStringToCoTaskMemUnicode(SecureString s)
+        {
+            if (s == null)
+            {
+                throw new ArgumentNullException("s");
+            }
+
+            return s.ToUniStr();
+        }
+
+        [System.Security.SecurityCritical]
+        public static void ZeroFreeCoTaskMemUnicode(IntPtr s)
+        {
+            Marshal.ZeroFreeCoTaskMemUnicode(s);
+        }
+    }
+}
+
+

--- a/src/System.Security.SecureString/src/packages.config
+++ b/src/System.Security.SecureString/src/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Runtime" version="4.0.20-beta-22605" targetFramework="portable-net45+win" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Security.Cryptography.Encryption" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
+  <package id="System.Threading" version="4.0.10-beta-22703" targetFramework="portable-net45+win"/>
+</packages>

--- a/src/System.Security.SecureString/tests/SecureStringTests.cs
+++ b/src/System.Security.SecureString/tests/SecureStringTests.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using Xunit;
+
+public static class SecureStringTest
+{
+    private static void VerifyString(SecureString ss, string exString)
+    {
+        IntPtr uniStr = IntPtr.Zero;
+        try
+        {
+            uniStr = SecureStringMarshal.SecureStringToCoTaskMemUnicode(ss);
+            string acString = Marshal.PtrToStringUni(uniStr);
+
+            Assert.Equal(exString.Length, acString.Length);
+            Assert.Equal(exString, acString);
+        }
+        finally
+        {
+            if (uniStr != IntPtr.Zero)
+                SecureStringMarshal.ZeroFreeCoTaskMemUnicode(uniStr);
+        }
+    }
+
+    private static SecureString CreateSecureString(string exValue)
+    {
+        SecureString ss = null;
+
+        if (string.IsNullOrEmpty(exValue))
+            ss = new SecureString();
+        else
+        {
+            unsafe
+            {
+                fixed (char* mychars = exValue.ToCharArray())
+                    ss = new SecureString(mychars, exValue.Length);
+            }
+        }
+
+        Assert.NotNull(ss);
+        return ss;
+    }
+
+    private static void CreateAndVerifySecureString(string exValue)
+    {
+        using (SecureString ss = CreateSecureString(exValue))
+        {
+            VerifyString(ss, exValue);
+        }
+    }
+
+
+    [Fact]
+    public static void SecureString_Ctor()
+    {
+        CreateAndVerifySecureString(string.Empty);
+    }
+
+    [Fact]
+    public static unsafe void SecureString_Ctor_CharInt()
+    {
+        // 1. Positive cases
+        CreateAndVerifySecureString("test");
+        CreateAndVerifySecureString(new string('a', UInt16.MaxValue + 1)/*Max allowed length is 65536*/);
+
+        // 2. Negative cases
+        Assert.Throws<ArgumentNullException>(() => new SecureString(null, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => { fixed (char* chars = "test") new SecureString(chars, -1); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateSecureString(new string('a', UInt16.MaxValue + 2 /*65537: Max allowed length is 65536*/)));
+    }
+
+
+    [Fact]
+    public static void SecureString_AppendChar()
+    {
+        using (SecureString testString = CreateSecureString(string.Empty))
+        {
+            StringBuilder sb = new StringBuilder();
+
+            testString.AppendChar('u');
+            sb.Append('u');
+            VerifyString(testString, sb.ToString());
+
+            //Append another character.
+            testString.AppendChar(char.MaxValue);
+            sb.Append(char.MaxValue);
+            VerifyString(testString, sb.ToString());
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => { using (SecureString ss = CreateSecureString(new string('a', UInt16.MaxValue + 1))) ss.AppendChar('a'); });
+        Assert.Throws<InvalidOperationException>(() => { using (SecureString ss = CreateSecureString(string.Empty)) { ss.MakeReadOnly(); ss.AppendChar('k'); } });
+    }
+
+    [Fact]
+    public static void SecureString_Clear()
+    {
+        String exString = String.Empty;
+        using (SecureString testString = CreateSecureString(exString))
+        {
+            testString.Clear();
+            VerifyString(testString, exString);
+        }
+
+        using (SecureString testString = CreateSecureString("test"))
+        {
+            testString.Clear();
+            VerifyString(testString, String.Empty);
+        }
+
+        // Check if readOnly
+        Assert.Throws<InvalidOperationException>(() => { using (SecureString ss = new SecureString()) { ss.MakeReadOnly(); ss.Clear(); } });
+        // Check if secureString has been disposed.
+        Assert.Throws<ObjectDisposedException>(() => { using (SecureString ss = CreateSecureString(new string('a', UInt16.MaxValue + 1))) { ss.Dispose(); ss.Clear(); } });
+    }
+
+    [Fact]
+    public static void SecureString_Copy()
+    {
+        string exString = new string('a', UInt16.MaxValue + 1);
+        using (SecureString testString = CreateSecureString(exString))
+        {
+            using (SecureString copy_string = testString.Copy())
+                VerifyString(copy_string, exString);
+        }
+
+        //ObjectDisposedException.
+        {
+            SecureString testString = CreateSecureString("SomeValue");
+            testString.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => testString.Copy());
+        }
+
+        //Check for ReadOnly.
+        exString = "test";
+        using (SecureString testString = CreateSecureString(exString))
+        {
+            testString.MakeReadOnly();
+            using (SecureString copy_string = testString.Copy())
+            {
+                VerifyString(copy_string, exString);
+                Assert.True(testString.IsReadOnly());
+                Assert.False(copy_string.IsReadOnly());
+            }
+        }
+    }
+
+
+    [Fact]
+    public static void SecureString_InsertAt()
+    {
+        using (SecureString testString = CreateSecureString("bd"))
+        {
+            testString.InsertAt(0, 'a');
+            VerifyString(testString, "abd");
+
+            testString.InsertAt(3, 'e');
+            VerifyString(testString, "abde");
+
+            testString.InsertAt(2, 'c');
+            VerifyString(testString, "abcde");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.InsertAt(-1, 'S'));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.InsertAt(6, 'S'));
+        }
+
+        using (SecureString testString = CreateSecureString(new string('a', UInt16.MaxValue + 1)))
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.InsertAt(22, 'S'));
+        }
+
+        using (SecureString testString = CreateSecureString("test"))
+        {
+            testString.MakeReadOnly();
+            Assert.Throws<InvalidOperationException>(() => testString.InsertAt(2, 'S'));
+        }
+
+        {
+            SecureString testString = CreateSecureString("test");
+            testString.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => testString.InsertAt(2, 'S'));
+        }
+    }
+
+
+    [Fact]
+    public static void SecureString_IsReadOnly()
+    {
+        using (SecureString testString = CreateSecureString("test"))
+        {
+            Assert.False(testString.IsReadOnly());
+
+            testString.MakeReadOnly();
+            Assert.True(testString.IsReadOnly());
+        }
+
+        {
+            SecureString testString = CreateSecureString("test");
+            testString.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => testString.IsReadOnly());
+        }
+    }
+
+
+    [Fact]
+    public static void SecureString_MakeReadOnly()
+    {
+        using (SecureString testString = CreateSecureString("test"))
+        {
+            Assert.False(testString.IsReadOnly());
+
+            testString.MakeReadOnly();
+            Assert.True(testString.IsReadOnly());
+
+            testString.MakeReadOnly();
+            Assert.True(testString.IsReadOnly());
+        }
+
+        {
+            SecureString testString = CreateSecureString("test");
+            testString.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => testString.MakeReadOnly());
+        }
+    }
+
+    [Fact]
+    public static void SecureString_RemoveAt()
+    {
+        using (SecureString testString = CreateSecureString("abcde"))
+        {
+            testString.RemoveAt(3);
+            VerifyString(testString, "abce");
+
+            testString.RemoveAt(3);
+            VerifyString(testString, "abc");
+
+            testString.RemoveAt(0);
+            VerifyString(testString, "bc");
+        }
+
+        using (SecureString testString = CreateSecureString(new string('a', UInt16.MaxValue + 1)))
+        {
+            testString.RemoveAt(22);
+            testString.AppendChar('a');
+            VerifyString(testString, new string('a', UInt16.MaxValue + 1));
+        }
+
+        using (SecureString testString = CreateSecureString("test"))
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.RemoveAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.RemoveAt(testString.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.RemoveAt(testString.Length + 1));
+
+            testString.MakeReadOnly();
+            Assert.Throws<InvalidOperationException>(() => testString.RemoveAt(0));
+        }
+
+        {
+            SecureString testString = CreateSecureString("test");
+            testString.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => testString.RemoveAt(0));
+        }
+    }
+
+    [Fact]
+    public static void SecureString_SetAt()
+    {
+        using (SecureString testString = CreateSecureString("abc"))
+        {
+            testString.SetAt(2, 'f');
+            VerifyString(testString, "abf");
+
+            testString.SetAt(0, 'd');
+            VerifyString(testString, "dbf");
+
+            testString.SetAt(1, 'e');
+            VerifyString(testString, "def");
+        }
+
+        string exString = new string('a', UInt16.MaxValue + 1);
+        using (SecureString testString = CreateSecureString(exString))
+        {
+            testString.SetAt(22, 'b');
+            char[] chars = exString.ToCharArray();
+            chars[22] = 'b';
+            VerifyString(testString, new string(chars));
+        }
+
+        using (SecureString testString = CreateSecureString("test"))
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.RemoveAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.RemoveAt(testString.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testString.RemoveAt(testString.Length + 1));
+
+            testString.MakeReadOnly();
+            Assert.Throws<InvalidOperationException>(() => testString.RemoveAt(0));
+        }
+
+        {
+            SecureString testString = CreateSecureString("test");
+            testString.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => testString.RemoveAt(0));
+        }
+    }
+}

--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{69609238-62C7-479D-A8CE-709F41101D3C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Security.SecureString.Tests</RootNamespace>
+    <AssemblyName>System.Security.SecureString.Tests</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnsupportedOperatingSystems>Linux</UnsupportedOperatingSystems>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <!-- References are resolved from packages.config -->
+  <ItemGroup>
+    <Compile Include="SecureStringTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Security.SecureString.csproj">
+      <Project>{A958BBDD-3238-4E58-AB7F-390AB6D88233}</Project>
+      <Name>System.Security.SecureString</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.SecureString/tests/packages.config
+++ b/src/System.Security.SecureString/tests/packages.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
+  <package id="System.Security.Cryptography.Encryption" version="4.0.0-beta-22703" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
+  <package id="xunit" version="2.0.0-beta5-build2785" />
+  <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.assert" version="2.0.0-beta5-build2785" />
+  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+</packages>


### PR DESCRIPTION
Initial commit for System.Security.SecureString src and tests.
SecureString provides a mechanism to represent a text that should be kept confidential. The text is encrypted for privacy when used, and is deleted from the computer memory when no longer needed.