### PR TITLE
Update xunit dependency to xunit.core.netcore.1.0.1-prerelease

### DIFF
--- a/src/Common/tests/XunitTraitsDiscoverers/packages.config
+++ b/src/Common/tests/XunitTraitsDiscoverers/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
@@ -16,6 +16,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" targetFramework="portable-net45+win+wpa81+wp80" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Win32.Primitives/tests/packages.config
+++ b/src/Microsoft.Win32.Primitives/tests/packages.config
@@ -5,5 +5,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/Microsoft.Win32.Registry/tests/packages.config
+++ b/src/Microsoft.Win32.Registry/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
@@ -14,5 +14,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Collections.Concurrent/tests/packages.config
+++ b/src/System.Collections.Concurrent/tests/packages.config
@@ -13,6 +13,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Collections.Immutable/tests/packages.config
+++ b/src/System.Collections.Immutable/tests/packages.config
@@ -3,5 +3,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Collections.NonGeneric/tests/packages.config
+++ b/src/System.Collections.NonGeneric/tests/packages.config
@@ -15,5 +15,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Collections.Specialized/tests/packages.config
+++ b/src/System.Collections.Specialized/tests/packages.config
@@ -14,6 +14,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Collections/tests/packages.config
+++ b/src/System.Collections/tests/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.ComponentModel.Annotations/tests/packages.config
+++ b/src/System.ComponentModel.Annotations/tests/packages.config
@@ -9,5 +9,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.ComponentModel.EventBasedAsync/tests/packages.config
+++ b/src/System.ComponentModel.EventBasedAsync/tests/packages.config
@@ -6,5 +6,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.ComponentModel.Primitives/tests/packages.config
+++ b/src/System.ComponentModel.Primitives/tests/packages.config
@@ -5,5 +5,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.ComponentModel.TypeConverter/tests/packages.config
+++ b/src/System.ComponentModel.TypeConverter/tests/packages.config
@@ -10,5 +10,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.ComponentModel/tests/packages.config
+++ b/src/System.ComponentModel/tests/packages.config
@@ -4,5 +4,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Console/tests/packages.config
+++ b/src/System.Console/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22703"/>
@@ -16,6 +16,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Diagnostics.Debug/tests/packages.config
+++ b/src/System.Diagnostics.Debug/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
   <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
@@ -18,6 +18,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Diagnostics.FileVersionInfo/tests/packages.config
+++ b/src/System.Diagnostics.FileVersionInfo/tests/packages.config
@@ -14,5 +14,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Win32.Primitives" version="4.0.0-beta-22703" />
   <package id="System.Collections" version="4.0.10-beta-22703" />
@@ -20,7 +20,7 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 
 </packages>

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/packages.config
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Diagnostics.TraceSource" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.IO" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
@@ -13,5 +13,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Diagnostics.TraceSource/tests/packages.config
+++ b/src/System.Diagnostics.TraceSource/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Diagnostics.TextWriterTraceListener" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Diagnostics.Process" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
@@ -15,5 +15,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Dynamic.Runtime/tests/packages.config
+++ b/src/System.Dynamic.Runtime/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CSharp" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Collections" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
@@ -28,5 +28,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Globalization.Extensions/tests/packages.config
+++ b/src/System.Globalization.Extensions/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.IO" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
@@ -14,5 +14,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.IO.Compression/tests/packages.config
+++ b/src/System.IO.Compression/tests/packages.config
@@ -19,6 +19,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>
 

--- a/src/System.IO.FileSystem.DriveInfo/tests/packages.config
+++ b/src/System.IO.FileSystem.DriveInfo/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
@@ -20,6 +20,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.IO.FileSystem.Primitives/tests/packages.config
+++ b/src/System.IO.FileSystem.Primitives/tests/packages.config
@@ -4,5 +4,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.IO.FileSystem.Watcher/tests/packages.config
+++ b/src/System.IO.FileSystem.Watcher/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Win32.Primitives" version="4.0.0-beta-22412" targetFramework="portable-net45+win+wpa81" />
   <package id="System.IO" version="4.0.10-beta-22412" targetFramework="portable-net45+win+wpa81" />
@@ -16,6 +16,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" targetFramework="portable-net45+win" />
 </packages>

--- a/src/System.IO.FileSystem/tests/packages.config
+++ b/src/System.IO.FileSystem/tests/packages.config
@@ -19,5 +19,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.IO.MemoryMappedFiles/tests/packages.config
+++ b/src/System.IO.MemoryMappedFiles/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Diagnostics.Process" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
@@ -20,5 +20,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.IO.Pipes/tests/packages.config
+++ b/src/System.IO.Pipes/tests/packages.config
@@ -14,5 +14,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.IO.UnmanagedMemoryStream/tests/packages.config
+++ b/src/System.IO.UnmanagedMemoryStream/tests/packages.config
@@ -14,5 +14,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Linq.Expressions/tests/packages.config
+++ b/src/System.Linq.Expressions/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
@@ -27,5 +27,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Linq.Parallel/tests/packages.config
+++ b/src/System.Linq.Parallel/tests/packages.config
@@ -15,5 +15,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Linq.Queryable/tests/packages.config
+++ b/src/System.Linq.Queryable/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
   <package id="System.IO" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
@@ -17,5 +17,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Linq/tests/packages.config
+++ b/src/System.Linq/tests/packages.config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="System.Collections" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
   <package id="System.Runtime" version="4.0.20-beta-22412" targetFramework="portable-net45+win" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />

