### PR TITLE
Make ImmutableDictionary.HashBucket.Equals throw NotSupportedException

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+HashBucket.cs
@@ -112,7 +112,7 @@ namespace System.Collections.Immutable
             bool IEquatable<HashBucket>.Equals(HashBucket other)
             {
                 // This should never be called, as hash buckets don't know how to equate themselves.
-                throw new Exception();
+                throw new NotSupportedException();
             }
 
             /// <summary>


### PR DESCRIPTION
The interface implementation currently throws the base Exception type.  It should throw the more specialized NotSupportedException type.  But it also shouldn't really matter, as it shouldn't ever be called.

Fixes #1391 