### PR TITLE
Add missing OuterLoop category for FileSystem tests

### DIFF
--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -7,6 +7,7 @@
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
In order for the test category inclusion/exclusion code to work properly, the test projects need to correctly identify the categories of tests that exist in their source files.  If a project doesn't identify that it contains outer loop tests, outer loop tests are not excluded when running inner loop tests.