### PR TITLE
Make ImmutableArray's SyncRoot throw NotSupportedException

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1414,14 +1414,7 @@ namespace System.Collections.Immutable
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         object ICollection.SyncRoot
         {
-            get
-            {
-                // As a struct, this instance will be boxed in order to call this property getter.
-                // We will return the boxed instance. If the caller boxes and reboxes repeatedly,
-                // they'll get a different SyncRoot each time.
-                // No real alternative, but we don't anticipate this will be much problem anyway.
-                return this;
-            }
+            get { throw new NotSupportedException(); }
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1265,6 +1265,13 @@ namespace System.Collections.Immutable.Test
             DebuggerAttributes.ValidateDebuggerDisplayReferences(ImmutableArray.Create(1, 2, 3));  // verify non-empty
         }
 
+        [Fact]
+        public void ICollectionSyncRoot_NotSupported()
+        {
+            ICollection c = ImmutableArray.Create(1, 2, 3);
+            Assert.Throws<NotSupportedException>(() => c.SyncRoot);
+        }
+
         protected override IEnumerable<T> GetEnumerableOf<T>(params T[] contents)
         {
             return ImmutableArray.Create(contents);


### PR DESCRIPTION
ImmutableArray<T>'s ICollection.SyncRoot implementation currently does "return this;".  Unfortunately, this will result in returning a new object each time, which means that any attempts to use the resulting object to synchronize blocks of arbitrary code will silently result in race conditions as different objects end up being used.  With ImmutableArray<T> being a single-field struct, and with it being a violation of its design to return the underlying array as the sync root, the best available option is to simply throw a NotSupportedException.

Fixes #1390.