### PR TITLE
Fix Issue #17: Some System.Xml.XPath.XDocument tests are failing

### DIFF
--- a/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
+++ b/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
@@ -4185,7 +4185,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// child::node()/preceding::node()[preceding-sibling::book and following-sibling::magazine]
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest225()
         {
             var xml = "books.xml";
@@ -8471,7 +8470,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// book/descendant::award/preceding::text()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest239()
         {
             var xml = "books.xml";
@@ -17815,7 +17813,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// descendant-or-self::node()[position()>=3 and position()<=15]/preceding::node()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest267()
         {
             var xml = "books.xml";
@@ -23032,7 +23029,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// preceding-sibling::*/preceding::node()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest282()
         {
             var xml = "books.xml";
@@ -48209,7 +48205,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// (bookstore/book |/bookstore/magazine | bookstore | bookstore//*//title)/preceding::node()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest2156()
         {
             var xml = "books.xml";
@@ -54033,7 +54028,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NSXX: //namespace::*[local-name()=""]/preceding::*
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest2183()
         {
             var xml = "name2.xml";
@@ -55723,7 +55717,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// //@*/preceding::*
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest2189()
         {
             var xml = "books.xml";
@@ -57647,7 +57640,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// //comment()/preceding::node()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesCombinationsTest2199()
         {
             var xml = "test63682.xml";

--- a/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeComplexExprTests.cs
+++ b/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeComplexExprTests.cs
@@ -9210,7 +9210,6 @@ namespace XPathTests.FunctionalTests.Location.Paths.Axes
         /// /descendant-or-self::node()/parent::node()/descendant::node()/preceding::*
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void ComplexExpressionsTest322()
         {
             var xml = "books.xml";

--- a/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxesTests.cs
+++ b/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxesTests.cs
@@ -6085,7 +6085,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// //*[last()]/preceding::processing-instruction()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesTest1138()
         {
             var xml = "books_2.xml";
@@ -8505,7 +8504,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// following::book/preceding::book
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesTest1202()
         {
             var xml = "books.xml";
@@ -10083,7 +10081,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// preceding::book/preceding::book
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesTest1216()
         {
             var xml = "books.xml";
@@ -11579,7 +11576,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// ancestor::*/preceding::book
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesTest1244()
         {
             var xml = "books.xml";
@@ -12143,7 +12139,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// //*[last()]/preceding::processing-instruction()
         /// </summary>
         [Fact]
-        [ActiveIssue(17)]
         public static void AxesTest1256()
         {
             var xml = "books_2.xml";


### PR DESCRIPTION
Background: When reusing tests for XPathDocument on XPathNavigator created from XDocument there were few issues:
- XDocument is sorting attributes/namespaces
- XDocument treats Whitespaces and SignificantWhitespaces as Text

Initial solution: Added NavigatorComparer which runs known good implementation of XPath along with XDocument implementation and compares their behavior and reducing known issues (i.e. if we find that both comparers are on Attribute then we return known implementation although both of them should point on any attribute or namespace and the numbers should be correct)

Issues found: In some places we still compared Namespace vs Attribute. Didn't predict that XDocument also treats significant whitespaces as Text.