### PR TITLE
"libcoreclr" -> "libcoreclrpal"

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
     {
         internal const string Libc = "libc";             // C library
         internal const string LibRt = "librt";           // POSIX Realtime Extensions library
-        internal const string LibCoreClr = "libcoreclr"; // CoreCLR runtime
+        internal const string LibCoreClrPal = "libcoreclrpal"; // CoreCLR runtime
         internal const string LibCrypto = "libcrypto";   // OpenSSL crypto library
     }
 }

--- a/src/Common/src/Interop/Unix/libcoreclrpal/Interop.ForkAndExecProcess.cs
+++ b/src/Common/src/Interop/Unix/libcoreclrpal/Interop.ForkAndExecProcess.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 internal static partial class Interop
 {
-    internal static partial class libcoreclr
+    internal static partial class libcoreclrpal
     {
         internal static unsafe int ForkAndExecProcess(
             string filename, string[] argv, string[] envp, string cwd,
@@ -32,7 +32,7 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.LibCoreClr, SetLastError = true)]
+        [DllImport(Libraries.LibCoreClrPal, SetLastError = true)]
         private static extern unsafe int ForkAndExecProcess(
             string filename, byte** argv, byte** envp, string cwd,
             int redirectStdin, int redirectStdout, int redirectStderr,

--- a/src/Common/src/Interop/Unix/libcoreclrpal/Interop.GetFileInformation.cs
+++ b/src/Common/src/Interop/Unix/libcoreclrpal/Interop.GetFileInformation.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static partial class libcoreclr
+    internal static partial class libcoreclrpal
     {
-        // Instead of calling stat(2) and friends directly, we call into libcoreclr which does so on our behalf
+        // Instead of calling stat(2) and friends directly, we call into libcoreclrpal which does so on our behalf
         // we do this because the ABI for this function is different across both OS and architectures and it
         // is easier to handle the differences in native code which builds against the platform headers.
 
@@ -41,10 +41,10 @@ internal static partial class Interop
             HasBTime = 0x1,
         }
 
-        [DllImport(Libraries.LibCoreClr, CharSet = CharSet.Ansi, SetLastError = true)]
+        [DllImport(Libraries.LibCoreClrPal, CharSet = CharSet.Ansi, SetLastError = true)]
         internal static extern unsafe int GetFileInformationFromPath(string path, out fileinfo buf);
 
-        [DllImport(Libraries.LibCoreClr, SetLastError = true)]
+        [DllImport(Libraries.LibCoreClrPal, SetLastError = true)]
         internal static extern unsafe int GetFileInformationFromFd(int fd, out fileinfo buf);
     }
 }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -50,13 +50,13 @@ namespace Microsoft.Win32.SafeHandles
 
                 // Make sure it's not a directory; we do this after opening it once we have a file descriptor 
                 // to avoid race conditions.
-                Interop.libcoreclr.fileinfo buf;
-                if (Interop.libcoreclr.GetFileInformationFromFd(fd, out buf) != 0)
+                Interop.libcoreclrpal.fileinfo buf;
+                if (Interop.libcoreclrpal.GetFileInformationFromFd(fd, out buf) != 0)
                 {
                     handle.Dispose();
                     throw Interop.GetExceptionForIoErrno(Marshal.GetLastWin32Error(), path);
                 }
