### PR TITLE
Fix System.IO.FileSystem product source and tests for Linux

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.readdir.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.readdir.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern IntPtr readdir(IntPtr dirp);
+        internal static extern IntPtr readdir(SafeDirHandle dirp);
 
         internal static unsafe DType GetDirEntType(IntPtr dirEnt)
         {

--- a/src/Common/src/Interop/OSX/libc/Interop.readdir.cs
+++ b/src/Common/src/Interop/OSX/libc/Interop.readdir.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, EntryPoint = "readdir$INODE64", SetLastError = true)]
-        internal static extern IntPtr readdir(IntPtr dirp);
+        internal static extern IntPtr readdir(SafeDirHandle dirp);
 
         internal static unsafe DType GetDirEntType(IntPtr dirEnt)
         {

--- a/src/Common/src/Interop/Unix/libc/Interop.closedir.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.closedir.cs
@@ -10,5 +10,22 @@ internal static partial class Interop
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
         internal static extern int closedir(IntPtr dirp);
+
+        internal sealed class SafeDirHandle : SafeHandle
+        {
+            private SafeDirHandle() : base(IntPtr.Zero, true)
+            {
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return closedir(handle) == 0;
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.opendir.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.opendir.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern IntPtr opendir(string name); // opendir/readdir/closedir defined in terms of IntPtr so it may be used in iterators (which don't allow unsafe code)
+        internal static extern SafeDirHandle opendir(string name);
     }
 }

--- a/src/Common/src/Interop/Unix/libc/Interop.rmdir.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.rmdir.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class libc
     {
         [DllImport(Libraries.Libc, SetLastError = true)]
-        internal static extern int remove(string pathname);
+        internal static extern int rmdir(string pathname);
     }
 }

--- a/src/Common/src/Interop/Unix/libcoreclr/Interop.GetFileInformation.cs
+++ b/src/Common/src/Interop/Unix/libcoreclr/Interop.GetFileInformation.cs
@@ -31,6 +31,7 @@ internal static partial class Interop
             internal const int S_IFIFO = 0x1000;
             internal const int S_IFDIR = 0x4000;
             internal const int S_IFREG = 0x8000;
+            internal const int S_IFLNK = 0xA000;
         }
 
         [Flags]

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Win32.SafeHandles
         /// <returns>A SafeFileHandle for the opened file.</returns>
         internal static SafeFileHandle Open(string path, Interop.libc.OpenFlags flags, int mode)
         {
+            Debug.Assert(path != null);
+
             // SafeFileHandle wraps a file descriptor rather than a pointer, and a file descriptor is always 4 bytes
             // rather than being pointer sized, which means we can't utilize the runtime's ability to marshal safe handles.
             // Ideally this would be a constrained execution region, but we don't have access to PrepareConstrainedRegions.
@@ -34,10 +36,31 @@ namespace Microsoft.Win32.SafeHandles
             SafeFileHandle handle = new SafeFileHandle(ownsHandle: true);
             try { } finally
             {
+                // If we fail to open the file due to a path not existing, we need to know whether to blame
+                // the file itself or its directory.  If we're creating the file, then we blame the directory,
+                // otherwise we blame the file.
+                bool enoentDueToDirectory = (flags & Interop.libc.OpenFlags.O_CREAT) != 0;
+
+                // Open the file.
                 int fd;
-                while (Interop.CheckIo(fd = Interop.libc.open(path, flags, mode), path)) ;
+                while (Interop.CheckIo(fd = Interop.libc.open(path, flags, mode), path, isDirectory: enoentDueToDirectory)) ;
                 Debug.Assert(fd >= 0);
                 handle.SetHandle((IntPtr)fd);
+                Debug.Assert(!handle.IsInvalid);
+
+                // Make sure it's not a directory; we do this after opening it once we have a file descriptor 
+                // to avoid race conditions.
+                Interop.libcoreclr.fileinfo buf;
+                if (Interop.libcoreclr.GetFileInformationFromFd(fd, out buf) != 0)
+                {
+                    handle.Dispose();
+                    throw Interop.GetExceptionForIoErrno(Marshal.GetLastWin32Error(), path);
+                }
+                if ((buf.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR)
+                {
+                    handle.Dispose();
+                    throw Interop.GetExceptionForIoErrno(Interop.Errors.EACCES, path, isDirectory: true);
+                }
             }
             return handle;
         }

--- a/src/Common/tests/XunitTraitsDiscoverers/XunitTraitsDiscoverers.csproj
+++ b/src/Common/tests/XunitTraitsDiscoverers/XunitTraitsDiscoverers.csproj
@@ -10,13 +10,10 @@
     <AssemblyName>XunitTraitsDiscoverers</AssemblyName>
     <RootNamespace>Xunit.TraitDiscoverers</RootNamespace>
     <CLSCompliant>false</CLSCompliant>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <!-- References are resolved from packages.config -->
   <ItemGroup>
     <Compile Include="..\..\src\Interop\Interop.PlatformDetection.cs">

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -137,6 +137,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
       <Link>Common\Interop\Unix\Interop.strerror.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
+      <Link>Common\Interop\Unix\Interop.GetFileInformation.cs"</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -80,6 +80,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.write.cs">
       <Link>Common\Interop\Unix\libc\Interop.write.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
+      <Link>Common\Interop\Unix\Interop.GetFileInformation.cs"</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -317,12 +317,14 @@
   </ItemGroup>
   <!-- Linux -->
   <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+    <Compile Include="System\IO\UnixFileSystem.Linux.cs" />
     <Compile Include="$(CommonPath)\Interop\Linux\libc\Interop.readdir.cs">
       <Link>Common\Interop\Linux\Interop.readdir.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- OSX -->
   <ItemGroup Condition="'$(TargetsOSX)' == 'true'">
+    <Compile Include="System\IO\UnixFileSystem.OSX.cs" />
     <Compile Include="$(CommonPath)\Interop\OSX\libc\Interop.readdir.cs">
       <Link>Common\Interop\OSX\Interop.readdir.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -296,7 +296,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.rename.cs">
       <Link>Common\Interop\Unix\Interop.rename.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.remove.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.rmdir.cs">
       <Link>Common\Interop\Unix\Interop.remove.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -576,12 +576,14 @@ namespace System.IO
             if (destPath.Length >= maxDirectoryPath)
                 throw new PathTooLongException(SR.IO_PathTooLong);
 
-            if (String.Compare(sourcePath, destPath, StringComparison.OrdinalIgnoreCase) == 0)
+            StringComparison pathComparison = PathHelpers.GetComparison(FileSystem.Current.CaseSensitive);
+
+            if (String.Compare(sourcePath, destPath, pathComparison) == 0)
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
             String sourceRoot = Path.GetPathRoot(sourcePath);
             String destinationRoot = Path.GetPathRoot(destPath);
-            if (String.Compare(sourceRoot, destinationRoot, StringComparison.OrdinalIgnoreCase) != 0)
+            if (String.Compare(sourceRoot, destinationRoot, pathComparison) != 0)
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
             FileSystem.Current.MoveDirectory(fullsourceDirName, fulldestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -109,7 +109,7 @@ namespace System.IO
             String newDirs = Path.Combine(FullPath, path);
             String fullPath = Path.GetFullPath(newDirs);
 
-            if (0 != String.Compare(FullPath, 0, fullPath, 0, FullPath.Length, StringComparison.OrdinalIgnoreCase))
+            if (0 != String.Compare(FullPath, 0, fullPath, 0, FullPath.Length, PathHelpers.GetComparison(FileSystem.Current.CaseSensitive)))
             {
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidSubPath, path, DisplayPath));
             }
@@ -417,13 +417,14 @@ namespace System.IO
             else
                 fullSourcePath = FullPath + PathHelpers.DirectorySeparatorCharAsString;
 
-            if (String.Compare(fullSourcePath, fullDestDirName, StringComparison.OrdinalIgnoreCase) == 0)
+            StringComparison pathComparison = PathHelpers.GetComparison(FileSystem.Current.CaseSensitive);
+            if (String.Compare(fullSourcePath, fullDestDirName, pathComparison) == 0)
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
             String sourceRoot = Path.GetPathRoot(fullSourcePath);
             String destinationRoot = Path.GetPathRoot(fullDestDirName);
 
-            if (String.Compare(sourceRoot, destinationRoot, StringComparison.OrdinalIgnoreCase) != 0)
+            if (String.Compare(sourceRoot, destinationRoot, pathComparison) != 0)
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
             FileSystem.Current.MoveDirectory(FullPath, fullDestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.cs
@@ -42,5 +42,6 @@ namespace System.IO
         public abstract void SetCurrentDirectory(string fullPath);
         public abstract int MaxPath { get; }
         public abstract int MaxDirectoryPath { get; }
+        public abstract bool CaseSensitive { get; }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/MultiplexingWin32WinRTFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/MultiplexingWin32WinRTFileSystem.cs
@@ -14,6 +14,7 @@ namespace System.IO
 
         public override int MaxPath { get { return Interop.mincore.MAX_PATH; } }
         public override int MaxDirectoryPath { get { return Interop.mincore.MAX_DIRECTORY_PATH; } }
+        public override bool CaseSensitive { get { return false; } }
 
         public override void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
         {

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -161,5 +161,10 @@ namespace System.IO
 
             return;
         }
+
+        internal static StringComparison GetComparison(bool caseSensitive)
+        {
+            return caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.cs
@@ -63,8 +63,8 @@ namespace System.IO
         //
         internal static void CheckSearchPattern(String searchPattern)
         {
-            int index;
-            while ((index = searchPattern.IndexOf("..", StringComparison.Ordinal)) != -1)
+            int index = 0;
+            while ((index = searchPattern.IndexOf("..", index, StringComparison.Ordinal)) != -1)
             {
                 if (index + 2 == searchPattern.Length) // Terminal ".." . Files names cannot end in ".."
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern);
@@ -72,7 +72,7 @@ namespace System.IO
                 if (IsDirectorySeparator(searchPattern[index + 2]))
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern);
 
-                searchPattern = searchPattern.Substring(index + 2);
+                index += 2;
             }
         }
 

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -134,6 +134,8 @@ namespace System.IO
             // Make sure the handle is open
             if (handle.IsInvalid)
                 throw new ArgumentException(SR.Arg_InvalidHandle, "handle");
+            if (handle.IsClosed)
+                throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
             if (access < FileAccess.Read || access > FileAccess.ReadWrite)
                 throw new ArgumentOutOfRangeException("access", SR.ArgumentOutOfRange_Enum);
             if (bufferSize <= 0)
