### PR TITLE
Fixing issue in SafeEventStreamHandle

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.EventStream.cs
+++ b/src/Common/src/Interop/OSX/Interop.EventStream.cs
@@ -163,14 +163,21 @@ internal static partial class Interop
         /// <param name="streamRef">The stream to stop receiving events on.</param>
         [DllImport(Interop.Libraries.CoreServicesLibrary)]
         internal static extern void FSEventStreamStop(SafeEventStreamHandle streamRef);
-       
+
+        /// <summary>
+        /// Stops receiving events on the specified stream. The stream can be restarted and not miss any events.
+        /// </summary>
+        /// <param name="streamRef">The stream to stop receiving events on.</param>
+        [DllImport(Interop.Libraries.CoreServicesLibrary)]
+        internal static extern void FSEventStreamStop(IntPtr streamRef);
+
         /// <summary>
         /// Invalidates an EventStream and removes it from any RunLoops.
         /// </summary>
         /// <param name="streamRef">The FSEventStream to invalidate</param>
         /// <remarks>This can only be called after FSEventStreamScheduleWithRunLoop has be called</remarks>
         [DllImport(Interop.Libraries.CoreServicesLibrary)]
-        internal static extern void FSEventStreamInvalidate(SafeEventStreamHandle streamRef);
+        internal static extern void FSEventStreamInvalidate(IntPtr streamRef);
 
         /// <summary>
         /// Removes the event stream from the RunLoop.
@@ -189,6 +196,6 @@ internal static partial class Interop
         /// </summary>
         /// <param name="streamRef">The stream on which to decrement the reference count.</param>
         [DllImport(Interop.Libraries.CoreServicesLibrary)]
-        internal static extern void FSEventStreamRelease(SafeEventStreamHandle streamRef);
+        internal static extern void FSEventStreamRelease(IntPtr streamRef);
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Win32.SafeHandles
         [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
-            Interop.EventStream.FSEventStreamStop(this);
-            Interop.EventStream.FSEventStreamInvalidate(this);
-            Interop.EventStream.FSEventStreamRelease(this);
+            Interop.EventStream.FSEventStreamStop(handle);
+            Interop.EventStream.FSEventStreamInvalidate(handle);
+            Interop.EventStream.FSEventStreamRelease(handle);
 
             return true;
         }


### PR DESCRIPTION
Fixing issue where SafeEventStreamHandle would pass 'this' to an Interop function during the ReleaseHandle call instead of passing the underlying handle

@ellismg @sharwell @stephentoub 