-                if ((buf.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR)
+                if ((buf.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) == Interop.libcoreclrpal.FileTypes.S_IFDIR)
                 {
                     handle.Dispose();
                     throw Interop.GetExceptionForIoErrno(Interop.Errors.EACCES, path, isDirectory: true);

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -140,7 +140,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.strerror.cs">
       <Link>Common\Interop\Unix\Interop.strerror.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclrpal\Interop.GetFileInformation.cs">
       <Link>Common\Interop\Unix\Interop.GetFileInformation.cs"</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -80,7 +80,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.write.cs">
       <Link>Common\Interop\Unix\libc\Interop.write.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclrpal\Interop.GetFileInformation.cs">
       <Link>Common\Interop\Unix\Interop.GetFileInformation.cs"</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs">

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -260,7 +260,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.waitpid.cs">
       <Link>Common\Interop\Unix\Interop.waitpid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.ForkAndExecProcess.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclrpal\Interop.ForkAndExecProcess.cs">
       <Link>Common\Interop\Unix\Interop.ForkAndExecProcess.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.ResourceLimits.cs">

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -208,7 +208,7 @@ namespace System.Diagnostics
             // is used to fork/execve as executing managed code in a forked process is not safe (only
             // the calling thread will transfer, thread IDs aren't stable across the fork, etc.)
             int childPid, stdinFd, stdoutFd, stderrFd;
-            if (Interop.libcoreclr.ForkAndExecProcess(
+            if (Interop.libcoreclrpal.ForkAndExecProcess(
                 filename, argv, envp, cwd,
                 startInfo.RedirectStandardInput, startInfo.RedirectStandardOutput, startInfo.RedirectStandardError,
                 out childPid, 

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -15,7 +15,7 @@ namespace System.IO.Compression.Test
             await testCreate("small", false);
             await testCreate("normal", true);
             await testCreate("normal", false);
-            if (!Interop.IsLinux) // TODO [ActiveIssue("https://github.com/dotnet/coreclr/issues/333")].  Remove this once libcoreclr uses UTF8 for marshaling.
+            if (!Interop.IsLinux) // TODO [ActiveIssue("https://github.com/dotnet/coreclr/issues/333")].  Remove this once libcoreclrpal uses UTF8 for marshaling.
             {
                 await testCreate("unicode", true);
                 await testCreate("unicode", false);

--- a/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -49,7 +49,7 @@ namespace System.IO.Compression.Test
         {
             await testFolder("normal");
             await testFolder("empty");
-            if (!Interop.IsLinux) // TODO [ActiveIssue("https://github.com/dotnet/coreclr/issues/333")].  Remove this once libcoreclr uses UTF8 for marshaling.
+            if (!Interop.IsLinux) // TODO [ActiveIssue("https://github.com/dotnet/coreclr/issues/333")].  Remove this once libcoreclrpal uses UTF8 for marshaling.
             {
                 await testFolder("unicode");
             }

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -311,7 +311,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.unlink.cs">
       <Link>Common\Interop\Unix\Interop.unlink.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclrpal\Interop.GetFileInformation.cs">
       <Link>Common\Interop\Unix\Interop.GetInformation.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -286,8 +286,8 @@ namespace System.IO
                 // Get the length of the file as reported by the OS
                 long length = SysCall<int, int>((fd, _, __) =>
                 {
-                    Interop.libcoreclr.fileinfo fileinfo;
-                    int result = Interop.libcoreclr.GetFileInformationFromFd(fd, out fileinfo);
+                    Interop.libcoreclrpal.fileinfo fileinfo;
+                    int result = Interop.libcoreclrpal.GetFileInformationFromFd(fd, out fileinfo);
                     return result >= 0 ? fileinfo.size : result;
                 });
 

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -63,8 +63,8 @@ namespace System.IO
             }
 
             // Now copy over relevant read/write/execute permissions from the source to the destination
-            Interop.libcoreclr.fileinfo fileinfo;
-            while (Interop.CheckIo(Interop.libcoreclr.GetFileInformationFromPath(sourceFullPath, out fileinfo), sourceFullPath)) ;
+            Interop.libcoreclrpal.fileinfo fileinfo;
+            while (Interop.CheckIo(Interop.libcoreclrpal.GetFileInformationFromPath(sourceFullPath, out fileinfo), sourceFullPath)) ;
             int newMode = fileinfo.mode & (int)Interop.libc.Permissions.Mask;
             while (Interop.CheckIo(Interop.libc.chmod(destFullPath, newMode), destFullPath)) ;
         }
@@ -315,22 +315,22 @@ namespace System.IO
 
         private bool DirectoryExists(string fullPath, out int errno)
         {
-            return FileExists(fullPath, Interop.libcoreclr.FileTypes.S_IFDIR, out errno);
+            return FileExists(fullPath, Interop.libcoreclrpal.FileTypes.S_IFDIR, out errno);
         }
 
         public override bool FileExists(string fullPath)
         {
             int errno;
-            return FileExists(fullPath, Interop.libcoreclr.FileTypes.S_IFREG, out errno);
+            return FileExists(fullPath, Interop.libcoreclrpal.FileTypes.S_IFREG, out errno);
         }
 
         private bool FileExists(string fullPath, int fileType, out int errno)
         {
-            Interop.libcoreclr.fileinfo fileinfo;
+            Interop.libcoreclrpal.fileinfo fileinfo;
             while (true)
             {
                 errno = 0;
-                int result = Interop.libcoreclr.GetFileInformationFromPath(fullPath, out fileinfo);
+                int result = Interop.libcoreclrpal.GetFileInformationFromPath(fullPath, out fileinfo);
                 if (result < 0)
                 {
                     errno = Marshal.GetLastWin32Error();
@@ -340,7 +340,7 @@ namespace System.IO
                     }
                     return false;
                 }
-                return (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == fileType;
+                return (fileinfo.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) == fileType;
             }
         }
 
@@ -483,10 +483,10 @@ namespace System.IO
                                 case Interop.libc.DType.DT_LNK:
                                 case Interop.libc.DType.DT_UNKNOWN:
                                     string fullPath = Path.Combine(dirPath.FullPath, name);
-                                    Interop.libcoreclr.fileinfo fileinfo;
-                                    while (Interop.CheckIo(Interop.libcoreclr.GetFileInformationFromPath(fullPath, out fileinfo), fullPath)) ;
-                                    isDir = (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR;
-                                    isFile = (fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFREG;
+                                    Interop.libcoreclrpal.fileinfo fileinfo;
+                                    while (Interop.CheckIo(Interop.libcoreclrpal.GetFileInformationFromPath(fullPath, out fileinfo), fullPath)) ;
+                                    isDir = (fileinfo.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) == Interop.libcoreclrpal.FileTypes.S_IFDIR;
+                                    isFile = (fileinfo.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) == Interop.libcoreclrpal.FileTypes.S_IFREG;
                                     break;
                             }
                             bool matchesSearchPattern =

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystemObject.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystemObject.cs
@@ -18,7 +18,7 @@ namespace System.IO
             private bool _isDirectory;
 
             /// <summary>The last cached stat information about the file.</summary>
-            private Interop.libcoreclr.fileinfo _fileinfo;
+            private Interop.libcoreclrpal.fileinfo _fileinfo;
 
             /// <summary>
             /// Whether we've successfully cached a stat structure.
@@ -92,7 +92,7 @@ namespace System.IO
             {
                 get
                 {
-                    return (_fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFDIR;
+                    return (_fileinfo.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) == Interop.libcoreclrpal.FileTypes.S_IFDIR;
                 }
             }
 
@@ -100,7 +100,7 @@ namespace System.IO
             {
                 get
                 {
-                    return (_fileinfo.mode & Interop.libcoreclr.FileTypes.S_IFMT) == Interop.libcoreclr.FileTypes.S_IFLNK;
+                    return (_fileinfo.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) == Interop.libcoreclrpal.FileTypes.S_IFLNK;
                 }
             }
 
@@ -174,7 +174,7 @@ namespace System.IO
                 get
                 {
                     EnsureStatInitialized();
-                    return (_fileinfo.flags & (uint)Interop.libcoreclr.FileInformationFlags.HasBTime) != 0 ?
+                    return (_fileinfo.flags & (uint)Interop.libcoreclrpal.FileInformationFlags.HasBTime) != 0 ?
                         DateTimeOffset.FromUnixTimeSeconds(_fileinfo.btime) :
                         default(DateTimeOffset);
                 }
@@ -228,7 +228,7 @@ namespace System.IO
                 int result;
                 while (true)
                 {
-                    result = Interop.libcoreclr.GetFileInformationFromPath(_fullPath, out _fileinfo);
+                    result = Interop.libcoreclrpal.GetFileInformationFromPath(_fullPath, out _fileinfo);
                     if (result >= 0)
                     {
                         _fileinfoInitialized = 0;

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -206,7 +206,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.write.cs">
       <Link>Common\Interop\Unix\Interop.write.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclr\Interop.GetFileInformation.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libcoreclrpal\Interop.GetFileInformation.cs">
       <Link>Common\Interop\Unix\Interop.GetInformation.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -66,11 +66,11 @@ namespace System.IO.Pipes
         {
             SysCall(safePipeHandle, (fd, _, __) =>
             {
-                Interop.libcoreclr.fileinfo buf;
-                int result = Interop.libcoreclr.GetFileInformationFromFd(fd, out buf);
+                Interop.libcoreclrpal.fileinfo buf;
+                int result = Interop.libcoreclrpal.GetFileInformationFromFd(fd, out buf);
                 if (result == 0)
                 {
-                    if ((buf.mode & Interop.libcoreclr.FileTypes.S_IFMT) != Interop.libcoreclr.FileTypes.S_IFIFO)
+                    if ((buf.mode & Interop.libcoreclrpal.FileTypes.S_IFMT) != Interop.libcoreclrpal.FileTypes.S_IFIFO)
                     {
                         throw new IOException(SR.IO_InvalidPipeHandle);
                     }


### PR DESCRIPTION
The runtime has factored out the PAL from the runtime and renamed it
from libcoreclr to libcoreclrpal.  This change just updates all our
pinvokes to consume the new name.