### PR TITLE
Improve System.IO.Compression's async usage

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
@@ -607,23 +607,22 @@ namespace System.IO.Compression
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled<int>(cancellationToken);
 
-            Interlocked.Increment(ref _asyncOperations);
+            return WriteAsyncCore(array, offset, count, cancellationToken);
+        }
 
+        private async Task WriteAsyncCore(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _asyncOperations);
             try
             {
-                return base.WriteAsync(array, offset, count, cancellationToken).ContinueWith(
-                        (t) => Interlocked.Decrement(ref _asyncOperations),
-                        cancellationToken,
-                        TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default
-                    );
+                await base.WriteAsync(array, offset, count, cancellationToken).ConfigureAwait(false);
             }
-            catch
+            finally
             {
                 Interlocked.Decrement(ref _asyncOperations);
-                throw;
             }
         }
+
     }  // public class DeflateStream
 }  // namespace System.IO.Compression
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
@@ -209,6 +209,14 @@ namespace System.IO.Compression
             return;
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            EnsureNotDisposed();
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                Task.CompletedTask;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException(SR.NotSupported);

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -189,6 +189,12 @@ namespace System.IO.Compression
             return _deflateStream.WriteAsync(array, offset, count, cancellationToken);
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            CheckDeflateStream();
+            return _deflateStream.FlushAsync(cancellationToken);
+        }
+
         private void CheckDeflateStream()
         {
             if (_deflateStream == null)


### PR DESCRIPTION
A few bug fixes in DeflateStream.WriteAsync, plus some improvements in Read/Write/FlushAsync to minimize overheads and improve readability/maintainability of the code.

Fixes #1334 