@@ -1015,14 +1017,19 @@ namespace System.IO
             TArg1 arg1 = default(TArg1), TArg2 arg2 = default(TArg2),
             bool throwOnError = true)
         {
+            SafeFileHandle handle = _fileHandle;
+
+            Debug.Assert(sysCall != null);
+            Debug.Assert(handle != null);
+
             bool gotRefOnHandle = false;
             try
             {
                 // Get the file descriptor from the handle.  We increment the ref count to help
                 // ensure it's not closed out from under us.
-                _fileHandle.DangerousAddRef(ref gotRefOnHandle);
+                handle.DangerousAddRef(ref gotRefOnHandle);
                 Debug.Assert(gotRefOnHandle);
-                int fd = (int)_fileHandle.DangerousGetHandle();
+                int fd = (int)handle.DangerousGetHandle();
                 Debug.Assert(fd >= 0);
 
                 // System calls may fail due to EINTR (signal interruption).  We need to retry in those cases.
@@ -1048,7 +1055,10 @@ namespace System.IO
             {
                 if (gotRefOnHandle)
                 {
-                    _fileHandle.DangerousRelease();
+                    if (!handle.IsClosed && !handle.IsInvalid) // TODO: Remove once runtime exception handling bug is fixed
+                    {
+                        handle.DangerousRelease();
+                    }
                 }
                 else
                 {

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -1055,10 +1055,7 @@ namespace System.IO
             {
                 if (gotRefOnHandle)
                 {
-                    if (!handle.IsClosed && !handle.IsInvalid) // TODO: Remove once runtime exception handling bug is fixed
-                    {
-                        handle.DangerousRelease();
-                    }
+                    handle.DangerousRelease();
                 }
                 else
                 {

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.Linux.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.Linux.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    internal sealed partial class UnixFileSystem
+    {
+        public override bool CaseSensitive { get { return true; } }
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.Linux.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.Linux.cs
@@ -5,6 +5,6 @@ namespace System.IO
 {
     internal sealed partial class UnixFileSystem
     {
-        public override bool CaseSensitive { get { return true; } }
+        public override bool CaseSensitive { get { return true; } } // TODO: Issue #1086. Consider doing a lookup based on the mounted file system.
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.OSX.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.OSX.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    internal sealed partial class UnixFileSystem
+    {
+        public override bool CaseSensitive { get { return false; } } // TODO: Issue #1086. OSX could be either true or false, though most commonly false.
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -520,11 +520,8 @@ namespace System.IO
                     finally
                     {
                         // Close the directory enumerator
-                        if (dirHandle != null && !dirHandle.IsClosed) // TODO: Remove once exception handling bug is fixed
-                        {
-                            dirHandle.Dispose();
-                            dirHandle = null;
-                        }
+                        dirHandle.Dispose();
+                        dirHandle = null;
                     }
 
                     if (toExplore != null && toExplore.Count > 0)

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Threading;
 
 namespace System.IO
 {
@@ -42,6 +45,13 @@ namespace System.IO
         {
             // Note: we could consider using sendfile here, but it isn't part of the POSIX spec, and
             // has varying degrees of support on different systems.
+
+            // The destination path may just be a directory into which the file should be copied.
+            // If it is, append the filename from the source onto the destination directory
+            if (DirectoryExists(destFullPath))
+            {
+                destFullPath = Path.Combine(destFullPath, Path.GetFileName(sourceFullPath));
+            }
 
             // Copy the contents of the file from the source to the destination, creating the destination in the process
             const int bufferSize = FileStream.DefaultBufferSize;
@@ -83,7 +93,7 @@ namespace System.IO
 
         public override void DeleteFile(string fullPath)
         {
-            while (Interop.libc.remove(fullPath) < 0)
+            while (Interop.libc.unlink(fullPath) < 0)
             {
                 int errno = Marshal.GetLastWin32Error();
                 if (errno == Interop.Errors.EINTR) // interrupted; try again
@@ -276,7 +286,7 @@ namespace System.IO
                 }
             }
 
-            while (Interop.libc.remove(fullPath) < 0)
+            while (Interop.libc.rmdir(fullPath) < 0)
             {
                 int errno = Marshal.GetLastWin32Error();
                 switch (errno)
@@ -334,9 +344,9 @@ namespace System.IO
             }
         }
 
-        public override IEnumerable<string> EnumeratePaths(string fullPath, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
+        public override IEnumerable<string> EnumeratePaths(string path, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
         {
-            return EnumerateResults<string>(fullPath, searchPattern, searchOption, searchTarget, (path, _) => path);
+            return new FileSystemEnumerable<string>(path, searchPattern, searchOption, searchTarget, (p, _) => p);
         }
 
         public override IEnumerable<FileSystemInfo> EnumerateFileSystemInfos(string fullPath, string searchPattern, SearchOption searchOption, SearchTarget searchTarget)
@@ -344,104 +354,223 @@ namespace System.IO
             switch (searchTarget)
             {
                 case SearchTarget.Files:
-                    return EnumerateResults<FileInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
+                    return new FileSystemEnumerable<FileInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
                         new FileInfo(path, new UnixFileSystemObject(path, isDir)));
                 case SearchTarget.Directories:
-                    return EnumerateResults<DirectoryInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
+                    return new FileSystemEnumerable<DirectoryInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) =>
                         new DirectoryInfo(path, new UnixFileSystemObject(path, isDir)));
                 default:
-                    return EnumerateResults<FileSystemInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) => isDir ?
+                    return new FileSystemEnumerable<FileSystemInfo>(fullPath, searchPattern, searchOption, searchTarget, (path, isDir) => isDir ?
                         (FileSystemInfo)new DirectoryInfo(path, new UnixFileSystemObject(path, isDir)) :
                         (FileSystemInfo)new FileInfo(path, new UnixFileSystemObject(path, isDir)));
             }
         }
 
-        private static IEnumerable<T> EnumerateResults<T>(string fullPath, string searchPattern, SearchOption searchOption, SearchTarget searchTarget, Func<string, bool, T> translateResult)
+        private sealed class FileSystemEnumerable<T> : IEnumerable<T>
         {
-            // Maintain a stack of the directories to explore, in the case of SearchOption.AllDirectories
-            // Lazily-initialized only if we find subdirectories that will be explored.
-            Stack<string> toExplore = null;
+            private readonly PathPair _initialDirectory;
+            private readonly string _searchPattern;
+            private readonly SearchOption _searchOption;
+            private readonly bool _includeFiles;
+            private readonly bool _includeDirectories;
+            private readonly Func<string, bool, T> _translateResult;
+            private IEnumerator<T> _firstEnumerator;
 
-            // Check whether we care about files, directories, or both
-            bool includeFiles = (searchTarget & SearchTarget.Files) != 0;
-            bool includeDirectories = (searchTarget & SearchTarget.Directories) != 0;
-
-            // Process directories until we're out
-            string dirPath = fullPath;
-            do
+            internal FileSystemEnumerable(
+                string userPath, string searchPattern,
+                SearchOption searchOption, SearchTarget searchTarget,
+                Func<string, bool, T> translateResult)
             {
-                // First time through the loop (the root directory), we've initialized dirPath to be the initial path,
-                // and toExplore will be null.  If toExplore is non-null, that means this is a subsequent iteration and
-                // it's been initialized to non-null because there are additional directories to traverse.
-                if (toExplore != null)
+                // Basic validation of the input path
+                if (userPath == null)
                 {
-                    dirPath = toExplore.Pop();
+                    throw new ArgumentNullException("path");
+                }
+                if (string.IsNullOrWhiteSpace(userPath))
+                {
+                    throw new ArgumentException(SR.Argument_EmptyPath, "path");
                 }
 
-                // Open an enumerator of its contents.
-                IntPtr pdir;
-                while (Interop.CheckIoPtr(pdir = Interop.libc.opendir(dirPath), dirPath, isDirectory: true)) ;
-                try
+                // Validate and normalize the search pattern.  If after doing so it's empty,
+                // matching Win32 behavior we can skip all additional validation and effectively
+                // return an empty enumerable.
+                searchPattern = NormalizeSearchPattern(searchPattern);
+                if (searchPattern.Length > 0)
                 {
-                    // Read each entry from the enumerator
-                    IntPtr curEntry;
-                    while ((curEntry = Interop.libc.readdir(pdir)) != IntPtr.Zero) // no validation needed for readdir
+                    PathHelpers.CheckSearchPattern(searchPattern);
+                    PathHelpers.ThrowIfEmptyOrRootedPath(searchPattern);
+
+                    // If the search pattern contains any paths, make sure we factor those into 
+                    // the user path, and then trim them off.
+                    int lastSlash = searchPattern.LastIndexOf(Path.DirectorySeparatorChar);
+                    if (lastSlash >= 0)
                     {
-                        string name = Interop.libc.GetDirEntName(curEntry);
-                        string fullNewName = Path.Combine(dirPath, name);
-
-                        // Get from the dir entry whether the entry is a file or directory.
-                        // If we're not sure from the dir entry itself, stat to the entry.
-                        bool isDir = false, isFile = false;
-                        switch (Interop.libc.GetDirEntType(curEntry))
+                        if (lastSlash >= 1)
                         {
-                            case Interop.libc.DType.DT_DIR:
-                                isDir = true;
-                                break;
-                            case Interop.libc.DType.DT_REG:
-                                isFile = true;
-                                break;
-                            case Interop.libc.DType.DT_LNK:
-                            case Interop.libc.DType.DT_UNKNOWN:
-                                Interop.libcoreclr.fileinfo fileinfo;
-                                while (Interop.CheckIo(Interop.libcoreclr.GetFileInformationFromPath(fullNewName, out fileinfo), fullNewName)) ;
-                                isDir = (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR;
-                                isFile = (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFREG;
-                                break;
+                            userPath = Path.Combine(userPath, searchPattern.Substring(0, lastSlash));
                         }
-                        bool matchesSearchPattern = Interop.libc.fnmatch(searchPattern, name, Interop.libc.FnmatchFlags.None) == 0;
+                        searchPattern = searchPattern.Substring(lastSlash + 1);
+                    }
+                    string fullPath = Path.GetFullPath(userPath);
 
-                        // Yield the result if the user has asked for it.  In the case of directories,
-                        // always explore it by pushing it onto the stack, regardless of whether
-                        // we're returning directories.
-                        if (isDir && !ShouldIgnoreDirectory(name))
+                    // Store everything for the enumerator
+                    _initialDirectory = new PathPair(userPath, fullPath);
+                    _searchPattern = searchPattern;
+                    _searchOption = searchOption;
+                    _includeFiles = (searchTarget & SearchTarget.Files) != 0;
+                    _includeDirectories = (searchTarget & SearchTarget.Directories) != 0;
+                    _translateResult = translateResult;
+                }
+
+                // Open the first enumerator so that any errors are propagated synchronously.
+                _firstEnumerator = Enumerate();
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return Interlocked.Exchange(ref _firstEnumerator, null) ?? Enumerate();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            private IEnumerator<T> Enumerate()
+            {
+                return Enumerate(
+                    _initialDirectory.FullPath != null ? 
+                        OpenDirectory(_initialDirectory.FullPath) : 
+                        null);
+            }
+
+            private IEnumerator<T> Enumerate(Interop.libc.SafeDirHandle dirHandle)
+            {
+                if (dirHandle == null)
+                {
+                    // Empty search
+                    yield break;
+                }
+
+                Debug.Assert(!dirHandle.IsInvalid);
+                Debug.Assert(!dirHandle.IsClosed);
+
+                // Maintain a stack of the directories to explore, in the case of SearchOption.AllDirectories
+                // Lazily-initialized only if we find subdirectories that will be explored.
+                Stack<PathPair> toExplore = null;
+                PathPair dirPath = _initialDirectory;
+                while (dirHandle != null)
+                {
+                    try
+                    {
+                        // Read each entry from the enumerator
+                        IntPtr curEntry;
+                        while ((curEntry = Interop.libc.readdir(dirHandle)) != IntPtr.Zero) // no validation needed for readdir
                         {
-                            if (includeDirectories && matchesSearchPattern)
+                            string name = Interop.libc.GetDirEntName(curEntry);
+
+                            // Get from the dir entry whether the entry is a file or directory.
+                            // If we're not sure from the dir entry itself, stat to the entry.
+                            bool isDir = false, isFile = false;
+                            switch (Interop.libc.GetDirEntType(curEntry))
                             {
-                                yield return translateResult(fullNewName, /*isDirectory*/true);
+                                case Interop.libc.DType.DT_DIR:
+                                    isDir = true;
+                                    break;
+                                case Interop.libc.DType.DT_REG:
+                                    isFile = true;
+                                    break;
+                                case Interop.libc.DType.DT_LNK:
+                                case Interop.libc.DType.DT_UNKNOWN:
+                                    string fullPath = Path.Combine(dirPath.FullPath, name);
+                                    Interop.libcoreclr.fileinfo fileinfo;
+                                    while (Interop.CheckIo(Interop.libcoreclr.GetFileInformationFromPath(fullPath, out fileinfo), fullPath)) ;
+                                    isDir = (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR;
+                                    isFile = (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFREG;
+                                    break;
                             }
-                            if (searchOption == SearchOption.AllDirectories)
+                            bool matchesSearchPattern =
+                                (isFile || isDir) &&
+                                Interop.libc.fnmatch(_searchPattern, name, Interop.libc.FnmatchFlags.None) == 0;
+
+                            // Yield the result if the user has asked for it.  In the case of directories,
+                            // always explore it by pushing it onto the stack, regardless of whether
+                            // we're returning directories.
+                            if (isDir && !ShouldIgnoreDirectory(name))
                             {
-                                if (toExplore == null)
+                                if (_includeDirectories && matchesSearchPattern)
                                 {
-                                    toExplore = new Stack<string>();
+                                    yield return _translateResult(Path.Combine(dirPath.UserPath, name), /*isDirectory*/true);
                                 }
-                                toExplore.Push(fullNewName);
+                                if (_searchOption == SearchOption.AllDirectories)
+                                {
+                                    if (toExplore == null)
+                                    {
+                                        toExplore = new Stack<PathPair>();
+                                    }
+                                    toExplore.Push(new PathPair(Path.Combine(dirPath.UserPath, name), Path.Combine(dirPath.FullPath, name)));
+                                }
                             }
-                        }
-                        else if (isFile && includeFiles && matchesSearchPattern)
-                        {
-                            yield return translateResult(fullNewName, /*isDirectory*/false);
+                            else if (isFile && _includeFiles && matchesSearchPattern)
+                            {
+                                yield return _translateResult(Path.Combine(dirPath.UserPath, name), /*isDirectory*/false);
+                            }
                         }
                     }
-                }
-                finally
-                {
-                    // Close the directory enumerator
-                    while (Interop.CheckIo(Interop.libc.closedir(pdir), dirPath, isDirectory: true)) ;
+                    finally
+                    {
+                        // Close the directory enumerator
+                        if (dirHandle != null && !dirHandle.IsClosed) // TODO: Remove once exception handling bug is fixed
+                        {
+                            dirHandle.Dispose();
+                            dirHandle = null;
+                        }
+                    }
+
+                    if (toExplore != null && toExplore.Count > 0)
+                    {
+                        // Open the next directory.
+                        dirPath = toExplore.Pop();
+                        dirHandle = OpenDirectory(dirPath.FullPath);
+                    }
                 }
             }
-            while (toExplore != null && toExplore.Count > 0); // only loop again if we're recursively processing directories and have more to process
+
+            private struct PathPair
+            {
+                internal readonly string UserPath;
+                internal readonly string FullPath;
+
+                internal PathPair(string userPath, string fullPath)
+                {
+                    UserPath = userPath;
+                    FullPath = fullPath;
+                }
+            }
+
+            private static string NormalizeSearchPattern(string searchPattern)
+            {
+                searchPattern = searchPattern.TrimEnd(PathHelpers.TrimEndChars);
+                if (searchPattern.Equals(".") || searchPattern == "*.*")
+                {
+                    searchPattern = "*";
+                }
+                else if (PathHelpers.EndsInDirectorySeparator(searchPattern))
+                {
+                    searchPattern += "*";
+                }
+                return searchPattern;
+            }
+
+            private static Interop.libc.SafeDirHandle OpenDirectory(string fullPath)
+            {
+                Interop.libc.SafeDirHandle handle = Interop.libc.opendir(fullPath);
+                if (handle.IsInvalid)
+                {
+                    throw Interop.GetExceptionForIoErrno(Marshal.GetLastWin32Error(), fullPath, isDirectory: true);
+                }
+                return handle;
+            }
         }
 
         /// <summary>Determines whether the specified directory name should be ignored.</summary>
@@ -499,7 +628,7 @@ namespace System.IO
 
         public override DateTimeOffset GetLastWriteTime(string fullPath)
         {
-            return new UnixFileSystemObject(fullPath, false).LastAccessTime;
+            return new UnixFileSystemObject(fullPath, false).LastWriteTime;
         }
 
         public override void SetLastWriteTime(string fullPath, DateTimeOffset time, bool asDirectory)

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystemObject.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystemObject.cs
@@ -50,6 +50,10 @@ namespace System.IO
                     {
                         attrs |= FileAttributes.ReadOnly;
                     }
+                    if (IsLink)
+                    {
+                        attrs |= FileAttributes.ReparsePoint;
+                    }
                     if (Path.GetFileName(_fullPath).StartsWith("."))
                     {
                         attrs |= FileAttributes.Hidden;
@@ -61,10 +65,25 @@ namespace System.IO
                 }
                 set
                 {
-                    // We can't change directory or hidden; the only thing we can reasonably change
-                    // is whether the file object is readonly, just changing its permissions accordingly.
+                    // Validate that only flags from the attribute are being provided.  This is an
+                    // approximation for the validation done by the Win32 function.
+                    const FileAttributes allValidFlags =
+                        FileAttributes.Archive | FileAttributes.Compressed | FileAttributes.Device |
+                        FileAttributes.Directory | FileAttributes.Encrypted | FileAttributes.Hidden |
+                        FileAttributes.Hidden | FileAttributes.IntegrityStream | FileAttributes.Normal |
+                        FileAttributes.NoScrubData | FileAttributes.NotContentIndexed | FileAttributes.Offline |
+                        FileAttributes.ReadOnly | FileAttributes.ReparsePoint | FileAttributes.SparseFile | 
+                        FileAttributes.System | FileAttributes.Temporary;
+                    if ((value & ~allValidFlags) != 0)
+                    {
+                        throw new ArgumentException(SR.Arg_InvalidFileAttrs);
+                    }
+
+                    // The only thing we can reasonably change is whether the file object is readonly,
+                    // just changing its permissions accordingly.
                     EnsureStatInitialized();
                     IsReadOnlyAssumesInitialized = (value & FileAttributes.ReadOnly) != 0;
+                    _fileinfoInitialized = -1;
                 }
             }
 
@@ -73,7 +92,15 @@ namespace System.IO
             {
                 get
                 {
-                    return (_fileinfo.mode & (int)Interop.libcoreclr.FileTypes.S_IFMT) == (int)Interop.libcoreclr.FileTypes.S_IFDIR;
+                    return (_fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR;
+                }
+            }
+
+            private bool IsLink
+            {
+                get
+                {
+                    return (_fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFLNK;
                 }
             }
 
@@ -88,17 +115,17 @@ namespace System.IO
                     Interop.libc.Permissions readBit, writeBit;
                     if (_fileinfo.uid == Interop.libc.geteuid())      // does the user effectively own the file?
                     {
-                        readBit = Interop.libc.Permissions.S_IRUSR;
+                        readBit  = Interop.libc.Permissions.S_IRUSR;
                         writeBit = Interop.libc.Permissions.S_IWUSR;
                     }
                     else if (_fileinfo.gid == Interop.libc.getegid()) // does the user belong to a group that effectively owns the file?
                     {
-                        readBit = Interop.libc.Permissions.S_IRGRP;
+                        readBit  = Interop.libc.Permissions.S_IRGRP;
                         writeBit = Interop.libc.Permissions.S_IWGRP;
                     }
-                    else                                        // everyone else
+                    else                                              // everyone else
                     {
-                        readBit = Interop.libc.Permissions.S_IROTH;
+                        readBit  = Interop.libc.Permissions.S_IROTH;
                         writeBit = Interop.libc.Permissions.S_IWOTH;
                     }
 
@@ -108,12 +135,6 @@ namespace System.IO
                 }
                 set
                 {
-                    bool isReadOnly = IsReadOnlyAssumesInitialized;
-                    if (value == isReadOnly)
-                    {
-                        return;
-                    }
-
                     int newMode = _fileinfo.mode;
                     if (value) // true if going from writable to readable, false if going from readable to writable
                     {
@@ -150,9 +171,14 @@ namespace System.IO
 
             public DateTimeOffset CreationTime
             {
-                // Not supported.
-                get { return default(DateTimeOffset); }
-                set { } // Not supported. Only some systems support "birthtime" from stat.
+                get
+                {
+                    EnsureStatInitialized();
+                    return (_fileinfo.flags & (uint)Interop.libcoreclr.FileInformationFlags.HasBTime) != 0 ?
+                        DateTimeOffset.FromUnixTimeSeconds(_fileinfo.btime) :
+                        default(DateTimeOffset);
+                }
+                set { } // Not supported
             }
 
             public DateTimeOffset LastAccessTime
@@ -231,7 +257,21 @@ namespace System.IO
                 {
                     int errno = _fileinfoInitialized;
                     _fileinfoInitialized = -1;
-                    throw Interop.GetExceptionForIoErrno(errno, _fullPath, _isDirectory);
+
+                    bool failedBecauseOfDirectory = _isDirectory;
+                    if (!failedBecauseOfDirectory && errno == Interop.Errors.ENOENT)
+                    {
+                        // Windows distinguishes between whether the directory or the file isn't found,
+                        // and throws a different exception in these cases.  We attempt to approximate that
+                        // here; there is a race condition here, where something could change between
+                        // when the error occurs and our checks, but it's the best we can do, and the
+                        // worst case in such a race condition (which could occur if the file system is
+                        // being manipulated concurrently with these checks) is that we throw a
+                        // FileNotFoundException instead of DirectoryNotFoundexception.
+                        failedBecauseOfDirectory = !Directory.Exists(Path.GetDirectoryName(_fullPath));
+                    }
+
+                    throw Interop.GetExceptionForIoErrno(errno, _fullPath, failedBecauseOfDirectory);
                 }
             }
         }

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -12,6 +12,7 @@ namespace System.IO
     {
         public override int MaxPath { get { return Interop.mincore.MAX_PATH; } }
         public override int MaxDirectoryPath { get { return Interop.mincore.MAX_DIRECTORY_PATH; } }
+        public override bool CaseSensitive { get { return false; } }
 
         public override void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
         {

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileSystem.cs
@@ -19,6 +19,7 @@ namespace System.IO
     {
         public override int MaxPath { get { return Interop.mincore.MAX_PATH; } }
         public override int MaxDirectoryPath { get { return Interop.mincore.MAX_DIRECTORY_PATH; } }
+        public override bool CaseSensitive { get { return false; } }
 
         private static System.IO.FileAttributes ConvertFileAttributes(WinRTFileAttributes fileAttributes)
         {

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -57,6 +57,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // alternate data streams
     public static void CreateDirectory_PathWithAlternativeDataStreams_ThrowsNotSupportedException()
     {
         var paths = IOInputs.GetPathsWithAlternativeDataStreams();
@@ -71,6 +72,7 @@ public class Directory_CreateDirectory
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows)] // device name prefixes
     public static void CreateDirectory_PathWithReservedDeviceNameAsPath_ThrowsDirectoryNotFoundException()
     {   // Throws DirectoryNotFoundException, when the behavior really should be an invalid path
         var paths = IOInputs.GetPathsWithReservedDeviceNames();
@@ -84,6 +86,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // UNC shares
     public static void CreateDirectory_UncPathWithoutShareNameAsPath_ThrowsArgumentException()
     {
         var paths = IOInputs.GetUncPathsWithoutShareName();
@@ -97,6 +100,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // max component size not fixed on Unix
     public static void CreateDirectory_DirectoryWithComponentLongerThanMaxComponentAsPath_ThrowsPathTooLongException()
     {
         // While paths themselves can be up to 260 characters including trailing null, file systems
@@ -114,6 +118,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // max directory size not fixed on Unix
     public static void CreateDirectory_DirectoryLongerThanMaxDirectoryAsPath_ThrowsPathTooLongException()
     {
         var paths = IOInputs.GetPathsLongerThanMaxDirectory();
@@ -140,6 +145,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // testing drive labels
     public static void CreateDirectory_NotReadyDriveAsPath_ThrowsDirectoryNotFoundException()
     {   // Behavior is suspect, should really have thrown IOException similar to the SubDirectory case
         var drive = IOServices.GetNotReadyDrive();
@@ -156,6 +162,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // testing drive labels
     public static void CreateDirectory_SubdirectoryOnNotReadyDriveAsPath_ThrowsIOException()
     {
         var drive = IOServices.GetNotReadyDrive();
@@ -173,6 +180,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // testing drive labels
     public static void CreateDirectory_NonExistentDriveAsPath_ThrowsDirectoryNotFoundException()
     {
         var drive = IOServices.GetNonExistentDrive();
@@ -190,6 +198,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // testing drive labels
     public static void CreateDirectory_SubdirectoryOnNonExistentDriveAsPath_ThrowsDirectoryNotFoundException()
     {
         var drive = IOServices.GetNonExistentDrive();
@@ -265,7 +274,7 @@ public class Directory_CreateDirectory
     [Fact]
     public static void CreateDirectory_DotWithoutTrailingSlashAsPath_DoesNotThrow()
     {
-        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\."); // "Current" directory
+        DirectoryInfo result = Directory.CreateDirectory(Path.Combine(TestInfo.CurrentDirectory, ".")); // "Current" directory
 
         Assert.True(Directory.Exists(result.FullName));
     }
@@ -273,7 +282,7 @@ public class Directory_CreateDirectory
     [Fact]
     public static void CreateDirectory_DotWithTrailingSlashAsPath_DoesNotThrow()
     {
-        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\.\"); // "Current" directory
+        DirectoryInfo result = Directory.CreateDirectory(Path.Combine(TestInfo.CurrentDirectory, ".") + Path.DirectorySeparatorChar); // "Current" directory
 
         Assert.True(Directory.Exists(result.FullName));
     }
@@ -281,7 +290,7 @@ public class Directory_CreateDirectory
     [Fact]
     public static void CreateDirectory_DotDotWithoutTrailingSlashAsPath_DoesNotThrow()
     {
-        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\..");    // "Parent" of current directory
+        DirectoryInfo result = Directory.CreateDirectory(Path.Combine(TestInfo.CurrentDirectory, ".."));    // "Parent" of current directory
 
         Assert.True(Directory.Exists(result.FullName));
     }
@@ -289,7 +298,7 @@ public class Directory_CreateDirectory
     [Fact]
     public static void CreateDirectory_DotDotWithTrailingSlashAsPath_DoesNotThrow()
     {
-        DirectoryInfo result = Directory.CreateDirectory(TestInfo.CurrentDirectory + @"\..\");    // "Parent" of current directory
+        DirectoryInfo result = Directory.CreateDirectory(Path.Combine(TestInfo.CurrentDirectory, "..") + Path.DirectorySeparatorChar);    // "Parent" of current directory
 
         Assert.True(Directory.Exists(result.FullName));
     }
@@ -378,11 +387,12 @@ public class Directory_CreateDirectory
 #endif
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
     public static void CreateDirectory_DirectoryEqualToMaxDirectory_CanBeCreated()
     {   // Recursively creates directories right up to the maximum directory length ("247 chars not including null")
         using (TemporaryDirectory directory = new TemporaryDirectory())
         {
-            PathInfo path = IOServices.GetPath(directory.Path, IOInputs.MaxDirectory);
+            PathInfo path = IOServices.GetPath(directory.Path, IOInputs.MaxDirectory, IOInputs.MaxComponent);
 
             // First create 'C:\AAA...AA', followed by 'C:\AAA...AAA\AAA...AAA', etc
             foreach (string subpath in path.SubPaths)
@@ -396,6 +406,7 @@ public class Directory_CreateDirectory
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
     public static void CreateDirectory_DirectoryEqualToMaxDirectory_CanBeCreatedAllAtOnce()
     {   // Creates directories up to the maximum directory length all at once
         using (TemporaryDirectory directory = new TemporaryDirectory())

--- a/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
@@ -22,6 +22,7 @@ public class Directory_Delete_MountVolume
 
     [Fact]
     [ActiveIssue(1221)]
+    [PlatformSpecific(PlatformID.Windows)] // testing volumes / mounts / drive letters
     public static void RunTest()
     {
         try

--- a/src/System.IO.FileSystem/tests/Directory/Delete_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_str.cs
@@ -39,6 +39,7 @@ public class Directory_Delete_str
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // readonly directories can be deleted on Unix
     public static void ShouldThrowIOExceptionDeletingReadOnlyDirectory()
     {
         string dirPath = Path.Combine(TestInfo.CurrentDirectory, s_dirName);
@@ -122,7 +123,7 @@ public class Directory_Delete_str
             throw;
         }
 
-        Directory.Delete(dir2.FullName.ToLower(), true);
+        Directory.Delete(dir2.FullName, true);
         if (Directory.Exists(dirPath))
         {
             printerr("Error_26y7b! Directory not deleted");
@@ -138,7 +139,7 @@ public class Directory_Delete_str
         //-----------------------------------------------------------------
         Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
         DirectoryInfo dir2 = Directory.CreateDirectory(Path.Combine(dirPath, Path.GetRandomFileName()));
-        Directory.Delete(dir2.FullName.ToUpper());
+        Directory.Delete(dir2.FullName);
 
         if (Directory.Exists(dir2.FullName))
         {

--- a/src/System.IO.FileSystem/tests/Directory/Delete_str_bool.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete_str_bool.cs
@@ -45,6 +45,7 @@ public class Directory_Co5663Delete_str_bool
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // readonly directories can be deleted on Unix
     public static void DirectoryWithReadOnlyAttribute()
     {
         // [] Deleting directory with Readonly property set should always fail 
@@ -90,6 +91,7 @@ public class Directory_Co5663Delete_str_bool
 #endif
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // directories with in-use files can be deleted on Unix
     public static void DirectoryWithFileInUse()
     {
         // [] Delete directory with a file that is in use
@@ -146,7 +148,7 @@ public class Directory_Co5663Delete_str_bool
             throw;
         }
 
-        Directory.Delete(dir2.FullName.ToLower(), true);
+        Directory.Delete(dir2.FullName, true);
         if (Directory.Exists(dirName))
         {
             printerr("Error_26y7b! Directory not deleted");
@@ -161,7 +163,7 @@ public class Directory_Co5663Delete_str_bool
         string dirName = Path.Combine(TestInfo.CurrentDirectory, s_dirName + "_withSubDirs");
         Directory.CreateDirectory(Path.Combine(dirName, "Test1"));
         DirectoryInfo dir2 = Directory.CreateDirectory(Path.Combine(dirName, "Test2"));
-        Directory.Delete(dir2.FullName.ToUpper(), false);
+        Directory.Delete(dir2.FullName, false);
         if (Directory.Exists(Path.Combine(dirName, "Test2")))
         {
             printerr("Error_49928! Directory not deleted");

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -27,6 +27,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows | PlatformID.OSX)] // testing case insensitivity
     public static void Exists_DoesCaseInsensitiveInvariantComparions()
     {
         using (TemporaryDirectory directory = new TemporaryDirectory())
@@ -124,6 +125,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // alternate data stream
     public static void Exists_PathWithAlternativeDataStreams_ReturnsFalse()
     {
         var paths = IOInputs.GetPathsWithAlternativeDataStreams();
@@ -137,6 +139,7 @@ public class Directory_Exists
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows)] // device names
     public static void Exists_PathWithReservedDeviceNameAsPath_ReturnsFalse()
     {
         var paths = IOInputs.GetPathsWithReservedDeviceNames();
@@ -149,6 +152,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // UNC paths
     public static void Exists_UncPathWithoutShareNameAsPath_ReturnsFalse()
     {
         var paths = IOInputs.GetUncPathsWithoutShareName();
@@ -162,6 +166,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
     public static void Exists_DirectoryEqualToMaxDirectory_ReturnsTrue()
     {   // Creates directories up to the maximum directory length all at once
         using (TemporaryDirectory directory = new TemporaryDirectory())
@@ -177,6 +182,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // max directory length not fixed on Unix
     public static void Exists_DirectoryWithComponentLongerThanMaxComponentAsPath_ReturnsFalse()
     {
         var paths = IOInputs.GetPathsWithComponentLongerThanMaxComponent();
@@ -216,6 +222,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // drive labels
     public static void Exists_NotReadyDriveAsPath_ReturnsFalse()
     {
         var drive = IOServices.GetNotReadyDrive();
@@ -231,6 +238,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // drive labels
     public static void Exists_SubdirectoryOnNotReadyDriveAsPath_ReturnsFalse()
     {
         var drive = IOServices.GetNotReadyDrive();
@@ -246,6 +254,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // drive labels
     public static void Exists_NonExistentDriveAsPath_ReturnsFalse()
     {
         var drive = IOServices.GetNonExistentDrive();
@@ -261,6 +270,7 @@ public class Directory_Exists
     }
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // drive labels
     public static void Exists_SubdirectoryOnNonExistentDriveAsPath_ReturnsFalse()
     {
         var drive = IOServices.GetNonExistentDrive();
@@ -331,7 +341,7 @@ public class Directory_Exists
     [Fact]
     public static void Exists_DotAsPath_ReturnsTrue()
     {
-        bool result = Directory.Exists(TestInfo.CurrentDirectory + @"\.");
+        bool result = Directory.Exists(Path.Combine(TestInfo.CurrentDirectory, "."));
 
         Assert.True(result);
     }
@@ -339,7 +349,7 @@ public class Directory_Exists
     [Fact]
     public static void Exists_DotDotAsPath_ReturnsTrue()
     {
-        bool result = Directory.Exists(TestInfo.CurrentDirectory + @"\..");
+        bool result = Directory.Exists(Path.Combine(TestInfo.CurrentDirectory, ".."));
 
         Assert.True(result);
     }

--- a/src/System.IO.FileSystem/tests/Directory/GetCreationTime_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetCreationTime_str.cs
@@ -18,6 +18,7 @@ public class Directory_GetCreationTime
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows | PlatformID.OSX)] // birth time only available on some Unix systems
     public static void runTest()
     {
         int iCountErrors = 0;
@@ -76,37 +77,39 @@ public class Directory_GetCreationTime
             dir.Delete(true);
 
 #if !TEST_WINRT
-            //#469226 - DirectoryInfo.CreationTime throws System.ArgumentOutOfRangeException for directories on CDs
-            //postponed but we will add the scenario
-            try
+            if (Interop.IsWindows) // testing drive labels
             {
-                IEnumerable<string> drives = IOServices.GetReadyDrives();
-                foreach (string drive in drives)
+                //#469226 - DirectoryInfo.CreationTime throws System.ArgumentOutOfRangeException for directories on CDs
+                //postponed but we will add the scenario
+                try
                 {
-                    String[] dirs = Directory.GetDirectories(drive);
-                    int count = 10;
-                    if (dirs.Length < count)
-                        count = dirs.Length;
-                    for (int i = 0; i < count; i++)
+                    IEnumerable<string> drives = IOServices.GetReadyDrives();
+                    foreach (string drive in drives)
                     {
-                        try
+                        String[] dirs = Directory.GetDirectories(drive);
+                        int count = 10;
+                        if (dirs.Length < count)
+                            count = dirs.Length;
+                        for (int i = 0; i < count; i++)
                         {
-                            DateTime time = Directory.GetCreationTime(dirs[i]);
-                        }
-                        catch (ArgumentOutOfRangeException)
-                        {
-                            Console.WriteLine("Info_9237tgfasd: #469226? drive: {0}, directory: {1}", drive, dirs[i]);
+                            try
+                            {
+                                DateTime time = Directory.GetCreationTime(dirs[i]);
+                            }
+                            catch (ArgumentOutOfRangeException)
+                            {
+                                Console.WriteLine("Info_9237tgfasd: #469226? drive: {0}, directory: {1}", drive, dirs[i]);
+                            }
                         }
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                ++iCountErrors;
-                Console.WriteLine("Err_734g@! exception thrown: {0}", ex);
+                catch (Exception ex)
+                {
+                    ++iCountErrors;
+                    Console.WriteLine("Err_734g@! exception thrown: {0}", ex);
+                }
             }
 #endif
-
         }
         catch (Exception exc_general)
         {

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str.cs
@@ -82,14 +82,14 @@ public class Directory_GetDirectories_str
             }
             //-----------------------------------------------------------------
 
-            // [] ArgumentException for all whitespace
+            // [] ArgumentException for invalid path
             //-----------------------------------------------------------------
             strLoc = "Loc_1190x";
 
             iCountTestcases++;
             try
             {
-                Directory.GetDirectories("*");
+                Directory.GetDirectories("\0");
                 iCountErrors++;
                 printerr("Error_2198y! Expected exception not thrown");
             }
@@ -263,7 +263,7 @@ public class Directory_GetDirectories_str
 
             strLoc = "Loc_48yg7";
 
-            dirArr = dir2.GetDirectories("T*st*d*2");
+            dirArr = dir2.GetDirectories("T*st*D*2");
             iCountTestcases++;
             if (dirArr.Length != 2)
             {
@@ -279,7 +279,7 @@ public class Directory_GetDirectories_str
 
             dirArr = dir2.GetDirectories("*BB*");
             iCountTestcases++;
-            if (dirArr.Length != 2)
+            if (dirArr.Length != (Interop.IsLinux ? 1 : 2)) // Linux is case-sensitive
             {
                 iCountErrors++;
                 printerr("Error_4y190! Incorrect number of directories==" + dirArr.Length);
@@ -295,11 +295,15 @@ public class Directory_GetDirectories_str
                 iCountErrors++;
                 printerr("Error_956yb! Incorrect name==" + dirArr[0]);
             }
-            iCountTestcases++;
-            if (Array.IndexOf(names, "aaabbcc") < 0)
+
+            if (!Interop.IsLinux) // linux is case-sensitive
             {
-                iCountErrors++;
-                printerr("Error_48yg7! Incorrect name==" + dirArr[1]);
+                iCountTestcases++;
+                if (Array.IndexOf(names, "aaabbcc") < 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_48yg7! Incorrect name==" + dirArr[1]);
+                }
             }
 
             // [] Should not search on fullpath

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str.cs
@@ -304,7 +304,7 @@ public class Directory_Co5674GetDirectories_Str_Str
 
             strArr = Directory.GetDirectories(Path.Combine(".", dirName), "*BB*");
             iCountTestcases++;
-            if (strArr.Length != 2)
+            if (strArr.Length != (Interop.IsLinux ? 1 : 2)) // Linux is case-sensitive
             {
                 iCountErrors++;
                 printerr("Error_4y190! Incorrect number of directories==" + strArr.Length);
@@ -319,11 +319,14 @@ public class Directory_Co5674GetDirectories_Str_Str
                 iCountErrors++;
                 printerr("Error_956yb! Incorrect name==" + strArr[0]);
             }
-            iCountTestcases++;
-            if (Array.IndexOf(names, "aaabbcc") < 0)
+            if (!Interop.IsLinux) // Linux is case-sensitive
             {
-                iCountErrors++;
-                printerr("Error_48yg7! Incorrect name==" + strArr[1]);
+                iCountTestcases++;
+                if (Array.IndexOf(names, "aaabbcc") < 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_48yg7! Incorrect name==" + strArr[1]);
+                }
             }
 
             // [] Should not search on fullpath

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectories_str_str_so.cs
@@ -312,8 +312,8 @@ public class Directory_GetDirectories_str_str_so
             //characters. The same for searchPattern parm as well
             try
             {
-                String[] invalidValuesForPath = { "", " ", ">" };
-                String[] invalidValuesForSearch = { "..", @"..\" };
+                String[] invalidValuesForPath = Interop.IsWindows ? new[]{ "", " ", ">" } : new[]{ "", "\0" };
+                String[] invalidValuesForSearch = { "..", @".." + Path.DirectorySeparatorChar };
                 CheckException<ArgumentNullException>(delegate { dirs = Directory.GetDirectories(null, "*", SearchOption.TopDirectoryOnly); }, "Err_347g! worng exception thrown");
                 CheckException<ArgumentNullException>(delegate { dirs = Directory.GetDirectories(Directory.GetCurrentDirectory(), null, SearchOption.TopDirectoryOnly); }, "Err_326pgt! worng exception thrown");
                 CheckException<ArgumentOutOfRangeException>(delegate { dirs = Directory.GetDirectories(Directory.GetCurrentDirectory(), "*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");

--- a/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetDirectoryRoot_str.cs
@@ -67,29 +67,32 @@ public class Directory_GetDirectoryRoot_str
                 printerr("Error_69y7b! Unexpected parent==" + str2);
             }
 
-            // [] Get root of \Directory
-
-            strLoc = "Loc_98ygg";
-
-            str2 = Directory.GetDirectoryRoot(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test"));
-            iCountTestcases++;
-            String root = Path.GetPathRoot(Directory.GetCurrentDirectory());
-            if (!str2.Equals(root))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_91y7b! Unexpected parent==" + str2);
-            }
+                // [] Get root of \Directory
 
-            // [] Get root of \\Machine\Directory
+                strLoc = "Loc_98ygg";
 
-            strLoc = "Loc_yg7bk";
+                str2 = Directory.GetDirectoryRoot(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test"));
+                iCountTestcases++;
+                String root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+                if (!str2.Equals(root))
+                {
+                    iCountErrors++;
+                    printerr("Error_91y7b! Unexpected parent==" + str2);
+                }
 
-            str2 = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test"));
-            iCountTestcases++;
-            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")))
-            {
-                iCountErrors++;
-                printerr("Error_4y7gb! Unexpected parent==" + str2);
+                // [] Get root of \\Machine\Directory
+
+                strLoc = "Loc_yg7bk";
+
+                str2 = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test"));
+                iCountTestcases++;
+                if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")))
+                {
+                    iCountErrors++;
+                    printerr("Error_4y7gb! Unexpected parent==" + str2);
+                }
             }
 
 
@@ -117,16 +120,19 @@ public class Directory_GetDirectoryRoot_str
                 printerr("Error_9887b! Unexpected parent==" + str2);
             }
 
-            // [] Get root of many subdirs on UNC share
-
-            strLoc = "Loc_y7t98";
-
-            str2 = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2", "Test3"));
-            iCountTestcases++;
-            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_69929! Unexpected parent==" + str2);
+                // [] Get root of many subdirs on UNC share
+
+                strLoc = "Loc_y7t98";
+
+                str2 = Directory.GetDirectoryRoot(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2", "Test3"));
+                iCountTestcases++;
+                if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
+                {
+                    iCountErrors++;
+                    printerr("Error_69929! Unexpected parent==" + str2);
+                }
             }
 
             // [] Play with "." and ".." in the middle of the directory string

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -195,7 +195,7 @@ public class Directory_GetFileSystemEntries_str_str
             iCountTestcases++;
             try
             {
-                String strTempDir = "..ab ab.. .. abc..d\abc..";
+                String strTempDir = Path.Combine("..ab ab.. .. abc..d", "abc..");
                 Directory.GetFileSystemEntries(dirName, strTempDir);
                 iCountErrors++;
                 printerr("Error_144003! Expected exception not thrown");
@@ -433,7 +433,7 @@ public class Directory_GetFileSystemEntries_str_str
             strArr = Directory.GetFileSystemEntries(dir2.Name, "*BB*");
 
             iCountTestcases++;
-            if (strArr.Length != 2)
+            if (strArr.Length != (Interop.IsLinux ? 1 : 2)) // Linux is case-sensitive
             {
                 iCountErrors++;
                 printerr("Error_4y190! Incorrect number of files==" + strArr.Length);
@@ -441,11 +441,14 @@ public class Directory_GetFileSystemEntries_str_str
             for (int iLoop = 0; iLoop < strArr.Length; iLoop++)
                 strArr[iLoop] = Path.GetFileName(strArr[iLoop]);
 
-            iCountTestcases++;
-            if (Array.IndexOf(strArr, "aaabbcc") < 0)
+            if (!Interop.IsLinux) // Linux is case-sensitive
             {
-                iCountErrors++;
-                printerr("Error_956yb! Incorrect name==" + strArr[0]);
+                iCountTestcases++;
+                if (Array.IndexOf(strArr, "aaabbcc") < 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_956yb! Incorrect name==" + strArr[0]);
+                }
             }
             iCountTestcases++;
             if (Array.IndexOf(strArr, "AAABB") < 0)

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str.cs
@@ -160,6 +160,11 @@ public class Directory_GetFiles_str
             foreach (FileInfo f in filArr)
                 names[i++] = f.Name;
 
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
+
             iCountTestcases++;
             if (Array.IndexOf(names, "TestFile1") < 0)
             {
@@ -194,6 +199,11 @@ public class Directory_GetFiles_str
             i = 0;
             foreach (FileInfo f in filArr)
                 names[i++] = f.Name;
+
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
 
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1File1") < 0)
@@ -257,7 +267,7 @@ public class Directory_GetFiles_str
             // [] Multiple wildcards in searchstring
 
             strLoc = "Loc_9438y";
-            filArr = dir2.GetFiles("*es*f*l*");
+            filArr = dir2.GetFiles("*es*F*l*");
             iCountTestcases++;
             if (filArr.Length != 5)
             {
@@ -280,12 +290,12 @@ public class Directory_GetFiles_str
 
             filArr = dir2.GetFiles("*BB*");
             iCountTestcases++;
-            if (filArr.Length != 2)
+            if (filArr.Length != (Interop.IsLinux ? 1 : 2)) // Linux is case-sensitive
             {
                 iCountErrors++;
                 printerr("Error_4y190! Incorrect number of files==" + filArr.Length);
             }
-            names = new String[2];
+            names = new String[filArr.Length];
             i = 0;
             foreach (FileInfo f in filArr)
             {
@@ -298,11 +308,14 @@ public class Directory_GetFiles_str
                 iCountErrors++;
                 printerr("Error_956yb! Incorrect name==" + filArr[0].Name);
             }
-            iCountTestcases++;
-            if (Array.IndexOf(names, "aaabbcc") < 0)
+            if (!Interop.IsLinux) // Linux is case-sensitive
             {
-                iCountErrors++;
-                printerr("Error_48yg7! Incorrect name==" + filArr[1].Name);
+                iCountTestcases++;
+                if (Array.IndexOf(names, "aaabbcc") < 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_48yg7! Incorrect name==" + filArr[1].Name);
+                }
             }
 
             // [] Exact match

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str_Str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str_Str.cs
@@ -211,6 +211,11 @@ public class Directory_GetFiles_str_str
             foreach (String f in strArr)
                 names[i++] = Path.GetFileName(f);
 
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
+
             iCountTestcases++;
             if (Array.IndexOf(names, "TestFile1") < 0)
             {
@@ -245,6 +250,11 @@ public class Directory_GetFiles_str_str
             i = 0;
             foreach (String f in strArr)
                 names[i++] = Path.GetFileName(f);
+
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
 
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1File1") < 0)
@@ -313,7 +323,7 @@ public class Directory_GetFiles_str_str
 
             strArr = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), dirName), "*BB*");
             iCountTestcases++;
-            if (strArr.Length != 2)
+            if (strArr.Length != (Interop.IsLinux ? 1 : 2)) // Linux is case-sensitive
             {
                 iCountErrors++;
                 printerr("Error_4y190! Incorrect number of files==" + strArr.Length);
@@ -328,11 +338,14 @@ public class Directory_GetFiles_str_str
                 iCountErrors++;
                 printerr("Error_956yb! Incorrect name==" + strArr[0].ToString());
             }
-            iCountTestcases++;
-            if (Array.IndexOf(names, "aaabbcc") < 0)
+            if (!Interop.IsLinux) // Linux is case-sensitive
             {
-                iCountErrors++;
-                printerr("Error_48yg7! Incorrect name==" + strArr[1].ToString());
+                iCountTestcases++;
+                if (Array.IndexOf(names, "aaabbcc") < 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_48yg7! Incorrect name==" + strArr[1].ToString());
+                }
             }
 
             // [] Exact match on searchstring
@@ -415,33 +428,36 @@ public class Directory_GetFiles_str_str
                 printerr("Err_24y7g! Incorrect exception thrown, exc==" + exc.ToString());
             }
 
-            //bug #417100 - not sure if this hard coded approach is safe in all 9x platforms!!!
-            //But RunAnotherScenario is probably more accurate
-            try
+            if (Interop.IsWindows) // TODO: [ActiveIssue(846)] Globalization on Unix
             {
-                int[] validGreaterThan128ButLessThans160 = { 129, 133, 141, 143, 144, 157 };
-                for (i = 0; i < validGreaterThan128ButLessThans160.Length; i++)
+                //bug #417100 - not sure if this hard coded approach is safe in all 9x platforms!!!
+                //But RunAnotherScenario is probably more accurate
+                try
                 {
-                    Directory.GetFiles(".", ((Char)validGreaterThan128ButLessThans160[i]).ToString());
+                    int[] validGreaterThan128ButLessThans160 = { 129, 133, 141, 143, 144, 157 };
+                    for (i = 0; i < validGreaterThan128ButLessThans160.Length; i++)
+                    {
+                        Directory.GetFiles(".", ((Char)validGreaterThan128ButLessThans160[i]).ToString());
+                    }
                 }
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Err_247gdo! Incorrect exception thrown, exc==" + exc.ToString());
-            }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Err_247gdo! Incorrect exception thrown, exc==" + exc.ToString());
+                }
 
-            try
-            {
-                for (i = 160; i < 256; i++)
+                try
                 {
-                    Directory.GetFiles(".", ((Char)i).ToString());
+                    for (i = 160; i < 256; i++)
+                    {
+                        Directory.GetFiles(".", ((Char)i).ToString());
+                    }
                 }
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Err_960tli! Incorrect exception thrown, exc==" + exc.ToString());
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Err_960tli! Incorrect exception thrown, exc==" + exc.ToString());
+                }
             }
 
 #if DESKTOP

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles_str_str_so.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles_str_str_so.cs
@@ -287,8 +287,8 @@ public class Directory_GetFiles_str_str_so
             // - Path contains empty, space and invalid filename, long, readonly invalid characters. The same for searchPattern parm as well
             try
             {
-                String[] invalidValuesForPath = { "", " ", ">" };
-                String[] invalidValuesForSearch = { "..", @"..\" };
+                String[] invalidValuesForPath = Interop.IsWindows ? new[]{ "", " ", ">" } : new[]{ "", "\0" };
+                String[] invalidValuesForSearch = { "..", @".." + Path.DirectorySeparatorChar };
                 CheckException<ArgumentNullException>(delegate { files = Directory.GetFiles(null, "*.*", SearchOption.TopDirectoryOnly); }, "Err_347g! worng exception thrown");
                 CheckException<ArgumentNullException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), null, SearchOption.TopDirectoryOnly); }, "Err_326pgt! worng exception thrown");
                 CheckException<ArgumentOutOfRangeException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
@@ -306,7 +306,7 @@ public class Directory_GetFiles_str_str_so
                 {
                     CheckException<ArgumentException>(delegate { files = Directory.GetFiles(invalidPaths[i].ToString(), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_538wyc! worng exception thrown: {1}", i, invalidPaths[i]));
                 }
-                Char[] invalidFileNames = Path.GetInvalidFileNameChars();
+                Char[] invalidFileNames = Interop.IsWindows ? Path.GetInvalidFileNameChars() : new[] { '\0' };
                 for (int i = 0; i < invalidFileNames.Length; i++)
                 {
                     switch (invalidFileNames[i])
@@ -321,7 +321,7 @@ public class Directory_GetFiles_str_str_so
                             // 1) we assumed that this will work in all non-9x machine
                             // 2) Then only in XP
                             // 3) NTFS?
-                            if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                            if (Interop.IsWindows && FileSystemDebugInfo.IsCurrentDriveNTFS()) // testing NTFS
                             {
                                 CheckException<IOException>(delegate { files = Directory.GetFiles(Directory.GetCurrentDirectory(), String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_997gqs_{0}! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
                             }
@@ -349,8 +349,8 @@ public class Directory_GetFiles_str_str_so
                     }
                 }
                 //path too long
-                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(Path.Combine(new String('a', 100), new String('b', 200)), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_927gs! wrong exception thrown"));
-                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(new String('a', 100), new String('b', 200), SearchOption.TopDirectoryOnly); }, String.Format("Err_213aka! wrong exception thrown"));
+                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(Path.Combine(new String('a', IOInputs.MaxPath), new String('b', IOInputs.MaxPath)), "*.*", SearchOption.TopDirectoryOnly); }, String.Format("Err_927gs! wrong exception thrown"));
+                CheckException<PathTooLongException>(delegate { files = Directory.GetFiles(new String('a', IOInputs.MaxPath), new String('b', IOInputs.MaxPath), SearchOption.TopDirectoryOnly); }, String.Format("Err_213aka! wrong exception thrown"));
             }
             catch (Exception ex)
             {

--- a/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -28,6 +28,11 @@ public class Directory_GetSetTimes
 
         foreach (TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
         {
+            if (!Interop.IsWindows && timeProperty == TimeProperty.CreationTime) // roundtripping birthtime not supported on Unix
+            {
+                continue;
+            }
+
             foreach (DateTimeKind kind in Enum.GetValues(typeof(DateTimeKind)))
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);

--- a/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
@@ -197,33 +197,36 @@ public class Directory_Move_str_str
             Directory.Delete(tempDirName);
 
 #if !TEST_WINRT
-            // [] Move to different drive will throw AccessException
-            //-----------------------------------------------------------------
-            strLoc = "Loc_00025";
-            string fullDirName = Path.GetFullPath(dirName);
-            Directory.CreateDirectory(dirName);
-            iCountTestcases++;
-            try
+            if (Interop.IsWindows) // moving between drive labels
             {
-                if (fullDirName.Substring(0, 3) == @"d:\" || fullDirName.Substring(0, 3) == @"D:\")
-                    Directory.Move(fullDirName, "C:\\TempDirectory");
-                else
-                    Directory.Move(fullDirName, "D:\\TempDirectory");
-                Console.WriteLine("Root directory..." + fullDirName.Substring(0, 3));
-                iCountErrors++;
-                printerr("Error_00026! Expected exception not thrown");
+                // [] Move to different drive will throw AccessException
+                //-----------------------------------------------------------------
+                strLoc = "Loc_00025";
+                string fullDirName = Path.GetFullPath(dirName);
+                Directory.CreateDirectory(dirName);
+                iCountTestcases++;
+                try
+                {
+                    if (fullDirName.Substring(0, 3) == @"d:\" || fullDirName.Substring(0, 3) == @"D:\")
+                        Directory.Move(fullDirName, "C:\\TempDirectory");
+                    else
+                        Directory.Move(fullDirName, "D:\\TempDirectory");
+                    Console.WriteLine("Root directory..." + fullDirName.Substring(0, 3));
+                    iCountErrors++;
+                    printerr("Error_00026! Expected exception not thrown");
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_00000! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                if (Directory.Exists(fullDirName))
+                    Directory.Delete(fullDirName, true);
+                //-----------------------------------------------------------------
             }
-            catch (IOException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_00000! Incorrect exception thrown, exc==" + exc.ToString());
-            }
-            if (Directory.Exists(fullDirName))
-                Directory.Delete(fullDirName, true);
-            //-----------------------------------------------------------------
 #endif
 
             // [] Moving Directory with subdirectories
@@ -306,7 +309,7 @@ public class Directory_Move_str_str
             iCountTestcases++;
             try
             {
-                Directory.Move(TestInfo.CurrentDirectory, "<MyDirectory>");
+                Directory.Move(TestInfo.CurrentDirectory, "<MyDirectory\0");
                 iCountErrors++;
                 printerr("Error_00041! Expected exception not thrown");
             }
@@ -324,9 +327,7 @@ public class Directory_Move_str_str
             //-----------------------------------------------------------------
             strLoc = "Loc_00044";
 
-            String str = "";
-            for (int i = 0; i < 250; i++)
-                str += "a";
+            String str = new string('a', IOInputs.MaxPath);
             iCountTestcases++;
             try
             {
@@ -349,23 +350,26 @@ public class Directory_Move_str_str
             //-----------------------------------------------------------------
             strLoc = "Loc_00048";
 
-            iCountTestcases++;
-            Directory.CreateDirectory(dirName);
-            try
+            if (Interop.IsWindows) // drive labels
             {
-                Directory.Move(dirName, "X:\\Temp");
-                iCountErrors++;
-                printerr("Error_00049! Expected exception not thrown");
+                iCountTestcases++;
+                Directory.CreateDirectory(dirName);
+                try
+                {
+                    Directory.Move(dirName, "X:\\Temp");
+                    iCountErrors++;
+                    printerr("Error_00049! Expected exception not thrown");
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_00051! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                Directory.Delete(dirName);
             }
-            catch (IOException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_00051! Incorrect exception thrown, exc==" + exc.ToString());
-            }
-            Directory.Delete(dirName);
             //-----------------------------------------------------------------
 
             // [] Use directory names with spaces

--- a/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
+++ b/src/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
@@ -19,6 +19,7 @@ public class Directory_ReparsePoints_MountVolume
 
     [Fact]
     [ActiveIssue(1221)]
+    [PlatformSpecific(PlatformID.Windows)] // testing mounting volumes and reparse points
     public static void runTest()
     {
         try

--- a/src/System.IO.FileSystem/tests/Directory/SetCreationTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetCreationTime_str_dt.cs
@@ -47,6 +47,7 @@ public class Directory_SetCreationTime_str_dt
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows)] // roundtripping birthtime not supported on Unix
     public static void runTest()
     {
         String strLoc = "Loc_0001";

--- a/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetCurrentDirectory_dir.cs
@@ -36,7 +36,7 @@ public class Directory_Co5736SetCurrentDirectory_dir
             //Code coverage
             try
             {
-                Directory.SetCurrentDirectory(new String('a', 1000));
+                Directory.SetCurrentDirectory(new String('a', IOInputs.MaxPath+1));
                 iCountErrors++;
                 Console.WriteLine("Err_34tgs! No exception thrown");
             }

--- a/src/System.IO.FileSystem/tests/Directory/SetLastAccessTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetLastAccessTime_str_dt.cs
@@ -114,12 +114,13 @@ public class Directory_SetLastAccessTime_str_dt
             iCountTestcases++;
             try
             {
-                Directory.SetLastAccessTime(fileName, DateTime.Now.AddYears(-1));
-                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddYears(-1)).Seconds;
-                if (iSeconds > 60)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                Directory.SetLastAccessTime(fileName, now.AddYears(-1));
+                if (Directory.GetLastAccessTime(fileName) != now.AddYears(-1))
                 {
                     iCountErrors++;
-                    printerr("Error_0013! Creation time cannot be correct" + iSeconds);
+                    printerr("Error_0013! Creation time cannot be correct");
                 }
             }
             catch (Exception exc)

--- a/src/System.IO.FileSystem/tests/Directory/SetLastWriteTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/Directory/SetLastWriteTime_str_dt.cs
@@ -115,12 +115,13 @@ public class Directory_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                Directory.SetLastWriteTime(fileName, DateTime.Now.AddYears(-1));
-                int iSeconds = (Directory.GetLastAccessTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds;
-                if (iSeconds > 60)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                Directory.SetLastWriteTime(fileName, now.AddYears(-1));
+                if (Directory.GetLastWriteTime(fileName) != now.AddYears(-1))
                 {
                     iCountErrors++;
-                    printerr("Error_0013! Creation time cannot be correct" + iSeconds);
+                    printerr("Error_0013! Creation time cannot be correct");
                 }
             }
             catch (Exception exc)

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -54,28 +54,24 @@ namespace System.IO.FileSystem.Tests
         public void PathTooLong()
         {
             StringBuilder sb = new StringBuilder(TestDirectory);
-            while (sb.Length < 259)
+            while (sb.Length < IOInputs.MaxPath)
             {
                 sb.Append("a");
             }
 
-            DirectoryInfo dir = new DirectoryInfo(sb.ToString());
-
-            Assert.Throws<PathTooLongException>(() => dir.Create());
+            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(sb.ToString()).Create());
         }
 
         [Fact]
         public void PathJustTooLong()
         {
             StringBuilder sb = new StringBuilder(TestDirectory + Path.DirectorySeparatorChar);
-            while (sb.Length < 248)
+            while (sb.Length < IOInputs.MaxDirectory + 1)
             {
                 sb.Append("a");
             }
 
-            DirectoryInfo dir = new DirectoryInfo(sb.ToString());
-
-            Assert.Throws<PathTooLongException>(() => dir.Create());
+            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(sb.ToString()).Create());
         }
 
         [Fact]
@@ -114,6 +110,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // colon valid filename char on Unix
         public void CreateColon()
         {
             Assert.Throws<ArgumentException>(() => new DirectoryInfo(":"));

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
@@ -33,6 +33,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // tab valid filename char on Unix
         public void Tab()
         {
             Assert.Throws<ArgumentException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory("\t"));
@@ -56,7 +57,7 @@ namespace System.IO.FileSystem.Tests
         public void PathTooLong()
         {
             StringBuilder sb = new StringBuilder();
-            while (sb.Length + TestDirectory.Count() + 1 < 259)
+            while (sb.Length + TestDirectory.Count() < IOInputs.MaxPath + 10)
                 sb.Append("a");
 
             Assert.Throws<PathTooLongException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(sb.ToString()));
@@ -66,7 +67,7 @@ namespace System.IO.FileSystem.Tests
         public void PathJustTooLong()
         {
             StringBuilder sb = new StringBuilder();
-            while (sb.Length + TestDirectory.Count() + 1 < 248)
+            while (sb.Length + TestDirectory.Count() < IOInputs.MaxDirectory)
                 sb.Append("a");
 
             Assert.Throws<PathTooLongException>(() => new DirectoryInfo(TestDirectory).CreateSubdirectory(sb.ToString()));
@@ -115,6 +116,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // colon is a valid filename char on Unix
         public void Colon()
         {
             string[] subdirNames = { ":", ":t", ":test", "te:", "test:", "te:st" };

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Delete_bool.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Delete_bool.cs
@@ -70,6 +70,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // directories with in-use files can be deleted on Unix
         public void FileInUse()
         {
             string subdirRoot = "FileInUse";
@@ -82,6 +83,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // readonly directories can be deleted on Unix
         public void ReadOnly()
         {
             DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(TestDirectory, "ReadOnly"));

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -30,12 +30,13 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        public void NonExistantDirectories()
+        public void NonExistentDirectories()
         {
             Assert.False(new DirectoryInfo("Da drar vi til fjells").Exists);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // drive labels
         public void BadDriveLetterFormat()
         {
             Assert.Throws<NotSupportedException>(() => new DirectoryInfo("xx:\\"));
@@ -44,16 +45,12 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void PathTooLong()
         {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < 500; i++)
-            {
-                sb.Append(i);
-            }
-
-            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(sb.ToString()));
+            string s = new string('s', IOInputs.MaxPath + 1);
+            Assert.Throws<PathTooLongException>(() => new DirectoryInfo(s));
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows | PlatformID.OSX)] // testing case-insensitivity
         public void CaseInsensitivity()
         {
             Assert.True(new DirectoryInfo(TestDirectory.ToUpperInvariant()).Exists);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str_so.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetDirectories_str_so.cs
@@ -91,7 +91,7 @@ public class DirectoryInfo_GetDirectories_str_so
                     CheckException<ArgumentNullException>(delegate { dirs = dirInfo.GetDirectories(null, SearchOption.TopDirectoryOnly); }, "Err_751mwu! worng exception thrown");
                     CheckException<ArgumentOutOfRangeException>(delegate { dirs = dirInfo.GetDirectories("*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
                     CheckException<ArgumentOutOfRangeException>(delegate { dirs = dirInfo.GetDirectories("*", (SearchOption)(-1)); }, "Err_359vcj! worng exception thrown - see bug #386545");
-                    String[] invalidValuesForSearch = { "..", @"..\" };
+                    String[] invalidValuesForSearch = { "..", @".." + Path.DirectorySeparatorChar };
                     for (int i = 0; i < invalidValuesForSearch.Length; i++)
                     {
                         CheckException<ArgumentException>(delegate { dirs = dirInfo.GetDirectories(invalidValuesForSearch[i], SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy! worng exception thrown: {1}", i, invalidValuesForSearch[i]));

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos.cs
@@ -86,6 +86,11 @@ public class DirectoryInfo_GetFileSystemInfos
             int i = 0;
             foreach (FileSystemInfo fse in fsArr)
                 names[i++] = fse.Name;
+            
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
 
             iCountTestcases++;
             if (Array.IndexOf(names, "TestDir1") < 0)

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFileSystemInfos_str.cs
@@ -93,7 +93,7 @@ public class DirectoryInfo_GetFileSystemInfos_str
             iCountTestcases++;
             try
             {
-                dir2.GetFileSystemInfos("..ab ab.. .. abc..d\abc..");
+                dir2.GetFileSystemInfos(Path.Combine("..ab ab.. .. abc..d", "abc.."));
                 iCountErrors++;
                 printerr("Error_2198y! Expected exception not thrown");
             }
@@ -153,6 +153,12 @@ public class DirectoryInfo_GetFileSystemInfos_str
             int i = 0;
             foreach (FileSystemInfo f in fsArr)
                 names[i++] = f.Name;
+            
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
+
             iCountTestcases++;
             if (Array.IndexOf(names, "TestFile1") < 0)
             {
@@ -186,6 +192,12 @@ public class DirectoryInfo_GetFileSystemInfos_str
             i = 0;
             foreach (FileSystemInfo f in fsArr)
                 names[i++] = f.Name;
+            
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
+
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1Dir1") < 0)
             {
@@ -318,7 +330,7 @@ public class DirectoryInfo_GetFileSystemInfos_str
 
             fsArr = dir2.GetFileSystemInfos("*BB*");
             iCountTestcases++;
-            if (fsArr.Length != 2)
+            if (fsArr.Length != (Interop.IsLinux ? 1 : 2)) // Linux is case-sensitive
             {
                 iCountErrors++;
                 printerr("Error_4y190! Incorrect number of files==" + fsArr.Length);
@@ -328,13 +340,17 @@ public class DirectoryInfo_GetFileSystemInfos_str
             foreach (FileSystemInfo fs in fsArr)
                 names[i++] = fs.Name;
 
-            iCountTestcases++;
-            if (Array.IndexOf(names, "aaabbcc") < 0)
+            if (!Interop.IsLinux) // Linux is case-sensitive
             {
-                iCountErrors++;
-                printerr("Error_956yb! Incorrect name==" + fsArr[0]);
-                foreach (FileSystemInfo s in fsArr)
-                    Console.WriteLine(s.Name);
+
+                iCountTestcases++;
+                if (Array.IndexOf(names, "aaabbcc") < 0)
+                {
+                    iCountErrors++;
+                    printerr("Error_956yb! Incorrect name==" + fsArr[0]);
+                    foreach (FileSystemInfo s in fsArr)
+                        Console.WriteLine(s.Name);
+                }
             }
             iCountTestcases++;
             if (Array.IndexOf(names, "AAABB") < 0)

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles.cs
@@ -82,6 +82,12 @@ public class DirectoryInfo_GetFiles
             int i = 0;
             foreach (FileInfo f in filArr)
                 names[i++] = f.Name;
+            
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
+
             iCountTestcases++;
             if (Array.IndexOf(names, "Test.bat") < 0)
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str.cs
@@ -160,6 +160,11 @@ public class DirectoryInfo_GetFiles_str
             {
                 names[i++] = Path.GetFileName(f);
             }
+            
+            if (!Interop.IsWindows) // test is expecting sorted order as provided by Windows
+            {
+                Array.Sort(names);
+            }
 
             iCountTestcases++;
             if (Array.IndexOf(names, "Test1File1") < 0)
@@ -281,8 +286,11 @@ public class DirectoryInfo_GetFiles_str
             {
                 dir2.GetFiles("<>");
 
-                iCountErrors++;
-                Console.WriteLine("Err_32497gs! No exception thrown");
+                if (Interop.IsWindows) // '<' and '>' are valid Unix filename chars
+                {
+                    iCountErrors++;
+                    Console.WriteLine("Err_32497gs! No exception thrown");
+                }
             }
             catch (ArgumentException)
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str_so.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetFiles_str_so.cs
@@ -15,7 +15,7 @@ using System.Security;
 using System.Globalization;
 using Xunit;
 
-public class DirectoryInfo_FetFiles_str_so
+public class DirectoryInfo_GetFiles_str_so
 {
     private delegate void ExceptionCode();
     private static bool s_pass = true;
@@ -92,12 +92,12 @@ public class DirectoryInfo_FetFiles_str_so
                     CheckException<ArgumentNullException>(delegate { files = dirInfo.GetFiles(null, SearchOption.TopDirectoryOnly); }, "Err_751mwu! worng exception thrown");
                     CheckException<ArgumentOutOfRangeException>(delegate { files = dirInfo.GetFiles("*.*", (SearchOption)100); }, "Err_589kvu! worng exception thrown - see bug #386545");
                     CheckException<ArgumentOutOfRangeException>(delegate { files = dirInfo.GetFiles("*.*", (SearchOption)(-1)); }, "Err_359vcj! worng exception thrown - see bug #386545");
-                    String[] invalidValuesForSearch = { "..", @"..\" };
+                    String[] invalidValuesForSearch = { "..", @".." + Path.DirectorySeparatorChar };
                     for (int i = 0; i < invalidValuesForSearch.Length; i++)
                     {
                         CheckException<ArgumentException>(delegate { files = dirInfo.GetFiles(invalidValuesForSearch[i], SearchOption.TopDirectoryOnly); }, String.Format("Err_631bwy! worng exception thrown: {1}", i, invalidValuesForSearch[i]));
                     }
-                    Char[] invalidFileNames = Path.GetInvalidFileNameChars();
+                    Char[] invalidFileNames = Interop.IsWindows ? Path.GetInvalidFileNameChars() : new[] { '\0' };
                     for (int i = 0; i < invalidFileNames.Length; i++)
                     {
                         switch (invalidFileNames[i])
@@ -111,7 +111,7 @@ public class DirectoryInfo_FetFiles_str_so
                                 // 1) we assumed that this will work in all non-9x machine
                                 // 2) Then only in XP
                                 // 3) NTFS?
-                                if (FileSystemDebugInfo.IsCurrentDriveNTFS())
+                                if (Interop.IsWindows && FileSystemDebugInfo.IsCurrentDriveNTFS())
                                     CheckException<IOException>(delegate { files = dirInfo.GetFiles(String.Format("te{0}st", invalidFileNames[i].ToString()), SearchOption.TopDirectoryOnly); }, String.Format("Err_997gqs! worng exception thrown: {1} - bug#387196", i, (int)invalidFileNames[i]));
                                 else
                                 {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -29,6 +29,11 @@ public class DirectoryInfo_GetSetTimes
 
         foreach (TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
         {
+            if (!Interop.IsWindows && timeProperty == TimeProperty.CreationTime) // roundtripping birthtime not supported on Unix
+            {
+                continue;
+            }
+
             foreach (DateTimeKind kind in Enum.GetValues(typeof(DateTimeKind)))
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
@@ -193,29 +193,33 @@ public class DirectoryInfo_Move_str
 #if !TEST_WINRT // Can't access other root drives
             // [] Move to different drive will throw AccessException
             //-----------------------------------------------------------------
-            strLoc = "Loc_00025";
+            if (Interop.IsWindows) // drive labels
 
-            dir2 = Directory.CreateDirectory(testDir);
-            iCountTestcases++;
-            try
             {
-                if (dir2.FullName.Substring(0, 3) == @"d:\" || dir2.FullName.Substring(0, 3) == @"D:\")
-                    dir2.MoveTo("C:\\TempDirectory");
-                else
-                    dir2.MoveTo("D:\\TempDirectory");
-                Console.WriteLine("Root directory..." + dir2.FullName.Substring(0, 3));
-                iCountErrors++;
-                printerr("Error_00078! Expected exception not thrown");
+                strLoc = "Loc_00025";
+
+                dir2 = Directory.CreateDirectory(testDir);
+                iCountTestcases++;
+                try
+                {
+                    if (dir2.FullName.Substring(0, 3) == @"d:\" || dir2.FullName.Substring(0, 3) == @"D:\")
+                        dir2.MoveTo("C:\\TempDirectory");
+                    else
+                        dir2.MoveTo("D:\\TempDirectory");
+                    Console.WriteLine("Root directory..." + dir2.FullName.Substring(0, 3));
+                    iCountErrors++;
+                    printerr("Error_00078! Expected exception not thrown");
+                }
+                catch (IOException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_23r0g! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                dir2.Delete(true);
             }
-            catch (IOException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_23r0g! Incorrect exception thrown, exc==" + exc.ToString());
-            }
-            dir2.Delete(true);
 #endif
 
             // [] Move non-existent directory
@@ -267,7 +271,7 @@ public class DirectoryInfo_Move_str
             strLoc = "Loc_2908y";
 
             StringBuilder sb = new StringBuilder(TestInfo.CurrentDirectory);
-            while (sb.Length < 260)
+            while (sb.Length < IOInputs.MaxPath + 1)
                 sb.Append("a");
 
             iCountTestcases++;
@@ -294,7 +298,7 @@ public class DirectoryInfo_Move_str
             strLoc = "Loc_48fyf";
 
             sb = new StringBuilder();
-            for (int i = 0; i < 260; i++)
+            for (int i = 0; i < IOInputs.MaxPath + 1; i++)
                 sb.Append("a");
 
             iCountTestcases++;
@@ -345,6 +349,10 @@ public class DirectoryInfo_Move_str
 
             iCountTestcases++;
             Directory.CreateDirectory(testDir + "a");
+            if (!Interop.IsWindows) // exception on Unix would only happen if the directory isn't empty
+            {
+                File.Create(Path.Combine(testDir + "a", "temp.txt")).Dispose(); 
+            }
             dir2 = Directory.CreateDirectory(testDir);
             try
             {
@@ -424,7 +432,7 @@ public class DirectoryInfo_Move_str
 
             String subDir = Path.Combine(TestInfo.CurrentDirectory, "LaksTemp");
             DeleteFileDir(subDir);
-            String[] values = { "TestDir", @"TestDir\" };
+            String[] values = { "TestDir", "TestDir" + Path.DirectorySeparatorChar };
             String moveDir = Path.Combine(TestInfo.CurrentDirectory, values[1]);
             foreach (String value in values)
             {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/SetCreationTime_dt.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/SetCreationTime_dt.cs
@@ -18,6 +18,7 @@ public class DirectoryInfo_set_CreationTime_dt
     public static String s_strTFPath = Directory.GetCurrentDirectory();
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // roundtripping birthtime not supported on Unix
     public static void runTest()
     {
         String strLoc = "Loc_0001";

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ctor_str.cs
@@ -44,6 +44,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // drive labels
         public void CDriveCase()
         {
             DirectoryInfo dir = new DirectoryInfo("c:\\");
@@ -71,6 +72,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // UNC shares
         public void NetworkShare()
         {
             string dirName = new string(Path.DirectorySeparatorChar, 2) + Path.Combine("contoso", "amusement", "device");

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Attributes.cs
@@ -94,7 +94,7 @@ public class DirectoryInfo_get_Attributes
 #if TEST_WINRT  // WinRT doesn't support hidden
             if((diratt & (FileAttributes.Hidden|FileAttributes.Directory)) != (FileAttributes.Directory)) {
 #else
-            if ((diratt & (FileAttributes.Hidden | FileAttributes.Directory)) != (FileAttributes.Hidden | FileAttributes.Directory))
+            if ((diratt & (FileAttributes.Hidden | FileAttributes.Directory)) != (FileAttributes.Hidden | FileAttributes.Directory) && Interop.IsWindows) // setting Hidden not supported on Unix
             {
 #endif
                 iCountErrors++;
@@ -126,7 +126,7 @@ public class DirectoryInfo_get_Attributes
 #if !TEST_WINRT  // WinRT doesn't support hidden
             diratt = dir.Attributes;
             iCountTestcases++;
-            if ((int)(diratt & FileAttributes.Hidden) == 0)
+            if ((int)(diratt & FileAttributes.Hidden) == 0 && Interop.IsWindows) // setting Hidden not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_20x97! Hidden attribute not set");
@@ -149,9 +149,9 @@ public class DirectoryInfo_get_Attributes
             diratt = dir.Attributes;
             iCountTestcases++;
 #if TEST_WINRT  // WinRT doesn't support system
-            if((diratt & (FileAttributes.System|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+            if ((diratt & (FileAttributes.System|FileAttributes.Directory)) != (FileAttributes.Directory)) {
 #else
-            if ((diratt & (FileAttributes.System | FileAttributes.Directory)) != (FileAttributes.System | FileAttributes.Directory))
+            if ((diratt & (FileAttributes.System | FileAttributes.Directory)) != (FileAttributes.System | FileAttributes.Directory) && Interop.IsWindows) // setting System not supported on Unix
             {
 #endif
                 iCountErrors++;
@@ -168,9 +168,9 @@ public class DirectoryInfo_get_Attributes
             diratt = dir.Attributes;
             iCountTestcases++;
 #if TEST_WINRT  // WinRT doesn't support archive
-            if((diratt & (FileAttributes.Archive|FileAttributes.Directory)) != (FileAttributes.Directory)) {
+            if ((diratt & (FileAttributes.Archive|FileAttributes.Directory)) != (FileAttributes.Directory)) {
 #else
-            if ((diratt & (FileAttributes.Archive | FileAttributes.Directory)) != (FileAttributes.Archive | FileAttributes.Directory))
+            if ((diratt & (FileAttributes.Archive | FileAttributes.Directory)) != (FileAttributes.Archive | FileAttributes.Directory) && Interop.IsWindows) // setting Archive not supported on Unix
             {
 #endif
                 iCountErrors++;

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_CreationTime.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_CreationTime.cs
@@ -18,6 +18,7 @@ public class DirectoryInfo_get_CreationTime
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows | PlatformID.OSX)] // getting birthtime not supported on all Unix systems
     public static void runTest()
     {
         int iCountErrors = 0;

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Parent.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Parent.cs
@@ -50,29 +50,32 @@ public class DirectoryInfo_get_Parent
                 printerr("Error_69y7b! Unexpected parent==" + dir2.FullName);
             }
 
-            // [] Get parent of \Directory
-
-            strLoc = "Loc_98ygg";
-
-            dir2 = new DirectoryInfo(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test")).Parent;
-            str2 = dir2.Name;
-            iCountTestcases++;
-            if (!str2.Equals("Machine"))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_91y7b! Unexpected parent==" + str2);
-            }
+                // [] Get parent of \Directory
 
-            // [] Get parent of UNC share root
+                strLoc = "Loc_98ygg";
 
-            strLoc = "Loc_yg7bk";
+                dir2 = new DirectoryInfo(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test")).Parent;
+                str2 = dir2.Name;
+                iCountTestcases++;
+                if (!str2.Equals("Machine"))
+                {
+                    iCountErrors++;
+                    printerr("Error_91y7b! Unexpected parent==" + str2);
+                }
 
-            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")).Parent;
-            iCountTestcases++;
-            if (dir2 != null)
-            {
-                iCountErrors++;
-                printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
+                // [] Get parent of UNC share root
+
+                strLoc = "Loc_yg7bk";
+
+                dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")).Parent;
+                iCountTestcases++;
+                if (dir2 != null)
+                {
+                    iCountErrors++;
+                    printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
+                }
             }
 
 
@@ -100,17 +103,20 @@ public class DirectoryInfo_get_Parent
                 printerr("Error_9887b! Unexpected parent==" + str2);
             }
 
-            // [] Get parent of subdirectories on UNC share
-
-            strLoc = "Loc_y7t98";
-
-            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2")).Parent;
-            str2 = dir2.FullName;
-            iCountTestcases++;
-            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_69929! Unexpected parent==" + str2);
+                // [] Get parent of subdirectories on UNC share
+
+                strLoc = "Loc_y7t98";
+
+                dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2")).Parent;
+                str2 = dir2.FullName;
+                iCountTestcases++;
+                if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
+                {
+                    iCountErrors++;
+                    printerr("Error_69929! Unexpected parent==" + str2);
+                }
             }
 
             // [] play with ".." and "." in the string
@@ -151,7 +157,7 @@ public class DirectoryInfo_get_Parent
             **/
 
             String parent = Directory.GetCurrentDirectory();
-            String[] values = { "testDir", @"TestDir\" };
+            String[] values = { "testDir", @"TestDir" + Path.DirectorySeparatorChar };
             foreach (String value in values)
             {
                 dir2 = new DirectoryInfo(value);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/get_Root.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/get_Root.cs
@@ -51,31 +51,34 @@ public class DirectoryInfo_get_Root
                 printerr("Error_69y7b! Unexpected parent==" + dir2.FullName);
             }
 
-            // [] Get root of \Directory
-
-            strLoc = "Loc_98ygg";
-
-            dir2 = new DirectoryInfo(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test")).Root;
-            str2 = dir2.FullName;
-            iCountTestcases++;
-            String root = Path.GetPathRoot(Directory.GetCurrentDirectory());
-            if (!str2.Equals(root))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_91y7b! Unexpected parent==" + str2);
-            }
+                // [] Get root of \Directory
 
-            // [] Get root of UNC share
+                strLoc = "Loc_98ygg";
 
-            strLoc = "Loc_yg7bk";
+                dir2 = new DirectoryInfo(Path.DirectorySeparatorChar + Path.Combine("Machine", "Test")).Root;
+                str2 = dir2.FullName;
+                iCountTestcases++;
+                String root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+                if (!str2.Equals(root))
+                {
+                    iCountErrors++;
+                    printerr("Error_91y7b! Unexpected parent==" + str2);
+                }
 
-            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")).Root;
-            str2 = dir2.FullName;
-            iCountTestcases++;
-            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")))
-            {
-                iCountErrors++;
-                printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
+                // [] Get root of UNC share
+
+                strLoc = "Loc_yg7bk";
+
+                dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")).Root;
+                str2 = dir2.FullName;
+                iCountTestcases++;
+                if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test")))
+                {
+                    iCountErrors++;
+                    printerr("Error_4y7gb! Unexpected parent==" + dir2.FullName);
+                }
             }
 
             // [] get root of subdirectories ending with \
@@ -103,17 +106,20 @@ public class DirectoryInfo_get_Root
             }
 
 
-            // [] Get root of nested subdirs on UNC share
-
-            strLoc = "Loc_y7t98";
-
-            dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2", "Test3")).Root;
-            str2 = dir2.FullName;
-            iCountTestcases++;
-            if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_69929! Unexpected parent==" + str2);
+                // [] Get root of nested subdirs on UNC share
+
+                strLoc = "Loc_y7t98";
+
+                dir2 = new DirectoryInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1", "Test2", "Test3")).Root;
+                str2 = dir2.FullName;
+                iCountTestcases++;
+                if (!str2.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Test1")))
+                {
+                    iCountErrors++;
+                    printerr("Error_69929! Unexpected parent==" + str2);
+                }
             }
 
             // [] Include ".." and "." in directory string

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/set_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/set_Attributes.cs
@@ -82,7 +82,7 @@ public class DirectoryInfo_set_Attributes
 #if TEST_WINRT  // WinRT doesn't support hidden
             if((diratt & (FileAttributes.Hidden|FileAttributes.Directory)) != (FileAttributes.Directory)) {
 #else
-            if ((diratt & (FileAttributes.Hidden | FileAttributes.Directory)) != (FileAttributes.Hidden | FileAttributes.Directory))
+            if ((diratt & (FileAttributes.Hidden | FileAttributes.Directory)) != (FileAttributes.Hidden | FileAttributes.Directory) && Interop.IsWindows) // setting Hidden not supported on Unix
             {
 #endif
                 iCountErrors++;
@@ -101,7 +101,7 @@ public class DirectoryInfo_set_Attributes
 #if !TEST_WINRT  // WinRT doesn't support hidden
             diratt = dir.Attributes;
             iCountTestcases++;
-            if ((int)(diratt & FileAttributes.Hidden) == 0)
+            if ((int)(diratt & FileAttributes.Hidden) == 0 && Interop.IsWindows) // setting Hidden not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_20x97! Hidden attribute not set");
@@ -126,7 +126,7 @@ public class DirectoryInfo_set_Attributes
 #if TEST_WINRT  // WinRT doesn't support system
             if((diratt & (FileAttributes.System|FileAttributes.Directory)) != (FileAttributes.Directory)) {
 #else
-            if ((diratt & (FileAttributes.System | FileAttributes.Directory)) != (FileAttributes.System | FileAttributes.Directory))
+            if ((diratt & (FileAttributes.System | FileAttributes.Directory)) != (FileAttributes.System | FileAttributes.Directory) && Interop.IsWindows) // setting System not supported on Unix
             {
 #endif
                 iCountErrors++;
@@ -145,7 +145,7 @@ public class DirectoryInfo_set_Attributes
 #if TEST_WINRT  // WinRT doesn't support archive
             if((diratt & (FileAttributes.Archive|FileAttributes.Directory)) != (FileAttributes.Directory)) {
 #else
-            if ((diratt & (FileAttributes.Archive | FileAttributes.Directory)) != (FileAttributes.Archive | FileAttributes.Directory))
+            if ((diratt & (FileAttributes.Archive | FileAttributes.Directory)) != (FileAttributes.Archive | FileAttributes.Directory) && Interop.IsWindows) // setting Archive not supported on Unix
             {
 #endif
                 iCountErrors++;

--- a/src/System.IO.FileSystem/tests/File/AppendAll_all.cs
+++ b/src/System.IO.FileSystem/tests/File/AppendAll_all.cs
@@ -222,7 +222,7 @@ public class File_AppendAll_all
             //That we are closing the file after append is imlictly tested above
 
             path = Path.GetTempFileName();
-            stream = new FileStream(path, FileMode.Open);
+            stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             reader = new StreamReader(stream);
 
             content = "";

--- a/src/System.IO.FileSystem/tests/File/Delete_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete_str.cs
@@ -179,34 +179,36 @@ public class File_Delete_str
 
             //-----------------------------------------------------------------
 
-
+            if (Interop.IsWindows) // readonly files can be deleted on Unix
+            {
 #if !TEST_WINRT  // TODO: Enable once we bring up file attributes
-            // [] Deleting a ReadOnly file should not work
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298b7";
-            fil2 = new FileInfo(filName);
-            new FileStream(filName, FileMode.Create).Dispose();
-            fil2.Attributes = FileAttributes.ReadOnly;
-            iCountTestcases++;
-            try
-            {
-                File.Delete(filName);
-                iCountErrors++;
-                printerr("Error_487bg! Expected exception not thrown");
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_2467y! Incorrect exception thrown, exc==" + exc.ToString());
-            }
-            fil2.Attributes = new FileAttributes();
-            fil2.Delete();
+                // [] Deleting a ReadOnly file should not work
+                //-----------------------------------------------------------------
+                strLoc = "Loc_298b7";
+                fil2 = new FileInfo(filName);
+                new FileStream(filName, FileMode.Create).Dispose();
+                fil2.Attributes = FileAttributes.ReadOnly;
+                iCountTestcases++;
+                try
+                {
+                    File.Delete(filName);
+                    iCountErrors++;
+                    printerr("Error_487bg! Expected exception not thrown");
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_2467y! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                fil2.Attributes = new FileAttributes();
+                fil2.Delete();
 
-            //-----------------------------------------------------------------
+                //-----------------------------------------------------------------
 #endif
+            }
 
             // ][ Filename starting with wildcard
             // ][ Filename ending with wildcard

--- a/src/System.IO.FileSystem/tests/File/Exists_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists_str.cs
@@ -130,7 +130,7 @@ public class File_FileExists_str
             strLoc = "Loc_t899t";
 
             StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < 500; i++)
+            for (int i = 0; i < IOInputs.MaxPath + 1; i++)
                 sb.Append(i);
 
             iCountTestcases++;

--- a/src/System.IO.FileSystem/tests/File/File_EnumerableAPIs.cs
+++ b/src/System.IO.FileSystem/tests/File/File_EnumerableAPIs.cs
@@ -261,13 +261,16 @@ namespace EnumerableTests
             String nullFileName = null;
             String emptyFileName1 = "";
             String emptyFileName2 = " ";
-            String longPath = new String('a', 240) + @"\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\test.txt";
+            String longPath = Path.Combine(new String('a', IOInputs.MaxDirectory), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "test.txt");
 
             String notExistsFileName = null;
-            String unusedDrive = EnumerableUtils.GetUnusedDrive();
-            if (unusedDrive != null)
+            if (Interop.IsWindows) // drive labels
             {
-                notExistsFileName = Path.Combine(unusedDrive, @"temp\notExists\temp.txt"); // just skip otherwise
+                String unusedDrive = EnumerableUtils.GetUnusedDrive();
+                if (unusedDrive != null)
+                {
+                    notExistsFileName = Path.Combine(unusedDrive, Path.Combine("temp", "notExists", "temp.txt")); // just skip otherwise
+                }
             }
             String[] lines = { "test line 1", "test line 2" };
             IEnumerable<String> contents = (IEnumerable<String>)lines;

--- a/src/System.IO.FileSystem/tests/File/GetAttributes_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetAttributes_str.cs
@@ -109,7 +109,7 @@ public class File_GetAttributes_str
 #if !TEST_WINRT
             iCountTestcases++;
             file1.Attributes = FileAttributes.Hidden;
-            if ((file1.Attributes & FileAttributes.Hidden) == 0)
+            if ((file1.Attributes & FileAttributes.Hidden) == 0 && Interop.IsWindows) // setting Hidden not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0010! Hidden not set");
@@ -118,7 +118,7 @@ public class File_GetAttributes_str
             iCountTestcases++;
             file1.Refresh();
             file1.Attributes = FileAttributes.System;
-            if ((File.GetAttributes(fileName) & FileAttributes.System) == 0)
+            if ((File.GetAttributes(fileName) & FileAttributes.System) == 0 && Interop.IsWindows) // setting System not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0011! System not set");
@@ -134,7 +134,7 @@ public class File_GetAttributes_str
             {
                 //NOTE: Normal is only allowed on its own. So, if there is already another attribute, this will not work
                 //@TODO!! This might have to be modified
-                if ((File.GetAttributes(fileName) & FileAttributes.Compressed) == 0)
+                if ((File.GetAttributes(fileName) & FileAttributes.Compressed) == 0 && Interop.IsWindows) // setting Compressed not supported on Unix
 #if TEST_WINRT
                 if((File.GetAttributes(fileName) & FileAttributes.Archive) == 0)
 #endif
@@ -148,7 +148,7 @@ public class File_GetAttributes_str
             iCountTestcases++;
             file1.Refresh();
             file1.Attributes = FileAttributes.Temporary;
-            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) == 0)
+            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) == 0 && Interop.IsWindows) // setting Temporary not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0013! Temporary not set");
@@ -157,7 +157,7 @@ public class File_GetAttributes_str
             file1.Attributes = file1.Attributes | FileAttributes.SparseFile;
             file1.Attributes = file1.Attributes | FileAttributes.ReparsePoint;
             iCountTestcases++;
-            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) != FileAttributes.Temporary)
+            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) != FileAttributes.Temporary && Interop.IsWindows) // setting Temporary not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0014! Temporary not set");
@@ -165,7 +165,7 @@ public class File_GetAttributes_str
 
             file1.Refresh();
             file1.Attributes = FileAttributes.Archive;
-            file1.Attributes = FileAttributes.ReadOnly | file1.Attributes;
+            file1.Attributes = FileAttributes.ReadOnly | FileAttributes.Archive; // setting Archive not supported on Unix
             iCountTestcases++;
             if ((File.GetAttributes(fileName) & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
             {
@@ -174,7 +174,7 @@ public class File_GetAttributes_str
             }
 
             iCountTestcases++;
-            if ((File.GetAttributes(fileName) & FileAttributes.Archive) != FileAttributes.Archive)
+            if ((File.GetAttributes(fileName) & FileAttributes.Archive) != FileAttributes.Archive && Interop.IsWindows)  // setting Archive not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0021! Archive attribute not set");

--- a/src/System.IO.FileSystem/tests/File/GetCreationTime_str.cs
+++ b/src/System.IO.FileSystem/tests/File/GetCreationTime_str.cs
@@ -20,6 +20,7 @@ public class File_GetCreationTime_str
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows | PlatformID.OSX)] // getting birthtime not supported on all Unix systems
     public static void runTest()
     {
         String strLoc = "Loc_0001";

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -28,6 +28,11 @@ public class File_GetSetTimes
         
         foreach(TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
         {
+            if (!Interop.IsWindows && timeProperty == TimeProperty.CreationTime) // roundtripping birthtime not supported on Unix
+            {
+                continue;
+            }
+
             foreach (DateTimeKind kind in  Enum.GetValues(typeof(DateTimeKind)))
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);

--- a/src/System.IO.FileSystem/tests/File/Open_str_fm_fa_fs.cs
+++ b/src/System.IO.FileSystem/tests/File/Open_str_fm_fa_fs.cs
@@ -214,8 +214,11 @@ public class File_Open_fm_fa_fs
                 //This should succeed
                 File.Delete(sourceFileName);
 
-                //But we shold still be able to call the file
-                Eval(File.Exists(sourceFileName), "Err_3947sg! File doesn't exists");
+                if (Interop.IsWindows) // file will be deleted on Unix
+                {
+                    //But we shold still be able to call the file
+                    Eval(File.Exists(sourceFileName), "Err_3947sg! File doesn't exists");
+                }
 
                 stream.Write(outbits, 0, outbits.Length);
 

--- a/src/System.IO.FileSystem/tests/File/ReadAll_all.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadAll_all.cs
@@ -375,7 +375,7 @@ public class File_ReadAll_all
             //That we are closing the file is imlictly tested above
 
             path = Path.GetTempFileName();
-            stream = new FileStream(path, FileMode.Create);
+            stream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
             writer = new StreamWriter(stream);
             builder = new StringBuilder();
             for (int i = 0; i < 100; i++)

--- a/src/System.IO.FileSystem/tests/File/SetAttributes_str_attrs.cs
+++ b/src/System.IO.FileSystem/tests/File/SetAttributes_str_attrs.cs
@@ -98,7 +98,7 @@ public class File_SetAttributes_str_attrs
 #if !TEST_WINRT
             iCountTestcases++;
             File.SetAttributes(fileName, FileAttributes.Hidden);
-            if ((File.GetAttributes(fileName) & FileAttributes.Hidden) == 0)
+            if ((File.GetAttributes(fileName) & FileAttributes.Hidden) == 0 && Interop.IsWindows) // setting Hidden not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0010! Hidden not set");
@@ -107,7 +107,7 @@ public class File_SetAttributes_str_attrs
             iCountTestcases++;
             file1.Refresh();
             File.SetAttributes(fileName, FileAttributes.System);
-            if ((File.GetAttributes(fileName) & FileAttributes.System) == 0)
+            if ((File.GetAttributes(fileName) & FileAttributes.System) == 0 && Interop.IsWindows) // setting System not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0011! System not set");
@@ -134,7 +134,7 @@ public class File_SetAttributes_str_attrs
             iCountTestcases++;
             file1.Refresh();
             File.SetAttributes(fileName, FileAttributes.Temporary);
-            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) == 0)
+            if ((File.GetAttributes(fileName) & FileAttributes.Temporary) == 0 && Interop.IsWindows) // setting Temporary not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0013! Temporary not set");
@@ -142,7 +142,7 @@ public class File_SetAttributes_str_attrs
 
             File.SetAttributes(fileName, FileAttributes.Archive);
             file1.Refresh();
-            File.SetAttributes(fileName, FileAttributes.ReadOnly | file1.Attributes);
+            File.SetAttributes(fileName, FileAttributes.ReadOnly | FileAttributes.Archive); // setting Archive not supported on Unix
             file1.Refresh();
             iCountTestcases++;
             if ((File.GetAttributes(fileName) & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
@@ -152,7 +152,7 @@ public class File_SetAttributes_str_attrs
             }
 
             iCountTestcases++;
-            if ((File.GetAttributes(fileName) & FileAttributes.Archive) != FileAttributes.Archive)
+            if ((File.GetAttributes(fileName) & FileAttributes.Archive) != FileAttributes.Archive && Interop.IsWindows) // setting Archive not supported on Unix
             {
                 iCountErrors++;
                 printerr("Error_0021! Archive attribute not set");

--- a/src/System.IO.FileSystem/tests/File/SetCreationTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/File/SetCreationTime_str_dt.cs
@@ -19,6 +19,7 @@ public class File_SetCreationTime_str_dt
     public static String s_strTFPath        = Directory.GetCurrentDirectory();
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // roundtripping birthtime not supported on Unix
     public static void runTest()
     {
         String strLoc = "Loc_0001";

--- a/src/System.IO.FileSystem/tests/File/SetLastAccessTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/File/SetLastAccessTime_str_dt.cs
@@ -99,8 +99,10 @@ public class File_SetLastAccessTime_str_dt
             fs2.Dispose();                        
                         iCountTestcases++;
             try {
-                File.SetLastAccessTime(fileName , DateTime.Now.AddYears(-1)) ;
-                if((File.GetLastAccessTime(fileName) - DateTime.Now.AddYears(-1)).Seconds > 0 ) {
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastAccessTime(fileName, now.AddYears(-1)) ;
+                if (File.GetLastAccessTime(fileName) != now.AddYears(-1)) {
                     Console.WriteLine(File.GetLastAccessTime(fileName));
                     Console.WriteLine(DateTime.Now.AddYears(-1));
                     iCountErrors++;

--- a/src/System.IO.FileSystem/tests/File/SetLastWriteTime_str_dt.cs
+++ b/src/System.IO.FileSystem/tests/File/SetLastWriteTime_str_dt.cs
@@ -71,8 +71,9 @@ public class File_SetLastWriteTime_str_dt
             fs2.Dispose();                        
                         iCountTestcases++;
             try {
-                File.SetLastWriteTime(fileName , DateTime.Today) ;
-                if((File.GetLastWriteTime(fileName) - DateTime.Now).Seconds > 0) {
+                DateTime today = DateTime.Today;
+                File.SetLastWriteTime(fileName, today) ;
+                if (File.GetLastWriteTime(fileName) != today) {
                     iCountErrors++;
                     printerr( "Error_0007! Creation time cannot be correct");
                 }
@@ -91,8 +92,10 @@ public class File_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                File.SetLastWriteTime(fileName , DateTime.Now.AddYears(1)) ;
-                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(1)).Seconds > 1)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastWriteTime(fileName , now.AddYears(1)) ;
+                if (File.GetLastWriteTime(fileName) != now.AddYears(1))
                 {
                     iCountErrors++;
                     Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddYears(1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(1)).Seconds  );
@@ -114,8 +117,10 @@ public class File_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                File.SetLastWriteTime(fileName, DateTime.Now.AddYears(-1));
-                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(-1)).Seconds > 1)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastWriteTime(fileName, now.AddYears(-1));
+                if (File.GetLastWriteTime(fileName) != now.AddYears(-1))
                 {
                     iCountErrors++;
                     Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddYears(-1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddYears(-1)).Seconds  );
@@ -137,8 +142,10 @@ public class File_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                File.SetLastWriteTime(fileName, DateTime.Now.AddMonths(1));
-                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(1)).Seconds > 1)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastWriteTime(fileName, now.AddMonths(1));
+                if (File.GetLastWriteTime(fileName) != now.AddMonths(1))
                 {
                     Console.WriteLine(DateTime.Now.AddMonths(1));
                 
@@ -161,8 +168,10 @@ public class File_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                File.SetLastWriteTime(fileName, DateTime.Now.AddMonths(-1));
-                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds > 1)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastWriteTime(fileName, now.AddMonths(-1));
+                if (File.GetLastWriteTime(fileName) != now.AddMonths(-1))
                 {
                     iCountErrors++;
                     Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddMonths(-1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddMonths(-1)).Seconds  );
@@ -184,8 +193,10 @@ public class File_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                File.SetLastWriteTime(fileName, DateTime.Now.AddDays(1));
-                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(1)).Seconds > 1)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastWriteTime(fileName, now.AddDays(1));
+                if (File.GetLastWriteTime(fileName) != now.AddDays(1))
                 {
                     iCountErrors++;
                     Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddDays(1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(-1)).Seconds  );
@@ -207,8 +218,10 @@ public class File_SetLastWriteTime_str_dt
             iCountTestcases++;
             try
             {
-                File.SetLastWriteTime(fileName, DateTime.Now.AddDays(-1));
-                if((File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(-1)).Seconds > 1)
+                DateTime now = DateTime.Now;
+                now = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                File.SetLastWriteTime(fileName, now.AddDays(-1));
+                if (File.GetLastWriteTime(fileName) != now.AddDays(-1))
                 {
                     iCountErrors++;
                     Console.WriteLine(" POINTTOBREAK !!!Error_0013! Creation time cannot be correct.. Expected...{0}, ...Actual...{1}...Seconds difference...{2}",File.GetLastWriteTime(fileName),DateTime.Now.AddDays(-1),(File.GetLastWriteTime(fileName) - DateTime.Now.AddDays(-1)).Seconds  );

--- a/src/System.IO.FileSystem/tests/File/WriteAll_all.cs
+++ b/src/System.IO.FileSystem/tests/File/WriteAll_all.cs
@@ -392,7 +392,7 @@ public class File_WriteAll_all
             //That we are closing the file after write is imlictly tested above
 
             path = Path.GetTempFileName();
-            stream = new FileStream(path, FileMode.Open);
+            stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             reader = new StreamReader(stream);
 
             content = "";

--- a/src/System.IO.FileSystem/tests/FileInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create.cs
@@ -169,7 +169,7 @@ public class FileInfo_Create
             iCountTestcases++;
             try
             {
-                file2 = new FileInfo(":");
+                file2 = new FileInfo("\0");
                 file2.Create();
                 iCountErrors++;
                 printerr("Error_19883! Expected exception not thrown, file2==" + file2.FullName);
@@ -225,32 +225,35 @@ public class FileInfo_Create
             }
             */
 
-            // [] Create file in current file2 by giving full File check casing as well
-            strLoc = "loc_89tbh";
-            fileName = Path.GetRandomFileName();
-            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToLowerInvariant(), fileName));
-            fs = file2.Create();
-            fs.Dispose();
-            iCountTestcases++;
-            if (!file2.Exists)
+            if (!Interop.IsLinux) // testing case insensitivity
             {
-                iCountErrors++;
-                printerr("Error_t87gy! File not created, file==" + file2.FullName);
-            }
-            file2.Delete();
+                // [] Create file in current file2 by giving full File check casing as well
+                strLoc = "loc_89tbh";
+                fileName = Path.GetRandomFileName();
+                file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToLowerInvariant(), fileName));
+                fs = file2.Create();
+                fs.Dispose();
+                iCountTestcases++;
+                if (!file2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_t87gy! File not created, file==" + file2.FullName);
+                }
+                file2.Delete();
 
-            strLoc = "loc_89mjd";
-            fileName = Path.GetRandomFileName();
-            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToUpperInvariant(), fileName));
-            fs = file2.Create();
-            fs.Dispose();
-            iCountTestcases++;
-            if (!file2.Exists)
-            {
-                iCountErrors++;
-                printerr("Error_hf3t4! File not created, file==" + file2.FullName);
+                strLoc = "loc_89mjd";
+                fileName = Path.GetRandomFileName();
+                file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToUpperInvariant(), fileName));
+                fs = file2.Create();
+                fs.Dispose();
+                iCountTestcases++;
+                if (!file2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_hf3t4! File not created, file==" + file2.FullName);
+                }
+                file2.Delete();
             }
-            file2.Delete();
         }
         catch (Exception exc_general)
         {

--- a/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
@@ -129,7 +129,7 @@ public class FileInfo_Create_str
             strLoc = "Loc_2908y";
 
             StringBuilder sb = new StringBuilder(TestInfo.CurrentDirectory);
-            while (sb.Length < 260)
+            while (sb.Length < IOInputs.MaxPath + 1)
                 sb.Append("a");
 
             iCountTestcases++;
@@ -205,7 +205,7 @@ public class FileInfo_Create_str
             iCountTestcases++;
             try
             {
-                file2 = new FileInfo(":");
+                file2 = new FileInfo("\0");
                 file2.Create();
                 iCountErrors++;
                 printerr("Error_19883! Expected exception not thrown, file2==" + file2.FullName);
@@ -270,20 +270,23 @@ public class FileInfo_Create_str
             }
             */
 
-            // [] Create file in current file2 by giving full File check casing as well
-            strLoc = "loc_89tbh";
-
-            string fileName2 = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
-            fs2 = File.Create(fileName2);
-            file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToLowerInvariant(), Path.GetFileNameWithoutExtension(fileName2).ToLowerInvariant() + Path.GetExtension(fileName2).ToUpperInvariant()));
-            iCountTestcases++;
-            if (!file2.Exists)
+            if (!Interop.IsLinux) // testing case-insensitivity
             {
-                iCountErrors++;
-                printerr("Error_t87gy! File not created, file==" + file2.FullName);
+                // [] Create file in current file2 by giving full File check casing as well
+                strLoc = "loc_89tbh";
+
+                string fileName2 = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName());
+                fs2 = File.Create(fileName2);
+                file2 = new FileInfo(Path.Combine(TestInfo.CurrentDirectory.ToLowerInvariant(), Path.GetFileNameWithoutExtension(fileName2).ToLowerInvariant() + Path.GetExtension(fileName2).ToUpperInvariant()));
+                iCountTestcases++;
+                if (!file2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_t87gy! File not created, file==" + file2.FullName);
+                }
+                fs2.Dispose();
+                file2.Delete();
             }
-            fs2.Dispose();
-            file2.Delete();
         }
         catch (Exception exc_general)
         {

--- a/src/System.IO.FileSystem/tests/FileInfo/Delete.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Delete.cs
@@ -51,53 +51,56 @@ public class FileInfo_Delete
             //-----------------------------------------------------------------
 
 
-            // [] Deleting a file in use should cause IOException
-            //-----------------------------------------------------------------
-            strLoc = "Loc_29yc7";
-
-            fs2 = new FileStream(filName, FileMode.Create);
-            fil2 = new FileInfo(filName);
-            iCountTestcases++;
-            try
+            if (Interop.IsWindows) // deleting in-use files is allowed on Unix
             {
-                fil2.Delete();
+                // [] Deleting a file in use should cause IOException
+                //-----------------------------------------------------------------
+                strLoc = "Loc_29yc7";
+
+                fs2 = new FileStream(filName, FileMode.Create);
+                fil2 = new FileInfo(filName);
+                iCountTestcases++;
+                try
+                {
+                    fil2.Delete();
 #if !TEST_WINRT  // WINRT always sets FILE_SHARE_DELETE
-                iCountErrors++;
-                printerr("Error_1y678! Expected exception not thrown");
-            }
-            catch (IOException)
-            {
+                    iCountErrors++;
+                    printerr("Error_1y678! Expected exception not thrown");
+                }
+                catch (IOException)
+                {
 #endif
-            }
-            catch (UnauthorizedAccessException iexc)
-            {
-                iCountErrors++;
-                printerr("Error_1213! This excepton shouldn't occur on Win9X platforms" + iexc.Message);
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_16709! Incorrect exception thrown, exc==" + exc.ToString());
-            }
-            fs2.Dispose();
+                }
+                catch (UnauthorizedAccessException iexc)
+                {
+                    iCountErrors++;
+                    printerr("Error_1213! This excepton shouldn't occur on Win9X platforms" + iexc.Message);
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_16709! Incorrect exception thrown, exc==" + exc.ToString());
+                }
+                fs2.Dispose();
 #if !TEST_WINRT
-            iCountTestcases++;
-            if (!fil2.Exists)
-            {
-                iCountErrors++;
-                printerr("Error_768bc! File does not exist==" + fil2.FullName);
-            }
-            fil2.Delete();
+                iCountTestcases++;
+                if (!fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_768bc! File does not exist==" + fil2.FullName);
+                }
+                fil2.Delete();
 #endif
-            fil2.Refresh();
-            iCountTestcases++;
-            if (fil2.Exists)
-            {
-                iCountErrors++;
-                printerr("Error_810x8! File not deleted==" + fil2.FullName);
-            }
+                fil2.Refresh();
+                iCountTestcases++;
+                if (fil2.Exists)
+                {
+                    iCountErrors++;
+                    printerr("Error_810x8! File not deleted==" + fil2.FullName);
+                }
 
-            //-----------------------------------------------------------------
+                //-----------------------------------------------------------------
+            }
 
 
             // [] Deleting a file should remove it

--- a/src/System.IO.FileSystem/tests/FileInfo/FullName.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/FullName.cs
@@ -45,20 +45,23 @@ public class FileInfo_FullName
             strFileName = Path.DirectorySeparatorChar + Path.Combine("Directory", "File");
             fil2 = new FileInfo(strFileName);
             s_iCountTestcases++;
-            if (fil2.FullName.IndexOf(strFileName) != 2)
+            if (fil2.FullName.IndexOf(strFileName) != (Interop.IsWindows ? 2 : 0)) // drive label
             {
                 s_iCountErrors++;
                 printerr("Error_78288! Incorrect name==" + fil2.FullName);
             }
 
-            // [] UNC share
-            strFileName =  new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File");
-            fil2 = new FileInfo(strFileName);
-            s_iCountTestcases++;
-            if (!fil2.FullName.Equals(strFileName))
+            if (Interop.IsWindows) // UNC shares
             {
-                s_iCountErrors++;
-                printerr("Error_67y8b! Incorrect name==" + fil2.FullName);
+                // [] UNC share
+                strFileName = new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File");
+                fil2 = new FileInfo(strFileName);
+                s_iCountTestcases++;
+                if (!fil2.FullName.Equals(strFileName))
+                {
+                    s_iCountErrors++;
+                    printerr("Error_67y8b! Incorrect name==" + fil2.FullName);
+                }
             }
 
             // [] Multiple spaces and dots in filename

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -29,6 +29,11 @@ public class FileInfo_GetSetTimes
         
         foreach(TimeProperty timeProperty in Enum.GetValues(typeof(TimeProperty)))
         {
+            if (Interop.IsLinux && timeProperty == TimeProperty.CreationTime) // birthtime not supported on Linux
+            {
+                continue;
+            }
+
             foreach (DateTimeKind kind in  Enum.GetValues(typeof(DateTimeKind)))
             {
                 DateTime dt = new DateTime(2014, 12, 1, 12, 0, 0, kind);

--- a/src/System.IO.FileSystem/tests/FileInfo/Open_fm_fa_fs.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Open_fm_fa_fs.cs
@@ -191,8 +191,11 @@ public class FileInfo_Open_fm_fa_fs
                 //This should succeed
                 File.Delete(sourceFileName);
 
-                //But we shold still be able to call the file
-                Eval(File.Exists(sourceFileName), "Err_3947sg! File doesn't exists");
+                if (Interop.IsWindows) // Unix allows files to be deleted while in-use
+                {
+                    //But we shold still be able to call the file
+                    Eval(File.Exists(sourceFileName), "Err_3947sg! File doesn't exists");
+                }
 
                 stream.Write(outbits, 0, outbits.Length);
 

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Attributes.cs
@@ -118,9 +118,9 @@ public class FileInfo_get_Attributes
                 fil2.Attributes = FileAttributes.Hidden;
                 iCountTestcases++;
 #if TEST_WINRT  // WinRT doesn't support hidden
-            if((fil2.Attributes & FileAttributes.Hidden)!=0) {
+                if ((fil2.Attributes & FileAttributes.Hidden) != 0) {
 #else
-                if ((fil2.Attributes & FileAttributes.Hidden) == 0)
+                if ((fil2.Attributes & FileAttributes.Hidden) == 0 && Interop.IsWindows) // setting Hidden not support on Unix
                 {
 #endif
                     iCountErrors++;
@@ -131,9 +131,9 @@ public class FileInfo_get_Attributes
                 iCountTestcases++;
                 fil2.Refresh();
 #if TEST_WINRT  // WinRT doesn't support system
-            if((fil2.Attributes & FileAttributes.System) == FileAttributes.System) {
+                if ((fil2.Attributes & FileAttributes.System) == FileAttributes.System) {
 #else
-                if ((fil2.Attributes & FileAttributes.System) != FileAttributes.System)
+                if ((fil2.Attributes & FileAttributes.System) != FileAttributes.System && Interop.IsWindows) // setting System not support on Unix
                 {
 #endif
                     iCountErrors++;
@@ -144,9 +144,9 @@ public class FileInfo_get_Attributes
                 iCountTestcases++;
                 if ((fil2.Attributes & FileAttributes.Normal) != FileAttributes.Normal)
                 {
-                    if ((fil2.Attributes & FileAttributes.Compressed) == 0)
+                    if ((fil2.Attributes & FileAttributes.Compressed) == 0 && Interop.IsWindows) // setting Compressed not support on Unix
 #if TEST_WINRT
-                if ((fil2.Attributes & FileAttributes.Archive) == 0) 
+                    if ((fil2.Attributes & FileAttributes.Archive) == 0) 
 #endif
                     {
                         iCountErrors++;
@@ -156,7 +156,7 @@ public class FileInfo_get_Attributes
                 fil2.Attributes = FileAttributes.Temporary;
                 fil2.Refresh();
                 iCountTestcases++;
-                if ((fil2.Attributes & FileAttributes.Temporary) == 0)
+                if ((fil2.Attributes & FileAttributes.Temporary) == 0 && Interop.IsWindows) // setting Temporary not support on Unix
                 {
                     iCountErrors++;
                     printerr("Error_87tg8! Temporary not set");
@@ -173,7 +173,7 @@ public class FileInfo_get_Attributes
 
                 fil2.Attributes = FileAttributes.Archive;
                 fil2.Refresh();
-                fil2.Attributes = FileAttributes.ReadOnly | fil2.Attributes;
+                fil2.Attributes = FileAttributes.ReadOnly | FileAttributes.Archive; // setting Archive not support on Unix
                 fil2.Refresh();
                 iCountTestcases++;
                 if ((fil2.Attributes & FileAttributes.ReadOnly) != FileAttributes.ReadOnly)
@@ -182,7 +182,7 @@ public class FileInfo_get_Attributes
                     printerr("Error_g58y8! ReadOnly attribute not set");
                 }
                 iCountTestcases++;
-                if ((fil2.Attributes & FileAttributes.Archive) != FileAttributes.Archive)
+                if ((fil2.Attributes & FileAttributes.Archive) != FileAttributes.Archive && Interop.IsWindows) // setting Archive not support on Unix
                 {
                     iCountErrors++;
                     printerr("Error_2g78b! Archive attribute not set");

--- a/src/System.IO.FileSystem/tests/FileInfo/get_CreationTime.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_CreationTime.cs
@@ -20,6 +20,7 @@ public class FileInfo_get_CreationTime
 
     [Fact]
     [OuterLoop]
+    [PlatformSpecific(PlatformID.Windows | PlatformID.OSX)] // getting birthtime not supported on Linux
     public static void runTest()
     {
         String strLoc = "Loc_000oo";

--- a/src/System.IO.FileSystem/tests/FileInfo/get_Directory.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_Directory.cs
@@ -59,14 +59,17 @@ public class FileInfo_get_Directory
                 printerr("Error_78288! Incorrect name==" + dir2.FullName);
             }
 
-            // [] UNC share
-            fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
-            dir2 = fil2.Directory;
-            iCountTestcases++;
-            if (!dir2.FullName.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory")))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_67y8b! Incorrect name==" + dir2.FullName);
+                // [] UNC share
+                fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
+                dir2 = fil2.Directory;
+                iCountTestcases++;
+                if (!dir2.FullName.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory")))
+                {
+                    iCountErrors++;
+                    printerr("Error_67y8b! Incorrect name==" + dir2.FullName);
+                }
             }
 
             // [] 

--- a/src/System.IO.FileSystem/tests/FileInfo/get_DirectoryName.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/get_DirectoryName.cs
@@ -57,13 +57,16 @@ public class FileInfo_get_DirectoryName
                 printerr("Error_78288! Incorrect name==" + fil2.DirectoryName);
             }
 
-            // [] UNC share
-            fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
-            iCountTestcases++;
-            if (!fil2.DirectoryName.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory")))
+            if (Interop.IsWindows) // UNC shares
             {
-                iCountErrors++;
-                printerr("Error_67y8b! Incorrect name==" + fil2.DirectoryName);
+                // [] UNC share
+                fil2 = new FileInfo(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
+                iCountTestcases++;
+                if (!fil2.DirectoryName.Equals(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory")))
+                {
+                    iCountErrors++;
+                    printerr("Error_67y8b! Incorrect name==" + fil2.DirectoryName);
+                }
             }
 
             // [] Names with spaces

--- a/src/System.IO.FileSystem/tests/FileInfo/set_Attributes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/set_Attributes.cs
@@ -118,9 +118,9 @@ public class FileInfo_set_Attributes
                 fil2.Attributes = FileAttributes.Hidden;
                 iCountTestcases++;
 #if TEST_WINRT  // WinRT doesn't support hidden
-            if((fil2.Attributes & FileAttributes.Hidden)!=0) {
+                if ((fil2.Attributes & FileAttributes.Hidden)!=0) {
 #else
-                if ((fil2.Attributes & FileAttributes.Hidden) == 0)
+                if ((fil2.Attributes & FileAttributes.Hidden) == 0 && Interop.IsWindows) // setting Hidden not supported on Unix
                 {
 #endif
                     iCountErrors++;
@@ -130,9 +130,9 @@ public class FileInfo_set_Attributes
                 fil2.Refresh();
                 iCountTestcases++;
 #if TEST_WINRT  // WinRT doesn't support system
-            if((fil2.Attributes & FileAttributes.System) == FileAttributes.System) {
+                if((fil2.Attributes & FileAttributes.System) == FileAttributes.System) {
 #else
-                if ((fil2.Attributes & FileAttributes.System) != FileAttributes.System)
+                if ((fil2.Attributes & FileAttributes.System) != FileAttributes.System && Interop.IsWindows) // setting System not supported on Unix
                 {
 #endif
                     iCountErrors++;
@@ -141,7 +141,7 @@ public class FileInfo_set_Attributes
                 fil2.Attributes = FileAttributes.Temporary;
                 fil2.Refresh();
                 iCountTestcases++;
-                if ((fil2.Attributes & FileAttributes.Temporary) == 0)
+                if ((fil2.Attributes & FileAttributes.Temporary) == 0 && Interop.IsWindows) // setting Temporary not supported on Unix
                 {
                     iCountErrors++;
                     printerr("Error_87tg8! Temporary not set");
@@ -167,7 +167,7 @@ public class FileInfo_set_Attributes
                 }
 
                 iCountTestcases++;
-                if ((fil2.Attributes & FileAttributes.Archive) != FileAttributes.Archive)
+                if ((fil2.Attributes & FileAttributes.Archive) != FileAttributes.Archive && Interop.IsWindows) // setting Archive not supported on Unix
                 {
                     iCountErrors++;
                     printerr("Error_2g78b! Archive attribute not set");

--- a/src/System.IO.FileSystem/tests/FileInfo/set_CreationTime_dt.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/set_CreationTime_dt.cs
@@ -19,6 +19,7 @@ public class FileInfo_SetCreationTime_dt
     public static String s_strTFPath        = Directory.GetCurrentDirectory();
 
     [Fact]
+    [PlatformSpecific(PlatformID.Windows)] // roundtripping birthtime not supported on Unix
     public static void runTest()
     {
 

--- a/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -90,8 +90,15 @@ namespace System.IO.FileSystem.Tests
                     Assert.Throws<IOException>(() => fs.Read(new byte[1], 0, 1));
 
                     fs.WriteByte(0);
-                    fsr.Position++; 
-                    Assert.Throws<IOException>(() => FSAssert.CompletesSynchronously(fs.ReadAsync(new byte[1], 0, 1)));
+                    fsr.Position++;
+                    if (Interop.IsWindows) // TODO: [ActiveIssue(812)]: Remove guard when async I/O is properly implemented on Unix
+                    {
+                        Assert.Throws<IOException>(() => FSAssert.CompletesSynchronously(fs.ReadAsync(new byte[1], 0, 1)));
+                    }
+                    else
+                    {
+                        Assert.ThrowsAsync<IOException>(() => fs.ReadAsync(new byte[1], 0, 1)).Wait();
+                    }
 
                     fs.WriteByte(0);
                     fsr.Position++; 

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.delete.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.delete.cs
@@ -17,7 +17,10 @@ namespace System.IO.FileSystem.Tests
             {
                 Assert.True(File.Exists(fileName));
                 File.Delete(fileName);
-                Assert.True(File.Exists(fileName));
+                if (Interop.IsWindows) // file sharing restriction limitations on Unix
+                {
+                    Assert.True(File.Exists(fileName));
+                }
             }
 
             Assert.False(File.Exists(fileName));
@@ -51,7 +54,10 @@ namespace System.IO.FileSystem.Tests
             using (FileStream fs = CreateFileStream(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete))
             {
                 File.Delete(fileName);
-                Assert.True(File.Exists(fileName));
+                if (Interop.IsWindows) // file sharing restriction limitations on Unix
+                {
+                    Assert.True(File.Exists(fileName));
+                }
             }
 
             Assert.False(File.Exists(fileName));
@@ -77,6 +83,7 @@ namespace System.IO.FileSystem.Tests
             }
         }
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // file sharing restriction limitations on Unix
         public void FileShareDeleteExistingMultipleClients()
         {
             // create the file
@@ -110,6 +117,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // file sharing restriction limitations on Unix
         public void FileShareWithoutDeleteThrows()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.read.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.read.cs
@@ -40,6 +40,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // file sharing restriction limitations on Unix
         public void FileShareWithoutReadThrows()
         {
             string fileName = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.write.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs.write.cs
@@ -45,9 +45,15 @@ namespace System.IO.FileSystem.Tests
             string fileName = GetTestFilePath();
 
             // Open without write sharing
-            using (FileStream fs = CreateFileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete))
+            using (FileStream fs = CreateFileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
                 FSAssert.ThrowsSharingViolation(() => CreateFileStream(fileName, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete));
+            }
+            
+            // Then try the other way around
+            using (FileStream fs = CreateFileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete))
+            {
+                FSAssert.ThrowsSharingViolation(() => CreateFileStream(fileName, FileMode.Open, FileAccess.Write, FileShare.None));
             }
         }
     }

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -96,10 +96,10 @@ internal class IOServices
 
     public static PathInfo GetPath(int characterCount)
     {
-        return GetPath("C:", characterCount);
+        return GetPath("C:", characterCount, IOInputs.MaxComponent);
     }
 
-    public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent = IOInputs.MaxComponent)
+    public static PathInfo GetPath(string rootPath, int characterCount, int maxComponent)
     {
         List<string> paths = new List<string>();
         rootPath = rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -208,6 +209,9 @@
     <Compile Include="FileInfo\AppendText.cs" />
     <Compile Include="FileInfo\CopyTo_str.cs" />
     <Compile Include="FileInfo\CopyTo_str_b.cs" />
+    
+    <!-- Helpers -->
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
     
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Prior to this set of changes, 110 of the ~570 FileSystem tests (inner loop and outer loop) were failing on Linux.  After this PR, there are 0 failing tests.

Primary product fixes:
- Using rmdir/unlink for directory/file deletion rather than using remove
- Disallowing FileStreams to be opened for directories
- Supporting copying files when only target directory (not target name) is specified
- Overhauling directory enumeration to ensure to match Win32 behaviors related to search pattern normalization, input validation, supporting re-iteration through an enumerable, outputting partial paths based on user-supplied path, using a SafeHandle to ensure resources are cleaned up
- Fixing FileSystemObject.LastWriteTime to correctly return the LastWriteTime rather than LastAccessTime
- Fixing FileAttributes.ReadOnly handling due to inappropriate caching
- Validating inputs to FileSystemObject.Attributes, and make sure that changes to attributes are visible afterwards
- Adding support for getting CreationTime if it's supported by the OS
- Marking links with FileAttributes.ReparsePoint
- Working around current runtime bug related to exception handling and finally blocks getting executed twice

Primary test fixes:
- Suppressing tests as platform-specific that dependend on Win32-isms like drive letters, alternate data streams, etc.
- Changing a bunch of '\' usage to instead use Path.DirectorySeparatorChar or Path.Combine
- Adapting to behavioral differences between Windows and Unix, e.g. whether a directory can be deleted if it's readonly, invalid path characters, max path lengths, file sharing differences, etc.

These changes should all accrue to OSX as well, but we'll need to separately do an exercise to clean this library and tests up there for anything OSX-specific.