### PR TITLE
Implement SecureString on Unix (w/o encryption)

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.mlock.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.mlock.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [DllImport(Libraries.Libc, SetLastError = true)]
+        internal static extern int mlock(IntPtr addr, size_t len);
+
+        [DllImport(Libraries.Libc, SetLastError = true)]
+        internal static extern int munlock(IntPtr addr, size_t len);
+    }
+}

--- a/src/Common/src/Interop/Unix/libc/Interop.mprotect.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.mprotect.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using size_t  = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [DllImport(Libraries.Libc, SetLastError = true)]
+        internal static extern int mprotect(IntPtr addr, size_t len, MemoryMappedProtections prot);
+    }
+}

--- a/src/System.Security.SecureString/System.Security.SecureString.sln
+++ b/src/System.Security.SecureString/System.Security.SecureString.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.SecureString", "src\System.Security.SecureString.csproj", "{A958BBDD-3238-4E58-AB7F-390AB6D88233}"
 EndProject
@@ -12,20 +12,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FBCF7C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.SecureString.Tests", "tests\System.Security.SecureString.Tests.csproj", "{69609238-62C7-479D-A8CE-709F41101D3C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTraitsDiscoverers", "..\Common\tests\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj", "{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Linux_Debug|Any CPU = Linux_Debug|Any CPU
+		Linux_Release|Any CPU = Linux_Release|Any CPU
+		OSX_Debug|Any CPU = OSX_Debug|Any CPU
+		OSX_Release|Any CPU = OSX_Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Linux_Debug|Any CPU.ActiveCfg = Linux_Debug|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Linux_Release|Any CPU.Build.0 = Linux_Release|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
+		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
 		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{A958BBDD-3238-4E58-AB7F-390AB6D88233}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.Linux_Release|Any CPU.Build.0 = Release|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.OSX_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69609238-62C7-479D-A8CE-709F41101D3C}.OSX_Release|Any CPU.Build.0 = Release|Any CPU
 		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69609238-62C7-479D-A8CE-709F41101D3C}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Linux_Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.OSX_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.OSX_Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.SecureString/src/Resources/Strings.resx
+++ b/src/System.Security.SecureString/src/Resources/Strings.resx
@@ -135,4 +135,7 @@
   <data name="InvalidOperation_ReadOnly" xml:space="preserve">
     <value>Instance is read-only.</value>
   </data>
+  <data name="OutOfMemory_MemoryResourceLimits" xml:space="preserve">
+    <value>Memory restrictions are preventing the allocation or locking of additional memory.</value>
+  </data>
 </root>

--- a/src/System.Security.SecureString/src/System.Security.SecureString.csproj
+++ b/src/System.Security.SecureString/src/System.Security.SecureString.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -12,10 +12,20 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <!-- References are resolved from packages.config -->
   <ItemGroup>
+    <Compile Include="System\Security\SecureString.cs" />
+    <Compile Include="System\Security\SecureStringMarshal.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <Compile Include="System\Security\SecureString.Windows.cs" />
+    <Compile Include="System\Security\SafeBSTRHandle.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
@@ -37,9 +47,36 @@
     <Compile Include="$(CommonPath)\Interop\Windows\oleaut32\Interop.SysStringLen.cs">
       <Link>Common\Interop\Windows\Interop.SysStringLen.cs</Link>
     </Compile>
