### PR TITLE
Move RestoreBuildTools to the build traversal from initial targets.

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" InitialTargets="_RestoreBuildToolsWrapper" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
   <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
@@ -33,12 +33,6 @@
       </Code>
     </Task>
   </UsingTask>
-
-  <!-- 
-    Needed to avoid the IntialTargets from having an Output which ends up getting
-    added to the output references when you have a project to project reference.
-  -->
-  <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
 
   <Target Name="_RestoreBuildTools"
           Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget\packages.config"

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -88,6 +88,7 @@
     </TraversalCleanDependsOn>
 
     <TraversalRestorePackagesDependsOn>
+      _RestoreBuildTools;
       RestoreAllProjectPackages;
       $(TraversalRestorePackagesDependsOn)
     </TraversalRestorePackagesDependsOn>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -77,6 +77,7 @@
 
   <PropertyGroup>
     <TraversalBuildDependsOn>
+      _RestoreBuildTools;
       BuildAllProjects;
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -10,6 +10,15 @@
   <Target Name="GetAssemblyVersion"
           Returns="$(AssemblyVersion)"/>
 
+  <!-- These gets overwritten when we restore the build tools and import the below targets -->
+  <Target Name="Build" Condition="!Exists('$(ToolsDir)Build.Common.targets')" >
+    <CallTarget Targets="_RestoreBuildTools" />
+  </Target>
+  <!-- Set a default clean target -->
+  <Target Name="Clean">
+    <RemoveDir Directories="$(BinDir)" />
+  </Target>
+
   <Import Project="$(ToolsDir)Build.Common.targets" Condition="Exists('$(ToolsDir)Build.Common.targets')" />
 
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -17,7 +17,8 @@
   </Target>
   <!-- Set a default empty clean target -->
   <Target Name="Clean" >
-    <Message Importance="High" Text="'Clean' target is empty. Restore build tools to enable 'Clean' target." />
+    <Message Importance="High" Text="'Clean' target is empty. A restore of build tools is required to enable the 'Clean' target." />
+    <CallTarget Targets="_RestoreBuildTools" />
   </Target>
 
   <Import Project="$(ToolsDir)Build.Common.targets" Condition="Exists('$(ToolsDir)Build.Common.targets')" />

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -10,13 +10,14 @@
   <Target Name="GetAssemblyVersion"
           Returns="$(AssemblyVersion)"/>
 
-  <!-- These gets overwritten when we restore the build tools and import the below targets -->
+  <!-- This Build target is only run if build tools have not been restored.  Once build tools have been restored, these gets overridden 
+       by the build tools import for the Build target. -->
   <Target Name="Build" Condition="!Exists('$(ToolsDir)Build.Common.targets')" >
     <CallTarget Targets="_RestoreBuildTools" />
   </Target>
-  <!-- Set a default clean target -->
-  <Target Name="Clean">
-    <RemoveDir Directories="$(BinDir)" />
+  <!-- Set a default empty clean target -->
+  <Target Name="Clean" >
+    <Message Importance="High" Text="'Clean' target is empty. Restore build tools to enable 'Clean' target." />
   </Target>
 
   <Import Project="$(ToolsDir)Build.Common.targets" Condition="Exists('$(ToolsDir)Build.Common.targets')" />


### PR DESCRIPTION
This change moves the restore of build tools from an InitialTarget into the build traversal.  While this somewhat degrades the experience of building a project and solution file in Visual Studio directly from a clean enlistment, it is also a bit less "weird" than the current state which does some "magic" in that experience.  This change is an improvement to the experience from build.cmd / msbuild and reduces weird scenarios like restoring build tools before executing the "clean" target.

It would be nice if we also had an initialtarget which did build tools check validation, and then notified the user to restore build tools if necessary.  Due to internal constraints, we're not at a place where this is feasible.  I believe, though, that this is transient and we'd be able to improve this experience once internal dependencies have been removed.