### PR TITLE
Enabled some tests that were disabled before

### DIFF
--- a/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
@@ -81,14 +81,13 @@ namespace Microsoft.Framework.WebEncoders
             Assert.Same(encoder1, encoder2);
         }
 
-        // TODO: fix xUnit escaping and then uncomment
-        //[Theory]
-        //[InlineData("<", "&lt;")]
-        //[InlineData(">", "&gt;")]
-        //[InlineData("&", "&amp;")]
-        //[InlineData("'", "&#x27;")]
-        //[InlineData("\"", "&quot;")]
-        //[InlineData("+", "&#x2B;")]
+        [Theory]
+        [InlineData("<", "&lt;")]
+        [InlineData(">", "&gt;")]
+        [InlineData("&", "&amp;")]
+        [InlineData("'", "&#x27;")]
+        [InlineData("\"", "&quot;")]
+        [InlineData("+", "&#x2B;")]
         public void HtmlEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple(string input, string expected)
         {
             // Arrange

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple_Escaping() {
             // The following two calls could be simply InlineData to the Theory below
-            // Unfortunatelly, the xUnit logger fails to escape the inputs when loffing the test results,
+            // Unfortunatelly, the xUnit logger fails to escape the inputs when logging the test results,
             // and so the suite fails despite all tests passing. 
             // TODO: I will try to fix it in xUnit, but for now this is a workaround to enable these tests.
             JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple("\b", @"\b");

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -81,21 +81,28 @@ namespace Microsoft.Framework.WebEncoders
             Assert.Same(encoder1, encoder2);
         }
 
-        // TODO: fix xUnit escaping and then uncomment
-        //[Theory]
-        //[InlineData("<", @"\u003C")]
-        //[InlineData(">", @"\u003E")]
-        //[InlineData("&", @"\u0026")]
-        //[InlineData("'", @"\u0027")]
-        //[InlineData("\"", @"\u0022")]
-        //[InlineData("+", @"\u002B")]
-        //[InlineData("\\", @"\\")]
-        //[InlineData("/", @"\/")]
-        //[InlineData("\b", @"\b")]
-        //[InlineData("\f", @"\f")]
-        //[InlineData("\n", @"\n")]
-        //[InlineData("\t", @"\t")]
-        //[InlineData("\r", @"\r")]
+        [Fact]
+        public void JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple_Escaping() {
+            // The following two calls could be simply InlineData to the Theory below
+            // Unfortunatelly, the xUnit logger fails to escape the inputs when loffing the test results,
+            // and so the suite fails despite all tests passing. 
+            // TODO: I will try to fix it in xUnit, but for now this is a workaround to enable these tests.
+            JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple("\b", @"\b");
+            JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple("\f", @"\f");
+        }
+
+        [Theory]
+        [InlineData("<", @"\u003C")]
+        [InlineData(">", @"\u003E")]
+        [InlineData("&", @"\u0026")]
+        [InlineData("'", @"\u0027")]
+        [InlineData("\"", @"\u0022")]
+        [InlineData("+", @"\u002B")]
+        [InlineData("\\", @"\\")]
+        [InlineData("/", @"\/")]
+        [InlineData("\n", @"\n")]
+        [InlineData("\t", @"\t")]
+        [InlineData("\r", @"\r")]
         public void JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple(string input, string expected)
         {
             // Arrange
@@ -281,10 +288,9 @@ namespace Microsoft.Framework.WebEncoders
             Assert.Equal(@"lo\u002Bwo", output.ToString());
         }
 
-        // TODO: fix xUnit escaping and then uncomment
-        //[Theory]
-        //[InlineData("\"", @"\u0022")]
-        //[InlineData("'", @"\u0027")]
+        [Theory]
+        [InlineData("\"", @"\u0022")]
+        [InlineData("'", @"\u0027")]
         public void JavaScriptStringEncode_Quotes(string input, string expected)
         {
             // Per the design document, we provide additional defense-in-depth

--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -30,16 +30,16 @@ namespace Microsoft.Framework.WebEncoders
             Assert.Same(retVal1, retVal2);
         }
 
-        // TODO: fix xUnit escaping and then uncomment
-        //[Theory]
-        //[InlineData(1, "a", (int)'a')] // normal BMP char, end of string
-        //[InlineData(2, "ab", (int)'a')] // normal BMP char, not end of string
-        //[InlineData(3, "\uDFFF", UnicodeReplacementChar)] // trailing surrogate, end of string
-        //[InlineData(4, "\uDFFFx", UnicodeReplacementChar)] // trailing surrogate, not end of string
-        //[InlineData(5, "\uD800", UnicodeReplacementChar)] // leading surrogate, end of string
-        //[InlineData(6, "\uD800x", UnicodeReplacementChar)] // leading surrogate, not end of string, followed by non-surrogate
-        //[InlineData(7, "\uD800\uD800", UnicodeReplacementChar)] // leading surrogate, not end of string, followed by leading surrogate
-        //[InlineData(8, "\uD800\uDFFF", 0x103FF)] // leading surrogate, not end of string, followed by trailing surrogate
+        
+        [Theory]
+        [InlineData(1, "a", (int)'a')] // normal BMP char, end of string
+        [InlineData(2, "ab", (int)'a')] // normal BMP char, not end of string
+        [InlineData(3, "\uDFFF", UnicodeReplacementChar)] // trailing surrogate, end of string
+        [InlineData(4, "\uDFFFx", UnicodeReplacementChar)] // trailing surrogate, not end of string
+        [InlineData(5, "\uD800", UnicodeReplacementChar)] // leading surrogate, end of string
+        [InlineData(6, "\uD800x", UnicodeReplacementChar)] // leading surrogate, not end of string, followed by non-surrogate
+        [InlineData(7, "\uD800\uD800", UnicodeReplacementChar)] // leading surrogate, not end of string, followed by leading surrogate
+        [InlineData(8, "\uD800\uDFFF", 0x103FF)] // leading surrogate, not end of string, followed by trailing surrogate
         public void GetScalarValueFromUtf16(int unused, string input, int expectedResult)
         {
             // The 'unused' parameter exists because the xunit runner can't distinguish


### PR DESCRIPTION
The tests were disabled as the xUnit logger was failing to escape some InlineData arguments.
This commit enables these tests back. Some of them turned out to be disabled unnecesarily.
Two tests were changed to not use InlineData.