### PR TITLE
Remove Assert in XmlException

### DIFF
--- a/src/System.Collections.Specialized/System.Collections.Specialized.sln
+++ b/src/System.Collections.Specialized/System.Collections.Specialized.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Specialized", "src\System.Collections.Specialized.csproj", "{63634289-90D7-4947-8BF3-DBBE98D76C85}"
 EndProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{961859
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Specialized.Tests", "tests\System.Collections.Specialized.Tests.csproj", "{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTraitsDiscoverers", "..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj", "{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +28,10 @@ Global
 		{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Collections.Specialized/tests/HybridDictionary/GetItemObjTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/GetItemObjTests.cs
@@ -16,6 +16,7 @@ namespace System.Collections.Specialized.Tests
 
 
         [Fact]
+        [ActiveIssue(1360)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -144,6 +144,10 @@
     <Compile Include="StringEnumerator\ResetTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">
+      <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
+      <Name>XunitTraitsDiscoverers</Name>
+    </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.Specialized.csproj">
       <Project>{63634289-90d7-4947-8bf3-dbbe98d76c85}</Project>
       <Name>System.Collections.Specialized</Name>

--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
@@ -136,6 +136,7 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact, OuterLoop]
+        [ActiveIssue(1355)]
         [PlatformSpecific(PlatformID.Windows)]
         public void TestVolumeLabel()
         {

--- a/src/System.Xml.ReaderWriter/src/System/Xml/XmlException.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/XmlException.cs
@@ -33,9 +33,6 @@ namespace System.Xml
         //provided to meet the ECMA standards
         public XmlException(String message) : this(message, ((Exception)null), 0, 0)
         {
-#if DEBUG
-            Debug.Assert(message == null || !message.StartsWith("Xml_", StringComparison.Ordinal), "Do not pass a resource here!");
-#endif
         }
 
         //provided to meet ECMA standards


### PR DESCRIPTION
This fixes the internal issue: when we intentionally remove resources to speed up the build and we run a test which expects exception we end up with getting different exception type or some other unexpected behavior.

I hat to disable some unrelated tests to get a clean build