### PR TITLE
Remove properties added back from incorrect merge

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.csproj
+++ b/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.csproj
@@ -8,8 +8,6 @@
     <OutputType>Library</OutputType>
     <NoWarn>649</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);USE_REFEMIT;FEATURE_LEGACYNETCF</DefineConstants>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <FileAlignment>512</FileAlignment>
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
When merging 67da6227, I made mistake and re-added lines that were
removed from TFS and master instead of just removing them both.

Remove the lines.