-    <Compile Include="System\Security\SecureString.cs" />
-    <Compile Include="System\Security\SafeBSTRHandle.cs" />
-    <Compile Include="System\Security\SecureStringMarshal.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="System\Security\SecureString.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.gnu_get_libc_version.cs">
+      <Link>Common\Interop\Unix\Interop.gnu_get_libc_version.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mlock.cs">
+      <Link>Common\Interop\Unix\Interop.mlock.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mprotect.cs">
+      <Link>Common\Interop\Unix\Interop.mprotect.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.mmap.cs">
+      <Link>Common\Interop\Unix\Interop.mmap.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.munmap.cs">
+      <Link>Common\Interop\Unix\Interop.munmap.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
+      <Link>Common\Interop\Unix\Interop.strerror.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.sysconf.cs">
+      <Link>Common\Interop\Unix\Interop.sysconf.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Unix.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Unix.cs
@@ -1,0 +1,413 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Security
+{
+    // TODO: Issue #1387.
+    // This implementation lacks encryption. We need to investigate adding such encryption support, at which point
+    // we could potentially remove the current implementation's reliance on mlock and mprotect (mlock places additional 
+    // constraints on non-privileged processes due to RLIMIT_MEMLOCK), neither of which provides a guarantee that the
+    // data-at-rest in memory can't be accessed; they just make it more difficult.  If we don't encrypt, at least on Linux
+    // we should consider also using madvise to set MADV_DONTDUMP and MADV_DONTFORK for the allocated pages.  And we
+    // should ensure the documentation gets updated appropriately.
+
+    public sealed partial class SecureString
+    {
+        private ProtectedBuffer _buffer;
+
+        [System.Security.SecurityCritical]  // auto-generated
+        internal unsafe SecureString(SecureString str)
+        {
+            // Allocate enough space to store the provided string
+            EnsureCapacity(str._decryptedLength);
+            _decryptedLength = str._decryptedLength;
+
+            // Copy the string into the newly allocated space
+            if (_decryptedLength > 0)
+                using (str._buffer.Unprotect())
+                    ProtectedBuffer.Copy(str._buffer, _buffer, (ulong)(str._decryptedLength * sizeof(char)));
+
+            // Protect the buffer
+            _buffer.Protect();
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private unsafe void InitializeSecureString(char* value, int length)
+        {
+            // Allocate enough space to store the provided string
+            EnsureCapacity(length);
+            _decryptedLength = length;
+            if (length == 0)
+                return;
+
+            // Copy the string into the newly allocated space
+            byte* ptr = null;
+            try
+            {
+                _buffer.AcquirePointer(ref ptr);
+                Buffer.MemoryCopy(value, ptr, _buffer.ByteLength, (ulong)(length * sizeof(char)));
+            }
+            finally
+            {
+                if (ptr != null)
+                    _buffer.ReleasePointer();
+            }
+
+            // Protect the buffer
+            _buffer.Protect();
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void DisposeCore()
+        {
+            if (_buffer != null && !_buffer.IsInvalid)
+            {
+                _buffer.Dispose();
+                _buffer = null;
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void EnsureNotDisposed()
+        {
+            if (_buffer == null)
+                throw new ObjectDisposedException(GetType().Name);
+        }
+
+        // clears the current contents. Only available if writable
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void ClearCore()
+        {
+            _decryptedLength = 0;
+            using (_buffer.Unprotect())
+                _buffer.Clear();
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private unsafe void AppendCharCore(char c)
+        {
+            // Make sure we have enough space for the new character,
+            // then write it at the end.
+            EnsureCapacity(_decryptedLength + 1);
+            using (_buffer.Unprotect())
+                _buffer.Write((ulong)(_decryptedLength * sizeof(char)), c);
+            _decryptedLength++;
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private unsafe void InsertAtCore(int index, char c)
+        {
+            // Make sure we have enough space for the new character,
+            // then shift all of the characters above it and insert it.
+            EnsureCapacity(_decryptedLength + 1);
+            byte* ptr = null;
+            try
+            {
+                _buffer.AcquirePointer(ref ptr);
+                char* charPtr = (char*)ptr;
+                using (_buffer.Unprotect())
+                {
+                    for (int i = _decryptedLength; i > index; i--)
+                        charPtr[i] = charPtr[i - 1];
+                    charPtr[index] = c;
+                }
+                ++_decryptedLength;
+            }
+            finally
+            {
+                if (ptr != null)
+                    _buffer.ReleasePointer();
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private unsafe void RemoveAtCore(int index)
+        {
+            // Shift down all values above the specified index,
+            // then null out the empty space at the end.
+            byte* ptr = null;
+            try
+            {
+                _buffer.AcquirePointer(ref ptr);
+                char* charPtr = (char*)ptr;
+                using (_buffer.Unprotect())
+                {
+                    for (int i = index; i < _decryptedLength - 1; i++)
+                        charPtr[i] = charPtr[i + 1];
+                    charPtr[--_decryptedLength] = (char)0;
+                }
+            }
+            finally
+            {
+                if (ptr != null)
+                    _buffer.ReleasePointer();
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void SetAtCore(int index, char c)
+        {
+            // Overwrite the character at the specified index
+            using (_buffer.Unprotect())
+                _buffer.Write((ulong)(index * sizeof(char)), c);
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        internal unsafe IntPtr ToUniStrCore()
+        {
+            int length = _decryptedLength;
+
+            byte* bufferPtr = null;
+            IntPtr stringPtr = IntPtr.Zero, result = IntPtr.Zero;
+            try
+            {
+                // Allocate space for the string to be returned, including space for a null terminator
+                if ((stringPtr = Marshal.AllocCoTaskMem((length + 1) * sizeof(char))) == IntPtr.Zero)
+                    throw new OutOfMemoryException();
+
+                _buffer.AcquirePointer(ref bufferPtr);
+
+                // Copy all of our data into it
+                using (_buffer.Unprotect())
+                    Buffer.MemoryCopy(
+                        source: bufferPtr,
+                        destination: (byte*)stringPtr.ToPointer(),
+                        destinationSizeInBytes: ((length + 1) * sizeof(char)),
+                        sourceBytesToCopy: length * sizeof(char));
+
+                // Add the null termination
+                *(length + (char*)stringPtr.ToPointer()) = '\0';
+
+                // Finally store the string pointer into our result.  We maintain
+                // a separate result variable to make clean up in the finally easier.
+                result = stringPtr;
+            }
+            finally
+            {
+                // If there was a failure, such that result isn't initialized, 
+                // release the string if we had one.
+                if (stringPtr != IntPtr.Zero && result == IntPtr.Zero)
+                {
+                    ProtectedBuffer.ZeroMemory((byte*)stringPtr, (ulong)(length * sizeof(char)));
+                    Marshal.FreeCoTaskMem(stringPtr);
+                }
+
+                if (bufferPtr != null)
+                    _buffer.ReleasePointer();
+            }
+
+            return result;
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+        private void EnsureCapacity(int capacity)
+        {
+            // Make sure the requested capacity doesn't exceed SecureString's defined limit
+            if (capacity > MaxLength)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);
+
+            // If we already have enough space allocated, we're done
+            if (_buffer != null && (capacity * sizeof(char)) <= (int)_buffer.ByteLength)
+                return;
+
+            // We need more space, so allocate a new buffer, copy all our data into it,
+            // and then swap the new for the old.
+            ProtectedBuffer newBuffer = ProtectedBuffer.Allocate(capacity * sizeof(char));
+            if (_buffer != null)
+            {
+                using (_buffer.Unprotect())
+                    ProtectedBuffer.Copy(_buffer, newBuffer, _buffer.ByteLength);
+                newBuffer.Protect();
+                _buffer.Dispose();
+            }
+            _buffer = newBuffer;
+        }
+
+        /// <summary>SafeBuffer for managing memory meant to be kept confidential.</summary>
+        private sealed class ProtectedBuffer : SafeBuffer
+        {
+            private static readonly int s_pageSize = 
+                Interop.libc.sysconf(Interop.libc.SysConfNames._SC_PAGESIZE);
+
+            internal ProtectedBuffer() : base(true) { }
+
+            internal static ProtectedBuffer Allocate(int bytes)
+            {
+                Debug.Assert(bytes >= 0);
+
+                // Round the number of bytes up to the next page size boundary.  mmap
+                // is going to allocate pages, anyway, and we lock/protect entire pages,
+                // so we might as well benefit from being able to use all of that space,
+                // rather than allocating it and having it be unusable.  As a SecureString
+                // grows, this will significantly help in avoiding unnecessary recreations
+                // of the buffer.
+                Debug.Assert(s_pageSize > 0);
+                bytes = RoundUpToPageSize(bytes);
+                Debug.Assert(bytes % s_pageSize == 0);
+
+                ProtectedBuffer buffer = new ProtectedBuffer();
+                IntPtr ptr = IntPtr.Zero;
+                try
+                {
+                    // Allocate the page(s) for the buffer.
+                    ptr = Interop.libc.mmap(
+                        IntPtr.Zero,
+                        (IntPtr)bytes,
+                        Interop.libc.MemoryMappedProtections.PROT_READ | Interop.libc.MemoryMappedProtections.PROT_WRITE,
+                        Interop.libc.MemoryMappedFlags.MAP_ANONYMOUS | Interop.libc.MemoryMappedFlags.MAP_PRIVATE, 0,
+                        0);
+                    if (ptr == IntPtr.Zero)
+                        throw CreateExceptionFromErrno();
+
+                    // Lock the pages into memory to minimize the chances that the pages get
+                    // swapped out, making the contents available on disk.
+                    if (Interop.libc.mlock(ptr, (IntPtr)bytes) != 0)
+                        throw CreateExceptionFromErrno();
+                }
+                catch
+                {
+                    // Something failed; release the allocation
+                    if (ptr != IntPtr.Zero)
+                        Interop.libc.munmap(ptr, (IntPtr)bytes); // ignore any errors
+                    throw;
+                }
+
+                // The memory was allocated; initialize the buffer with it.
+                buffer.SetHandle(ptr);
+                buffer.Initialize((ulong)bytes);
+                return buffer;
+            }
+
+            internal void Protect()
+            {
+                // Make the pages unreadable/writable; attempts to read/write this memory will result in seg faults.
+                ChangeProtection(Interop.libc.MemoryMappedProtections.PROT_NONE);
+            }
+
+            internal ProtectOnDispose Unprotect()
+            {
+                // Make the pages readable/writable; attempts to read/write this memory will succeed.
+                // Then return a disposable that will re-protect the memory when done with it.
+                ChangeProtection(Interop.libc.MemoryMappedProtections.PROT_READ | Interop.libc.MemoryMappedProtections.PROT_WRITE);
+                return new ProtectOnDispose(this);
+            }
+
+            internal struct ProtectOnDispose : IDisposable
+            {
+                private readonly ProtectedBuffer _buffer;
+
+                internal ProtectOnDispose(ProtectedBuffer buffer)
+                {
+                    Debug.Assert(buffer != null);
+                    _buffer = buffer;
+                }
+
+                public void Dispose()
+                {
+                    _buffer.Protect();
+                }
+            }
+
+            private unsafe void ChangeProtection(Interop.libc.MemoryMappedProtections prots)
+            {
+                byte* ptr = null;
+                try
+                {
+                    AcquirePointer(ref ptr);
+                    if (Interop.libc.mprotect((IntPtr)ptr, (IntPtr)ByteLength, prots) != 0)
+                        throw CreateExceptionFromErrno();
+                }
+                finally
+                {
+                    if (ptr != null)
+                        ReleasePointer();
+                }
+            }
+
+            internal unsafe void Clear()
+            {
+                byte* ptr = null;
+                try
+                {
+                    AcquirePointer(ref ptr);
+                    ZeroMemory(ptr, ByteLength);
+                }
+                finally
+                {
+                    if (ptr != null)
+                        ReleasePointer();
+                }
+            }
+
+            internal static unsafe void Copy(ProtectedBuffer source, ProtectedBuffer destination, ulong bytesLength)
+            {
+                if (bytesLength == 0)
+                    return;
+
+                byte* srcPtr = null, dstPtr = null;
+                try
+                {
+                    source.AcquirePointer(ref srcPtr);
+                    destination.AcquirePointer(ref dstPtr);
+                    Buffer.MemoryCopy(srcPtr, dstPtr, destination.ByteLength, bytesLength);
+                }
+                finally
+                {
+                    if (dstPtr != null)
+                        destination.ReleasePointer();
+                    if (srcPtr != null)
+                        source.ReleasePointer();
+                }
+            }
+
+            protected override unsafe bool ReleaseHandle()
+            {
+                bool success = true;
+
+                IntPtr h = handle;
+                if (h != IntPtr.Zero)
+                {
+                    IntPtr len = (IntPtr)ByteLength;
+                    success &= Interop.libc.mprotect(h, len, 
+                        Interop.libc.MemoryMappedProtections.PROT_READ | Interop.libc.MemoryMappedProtections.PROT_WRITE) == 0;
+                    if (success)
+                    {
+                        ZeroMemory((byte*)h, ByteLength);
+                        success &= (Interop.libc.munlock(h, len) == 0);
+                    }
+                    success &= (Interop.libc.munmap(h, len) == 0);
+                }
+
+                return success;
+            }
+
+            internal static unsafe void ZeroMemory(byte* ptr, ulong len)
+            {
+                for (ulong i = 0; i < len; i++)
+                    *ptr++ = 0;
+            }
+
+            private static Exception CreateExceptionFromErrno()
+            {
+                int errno = Marshal.GetLastWin32Error();
+                return (errno == Interop.Errors.ENOMEM || errno == Interop.Errors.EPERM) ?
+                    (Exception)new OutOfMemoryException(SR.OutOfMemory_MemoryResourceLimits) :
+                    (Exception)new InvalidOperationException(Interop.libc.strerror(errno));
+            }
+
+            private static int RoundUpToPageSize(int bytes)
+            {
+                return bytes > 0 ?
+                    (bytes + (s_pageSize - 1)) & ~(s_pageSize - 1) :
+                    s_pageSize;
+            }
+        }
+
+    }
+}

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
@@ -1,0 +1,305 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace System.Security
+{
+    public sealed partial class SecureString
+    {
+        [System.Security.SecurityCritical]  // auto-generated
+        internal SecureString(SecureString str)
+        {
+            AllocateBuffer(str.EncryptedBufferLength);
+            SafeBSTRHandle.Copy(str._encryptedBuffer, _encryptedBuffer);
+            _decryptedLength = str._decryptedLength;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private unsafe void InitializeSecureString(char* value, int length)
+        {
+            if (length == 0)
+            {
+                AllocateBuffer(0);
+                _decryptedLength = 0;
+                return;
+            }
+
+            _encryptedBuffer = SafeBSTRHandle.Allocate(null, 0);
+            SafeBSTRHandle decryptedBuffer = SafeBSTRHandle.Allocate(null, (uint)length);
+            _decryptedLength = length;
+
+            byte* bufferPtr = null;
+            try
+            {
+                decryptedBuffer.AcquirePointer(ref bufferPtr);
+                Buffer.MemoryCopy((byte*)value, bufferPtr, decryptedBuffer.Length * sizeof(char), length * sizeof(char));
+            }
+            finally
+            {
+                if (bufferPtr != null)
+                    decryptedBuffer.ReleasePointer();
+            }
+
+            ProtectMemory(decryptedBuffer);
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void AppendCharCore(char c)
+        {
+            SafeBSTRHandle decryptedBuffer = null;
+            try
+            {
+                decryptedBuffer = UnProtectMemory();
+                EnsureCapacity(ref decryptedBuffer, _decryptedLength + 1);
+                decryptedBuffer.Write<char>((uint)_decryptedLength * sizeof(char), c);
+                _decryptedLength++;
+            }
+            finally
+            {
+                ProtectMemory(decryptedBuffer);
+            }
+        }
+
+        // clears the current contents. Only available if writable
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void ClearCore()
+        {
+            _decryptedLength = 0;
+            _encryptedBuffer.ClearBuffer();
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void DisposeCore()
+        {
+            if (_encryptedBuffer != null && !_encryptedBuffer.IsInvalid)
+            {
+                _encryptedBuffer.Dispose();
+                _encryptedBuffer = null;
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private unsafe void InsertAtCore(int index, char c)
+        {
+            byte* bufferPtr = null;
+            SafeBSTRHandle decryptedBuffer = null;
+            try
+            {
+                decryptedBuffer = UnProtectMemory();
+                EnsureCapacity(ref decryptedBuffer, _decryptedLength + 1);
+
+                decryptedBuffer.AcquirePointer(ref bufferPtr);
+                char* pBuffer = (char*)bufferPtr;
+
+                for (int i = _decryptedLength; i > index; i--)
+                {
+                    pBuffer[i] = pBuffer[i - 1];
+                }
+                pBuffer[index] = c;
+                ++_decryptedLength;
+            }
+            finally
+            {
+                ProtectMemory(decryptedBuffer);
+                if (bufferPtr != null)
+                    decryptedBuffer.ReleasePointer();
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private unsafe void RemoveAtCore(int index)
+        {
+            byte* bufferPtr = null;
+            SafeBSTRHandle decryptedBuffer = null;
+            try
+            {
+                decryptedBuffer = UnProtectMemory();
+                decryptedBuffer.AcquirePointer(ref bufferPtr);
+                char* pBuffer = (char*)bufferPtr;
+
+                for (int i = index; i < _decryptedLength - 1; i++)
+                {
+                    pBuffer[i] = pBuffer[i + 1];
+                }
+                pBuffer[--_decryptedLength] = (char)0;
+            }
+            finally
+            {
+                ProtectMemory(decryptedBuffer);
+                if (bufferPtr != null)
+                    decryptedBuffer.ReleasePointer();
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private void SetAtCore(int index, char c)
+        {
+            SafeBSTRHandle decryptedBuffer = null;
+            try
+            {
+                decryptedBuffer = UnProtectMemory();
+                decryptedBuffer.Write<char>((uint)index * sizeof(char), c);
+            }
+            finally
+            {
+                ProtectMemory(decryptedBuffer);
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        internal unsafe IntPtr ToUniStrCore()
+        {
+            int length = _decryptedLength;
+            IntPtr ptr = IntPtr.Zero;
+            IntPtr result = IntPtr.Zero;
+            byte* bufferPtr = null;
+
+            SafeBSTRHandle decryptedBuffer = null;
+            try
+            {
+                ptr = Marshal.AllocCoTaskMem((length + 1) * 2);
+
+                if (ptr == IntPtr.Zero)
+                {
+                    throw new OutOfMemoryException();
+                }
+
+                decryptedBuffer = UnProtectMemory();
+                decryptedBuffer.AcquirePointer(ref bufferPtr);
+                Buffer.MemoryCopy(bufferPtr, (byte*)ptr.ToPointer(), ((length + 1) * 2), length * 2);
+                char* endptr = (char*)ptr.ToPointer();
+                *(endptr + length) = '\0';
+                result = ptr;
+            }
+            finally
+            {
+                if (result == IntPtr.Zero)
+                {
+                    // If we failed for any reason, free the new buffer
+                    if (ptr != IntPtr.Zero)
+                    {
+                        Interop.NtDll.ZeroMemory(ptr, (UIntPtr)(length * 2));
+                        Marshal.FreeCoTaskMem(ptr);
+                    }
+                }
+
+                if (bufferPtr != null)
+                    decryptedBuffer.ReleasePointer();
+            }
+            return result;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void EnsureNotDisposed()
+        {
+            if (_encryptedBuffer == null)
+            {
+                throw new ObjectDisposedException(null);
+            }
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+
+        [System.Security.SecurityCritical] // auto-generated
+        private SafeBSTRHandle _encryptedBuffer;
+
+        private uint EncryptedBufferLength
+        {
+            [System.Security.SecurityCritical]  // auto-generated
+            get
+            {
+                Debug.Assert(_encryptedBuffer != null, "Buffer is not initialized!");
+                return _encryptedBuffer.Length;
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void AllocateBuffer(uint size)
+        {
+            _encryptedBuffer = SafeBSTRHandle.Allocate(null, size);
+            if (_encryptedBuffer.IsInvalid)
+            {
+                throw new OutOfMemoryException();
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void EnsureCapacity(ref SafeBSTRHandle decryptedBuffer, int capacity)
+        {
+            if (capacity > MaxLength)
+            {
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);
+            }
+
+            if (capacity <= _decryptedLength)
+            {
+                return;
+            }
+
+            SafeBSTRHandle newBuffer = SafeBSTRHandle.Allocate(null, (uint)capacity);
+
+            if (newBuffer.IsInvalid)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            SafeBSTRHandle.Copy(decryptedBuffer, newBuffer);
+            decryptedBuffer.Dispose();
+            decryptedBuffer = newBuffer;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private void ProtectMemory(SafeBSTRHandle decryptedBuffer)
+        {
+            Debug.Assert(!decryptedBuffer.IsInvalid, "Invalid buffer!");
+
+            if (_decryptedLength == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                SafeBSTRHandle newEncryptedBuffer = null;
+                if (Interop.Crypt32.CryptProtectData(decryptedBuffer, out newEncryptedBuffer))
+                {
+                    _encryptedBuffer.Dispose();
+                    _encryptedBuffer = newEncryptedBuffer;
+                }
+                else
+                {
+                    throw new CryptographicException(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                decryptedBuffer.ClearBuffer();
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private SafeBSTRHandle UnProtectMemory()
+        {
+            Debug.Assert(!_encryptedBuffer.IsInvalid, "Invalid buffer!");
+
+            SafeBSTRHandle decryptedBuffer = null;
+            if (_decryptedLength == 0)
+            {
+                return _encryptedBuffer;
+            }
+
+            if (!Interop.Crypt32.CryptUnProtectData(_encryptedBuffer, out decryptedBuffer))
+            {
+                throw new CryptographicException(Marshal.GetLastWin32Error());
+            }
+
+            return decryptedBuffer;
+        }
+
+    }
+}

--- a/src/System.Security.SecureString/src/System/Security/SecureString.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.cs
@@ -2,63 +2,20 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 
 namespace System.Security
 {
-    public sealed class SecureString : IDisposable
+    public sealed partial class SecureString : IDisposable
     {
-        [System.Security.SecurityCritical] // auto-generated
-        private SafeBSTRHandle _encryptedBuffer;
-
-        private int _decryptedLength;
-        private bool _readOnly;
-
         private const int MaxLength = 65536;
-
         private readonly object _methodLock = new object();
+        private bool _readOnly;
+        private int _decryptedLength;
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        static SecureString()
+        public unsafe SecureString()
         {
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
-        internal SecureString(SecureString str)
-        {
-            AllocateBuffer(str.EncryptedBufferLength);
-            SafeBSTRHandle.Copy(str._encryptedBuffer, _encryptedBuffer);
-            _decryptedLength = str._decryptedLength;
-        }
-
-        [System.Security.SecuritySafeCritical]  // auto-generated
-        public SecureString()
-        {
-            AllocateBuffer(0);
-            _decryptedLength = 0;
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
-        private unsafe void InitializeSecureString(char* value, int length)
-        {
-            _encryptedBuffer = SafeBSTRHandle.Allocate(null, 0);
-            SafeBSTRHandle decryptedBuffer = SafeBSTRHandle.Allocate(null, (uint)length);
-            _decryptedLength = length;
-
-            byte* bufferPtr = null;
-            try
-            {
-                decryptedBuffer.AcquirePointer(ref bufferPtr);
-                Buffer.MemoryCopy((byte*)value, bufferPtr, decryptedBuffer.Length * sizeof(char), length * sizeof(char));
-            }
-            finally
-            {
-                if (bufferPtr != null)
-                    decryptedBuffer.ReleasePointer();
-            }
-
-            ProtectMemory(decryptedBuffer);
+            InitializeSecureString(null, 0);
         }
 
         [System.Security.SecurityCritical]  // auto-generated
@@ -104,19 +61,7 @@ namespace System.Security
             {
                 EnsureNotDisposed();
                 EnsureNotReadOnly();
-
-                SafeBSTRHandle decryptedBuffer = null;
-                try
-                {
-                    decryptedBuffer = UnProtectMemory();
-                    EnsureCapacity(ref decryptedBuffer, _decryptedLength + 1);
-                    decryptedBuffer.Write<char>((uint)_decryptedLength * sizeof(char), c);
-                    _decryptedLength++;
-                }
-                finally
-                {
-                    ProtectMemory(decryptedBuffer);
-                }
+                AppendCharCore(c);
             }
         }
 
@@ -128,9 +73,7 @@ namespace System.Security
             {
                 EnsureNotDisposed();
                 EnsureNotReadOnly();
-
-                _decryptedLength = 0;
-                _encryptedBuffer.ClearBuffer();
+                ClearCore();
             }
         }
 
@@ -150,11 +93,7 @@ namespace System.Security
         {
             lock (_methodLock)
             {
-                if (_encryptedBuffer != null && !_encryptedBuffer.IsInvalid)
-                {
-                    _encryptedBuffer.Dispose();
-                    _encryptedBuffer = null;
-                }
+                DisposeCore();
             }
         }
 
@@ -171,32 +110,7 @@ namespace System.Security
                 EnsureNotDisposed();
                 EnsureNotReadOnly();
 
-                unsafe
-                {
-                    byte* bufferPtr = null;
-                    SafeBSTRHandle decryptedBuffer = null;
-                    try
-                    {
-                        decryptedBuffer = UnProtectMemory();
-                        EnsureCapacity(ref decryptedBuffer, _decryptedLength + 1);
-
-                        decryptedBuffer.AcquirePointer(ref bufferPtr);
-                        char* pBuffer = (char*)bufferPtr;
-
-                        for (int i = _decryptedLength; i > index; i--)
-                        {
-                            pBuffer[i] = pBuffer[i - 1];
-                        }
-                        pBuffer[index] = c;
-                        ++_decryptedLength;
-                    }
-                    finally
-                    {
-                        ProtectMemory(decryptedBuffer);
-                        if (bufferPtr != null)
-                            decryptedBuffer.ReleasePointer();
-                    }
-                }
+                InsertAtCore(index, c);
             }
         }
 
@@ -233,29 +147,7 @@ namespace System.Security
                     throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_IndexString);
                 }
 
-                unsafe
-                {
-                    byte* bufferPtr = null;
-                    SafeBSTRHandle decryptedBuffer = null;
-                    try
-                    {
-                        decryptedBuffer = UnProtectMemory();
-                        decryptedBuffer.AcquirePointer(ref bufferPtr);
-                        char* pBuffer = (char*)bufferPtr;
-
-                        for (int i = index; i < _decryptedLength - 1; i++)
-                        {
-                            pBuffer[i] = pBuffer[i + 1];
-                        }
-                        pBuffer[--_decryptedLength] = (char)0;
-                    }
-                    finally
-                    {
-                        ProtectMemory(decryptedBuffer);
-                        if (bufferPtr != null)
-                            decryptedBuffer.ReleasePointer();
-                    }
-                }
+                RemoveAtCore(index);
             }
         }
 
@@ -273,70 +165,7 @@ namespace System.Security
                 EnsureNotDisposed();
                 EnsureNotReadOnly();
 
-                SafeBSTRHandle decryptedBuffer = null;
-                try
-                {
-                    decryptedBuffer = UnProtectMemory();
-                    decryptedBuffer.Write<char>((uint)index * sizeof(char), c);
-                }
-                finally
-                {
-                    ProtectMemory(decryptedBuffer);
-                }
-            }
-        }
-
-        private uint EncryptedBufferLength
-        {
-            [System.Security.SecurityCritical]  // auto-generated
-            get
-            {
-                Debug.Assert(_encryptedBuffer != null, "Buffer is not initialized!");
-                return _encryptedBuffer.Length;
-            }
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
-        private void AllocateBuffer(uint size)
-        {
-            _encryptedBuffer = SafeBSTRHandle.Allocate(null, size);
-            if (_encryptedBuffer.IsInvalid)
-            {
-                throw new OutOfMemoryException();
-            }
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
-        private void EnsureCapacity(ref SafeBSTRHandle decryptedBuffer, int capacity)
-        {
-            if (capacity > MaxLength)
-            {
-                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);
-            }
-
-            if (capacity <= _decryptedLength)
-            {
-                return;
-            }
-
-            SafeBSTRHandle newBuffer = SafeBSTRHandle.Allocate(null, (uint)capacity);
-
-            if (newBuffer.IsInvalid)
-            {
-                throw new OutOfMemoryException();
-            }
-
-            SafeBSTRHandle.Copy(decryptedBuffer, newBuffer);
-            decryptedBuffer.Dispose();
-            decryptedBuffer = newBuffer;
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
-        private void EnsureNotDisposed()
-        {
-            if (_encryptedBuffer == null)
-            {
-                throw new ObjectDisposedException(null);
+                SetAtCore(index, c);
             }
         }
 
@@ -349,98 +178,13 @@ namespace System.Security
         }
 
         [System.Security.SecurityCritical]  // auto-generated
-        private void ProtectMemory(SafeBSTRHandle decryptedBuffer)
-        {
-            Debug.Assert(!decryptedBuffer.IsInvalid, "Invalid buffer!");
-
-            if (_decryptedLength == 0)
-            {
-                return;
-            }
-
-            try
-            {
-                SafeBSTRHandle newEncryptedBuffer = null;
-                if (Interop.Crypt32.CryptProtectData(decryptedBuffer, out newEncryptedBuffer))
-                {
-                    _encryptedBuffer.Dispose();
-                    _encryptedBuffer = newEncryptedBuffer;
-                }
-                else
-                {
-                    throw new CryptographicException(Marshal.GetLastWin32Error());
-                }
-            }
-            finally
-            {
-                decryptedBuffer.ClearBuffer();
-            }
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe IntPtr ToUniStr()
         {
             lock (_methodLock)
             {
                 EnsureNotDisposed();
-                int length = _decryptedLength;
-                IntPtr ptr = IntPtr.Zero;
-                IntPtr result = IntPtr.Zero;
-                byte* bufferPtr = null;
-
-                SafeBSTRHandle decryptedBuffer = null;
-                try
-                {
-                    ptr = Marshal.AllocCoTaskMem((length + 1) * 2);
-
-                    if (ptr == IntPtr.Zero)
-                    {
-                        throw new OutOfMemoryException();
-                    }
-
-                    decryptedBuffer = UnProtectMemory();
-                    decryptedBuffer.AcquirePointer(ref bufferPtr);
-                    Buffer.MemoryCopy(bufferPtr, (byte*)ptr.ToPointer(), ((length + 1) * 2), length * 2);
-                    char* endptr = (char*)ptr.ToPointer();
-                    *(endptr + length) = '\0';
-                    result = ptr;
-                }
-                finally
-                {
-                    if (result == IntPtr.Zero)
-                    {
-                        // If we failed for any reason, free the new buffer
-                        if (ptr != IntPtr.Zero)
-                        {
-                            Interop.NtDll.ZeroMemory(ptr, (UIntPtr)(length * 2));
-                            Marshal.FreeCoTaskMem(ptr);
-                        }
-                    }
-
-                    if (bufferPtr != null)
-                        decryptedBuffer.ReleasePointer();
-                }
-                return result;
+                return ToUniStrCore();
             }
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated
-        private SafeBSTRHandle UnProtectMemory()
-        {
-            Debug.Assert(!_encryptedBuffer.IsInvalid, "Invalid buffer!");
-
-            SafeBSTRHandle decryptedBuffer = null;
-            if (_decryptedLength == 0)
-            {
-                return _encryptedBuffer;
-            }
-
-            if (!Interop.Crypt32.CryptUnProtectData(_encryptedBuffer, out decryptedBuffer))
-            {
-                throw new CryptographicException(Marshal.GetLastWin32Error());
-            }
-
-            return decryptedBuffer;
         }
     }
 }

--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System.Security.SecureString.Tests</RootNamespace>
     <AssemblyName>System.Security.SecureString.Tests</AssemblyName>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UnsupportedPlatforms>Linux</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -19,15 +19,24 @@
   <!-- References are resolved from packages.config -->
   <ItemGroup>
     <Compile Include="SecureStringTests.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.geteuid.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Security.SecureString.csproj">
       <Project>{A958BBDD-3238-4E58-AB7F-390AB6D88233}</Project>
       <Name>System.Security.SecureString</Name>
     </ProjectReference>
+    <ProjectReference Include="$(CommonTestPath)\XunitTraitsDiscoverers\XunitTraitsDiscoverers.csproj">
+      <Project>{be8ed8c1-c314-4c4e-a929-64c9c8b3552a}</Project>
+      <Name>XunitTraitsDiscoverers</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.SecureString/tests/packages.config
+++ b/src/System.Security.SecureString/tests/packages.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
   <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
   <package id="System.Security.Cryptography.Encryption" version="4.0.0-beta-22703" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />


### PR DESCRIPTION
This commit provides a basic implementation of SecureString that will run on Unix and that will provide the expected inputs/outputs for consumers, but that doesn't actually do any encryption.  That will need to be added later.