--- a/src/System.Numerics.Vectors/tests/packages.config
+++ b/src/System.Numerics.Vectors/tests/packages.config
@@ -3,7 +3,7 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="System.Runtime" version="4.0.20-beta-22703" />
   <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
   <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />

--- a/src/System.ObjectModel/tests/packages.config
+++ b/src/System.ObjectModel/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
@@ -10,5 +10,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Reflection.DispatchProxy/tests/packages.config
+++ b/src/System.Reflection.DispatchProxy/tests/packages.config
@@ -15,5 +15,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Reflection.Metadata/tests/packages.config
+++ b/src/System.Reflection.Metadata/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
@@ -25,5 +25,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Resources.ResourceWriter/tests/packages.config
+++ b/src/System.Resources.ResourceWriter/tests/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Runtime.Extensions/tests/packages.config
+++ b/src/System.Runtime.Extensions/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.IO.FileSystem" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
@@ -11,5 +11,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Runtime.Numerics/tests/packages.config
+++ b/src/System.Runtime.Numerics/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Console" version="4.0.0-beta-22703" />
@@ -11,5 +11,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Runtime.Serialization.Json/tests/packages.config
+++ b/src/System.Runtime.Serialization.Json/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22605" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22605" />
@@ -25,5 +25,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Runtime.Serialization.Xml/tests/packages.config
+++ b/src/System.Runtime.Serialization.Xml/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22605" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22605" />
@@ -25,5 +25,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Runtime/tests/packages.config
+++ b/src/System.Runtime/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Globalization" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
@@ -11,5 +11,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/packages.config
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Win32.Primitives" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
   <package id="Microsoft.Win32.Registry" version="4.0.0-beta-22703" targetFramework="portable-net45+win" />
@@ -15,5 +15,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Text.Encoding.CodePages/tests/packages.config
+++ b/src/System.Text.Encoding.CodePages/tests/packages.config
@@ -9,6 +9,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Text.RegularExpressions/tests/packages.config
+++ b/src/System.Text.RegularExpressions/tests/packages.config
@@ -11,5 +11,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Threading.Tasks.Dataflow/tests/packages.config
+++ b/src/System.Threading.Tasks.Dataflow/tests/packages.config
@@ -23,5 +23,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Threading.Tasks.Parallel/tests/packages.config
+++ b/src/System.Threading.Tasks.Parallel/tests/packages.config
@@ -12,5 +12,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/packages.config
@@ -6,6 +6,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/packages.config
@@ -6,6 +6,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/packages.config
@@ -6,6 +6,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/packages.config
@@ -7,6 +7,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/packages.config
@@ -8,6 +8,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/packages.config
@@ -6,6 +6,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/packages.config
@@ -7,6 +7,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/packages.config
@@ -9,6 +9,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/packages.config
@@ -7,6 +7,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/packages.config
@@ -12,6 +12,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/packages.config
@@ -8,6 +8,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/packages.config
@@ -8,6 +8,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/packages.config
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/Properties/packages.config
+++ b/src/System.Xml.XDocument/tests/Properties/packages.config
@@ -13,6 +13,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/SDMSample/packages.config
+++ b/src/System.Xml.XDocument/tests/SDMSample/packages.config
@@ -12,6 +12,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/Streaming/packages.config
+++ b/src/System.Xml.XDocument/tests/Streaming/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/TreeManipulation/packages.config
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/packages.config
@@ -12,6 +12,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/axes/packages.config
+++ b/src/System.Xml.XDocument/tests/axes/packages.config
@@ -7,6 +7,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/events/packages.config
+++ b/src/System.Xml.XDocument/tests/events/packages.config
@@ -8,6 +8,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/misc/packages.config
+++ b/src/System.Xml.XDocument/tests/misc/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/packages.config
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/packages.config
@@ -14,6 +14,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XDocument/tests/xNodeReader/packages.config
+++ b/src/System.Xml.XDocument/tests/xNodeReader/packages.config
@@ -11,6 +11,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XPath.XDocument/tests/packages.config
+++ b/src/System.Xml.XPath.XDocument/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Globalization" version="4.0.10-beta-22703" />
   <package id="System.IO" version="4.0.10-beta-22703" />
@@ -15,6 +15,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XPath.XmlDocument/tests/packages.config
+++ b/src/System.Xml.XPath.XmlDocument/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Globalization" version="4.0.10-beta-22703" />
   <package id="System.IO" version="4.0.10-beta-22703" />
@@ -14,6 +14,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XPath/tests/packages.config
+++ b/src/System.Xml.XPath/tests/packages.config
@@ -12,6 +12,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XmlDocument/tests/packages.config
+++ b/src/System.Xml.XmlDocument/tests/packages.config
@@ -6,6 +6,6 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.visualstudio" version="0.99.9-build1021" />
 </packages>

--- a/src/System.Xml.XmlSerializer/tests/packages.config
+++ b/src/System.Xml.XmlSerializer/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.10-beta-22605" />
   <package id="System.Diagnostics.Debug" version="4.0.10-beta-22605" />
@@ -26,5 +26,5 @@
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />
   <package id="xunit.assert" version="2.0.0-beta5-build2785" />
-  <package id="xunit.core.netcore" version="1.0.0-prerelease" />    
+  <package id="xunit.core.netcore" version="1.0.1-prerelease" />    
 </packages>


### PR DESCRIPTION
Update xunit dependency.  New package corrects its dependency on
xunit.abstractions to version 2.0.0-beta5-build2785.