### PR TITLE
Remove Console.WriteLine from Complex tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/Complex/ComplexTestSupport.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/ComplexTestSupport.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Numerics;
 using Xunit;
 
@@ -11,14 +10,10 @@ namespace ComplexTestSupport
     public static class Support
     {
         private static Random s_random;
-        public static int randomSample;
 
         static Support()
         {
             s_random = new Random(-55);
-
-            // randomSample assignment
-            randomSample = 3;
         }
 
         public static Random Random
@@ -26,26 +21,21 @@ namespace ComplexTestSupport
             get { return s_random; }
         }
 
-        public static int RandomSampleCount
-        {
-            get { return randomSample; }
-        }
-
         // Valid values in double type
         public static Double[] doubleValidValues = new Double[] {
-            Double.MinValue,
+            double.MinValue,
             -1,
             0,
-            Double.Epsilon,
+            double.Epsilon,
             1,
-            Double.MaxValue,
+            double.MaxValue,
         };
 
         // Invalid values in double type
         public static Double[] doubleInvalidValues = new Double[] {
-            Double.NegativeInfinity,
-            Double.PositiveInfinity,
-            Double.NaN
+            double.NegativeInfinity,
+            double.PositiveInfinity,
+            double.NaN
         };
 
         // Typical phase values in double type
@@ -57,22 +47,16 @@ namespace ComplexTestSupport
 
         public static String[] supportedStdNumericFormats = new String[] { "C", "E", "F", "G", "N", "P", "R" };
 
-        private static double GetRandomValue(Double mult, bool fIsNegative)
+        private static double GetRandomValue(double mult, bool fIsNegative)
         {
-            Double randomDouble = (mult * s_random.NextDouble());
+            double randomDouble = (mult * s_random.NextDouble());
             randomDouble %= (Double)(mult);
-
-            if (fIsNegative)
-            {
-                return -randomDouble;
-            }
-
-            return randomDouble;
+            return fIsNegative ? -randomDouble : randomDouble;
         }
 
         public static double GetRandomDoubleValue(bool fIsNegative)
         {
-            return GetRandomValue(Double.MaxValue, fIsNegative);
+            return GetRandomValue(double.MaxValue, fIsNegative);
         }
 
         public static double GetSmallRandomDoubleValue(bool fIsNegative)
@@ -101,18 +85,14 @@ namespace ComplexTestSupport
         {
             return ((Int64)GetRandomValue(Int64.MaxValue, fIsNegative));
         }
-
-
-
-
-
+        
         public static Byte GetRandomByteValue()
         {
             return ((Byte)s_random.Next(1, Byte.MaxValue));
         }
 
 #if CLS_Compliant
-		 public static SByte GetRandomSByteValue(bool fIsNegative)
+        public static SByte GetRandomSByteValue(bool fIsNegative)
         {
             if (fIsNegative)
             {
@@ -124,21 +104,22 @@ namespace ComplexTestSupport
             }
         }
 
-		public static UInt16 GetRandomUInt16Value()
-		{
-			return ((UInt16)random.Next(1, UInt16.MaxValue));
-		}
+        public static UInt16 GetRandomUInt16Value()
+        {
+            return ((UInt16)random.Next(1, UInt16.MaxValue));
+        }
 
-		public static UInt32 GetRandomUInt32Value()
-		{
-			return ((UInt32)GetRandomValue(UInt32.MaxValue, false));
-		}
+        public static UInt32 GetRandomUInt32Value()
+        {
+            return ((UInt32)GetRandomValue(UInt32.MaxValue, false));
+        }
 
         public static UInt64 GetRandomUInt64Value()
         {
             return ((UInt64)GetRandomValue(UInt64.MaxValue, false));
         }
 #endif
+
         public static Single GetRandomSingleValue(bool fIsNegative)
         {
             return ((Single)GetRandomValue(Single.MaxValue, fIsNegative));
@@ -146,7 +127,7 @@ namespace ComplexTestSupport
 
         public static BigInteger GetRandomBigIntegerValue(bool fIsNegative)
         {
-            return ((BigInteger)GetRandomValue(Double.MaxValue, fIsNegative));
+            return ((BigInteger)GetRandomValue(double.MaxValue, fIsNegative));
         }
 
         public static Decimal GetRandomDecimalValue(bool fIsNegative)
@@ -176,58 +157,32 @@ namespace ComplexTestSupport
             return GetRandomValue((Math.PI / 2), fIsNegative);
         }
 
-        public static bool IsDiffTolerable(Double d1, Double d2)
+        public static bool IsDiffTolerable(double d1, double d2)
         {
-            Double diffRatio = (d1 - d2) / d1;
+            double diffRatio = (d1 - d2) / d1;
             diffRatio *= Math.Pow(10, 6);
             diffRatio = Math.Abs(diffRatio);
             return (diffRatio < 1);
         }
 
-        public static bool VerifyRealImaginaryProperties(Complex complex, double real, double imaginary)
+        public static void VerifyRealImaginaryProperties(Complex complex, double real, double imaginary, string message)
         {
-            bool retValue = true; // assume verification is true!
-
-            if (!(real.Equals((Double)complex.Real) || IsDiffTolerable(complex.Real, real)))
-            {
-                Console.WriteLine("ErRoR!!! Actual Complex ({0}, {1}) real part to be equal to Double:{2}", complex.Real, complex.Imaginary, real);
-                retValue = false;
-            }
-
-            if (!(imaginary.Equals((Double)complex.Imaginary) || IsDiffTolerable(complex.Imaginary, imaginary)))
-            {
-                Console.WriteLine("ErRoR!!! Actual Complex ({0}, {1}) imaginary part to be equal to Double:{2}", complex.Real, complex.Imaginary, imaginary);
-                retValue = false;
-            }
-
-            return retValue;
+            Assert.True(real.Equals((Double)complex.Real) || IsDiffTolerable(complex.Real, real), message);
+            Assert.True(imaginary.Equals((Double)complex.Imaginary) || IsDiffTolerable(complex.Imaginary, imaginary), message);
         }
 
-        public static bool VerifyMagnitudePhaseProperties(Complex complex, double magnitude, double phase)
+        public static void VerifyMagnitudePhaseProperties(Complex complex, double magnitude, double phase, string message)
         {
-            bool retValue = true; // assume verification is true!
+            // The magnitude (m) of a complex number (z = x + yi) is the absolute value - |z| = sqrt(x^2 + y^2)
+            // Verification is done using the square of the magnitude since m^2 = x^2 + y^2
+            double expectedMagnitudeSqr = magnitude * magnitude;
+            double actualMagnitudeSqr = complex.Magnitude * complex.Magnitude;
 
-            // the magnitude is abs value
-            // Verification is done by square of magnitude, since m*m == r*r + i*i
-            Double expectedMagnitudeSqr = magnitude * magnitude;
-            Double actualMagnitudeSqr = complex.Magnitude * complex.Magnitude;
+            Assert.True(expectedMagnitudeSqr.Equals((Double)(actualMagnitudeSqr)) || IsDiffTolerable(actualMagnitudeSqr, expectedMagnitudeSqr), message);
 
-            if (!(expectedMagnitudeSqr.Equals((Double)(actualMagnitudeSqr)) || IsDiffTolerable(actualMagnitudeSqr, expectedMagnitudeSqr)))
+            if (double.IsNaN(magnitude))
             {
-                Console.WriteLine(
-                                    "ErRoR!!! Actual Complex({0}, {1}) -  Magnitude:{2}, Phase:{3} - magnitude to be equal to Double:{4}",
-                                    complex.Real,
-                                    complex.Imaginary,
-                                    complex.Magnitude,
-                                    complex.Phase,
-                                    Math.Sqrt(expectedMagnitudeSqr)
-                                 );
-                retValue = false;
-            }
-
-            if (Double.IsNaN(magnitude))
-            {
-                phase = Double.NaN;
+                phase = double.NaN;
             }
             else if (magnitude == 0)
             {
@@ -235,62 +190,10 @@ namespace ComplexTestSupport
             }
             else if (magnitude < 0)
             {
-                if (phase < 0)
-                    phase += Math.PI;
-                else
-                    phase -= Math.PI;
+                phase += (phase < 0) ? Math.PI : -Math.PI;
             }
 
-            if (!(phase.Equals((Double)complex.Phase) || IsDiffTolerable(complex.Phase, phase)))
-            {
-                Console.WriteLine(
-                                    "ErRoR!!! Actual Complex({0}, {1}) - Magnitude:{2}, Phase:{3} - phase to be equal to Double:{4}",
-                                    complex.Real,
-                                    complex.Imaginary,
-                                    complex.Magnitude,
-                                    complex.Phase,
-                                    phase
-                                 );
-                retValue = false;
-            }
-
-            return retValue;
+            Assert.True(phase.Equals((Double)complex.Phase) || IsDiffTolerable(complex.Phase, phase), message);
         }
-
-        public static bool EvaluateTestResult(int countTestCase, int countError, string strLog)
-        {
-            Console.WriteLine(strLog);
-            if (0 == countError)
-            {
-                Console.WriteLine("PaSs!!! Number of Test Cases: {0}", countTestCase);
-                return true;
-            }
-            Console.WriteLine("FaiL!!! Number of Test Cases: {0}, Number of ErRoRs: {1}", countTestCase, countError);
-            return false;
-        }
-
-        //public static Boolean IsX86orWOW
-        //{
-        //	get
-        //	{
-        //		return String.Compare(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE"), "x86", StringComparison.InvariantCultureIgnoreCase) == 0;
-        //	}
-        //}
-
-        //public static Boolean IsIA64
-        //{
-        //	get
-        //	{
-        //		return String.Compare(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE"), "IA64", StringComparison.InvariantCultureIgnoreCase) == 0;
-        //	}
-        //}
-
-        //public static Boolean IsARM
-        //{
-        //	get
-        //	{
-        //		return String.Compare(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE"), "ARM", StringComparison.InvariantCultureIgnoreCase) == 0;
-        //	}
-        //}
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Abs.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Abs.cs
@@ -2,33 +2,24 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_AbsTest
     {
-        private static void VerifyBinaryAbs(Double real, Double imaginary, Double expected)
+        private static void VerifyBinaryAbs(double real, double imaginary, double expected)
         {
             // Create complex numbers
             Complex cComplex = new Complex(real, imaginary);
-            Double abs = Complex.Abs(cComplex);
+            double abs = Complex.Abs(cComplex);
 
-            if (!(abs.Equals((Double)expected) || Support.IsDiffTolerable(abs, expected)))
-            {
-                Console.WriteLine("Error_asd872!!! Abs ({0}, {1}) Actual: {2}, Expected: {3}", real, imaginary, abs, expected);
-                Assert.True(false, "Verification Failed");
-            }
-            else // do the second verification
-            {
-                Double absNegative = Complex.Abs(-cComplex);
-                if (!absNegative.Equals((Double)abs))
-                {
-                    Console.WriteLine("Error_asd872!!! Abs ({0}, {1}) = {2} != Abs(-neg)={3}", real, imaginary, abs, absNegative);
-                    Assert.True(false, "Verification Failed");
-                }
-            }
+            Assert.True((abs.Equals((Double)expected) || Support.IsDiffTolerable(abs, expected)),
+                string.Format("Abs ({0}, {1}) Actual: {2}, Expected: {3}", real, imaginary, abs, expected));
+           
+            double absNegative = Complex.Abs(-cComplex);
+            Assert.True(absNegative.Equals((Double)abs), 
+                string.Format("Abs ({0}, {1}) = {2} != Abs(-neg)={3}", real, imaginary, abs, absNegative));
         }
 
         [Fact]
@@ -42,9 +33,9 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryAbs(real, imaginary, Math.Sqrt(real * real + imaginary * imaginary));
 
             // Verify test results with ComplexInSecondQuad
@@ -66,21 +57,20 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            VerifyBinaryAbs(Double.MaxValue, Double.MaxValue, Double.PositiveInfinity);
-            VerifyBinaryAbs(Double.MaxValue, 0, Double.MaxValue);
-            VerifyBinaryAbs(0, Double.MaxValue, Double.MaxValue);
+            VerifyBinaryAbs(double.MaxValue, double.MaxValue, double.PositiveInfinity);
+            VerifyBinaryAbs(double.MaxValue, 0, double.MaxValue);
+            VerifyBinaryAbs(0, double.MaxValue, double.MaxValue);
 
-            VerifyBinaryAbs(Double.MinValue, Double.MinValue, Double.PositiveInfinity);
-            VerifyBinaryAbs(Double.MinValue, 0, Double.MaxValue);
-            VerifyBinaryAbs(0, Double.MinValue, Double.MaxValue);
+            VerifyBinaryAbs(double.MinValue, double.MinValue, double.PositiveInfinity);
+            VerifyBinaryAbs(double.MinValue, 0, double.MaxValue);
+            VerifyBinaryAbs(0, double.MinValue, double.MaxValue);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double realRandom = Support.GetRandomDoubleValue(false);
-            Double imaginaryRandom = Support.GetRandomDoubleValue(false);
+            double realRandom = Support.GetRandomDoubleValue(false);
+            double imaginaryRandom = Support.GetRandomDoubleValue(false);
 
             // Complex number with a valid real and an invalid imaginary part
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)
@@ -99,12 +89,12 @@ namespace System.Numerics.Tests
             {
                 foreach (double imaginaryInvalid in Support.doubleInvalidValues)
                 {
-                    VerifyBinaryAbs(realInvalid, imaginaryInvalid, (Double.IsInfinity(realInvalid) || Double.IsInfinity(imaginaryInvalid)) ? Double.PositiveInfinity : Double.NaN);
+                    VerifyBinaryAbs(realInvalid, imaginaryInvalid, (double.IsInfinity(realInvalid) || double.IsInfinity(imaginaryInvalid)) ? double.PositiveInfinity : double.NaN);
                 }
             }
 
             //Regression test case for issue: Complex.Abs() is inconsistent on NaN / Complex.
-            VerifyBinaryAbs(Double.NaN, 0, Double.NaN);
+            VerifyBinaryAbs(double.NaN, 0, double.NaN);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryDivide_Divide.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryDivide_Divide.cs
@@ -2,61 +2,55 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_BinaryDivide_DivideTest
     {
-        //Verification is done with Abs and Conjugate methods
-        private static void VerifyBinaryDivideResult(Double realFirst, Double imgFirst, Double realSecond, Double imgSecond)
+        // Verification is done with Abs and Conjugate methods
+        private static void VerifyBinaryDivideResult(double realFirst, double imgFirst, double realSecond, double imgSecond)
         {
             // Create complex numbers
             Complex cFirst = new Complex(realFirst, imgFirst);
             Complex cSecond = new Complex(realSecond, imgSecond);
-
-
+            
             Complex cExpectedResult = (cFirst * Complex.Conjugate(cSecond));
-            Double cExpectedReal = cExpectedResult.Real;
-            Double cExpectedImaginary = cExpectedResult.Imaginary;
+            double cExpectedReal = cExpectedResult.Real;
+            double cExpectedImaginary = cExpectedResult.Imaginary;
 
-            if (!Double.IsInfinity(cExpectedReal))
+            if (!double.IsInfinity(cExpectedReal))
+            {
                 cExpectedReal = cExpectedReal / (cSecond.Magnitude * cSecond.Magnitude);
-            if (!Double.IsInfinity(cExpectedImaginary))
+            }
+            if (!double.IsInfinity(cExpectedImaginary))
+            {
                 cExpectedImaginary = cExpectedImaginary / (cSecond.Magnitude * cSecond.Magnitude);
+            }
 
-            //local variables
+            // local variables
             Complex cResult;
 
             // arithmetic binary divide operation
             cResult = cFirst / cSecond;
 
             // verify the result
-            if (false == Support.VerifyRealImaginaryProperties(cResult, cExpectedReal, cExpectedImaginary))
-            {
-                Console.WriteLine("Error_ryt02!!! Binary Divide test = ({0}, {1}) / ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, cExpectedReal, cExpectedImaginary,
+                string.Format("Binary Divide test = ({0}, {1}) / ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
 
             // arithmetic divide (static) operation
             cResult = Complex.Divide(cFirst, cSecond);
 
             // verify the result
-            if (false == Support.VerifyRealImaginaryProperties(cResult, cExpectedReal, cExpectedImaginary))
-            {
-                Console.WriteLine("Error_a1s12!!! Divide (Static) test = ({0}, {1}) / ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, cExpectedReal, cExpectedImaginary,
+                string.Format("Divide (Static) test = ({0}, {1}) / ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
         }
 
         [Fact]
         public static void RunTests_ZeroOneImaginaryOne()
         {
-            Double real = 10;//Support.GetRandomDoubleValue(false);
-            Double imaginary = 50;//Support.GetRandomPhaseValue(false);
+            double real = 10;
+            double imaginary = 50;
 
             // Test with Zero
             VerifyBinaryDivideResult(0.0, 0.0, real, imaginary); // Verify 0/x=0
@@ -74,84 +68,83 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            // local variables
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double img = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double img = Support.GetSmallRandomDoubleValue(false);
 
             // test with 'Max'
-            VerifyBinaryDivideResult(Double.MaxValue, Double.MaxValue, real, img);
+            VerifyBinaryDivideResult(double.MaxValue, double.MaxValue, real, img);
 
             // test with 'Min'
-            VerifyBinaryDivideResult(Double.MinValue, Double.MinValue, real, img);
+            VerifyBinaryDivideResult(double.MinValue, double.MinValue, real, img);
         }
 
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad / ComplexInFirstQuad
-            Double realFirst = Support.GetSmallRandomDoubleValue(false);
-            Double imgFirst = Support.GetSmallRandomDoubleValue(false);
-            Double realSecond = Support.GetSmallRandomDoubleValue(false);
-            Double imgSecond = Support.GetSmallRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad / ComplexInFirstQuad
+            double realFirst = Support.GetSmallRandomDoubleValue(false);
+            double imgFirst = Support.GetSmallRandomDoubleValue(false);
+            double realSecond = Support.GetSmallRandomDoubleValue(false);
+            double imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad / ComplexInSecondQuad
+            // Verify test results with ComplexInFirstQuad / ComplexInSecondQuad
             realFirst = Support.GetSmallRandomDoubleValue(false);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad / ComplexInThirdQuad
+            // Verify test results with ComplexInFirstQuad / ComplexInThirdQuad
             realFirst = Support.GetSmallRandomDoubleValue(false);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad / ComplexInFourthQuad
+            // Verify test results with ComplexInFirstQuad / ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(false);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad / ComplexInSecondQuad
+            // Verify test results with ComplexInSecondQuad / ComplexInSecondQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad / ComplexInThirdQuad
+            // Verify test results with ComplexInSecondQuad / ComplexInThirdQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad / ComplexInFourthQuad
+            // Verify test results with ComplexInSecondQuad / ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad / ComplexInThirdQuad
+            // Verify test results with ComplexInThirdQuad / ComplexInThirdQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(true);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad / ComplexInFourthQuad
+            // Verify test results with ComplexInThirdQuad / ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(true);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFourthQuad / ComplexInFourthQuad
+            // Verify test results with ComplexInFourthQuad / ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
@@ -162,43 +155,42 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidImaginaryValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (valid, PositiveInfinity) / (valid, PositiveValid)
             realFirst = Support.GetSmallRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, PositiveInfinity) / (valid, NegativeValid)
             realFirst = Support.GetSmallRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) / (valid, PositiveValid)
             realFirst = Support.GetSmallRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) / (valid, NegativeValid)
             realFirst = Support.GetSmallRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NaN) / (valid, Valid)
             realFirst = Support.GetSmallRandomDoubleValue(false);
-            imgFirst = Double.NaN;
+            imgFirst = double.NaN;
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
@@ -207,42 +199,41 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidRealValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (PositiveInfinity, valid) / (PositiveValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (PositiveInfinity, valid) / (NegativeValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) / (PositiveValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) / (NegativeValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryDivideResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NaN, valid) / (valid, valid)
-            realFirst = Double.NaN;
+            realFirst = double.NaN;
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(false);

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMinus_Subtract.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMinus_Subtract.cs
@@ -2,22 +2,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_BinaryMinus_SubtractTest
     {
-        private static void VerifyBinaryMinusResult(Double realFirst, Double imgFirst, Double realSecond, Double imgSecond)
+        private static void VerifyBinaryMinusResult(double realFirst, double imgFirst, double realSecond, double imgSecond)
         {
             // Create complex numbers
             Complex cFirst = new Complex(realFirst, imgFirst);
             Complex cSecond = new Complex(realSecond, imgSecond);
 
             // calculate the expected results
-            Double realExpectedResult = realFirst - realSecond;
-            Double imgExpectedResult = imgFirst - imgSecond;
+            double realExpectedResult = realFirst - realSecond;
+            double imgExpectedResult = imgFirst - imgSecond;
 
             // local varuables
             Complex cResult;
@@ -26,31 +25,22 @@ namespace System.Numerics.Tests
             cResult = cFirst - cSecond;
 
             // verify the result
-            if (false == Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult))
-            {
-                Console.WriteLine("ErRoR! Binary Minus Error!");
-                Console.WriteLine("Binary Minus test = ({0}, {1}) - ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult,
+                string.Format("Binary Minus test = ({0}, {1}) - ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
 
             // arithmetic substract operation
             cResult = Complex.Subtract(cFirst, cSecond);
 
             // verify the result
-            if (false == Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult))
-            {
-                Console.WriteLine("ErRoR! Substract Error!");
-                Console.WriteLine("Substract test = ({0}, {1}) - ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult, 
+                string.Format("Substract test = ({0}, {1}) - ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
         }
 
         [Fact]
         public static void RunTests_Zero()
         {
-            // local variables
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
 
             // Test with Zero
             VerifyBinaryMinusResult(real, imaginary, 0.0, 0.0); // Verify x-0=0
@@ -60,118 +50,117 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            // local variables
-            Double real;
-            Double img;
+            double real;
+            double img;
 
             // test with 'Max' - (Positive, Positive)
             real = Support.GetRandomDoubleValue(false);
             img = Support.GetRandomDoubleValue(false);
-            VerifyBinaryMinusResult(Double.MaxValue, Double.MaxValue, real, img);
+            VerifyBinaryMinusResult(double.MaxValue, double.MaxValue, real, img);
 
             // test with (Positive, Positive) - 'Max'
             real = Support.GetRandomDoubleValue(false);
             img = Support.GetRandomDoubleValue(false);
-            VerifyBinaryMinusResult(real, img, Double.MaxValue, Double.MaxValue);
+            VerifyBinaryMinusResult(real, img, double.MaxValue, double.MaxValue);
 
             // test with 'Max' - (Negative, Negative)
             real = Support.GetRandomDoubleValue(true);
             img = Support.GetRandomDoubleValue(true);
-            VerifyBinaryMinusResult(Double.MaxValue, Double.MaxValue, real, img);
+            VerifyBinaryMinusResult(double.MaxValue, double.MaxValue, real, img);
 
             // test with (Negative, Negative) - 'Max'
             real = Support.GetRandomDoubleValue(true);
             img = Support.GetRandomDoubleValue(true);
-            VerifyBinaryMinusResult(real, img, Double.MaxValue, Double.MaxValue);
+            VerifyBinaryMinusResult(real, img, double.MaxValue, double.MaxValue);
 
             // test with 'Min' - (Positive, Positive)
             real = Support.GetRandomDoubleValue(false);
             img = Support.GetRandomDoubleValue(false);
-            VerifyBinaryMinusResult(Double.MinValue, Double.MinValue, real, img);
+            VerifyBinaryMinusResult(double.MinValue, double.MinValue, real, img);
 
             // test with (Positive, Positive) - 'Min'
             real = Support.GetRandomDoubleValue(false);
             img = Support.GetRandomDoubleValue(false);
-            VerifyBinaryMinusResult(real, img, Double.MinValue, Double.MinValue);
+            VerifyBinaryMinusResult(real, img, double.MinValue, double.MinValue);
 
             // test with 'Min' - (Negative, Negative)
             real = Support.GetRandomDoubleValue(true);
             img = Support.GetRandomDoubleValue(true);
-            VerifyBinaryMinusResult(Double.MinValue, Double.MinValue, real, img);
+            VerifyBinaryMinusResult(double.MinValue, double.MinValue, real, img);
 
             // test with (Negative, Negative) - 'Min'
             real = Support.GetRandomDoubleValue(true);
             img = Support.GetRandomDoubleValue(true);
-            VerifyBinaryMinusResult(real, img, Double.MinValue, Double.MinValue);
+            VerifyBinaryMinusResult(real, img, double.MinValue, double.MinValue);
         }
 
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad - ComplexInFirstQuad
-            Double realFirst = Support.GetRandomDoubleValue(false);
-            Double imgFirst = Support.GetRandomDoubleValue(false);
-            Double realSecond = Support.GetRandomDoubleValue(false);
-            Double imgSecond = Support.GetRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad - ComplexInFirstQuad
+            double realFirst = Support.GetRandomDoubleValue(false);
+            double imgFirst = Support.GetRandomDoubleValue(false);
+            double realSecond = Support.GetRandomDoubleValue(false);
+            double imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad - ComplexInSecondQuad
+            // Verify test results with ComplexInFirstQuad - ComplexInSecondQuad
             realFirst = Support.GetRandomDoubleValue(false);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad - ComplexInThirdQuad
+            // Verify test results with ComplexInFirstQuad - ComplexInThirdQuad
             realFirst = Support.GetRandomDoubleValue(false);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad - ComplexInFourthQuad
+            // Verify test results with ComplexInFirstQuad - ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(false);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad - ComplexInSecondQuad
+            // Verify test results with ComplexInSecondQuad - ComplexInSecondQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad - ComplexInThirdQuad
+            // Verify test results with ComplexInSecondQuad - ComplexInThirdQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad - ComplexInFourthQuad
+            // Verify test results with ComplexInSecondQuad - ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad - ComplexInThirdQuad
+            // Verify test results with ComplexInThirdQuad - ComplexInThirdQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(true);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad - ComplexInFourthQuad
+            // Verify test results with ComplexInThirdQuad - ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(true);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFourthQuad - ComplexInFourthQuad
+            // Verify test results with ComplexInFourthQuad - ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
@@ -182,43 +171,42 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidImaginaryValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (valid, PositiveInfinity) - (valid, PositiveValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, PositiveInfinity) - (valid, NegativeValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) - (valid, PositiveValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) - (valid, NegativeValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NaN) - (valid, Valid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NaN;
+            imgFirst = double.NaN;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
@@ -227,42 +215,41 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidRealValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (PositiveInfinity, valid) - (PositiveValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (PositiveInfinity, valid) - (NegativeValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) - (PositiveValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) - (NegativeValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMinusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NaN, valid) - (valid, valid)
-            realFirst = Double.NaN;
+            realFirst = double.NaN;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMultiply_Multiply.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryMultiply_Multiply.cs
@@ -2,18 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_BinaryMultiply_MultiplyTest
     {
-        private static void VerifyBinaryMultiplyResult(Double realFirst, Double imgFirst, Double realSecond, Double imgSecond)
+        private static void VerifyBinaryMultiplyResult(double realFirst, double imgFirst, double realSecond, double imgSecond)
         {
             // calculate the expected results
-            Double realExpectedResult = realFirst * realSecond - imgFirst * imgSecond;
-            Double imaginaryExpectedResult = realFirst * imgSecond + imgFirst * realSecond;
+            double realExpectedResult = realFirst * realSecond - imgFirst * imgSecond;
+            double imaginaryExpectedResult = realFirst * imgSecond + imgFirst * realSecond;
 
             // Create complex numbers
             Complex cFirst = new Complex(realFirst, imgFirst);
@@ -23,30 +22,22 @@ namespace System.Numerics.Tests
             Complex cResult = cFirst * cSecond;
 
             // verify the result
-            if (false == Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imaginaryExpectedResult))
-            {
-                Console.WriteLine("ErRoR! Binary Multiply Error!");
-                Console.WriteLine("Binary Multiply test = ({0}, {1}) * ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imaginaryExpectedResult,
+                string.Format("Binary Multiply test = ({0}, {1}) * ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
 
             // arithmetic multiply (static) operation
             cResult = Complex.Multiply(cFirst, cSecond);
 
             // verify the result
-            if (false == Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imaginaryExpectedResult))
-            {
-                Console.WriteLine("ErRoR! Multiply (Static) Error!");
-                Console.WriteLine("Multiply (Static) test = ({0}, {1}) * ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imaginaryExpectedResult,
+                string.Format("Multiply (Static) test = ({0}, {1}) * ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
         }
 
         [Fact]
         public static void RunTests_ZeroOneImaginaryOne()
         {
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomPhaseValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomPhaseValue(false);
 
             // Test with Zero
             VerifyBinaryMultiplyResult(0.0, 0.0, real, imaginary); // Verify 0*x=0
@@ -64,88 +55,87 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            // local variables
-            Double real;
-            Double img;
+            double real;
+            double img;
 
             // test with 'Max' * (SmallPositive, SmallPositive)
             real = Support.GetSmallRandomDoubleValue(false);
             img = Support.GetSmallRandomDoubleValue(false);
-            VerifyBinaryMultiplyResult(Double.MaxValue, Double.MaxValue, real, img);
+            VerifyBinaryMultiplyResult(double.MaxValue, double.MaxValue, real, img);
 
             // test with 'Min' * (SmallPositive, SmallPositive)
             real = Support.GetSmallRandomDoubleValue(false);
             img = Support.GetSmallRandomDoubleValue(false);
-            VerifyBinaryMultiplyResult(Double.MinValue, Double.MinValue, real, img);
+            VerifyBinaryMultiplyResult(double.MinValue, double.MinValue, real, img);
         }
 
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad * ComplexInFirstQuad
-            Double realFirst = Support.GetSmallRandomDoubleValue(false);
-            Double imgFirst = Support.GetSmallRandomDoubleValue(false);
-            Double realSecond = Support.GetSmallRandomDoubleValue(false);
-            Double imgSecond = Support.GetSmallRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad * ComplexInFirstQuad
+            double realFirst = Support.GetSmallRandomDoubleValue(false);
+            double imgFirst = Support.GetSmallRandomDoubleValue(false);
+            double realSecond = Support.GetSmallRandomDoubleValue(false);
+            double imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad * ComplexInSecondQuad
+            // Verify test results with ComplexInFirstQuad * ComplexInSecondQuad
             realFirst = Support.GetSmallRandomDoubleValue(false);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad * ComplexInThirdQuad
+            // Verify test results with ComplexInFirstQuad * ComplexInThirdQuad
             realFirst = Support.GetSmallRandomDoubleValue(false);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad * ComplexInFourthQuad
+            // Verify test results with ComplexInFirstQuad * ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(false);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad * ComplexInSecondQuad
+            // Verify test results with ComplexInSecondQuad * ComplexInSecondQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad * ComplexInThirdQuad
+            // Verify test results with ComplexInSecondQuad * ComplexInThirdQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad * ComplexInFourthQuad
+            // Verify test results with ComplexInSecondQuad * ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad * ComplexInThirdQuad
+            // Verify test results with ComplexInThirdQuad * ComplexInThirdQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(true);
             realSecond = Support.GetSmallRandomDoubleValue(true);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad * ComplexInFourthQuad
+            // Verify test results with ComplexInThirdQuad * ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(true);
             realSecond = Support.GetSmallRandomDoubleValue(false);
             imgSecond = Support.GetSmallRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFourthQuad * ComplexInFourthQuad
+            // Verify test results with ComplexInFourthQuad * ComplexInFourthQuad
             realFirst = Support.GetSmallRandomDoubleValue(true);
             imgFirst = Support.GetSmallRandomDoubleValue(false);
             realSecond = Support.GetSmallRandomDoubleValue(true);
@@ -156,43 +146,42 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidImaginaryValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (valid, PositiveInfinity) * (valid, PositiveValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, PositiveInfinity) * (valid, NegativeValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) * (valid, PositiveValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) * (valid, NegativeValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NaN) * (valid, Valid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NaN;
+            imgFirst = double.NaN;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
@@ -201,42 +190,41 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidRealValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (PositiveInfinity, valid) * (PositiveValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (PositiveInfinity, valid) * (NegativeValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) * (PositiveValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) * (NegativeValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryMultiplyResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NaN, valid) * (valid, valid)
-            realFirst = Double.NaN;
+            realFirst = double.NaN;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryPlus_Add.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_BinaryPlus_Add.cs
@@ -2,155 +2,144 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_BinaryPlus_AddTest
     {
-        private static void VerifyBinaryPlusResult(Double realFirst, Double imgFirst, Double realSecond, Double imgSecond)
+        private static void VerifyBinaryPlusResult(double realFirst, double imgFirst, double realSecond, double imgSecond)
         {
             // Create complex numbers
             Complex cFirst = new Complex(realFirst, imgFirst);
             Complex cSecond = new Complex(realSecond, imgSecond);
 
             // calculate the expected results
-            Double realExpectedResult = realFirst + realSecond;
-            Double imgExpectedResult = imgFirst + imgSecond;
+            double realExpectedResult = realFirst + realSecond;
+            double imgExpectedResult = imgFirst + imgSecond;
 
-            //local variable
+            // local variable
             Complex cResult;
 
             // arithmetic addition operation
             cResult = cFirst + cSecond;
 
             // verify the result
-            if (!Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult))
-            {
-                Console.WriteLine("ErRoR! Binary Plus Error!");
-                Console.WriteLine("Binary Plus test = ({0}, {1}) + ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult,
+                string.Format("Binary Plus test = ({0}, {1}) + ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
 
             // arithmetic static addition operation
             cResult = Complex.Add(cFirst, cSecond);
 
             // verify the result
-            if (!Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult))
-            {
-                Console.WriteLine("ErRoR! Add Error!");
-                Console.WriteLine("Add test = ({0}, {1}) + ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cResult, realExpectedResult, imgExpectedResult,
+                string.Format("Add test = ({0}, {1}) + ({2}, {3})", realFirst, imgFirst, realSecond, imgSecond));
         }
 
         [Fact]
         public static void RunTests_Zero()
         {
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
 
             VerifyBinaryPlusResult(0.0, 0.0, real, imaginary); // Verify 0+x=0
             VerifyBinaryPlusResult(real, imaginary, 0.0, 0.0); // Verify 0+x=0
         }
-
-
+        
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            // local variables
-            Double real;
-            Double img;
+            double real;
+            double img;
 
             // test with 'Max' + (Positive, Positive)
             real = Support.GetRandomDoubleValue(false);
             img = Support.GetRandomDoubleValue(false);
-            VerifyBinaryPlusResult(Double.MaxValue, Double.MaxValue, real, img);
+            VerifyBinaryPlusResult(double.MaxValue, double.MaxValue, real, img);
 
             // test with 'Max' + (Negative, Negative)
             real = Support.GetRandomDoubleValue(true);
             img = Support.GetRandomDoubleValue(true);
-            VerifyBinaryPlusResult(Double.MaxValue, Double.MaxValue, real, img);
+            VerifyBinaryPlusResult(double.MaxValue, double.MaxValue, real, img);
 
             // test with 'Min' + (Positive, Positive)
             real = Support.GetRandomDoubleValue(false);
             img = Support.GetRandomDoubleValue(false);
-            VerifyBinaryPlusResult(Double.MinValue, Double.MinValue, real, img);
+            VerifyBinaryPlusResult(double.MinValue, double.MinValue, real, img);
 
             // test with 'Min' + (Negative, Negative)
             real = Support.GetRandomDoubleValue(true);
             img = Support.GetRandomDoubleValue(true);
-            VerifyBinaryPlusResult(Double.MinValue, Double.MinValue, real, img);
+            VerifyBinaryPlusResult(double.MinValue, double.MinValue, real, img);
         }
 
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad + ComplexInFirstQuad
-            Double realFirst = Support.GetRandomDoubleValue(false);
-            Double imgFirst = Support.GetRandomDoubleValue(false);
-            Double realSecond = Support.GetRandomDoubleValue(false);
-            Double imgSecond = Support.GetRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad + ComplexInFirstQuad
+            double realFirst = Support.GetRandomDoubleValue(false);
+            double imgFirst = Support.GetRandomDoubleValue(false);
+            double realSecond = Support.GetRandomDoubleValue(false);
+            double imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad + ComplexInSecondQuad
+            // Verify test results with ComplexInFirstQuad + ComplexInSecondQuad
             realFirst = Support.GetRandomDoubleValue(false);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad + ComplexInThirdQuad
+            // Verify test results with ComplexInFirstQuad + ComplexInThirdQuad
             realFirst = Support.GetRandomDoubleValue(false);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFirstQuad + ComplexInFourthQuad
+            // Verify test results with ComplexInFirstQuad + ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(false);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad + ComplexInSecondQuad
+            // Verify test results with ComplexInSecondQuad + ComplexInSecondQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad + ComplexInThirdQuad
+            // Verify test results with ComplexInSecondQuad + ComplexInThirdQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInSecondQuad + ComplexInFourthQuad
+            // Verify test results with ComplexInSecondQuad + ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad + ComplexInThirdQuad
+            // Verify test results with ComplexInThirdQuad + ComplexInThirdQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(true);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInThirdQuad + ComplexInFourthQuad
+            // Verify test results with ComplexInThirdQuad + ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(true);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
-            // Verify test results with ComlexInFourthQuad + ComplexInFourthQuad
+            // Verify test results with ComplexInFourthQuad + ComplexInFourthQuad
             realFirst = Support.GetRandomDoubleValue(true);
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
@@ -161,43 +150,42 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidImaginaryValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (valid, PositiveInfinity) + (valid, PositiveValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, PositiveInfinity) + (valid, NegativeValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.PositiveInfinity;
+            imgFirst = double.PositiveInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) + (valid, PositiveValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NegativeInfinity) + (valid, NegativeValid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NegativeInfinity;
+            imgFirst = double.NegativeInfinity;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(true);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (valid, NaN) + (valid, Valid)
             realFirst = Support.GetRandomDoubleValue(false);
-            imgFirst = Double.NaN;
+            imgFirst = double.NaN;
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
@@ -206,42 +194,41 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidRealValues()
         {
-            // local variables
-            Double realFirst;
-            Double imgFirst;
-            Double realSecond;
-            Double imgSecond;
+            double realFirst;
+            double imgFirst;
+            double realSecond;
+            double imgSecond;
 
             // Verify with (PositiveInfinity, valid) + (PositiveValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (PositiveInfinity, valid) + (NegativeValid, valid)
-            realFirst = Double.PositiveInfinity;
+            realFirst = double.PositiveInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) + (PositiveValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NegativeInfinity, valid) + (NegativeValid, valid)
-            realFirst = Double.NegativeInfinity;
+            realFirst = double.NegativeInfinity;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(true);
             imgSecond = Support.GetRandomDoubleValue(false);
             VerifyBinaryPlusResult(realFirst, imgFirst, realSecond, imgSecond);
 
             // Verify with (NaN, valid) + (valid, valid)
-            realFirst = Double.NaN;
+            realFirst = double.NaN;
             imgFirst = Support.GetRandomDoubleValue(false);
             realSecond = Support.GetRandomDoubleValue(false);
             imgSecond = Support.GetRandomDoubleValue(false);

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Conjugate.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Conjugate.cs
@@ -2,52 +2,44 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_ConjugateTest
     {
-        private static void VerifyConjugate(Double real, Double imaginary)
+        private static void VerifyConjugate(double real, double imaginary)
         {
             // Create complex numbers
             Complex c_test = new Complex(real, imaginary);
             Complex c_conj = Complex.Conjugate(c_test);
 
-            if (false == Support.VerifyRealImaginaryProperties(c_conj, real, -imaginary))
-            {
-                Console.WriteLine("ErRoR! Conjugate Real and Imaginary Part Verification Error!");
-                Console.WriteLine("Conjugate test ({0}, {1})", real, imaginary);
-                Assert.True(false, "Verification Failed");
-            }
-            else if (false == Support.VerifyMagnitudePhaseProperties(c_conj, c_test.Magnitude, -c_test.Phase))
-            {
-                Console.WriteLine("ErRoR! Conjugate Magnitude and Phase Verification Error!");
-                Console.WriteLine("Conjugate test ({0}, {1})", real, imaginary);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(c_conj, real, -imaginary,
+                string.Format("Conjugate test ({0}, {1})", real, imaginary));
+
+            Support.VerifyMagnitudePhaseProperties(c_conj, c_test.Magnitude, -c_test.Phase,
+                string.Format("Conjugate test ({0}, {1})", real, imaginary));
         }
 
         [Fact]
         public static void RunTests_ZeroOneImaginaryOne()
         {
-            VerifyConjugate(0.0, 0.0); // Verify with Double.Zero
-            VerifyConjugate(1.0, 0.0); // Verify with Double.One
-            VerifyConjugate(-1.0, 0.0); // Verify with Double.MinusOne
-            VerifyConjugate(0.0, 1.0); // Verify with Double.ImaginaryOne
-            VerifyConjugate(0.0, -1.0); // Verify with Double.MinusImaginaryOne
+            VerifyConjugate(0.0, 0.0); // Verify with double.Zero
+            VerifyConjugate(1.0, 0.0); // Verify with double.One
+            VerifyConjugate(-1.0, 0.0); // Verify with double.MinusOne
+            VerifyConjugate(0.0, 1.0); // Verify with double.ImaginaryOne
+            VerifyConjugate(0.0, -1.0); // Verify with double.MinusImaginaryOne
         }
 
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
             VerifyConjugate(real, imaginary);
 
-            // Verify test results with Small_ComlexInFirstQuad
+            // Verify test results with Small_ComplexInFirstQuad
             real = Support.GetSmallRandomDoubleValue(false);
             imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyConjugate(real, imaginary);
@@ -86,20 +78,30 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            VerifyConjugate(Double.MaxValue, Double.MaxValue); // test with 'Max'
-            VerifyConjugate(Double.MaxValue, 0); // test with 'MaxReal'
-            VerifyConjugate(0, Double.MaxValue); // test with 'MaxImaginary'
-            VerifyConjugate(Double.MinValue, Double.MinValue); // test with 'Min'
-            VerifyConjugate(Double.MinValue, 0); // test with 'MinReal'
-            VerifyConjugate(0, Double.MinValue); // test with 'MinImaginary'
+            // Max
+            VerifyConjugate(double.MaxValue, double.MaxValue);
+
+            // MaxReal
+            VerifyConjugate(double.MaxValue, 0);
+
+            // MaxImaginary
+            VerifyConjugate(0, double.MaxValue);
+
+            // Min
+            VerifyConjugate(double.MinValue, double.MinValue);
+
+            // MinReal
+            VerifyConjugate(double.MinValue, 0);
+
+            // MinImaginary
+            VerifyConjugate(0, double.MinValue);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double realRandom;
-            Double imaginaryRandom;
+            double realRandom;
+            double imaginaryRandom;
 
             // Complex number with a valid positive real and an invalid imaginary part
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Reciprocal.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_Reciprocal.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_ReciprocalTest
     {
-        private static void VerifyReciprocal(Double real, Double imaginary)
+        private static void VerifyReciprocal(double real, double imaginary)
         {
             // Create complex numbers
             Complex c_test = new Complex(real, imaginary);
@@ -17,37 +16,34 @@ namespace System.Numerics.Tests
 
             Complex c_expected = Complex.Zero;
             if (Complex.Zero != c_test &&
-                !(Double.IsInfinity(real) && !(Double.IsInfinity(imaginary) || Double.IsNaN(imaginary))) &&
-                !(Double.IsInfinity(imaginary) && !(Double.IsInfinity(real) || Double.IsNaN(real))))
+                !(double.IsInfinity(real) && !(double.IsInfinity(imaginary) || double.IsNaN(imaginary))) &&
+                !(double.IsInfinity(imaginary) && !(double.IsInfinity(real) || double.IsNaN(real))))
             {
-                Double magnitude = c_test.Magnitude;
+                double magnitude = c_test.Magnitude;
                 c_expected = (Complex.Conjugate(c_test) / magnitude); // in order to avoid Infinity = magnitude* magnitude
-                c_expected = c_expected / magnitude;
+                c_expected /= magnitude;
             }
 
-            if (false == Support.VerifyRealImaginaryProperties(c_rcp, c_expected.Real, c_expected.Imaginary))
-            {
-                Console.WriteLine("Error_rye102!!! Reciprocal({0})", c_test);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(c_rcp, c_expected.Real, c_expected.Imaginary,
+                string.Format("Reciprocal ({0}, {1}) Actual: {2}, Expected: {3}", real, imaginary, c_rcp, c_expected));
         }
 
         [Fact]
         public static void RunTests_ZeroOneImaginaryOne()
         {
-            VerifyReciprocal(0.0, 0.0); // Verify with Double.Zero
-            VerifyReciprocal(1.0, 0.0); // Verify with Double.One
-            VerifyReciprocal(-1.0, 0.0); // Verify with Double.MinusOne
-            VerifyReciprocal(0.0, 1.0); // Verify with Double.ImaginaryOne
-            VerifyReciprocal(0.0, -1.0); // Verify with Double.MinusImaginaryOne
+            VerifyReciprocal(0.0, 0.0); // Verify with double.Zero
+            VerifyReciprocal(1.0, 0.0); // Verify with double.One
+            VerifyReciprocal(-1.0, 0.0); // Verify with double.MinusOne
+            VerifyReciprocal(0.0, 1.0); // Verify with double.ImaginaryOne
+            VerifyReciprocal(0.0, -1.0); // Verify with double.MinusImaginaryOne
         }
 
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyReciprocal(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -69,19 +65,24 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            // local variables
-            VerifyReciprocal(Double.MaxValue, 0); // test with 'MaxReal'
-            VerifyReciprocal(0, Double.MaxValue); // test with 'MaxImaginary'
-            VerifyReciprocal(Double.MinValue, 0); // test with 'MinReal'
-            VerifyReciprocal(0, Double.MinValue); // test with 'MinImaginary'
+            // MaxReal
+            VerifyReciprocal(double.MaxValue, 0);
+
+            // MaxImaginary
+            VerifyReciprocal(0, double.MaxValue);
+
+            // MinReal
+            VerifyReciprocal(double.MinValue, 0);
+
+            // MinImaginary
+            VerifyReciprocal(0, double.MinValue);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double realRandom = Support.GetRandomDoubleValue(false);
-            Double imaginaryRandom = Support.GetRandomDoubleValue(false);
+            double realRandom = Support.GetRandomDoubleValue(false);
+            double imaginaryRandom = Support.GetRandomDoubleValue(false);
 
             // Complex number with a valid  real and an invalid imaginary part
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)

--- a/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_UnaryMinus_Negate.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/arithmaticOperation_UnaryMinus_Negate.cs
@@ -2,43 +2,33 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class arithmaticOperation_UnaryMinus_NegateTest
     {
-        private static void VerifyUnaryMinusResult(Double real, Double imaginary)
+        private static void VerifyUnaryMinusResult(double real, double imaginary)
         {
-            //local variables
-            Complex unaryComplex;
             Complex c_new = new Complex(real, imaginary);
 
-            unaryComplex = -c_new;
-            if (!Support.VerifyRealImaginaryProperties(unaryComplex, -c_new.Real, -c_new.Imaginary))
-            {
-                Console.WriteLine("ErRoR! Unary Minus Error -{0} does not equal to {1}!", c_new, unaryComplex);
-                Console.WriteLine("Unary Minus test with ({0}, {1})", real, imaginary);
-                Assert.True(false, "Verification Failed");
-            }
+            Complex unaryComplex = -c_new;
+            Support.VerifyRealImaginaryProperties(unaryComplex, -c_new.Real, -c_new.Imaginary,
+                string.Format("Unary Minus Error -{0} does not equal to {1} with ({2}, {3})!", c_new, unaryComplex, real, imaginary));
 
             unaryComplex = Complex.Negate(c_new);
-            if (!Support.VerifyRealImaginaryProperties(unaryComplex, -c_new.Real, -c_new.Imaginary))
-            {
-                Console.WriteLine("ErRoR! Negate Error -{0} does not equal to {1}!", c_new, unaryComplex);
-                Console.WriteLine("Negate test with ({0}, {1})", real, imaginary);
-                Assert.True(false, "Verification Failed");
-            }
+
+            Support.VerifyRealImaginaryProperties(unaryComplex, -c_new.Real, -c_new.Imaginary,
+                string.Format("Negate Error -{0} does not equal to {1} with ({2}, {3})!", c_new, unaryComplex, real, imaginary));
         }
 
         [Fact]
         public static void RunTests_TypicalValidValues()
         {
             // Test with valid double value pairs
-            foreach (Double real in Support.doubleValidValues)
+            foreach (double real in Support.doubleValidValues)
             {
-                foreach (Double imaginary in Support.doubleValidValues)
+                foreach (double imaginary in Support.doubleValidValues)
                 {
                     VerifyUnaryMinusResult(real, imaginary);
                 }
@@ -53,7 +43,7 @@ namespace System.Numerics.Tests
             double imaginaryRandom;
 
             // Complex numbers in the first quadrant: (postive real, positive imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(false);
                 imaginaryRandom = Support.GetRandomDoubleValue(false);
@@ -61,7 +51,7 @@ namespace System.Numerics.Tests
             }
 
             // Complex numbers in the second quadrant: (negative real, positive imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(true);
                 imaginaryRandom = Support.GetRandomDoubleValue(false);
@@ -69,7 +59,7 @@ namespace System.Numerics.Tests
             }
 
             // Complex numbers in the third quadrant: (negative real, negative imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(true);
                 imaginaryRandom = Support.GetRandomDoubleValue(true);
@@ -77,7 +67,7 @@ namespace System.Numerics.Tests
             }
 
             // Complex numbers in the fourth quadrant: (postive real, negative imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(false);
                 imaginaryRandom = Support.GetRandomDoubleValue(true);
@@ -88,9 +78,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double realRandom;
-            Double imaginaryRandom;
+            double realRandom;
+            double imaginaryRandom;
 
             // Complex number with a valid positive real and an invalid imaginary part
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)

--- a/src/System.Runtime.Numerics/tests/Complex/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/ctor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -12,20 +11,17 @@ namespace System.Numerics.Tests
         private static void VerifyCtor(double real, double imaginary)
         {
             Complex c_new = new Complex(real, imaginary);
-            if (false == Support.VerifyRealImaginaryProperties(c_new, real, imaginary))
-            {
-                Console.WriteLine("Error_ctor(Complex): ({0}, {1})", real, imaginary);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(c_new, real, imaginary, 
+                string.Format("Error_ctor(Complex): ({0}, {1})", real, imaginary));
         }
 
         [Fact]
         public static void RunTests_TypicalValidValues()
         {
             // Test with valid double value pairs
-            foreach (Double real in Support.doubleValidValues)
+            foreach (double real in Support.doubleValidValues)
             {
-                foreach (Double imaginary in Support.doubleValidValues)
+                foreach (double imaginary in Support.doubleValidValues)
                 {
                     VerifyCtor(real, imaginary);
                 }
@@ -40,7 +36,7 @@ namespace System.Numerics.Tests
             double imaginaryRandom;
 
             // Complex numbers in the first quadrant: (postive real, positive imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(false);
                 imaginaryRandom = Support.GetRandomDoubleValue(false);
@@ -48,7 +44,7 @@ namespace System.Numerics.Tests
             }
 
             // Complex numbers in the second quadrant: (negative real, positive imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(true);
                 imaginaryRandom = Support.GetRandomDoubleValue(false);
@@ -56,7 +52,7 @@ namespace System.Numerics.Tests
             }
 
             // Complex numbers in the third quadrant: (negative real, negative imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(true);
                 imaginaryRandom = Support.GetRandomDoubleValue(true);
@@ -64,7 +60,7 @@ namespace System.Numerics.Tests
             }
 
             // Complex numbers in the fourth quadrant: (postive real, negative imaginary)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 realRandom = Support.GetRandomDoubleValue(false);
                 imaginaryRandom = Support.GetRandomDoubleValue(true);
@@ -75,9 +71,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double realRandom = Support.GetRandomDoubleValue(false);
-            Double imaginaryRandom = Support.GetRandomDoubleValue(false);
+            double realRandom = Support.GetRandomDoubleValue(false);
+            double imaginaryRandom = Support.GetRandomDoubleValue(false);
 
             // Complex number with a valid positive/negative real and an invalid imaginary part
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)

--- a/src/System.Runtime.Numerics/tests/Complex/factoryMethod.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/factoryMethod.cs
@@ -2,47 +2,37 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class factoryMethodTest
     {
-        private static void VerifyFactoryMethod(double magnitude, double phase)
+        private static void VerifyFromPolarCoordinates(double magnitude, double phase)
         {
             double m = magnitude;
             double p = phase;
             Complex c_new = Complex.FromPolarCoordinates(magnitude, phase);
-            //Double.IsNaN(magnitude) is checked in the verifiation method.
-            if (Double.IsNaN(phase) || Double.IsInfinity(phase))
+
+            // double.IsNaN(magnitude) is checked in the verification method.
+            if (double.IsNaN(phase) || double.IsInfinity(phase))
             {
-                magnitude = Double.NaN;
-                phase = Double.NaN;
+                magnitude = double.NaN;
+                phase = double.NaN;
             }
             // Special check in Complex.Abs method
-            else if (Double.IsInfinity(magnitude))
+            else if (double.IsInfinity(magnitude))
             {
-                magnitude = Double.PositiveInfinity;
-                phase = Double.NaN;
+                magnitude = double.PositiveInfinity;
+                phase = double.NaN;
             }
 
-            if (false == Support.VerifyMagnitudePhaseProperties(c_new, magnitude, phase))
-            {
-                Console.WriteLine("Error_89fdl!!! FromPolorCoordinates: ({0}, {1})", m, p);
+            Support.VerifyMagnitudePhaseProperties(c_new, magnitude, phase, 
+                string.Format("FromPolarCoordinates: ({0}, {1})", m, p));
 
-                Assert.True(false, "Verification Failed");
-            }
-            else // if the first verification returns TrUe, do the second one!
-            {
-                Complex c_new_ctor = new Complex(c_new.Real, c_new.Imaginary);
-                if (false == Support.VerifyMagnitudePhaseProperties(c_new_ctor, magnitude, phase))
-                {
-                    Console.WriteLine("Error_fs46!!! FromPolorCoordinates: ({0}, {1})", m, p);
-
-                    Assert.True(false, "Verification Failed");
-                }
-            }
+            Complex c_new_ctor = new Complex(c_new.Real, c_new.Imaginary);
+            Support.VerifyMagnitudePhaseProperties(c_new_ctor, magnitude, phase, 
+                string.Format("FromPolarCoordinates: ({0}, {1})", m, p));
         }
 
         [Fact]
@@ -53,7 +43,7 @@ namespace System.Numerics.Tests
             {
                 foreach (double phase in Support.phaseTypicalValues)
                 {
-                    VerifyFactoryMethod(magnitude, phase);
+                    VerifyFromPolarCoordinates(magnitude, phase);
                 }
             }
         }
@@ -66,57 +56,56 @@ namespace System.Numerics.Tests
             double phaseRandom;
 
             // Complex numbers (postive magnitude, positive phase)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 magnitudeRandom = Support.GetRandomDoubleValue(false);
                 phaseRandom = Support.GetRandomPhaseValue(false);
-                VerifyFactoryMethod(magnitudeRandom, phaseRandom);
+                VerifyFromPolarCoordinates(magnitudeRandom, phaseRandom);
             }
 
             // Complex numbers (negative magnitude, positive phase)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 magnitudeRandom = Support.GetRandomDoubleValue(true);
                 phaseRandom = Support.GetRandomPhaseValue(false);
-                VerifyFactoryMethod(magnitudeRandom, phaseRandom);
+                VerifyFromPolarCoordinates(magnitudeRandom, phaseRandom);
             }
 
             // Complex numbers (negative magnitude, negative phase)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 magnitudeRandom = Support.GetRandomDoubleValue(true);
                 phaseRandom = Support.GetRandomPhaseValue(true);
-                VerifyFactoryMethod(magnitudeRandom, phaseRandom);
+                VerifyFromPolarCoordinates(magnitudeRandom, phaseRandom);
             }
 
             // Complex numbers (positive magnitude, negative phase)
-            for (int i = 0; i < Support.randomSample; i++)
+            for (int i = 0; i < 3; i++)
             {
                 magnitudeRandom = Support.GetRandomDoubleValue(false);
                 phaseRandom = Support.GetRandomPhaseValue(true);
-                VerifyFactoryMethod(magnitudeRandom, phaseRandom);
+                VerifyFromPolarCoordinates(magnitudeRandom, phaseRandom);
             }
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double magnitudeRandom = Support.GetRandomDoubleValue(false);
-            Double phaseRandom = Support.GetRandomDoubleValue(false);
+            double magnitudeRandom = Support.GetRandomDoubleValue(false);
+            double phaseRandom = Support.GetRandomDoubleValue(false);
 
             // Complex number with a random positive/negative magnitude and an invalid phase part
             foreach (double phaseInvalid in Support.doubleInvalidValues)
             {
-                VerifyFactoryMethod(magnitudeRandom, phaseInvalid);
-                VerifyFactoryMethod(-magnitudeRandom, phaseInvalid);
+                VerifyFromPolarCoordinates(magnitudeRandom, phaseInvalid);
+                VerifyFromPolarCoordinates(-magnitudeRandom, phaseInvalid);
             }
 
             // Complex number with an invalid magnitude and a random positive phase part
             foreach (double magnitudeInvalid in Support.doubleInvalidValues)
             {
-                VerifyFactoryMethod(magnitudeInvalid, phaseRandom);
-                VerifyFactoryMethod(magnitudeInvalid, -phaseRandom);
+                VerifyFromPolarCoordinates(magnitudeInvalid, phaseRandom);
+                VerifyFromPolarCoordinates(magnitudeInvalid, -phaseRandom);
             }
 
             // Complex number with an invalid magnitude and an invalid phase
@@ -124,7 +113,7 @@ namespace System.Numerics.Tests
             {
                 foreach (double phaseInvalid in Support.doubleInvalidValues)
                 {
-                    VerifyFactoryMethod(magnitudeInvalid, phaseInvalid);
+                    VerifyFromPolarCoordinates(magnitudeInvalid, phaseInvalid);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/formattingOperations.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/formattingOperations.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
@@ -12,51 +11,32 @@ namespace System.Numerics.Tests
     {
         private static void VerifyToString(Complex complex)
         {
-            Double real = complex.Real;
-            Double imaginary = complex.Imaginary;
-            String manual;
-            String automatic;
+            double real = complex.Real;
+            double imaginary = complex.Imaginary;
+            string expected;
+            string actual;
 
-            manual = "(" + real.ToString() + ", " + imaginary.ToString() + ")";
-            automatic = complex.ToString();
-
-            if (!automatic.Equals(manual))
-            {
-                Console.WriteLine("Error-str2F3P4001! automatic:{0} does not equal to manual:{1}", automatic, manual);
-                Assert.True(false, "Verification Failed");
-            }
+            expected = "(" + real.ToString() + ", " + imaginary.ToString() + ")";
+            actual = complex.ToString();
+            Assert.Equal(expected, actual);
 
             CultureInfo germanCultureInfo = new CultureInfo("de-DE");
             NumberFormatInfo germanNumberFormatInfo = CultureInfo.CurrentCulture.NumberFormat;
 
-            manual = "(" + real.ToString(germanNumberFormatInfo) + ", " + imaginary.ToString(germanNumberFormatInfo) + ")";
-            automatic = complex.ToString(germanNumberFormatInfo);
-            if (!automatic.Equals(manual))
+            expected = "(" + real.ToString(germanNumberFormatInfo) + ", " + imaginary.ToString(germanNumberFormatInfo) + ")";
+            actual = complex.ToString(germanNumberFormatInfo);
+            Assert.Equal(expected, actual);
+
+            foreach (string format in Support.supportedStdNumericFormats)
             {
-                Console.WriteLine("Error-str2F3P4+NFI! automatic:{0} does not equal to manual:{1}", automatic, manual);
-                Assert.True(false, "Verification Failed");
-            }
-
-            foreach (String format in Support.supportedStdNumericFormats)
-            {
-                manual = "(" + real.ToString(format) + ", " + imaginary.ToString(format) + ")";
-                automatic = complex.ToString(format);
-
-                if (!automatic.Equals(manual))
-                {
-                    Console.WriteLine("Error-str2F3P4+FMT-{0}! automatic:{1} does not equal to manual:{2}", format, automatic, manual);
-                    Assert.True(false, "Verification Failed");
-                }
-
+                expected = "(" + real.ToString(format) + ", " + imaginary.ToString(format) + ")";
+                actual = complex.ToString(format);
+                Assert.True(expected.Equals(actual), string.Format("ToString() failed for format {0}.\n\tExpected: <{1}>\n\tActual: <{2}>", format, actual, expected));
+                
                 germanNumberFormatInfo = CultureInfo.CurrentCulture.NumberFormat;
-                manual = "(" + real.ToString(format, germanNumberFormatInfo) + ", " + imaginary.ToString(format, germanNumberFormatInfo) + ")";
-                automatic = complex.ToString(format, germanNumberFormatInfo);
-
-                if (!automatic.Equals(manual))
-                {
-                    Console.WriteLine("Error-str2F3P4+FMT-{0}+{1}! automatic:{2} does not equal to manual:{3}", format, "de-DE", automatic, manual);
-                    Assert.True(false, "Verification Failed");
-                }
+                expected = "(" + real.ToString(format, germanNumberFormatInfo) + ", " + imaginary.ToString(format, germanNumberFormatInfo) + ")";
+                actual = complex.ToString(format, germanNumberFormatInfo);
+                Assert.True(expected.Equals(actual), string.Format("ToString() failed for format {0} in de-DE.\n\tExpected: <{1}>\n\tActual: <{2}>", format, actual, expected));
             }
         }
 
@@ -82,19 +62,18 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            // Verify test results with ComlexInFirstQuad
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            // Verify test results with ComplexInFirstQuad
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
             Complex complexFirst = new Complex(real, imaginary);
             VerifyToString(complexFirst);
 
-            // Verify test results with Small_ComlexInFirstQuad
+            // Verify test results with Small_ComplexInFirstQuad
             real = Support.GetSmallRandomDoubleValue(false);
             imaginary = Support.GetSmallRandomDoubleValue(false);
             Complex complexFirstSmall = new Complex(real, imaginary);
             VerifyToString(complexFirstSmall);
-
-
+            
             // Verify test results with ComplexInSecondQuad
             real = Support.GetRandomDoubleValue(true);
             imaginary = Support.GetRandomDoubleValue(false);
@@ -106,28 +85,26 @@ namespace System.Numerics.Tests
             imaginary = Support.GetSmallRandomDoubleValue(false);
             Complex complexSecondSmall = new Complex(real, imaginary);
             VerifyToString(complexSecondSmall);
-
-
-            // Verify test results with ComlexInThirdQuad
+            
+            // Verify test results with ComplexInThirdQuad
             real = Support.GetRandomDoubleValue(true);
             imaginary = Support.GetRandomDoubleValue(true);
             Complex complexThird = new Complex(real, imaginary);
             VerifyToString(complexThird);
 
-            // Verify test results with Small_ComlexInThirdQuad
+            // Verify test results with Small_ComplexInThirdQuad
             real = Support.GetSmallRandomDoubleValue(true);
             imaginary = Support.GetSmallRandomDoubleValue(true);
             Complex complexThirdSmall = new Complex(real, imaginary);
             VerifyToString(complexThirdSmall);
-
-
-            // Verify test results with ComlexInFourthQuad
+            
+            // Verify test results with ComplexInFourthQuad
             real = Support.GetRandomDoubleValue(false);
             imaginary = Support.GetRandomDoubleValue(true);
             Complex complexFourth = new Complex(real, imaginary);
             VerifyToString(complexFourth);
 
-            // Verify test results with Small_ComlexInFourthQuad
+            // Verify test results with Small_ComplexInFourthQuad
             real = Support.GetSmallRandomDoubleValue(false);
             imaginary = Support.GetSmallRandomDoubleValue(true);
             Complex complexFourthSmall = new Complex(real, imaginary);
@@ -138,36 +115,35 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Max.ToString()
-            Complex c_max = new Complex(Double.MaxValue, Double.MaxValue);
+            Complex c_max = new Complex(double.MaxValue, double.MaxValue);
             VerifyToString(c_max);
 
             // MaxReal.ToString()
-            Complex c_maxReal = new Complex(Double.MaxValue, 0.0);
+            Complex c_maxReal = new Complex(double.MaxValue, 0.0);
             VerifyToString(c_maxReal);
 
             // MaxImaginary.ToString()
-            Complex c_maxImg = new Complex(0.0, Double.MaxValue);
+            Complex c_maxImg = new Complex(0.0, double.MaxValue);
             VerifyToString(c_maxImg);
 
             // Min.ToString()
-            Complex c_min = new Complex(Double.MinValue, Double.MinValue);
+            Complex c_min = new Complex(double.MinValue, double.MinValue);
             VerifyToString(c_min);
 
             // MinReal.ToString()
-            Complex c_minReal = new Complex(Double.MinValue, 0.0);
+            Complex c_minReal = new Complex(double.MinValue, 0.0);
             VerifyToString(c_minReal);
 
             // MinImaginary.ToString()
-            Complex c_minImaginary = new Complex(0.0, Double.MinValue);
+            Complex c_minImaginary = new Complex(0.0, double.MinValue);
             VerifyToString(c_minImaginary);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            // local variables
-            Double realRandom;
-            Double imaginaryRandom;
+            double realRandom;
+            double imaginaryRandom;
 
             // Complex number with a valid positive real and an invalid imaginary part
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)

--- a/src/System.Runtime.Numerics/tests/Complex/implicitExplicitCastOperators.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/implicitExplicitCastOperators.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -13,32 +12,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0, 
+                string.Format("Int16ImplicitCast ({0})", value));
+            
+            if (value != Int16.MaxValue)
             {
-                Console.WriteLine("Int16ImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0, 
+                    string.Format("PLuS + Int16ImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Int16.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + Int16ImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Int16.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - Int16ImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != Int16.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0, 
+                    string.Format("Minus - Int16ImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -47,7 +35,7 @@ namespace System.Numerics.Tests
         {
             VerifyInt16ImplicitCastToComplex(Int16.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Int16 randomValue = Support.GetRandomInt16Value(true);
                 VerifyInt16ImplicitCastToComplex(randomValue);
@@ -57,7 +45,7 @@ namespace System.Numerics.Tests
             VerifyInt16ImplicitCastToComplex(0);
             VerifyInt16ImplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Int16 randomValue = Support.GetRandomInt16Value(false);
                 VerifyInt16ImplicitCastToComplex(randomValue);
@@ -70,32 +58,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0, 
+                string.Format("Int32ImplicitCast ({0})", value));
+            
+            if (value != Int32.MaxValue)
             {
-                Console.WriteLine("Int32ImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + Int32ImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Int32.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + Int32ImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Int32.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - Int32ImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != Int32.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0,
+                    string.Format("Minus - Int32ImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -104,7 +81,7 @@ namespace System.Numerics.Tests
         {
             VerifyInt32ImplicitCastToComplex(Int32.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Int32 randomValue = Support.GetRandomInt32Value(true);
                 VerifyInt32ImplicitCastToComplex(randomValue);
@@ -114,7 +91,7 @@ namespace System.Numerics.Tests
             VerifyInt32ImplicitCastToComplex(0);
             VerifyInt32ImplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Int32 randomValue = Support.GetRandomInt32Value(false);
                 VerifyInt32ImplicitCastToComplex(randomValue);
@@ -127,32 +104,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0, 
+                string.Format("Int64ImplicitCast ({0})", value));
+           
+            if (value != Int64.MaxValue)
             {
-                Console.WriteLine("Int64ImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0, 
+                    string.Format("PLuS + Int64ImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Int64.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + Int64ImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Int64.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - Int64ImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != Int64.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0, 
+                    string.Format("Minus - Int64ImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -161,7 +127,7 @@ namespace System.Numerics.Tests
         {
             VerifyInt64ImplicitCastToComplex(Int64.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Int64 randomValue = Support.GetRandomInt64Value(true);
                 VerifyInt64ImplicitCastToComplex(randomValue);
@@ -171,7 +137,7 @@ namespace System.Numerics.Tests
             VerifyInt64ImplicitCastToComplex(0);
             VerifyInt64ImplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Int64 randomValue = Support.GetRandomInt64Value(false);
                 VerifyInt64ImplicitCastToComplex(randomValue);
@@ -184,32 +150,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0,
+                string.Format("UInt16ImplicitCast ({0})", value));
+            
+            if (value != UInt16.MaxValue)
             {
-                Console.WriteLine("UInt16ImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + UInt16ImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != UInt16.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + UInt16ImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != UInt16.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - UInt16ImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != UInt16.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0,
+                    string.Format("Minus - UInt16ImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -221,7 +176,7 @@ namespace System.Numerics.Tests
             VerifyUInt16ImplicitCastToComplex(1);
 
 #if  CLS_Compliant
-        for (int i = 0; i < Support.RandomSampleCount; ++i)
+        for (int i = 0; i < 3; ++i)
         {
             UInt16 randomValue = Support.GetRandomUInt16Value();
             VerifyUInt16ImplicitCastToComplex(randomValue);
@@ -234,32 +189,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0, 
+                string.Format("UInt32ImplicitCast ({0})", value));
+            
+            if (value != UInt32.MaxValue)
             {
-                Console.WriteLine("UInt32ImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + UInt32ImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != UInt32.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + UInt32ImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != UInt32.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - UInt32ImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != UInt32.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0,
+                    string.Format("Minus - UInt32ImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -271,7 +215,7 @@ namespace System.Numerics.Tests
             VerifyUInt32ImplicitCastToComplex(1);
 
 #if  CLS_Compliant
-        for (int i = 0; i < Support.RandomSampleCount; ++i)
+        for (int i = 0; i < 3; ++i)
         {
             UInt32 randomValue = Support.GetRandomUInt32Value();
             VerifyUInt32ImplicitCastToComplex(randomValue);
@@ -285,32 +229,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0,
+                string.Format("UInt64ImplicitCast ({0})", value));
+            
+            if (value != UInt64.MaxValue)
             {
-                Console.WriteLine("UInt64ImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + UInt64ImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != UInt64.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + UInt64ImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != UInt64.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - UInt64ImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != UInt64.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0,
+                    string.Format("Minus - UInt64ImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -322,7 +255,7 @@ namespace System.Numerics.Tests
             VerifyUInt64ImplicitCastToComplex(1);
 
 #if CLS_Compliant
-        for (int i = 0; i < Support.RandomSampleCount; ++i)
+        for (int i = 0; i < 3; ++i)
         {
             UInt64 randomValue = Support.GetRandomUInt64Value();
             VerifyUInt64ImplicitCastToComplex(randomValue);
@@ -335,32 +268,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0,
+                string.Format("SByteImplicitCast ({0})", value));
+            
+            if (value != SByte.MaxValue)
             {
-                Console.WriteLine("SByteImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + SByteImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != SByte.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + SByteImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != SByte.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - SByteImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != SByte.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0,
+                    string.Format("Minus - SByteImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -369,7 +291,7 @@ namespace System.Numerics.Tests
         {
             VerifySByteImplicitCastToComplex(SByte.MinValue);
 #if  CLS_Compliant
-        for (int i = 0; i < Support.RandomSampleCount; ++i)
+        for (int i = 0; i < 3; ++i)
         {
             SByte randomValue = Support.GetRandomSByteValue(false);
             VerifySByteImplicitCastToComplex(randomValue);
@@ -379,7 +301,7 @@ namespace System.Numerics.Tests
             VerifySByteImplicitCastToComplex(1);
 
 #if  CLS_Compliant
-        for (int i = 0; i < Support.RandomSampleCount; ++i)
+        for (int i = 0; i < 3; ++i)
         {
             SByte randomValue = Support.GetRandomSByteValue(true);
             VerifySByteImplicitCastToComplex(randomValue);
@@ -393,32 +315,21 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0, 
+                string.Format("ByteImplicitCast ({0})", value));
+           
+            if (value != Byte.MaxValue)
             {
-                Console.WriteLine("ByteImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + ByteImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Byte.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + ByteImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Byte.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - ByteImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != Byte.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0,
+                    string.Format("Minus - ByteImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -429,7 +340,7 @@ namespace System.Numerics.Tests
             VerifyByteImplicitCastToComplex(0);
             VerifyByteImplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Byte randomValue = Support.GetRandomByteValue();
                 VerifyByteImplicitCastToComplex(randomValue);
@@ -442,32 +353,20 @@ namespace System.Numerics.Tests
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0,
+                string.Format("SingleImplicitCast ({0})",  value));
+            if (value != Single.MaxValue)
             {
-                Console.WriteLine("SingleImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0, 
+                    string.Format("PLuS + SingleImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Single.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + SingleImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Single.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - SingleImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != Single.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0, 
+                    string.Format("Minus - SingleImplicitCast + 1 ({0})", value));
             }
         }
 
@@ -476,7 +375,7 @@ namespace System.Numerics.Tests
         {
             VerifySingleImplicitCastToComplex(Single.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Single randomValue = Support.GetRandomSingleValue(false);
                 VerifySingleImplicitCastToComplex(randomValue);
@@ -485,7 +384,7 @@ namespace System.Numerics.Tests
             VerifySingleImplicitCastToComplex(0);
             VerifySingleImplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Single randomValue = Support.GetRandomSingleValue(true);
                 VerifySingleImplicitCastToComplex(randomValue);
@@ -494,101 +393,77 @@ namespace System.Numerics.Tests
             VerifySingleImplicitCastToComplex(Single.MaxValue);
         }
 
-        private static void VerifyDoubleImplicitCastToComplex(Double value)
+        private static void VerifyDoubleImplicitCastToComplex(double value)
         {
             Complex c_cast = value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, value, 0.0, 
+                string.Format("DoubleImplicitCast ({0})", value));
+            if (value != double.MaxValue)
             {
-                Console.WriteLine("DoubleImplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0,
+                    string.Format("PLuS + DoubleImplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Double.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, value + 1, 0.0))
-                    {
-                        Console.WriteLine("PLuS + DoubleImplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Double.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0))
-                    {
-                        Console.WriteLine("Minus - DoubleImplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != double.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, value - 1, 0.0, 
+                    string.Format("Minus - DoubleImplicitCast + 1 ({0})", value));
             }
         }
 
         [Fact]
         public static void RunTests_DoubleImplicitCastToComplex()
         {
-            VerifyDoubleImplicitCastToComplex(Double.MinValue);
+            VerifyDoubleImplicitCastToComplex(double.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
-                Double randomValue = Support.GetRandomDoubleValue(false);
+                double randomValue = Support.GetRandomDoubleValue(false);
                 VerifyDoubleImplicitCastToComplex(randomValue);
             }
 
             VerifyDoubleImplicitCastToComplex(0);
             VerifyDoubleImplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
-                Double randomValue = Support.GetRandomDoubleValue(true);
+                double randomValue = Support.GetRandomDoubleValue(true);
                 VerifyDoubleImplicitCastToComplex(randomValue);
             }
 
-            VerifyDoubleImplicitCastToComplex(Double.MaxValue);
+            VerifyDoubleImplicitCastToComplex(double.MaxValue);
         }
 
         private static void VerifyBigIntegerExplicitCastToComplex(BigInteger value)
         {
             Complex c_cast = (Complex)value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, (Double)value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, (Double)value, 0.0,
+                string.Format("BigIntegerExplicitCast ({0})", value));
+            if (value != (BigInteger)double.MaxValue)
             {
-                Console.WriteLine("BigIntegerExplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, (Double)(value + 1), 0.0,
+                    string.Format("PLuS + BigIntegerExplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != (BigInteger)Double.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, (Double)(value + 1), 0.0))
-                    {
-                        Console.WriteLine("PLuS + BigIntegerExplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != (BigInteger)Double.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, (Double)(value - 1), 0.0))
-                    {
-                        Console.WriteLine("Minus - BigIntegerExplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != (BigInteger)double.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, (Double)(value - 1), 0.0,
+                    string.Format("Minus - BigIntegerExplicitCast + 1 ({0})", value));
             }
         }
 
         [Fact]
         public static void RunTests_BigIntegerExplicitCastToComplex()
         {
-            VerifyBigIntegerExplicitCastToComplex((BigInteger)Double.MinValue);
+            VerifyBigIntegerExplicitCastToComplex((BigInteger)double.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 BigInteger randomValue = Support.GetRandomBigIntegerValue(false);
                 VerifyBigIntegerExplicitCastToComplex(randomValue);
@@ -597,45 +472,33 @@ namespace System.Numerics.Tests
             VerifyBigIntegerExplicitCastToComplex(0);
             VerifyBigIntegerExplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 BigInteger randomValue = Support.GetRandomBigIntegerValue(true);
                 VerifyBigIntegerExplicitCastToComplex(randomValue);
             }
 
-            VerifyBigIntegerExplicitCastToComplex((BigInteger)Double.MaxValue);
+            VerifyBigIntegerExplicitCastToComplex((BigInteger)double.MaxValue);
         }
 
         private static void VerifyDecimalExplicitCastToComplex(Decimal value)
         {
             Complex c_cast = (Complex)value;
 
-            if (false == Support.VerifyRealImaginaryProperties(c_cast, (Double)value, 0.0))
+            Support.VerifyRealImaginaryProperties(c_cast, (Double)value, 0.0, 
+                string.Format("DecimalExplicitCast ({0})", value));
+            if (value != Decimal.MaxValue)
             {
-                Console.WriteLine("DecimalExplicitCast ({0})" + value);
-                Assert.True(false, "Verification Failed");
+                Complex c_cast_plus = c_cast + 1;
+                Support.VerifyRealImaginaryProperties(c_cast_plus, (Double)(value + 1), 0.0, 
+                    string.Format("PLuS + DecimalExplicitCast ({0})", value));
             }
-            else
-            {
-                if (value != Decimal.MaxValue)
-                {
-                    Complex c_cast_plus = c_cast + 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_plus, (Double)(value + 1), 0.0))
-                    {
-                        Console.WriteLine("PLuS + DecimalExplicitCast ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
 
-                if (value != Decimal.MinValue)
-                {
-                    Complex c_cast_minus = c_cast - 1;
-                    if (false == Support.VerifyRealImaginaryProperties(c_cast_minus, (Double)(value - 1), 0.0))
-                    {
-                        Console.WriteLine("Minus - DecimalExplicitCast + 1 ({0})" + value);
-                        Assert.True(false, "Verification Failed");
-                    }
-                }
+            if (value != Decimal.MinValue)
+            {
+                Complex c_cast_minus = c_cast - 1;
+                Support.VerifyRealImaginaryProperties(c_cast_minus, (Double)(value - 1), 0.0,
+                    string.Format("Minus - DecimalExplicitCast + 1 ({0})", value));
             }
         }
 
@@ -644,7 +507,7 @@ namespace System.Numerics.Tests
         {
             VerifyDecimalExplicitCastToComplex(Decimal.MinValue);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Decimal randomValue = Support.GetRandomDecimalValue(false);
                 VerifyDecimalExplicitCastToComplex(randomValue);
@@ -653,7 +516,7 @@ namespace System.Numerics.Tests
             VerifyDecimalExplicitCastToComplex(0);
             VerifyDecimalExplicitCastToComplex(1);
 
-            for (int i = 0; i < Support.RandomSampleCount; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 Decimal randomValue = Support.GetRandomDecimalValue(true);
                 VerifyDecimalExplicitCastToComplex(randomValue);

--- a/src/System.Runtime.Numerics/tests/Complex/operation_ComparisonHashCode.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/operation_ComparisonHashCode.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -11,74 +10,29 @@ namespace System.Numerics.Tests
     {
         private static void VerifyComplexComparison(Complex c1, Complex c2, bool expectedResult, bool expectedResultEqual)
         {
-            if (expectedResult != (c1 == c2))
-            {
-                Console.WriteLine("Error-8592 c1:{0} == c2{1} is not '{2}' as expected", c1, c2, expectedResult);
-                Assert.True(false, "Verification Failed");
-            }
-
-
-            if (expectedResult != (c2 == c1))
-            {
-                Console.WriteLine("Error-8592-1 c2:{0} == c1{1} is not '{2}' as expected", c2, c1, expectedResult);
-                Assert.True(false, "Verification Failed");
-            }
-
-            if (expectedResult == (c1 != c2))
-            {
-                Console.WriteLine("Error-81792 c1:{0} != c2{1} is not '{2}' as expected", c1, c2, !expectedResult);
-                Assert.True(false, "Verification Failed");
-            }
-
-            if (expectedResult == (c2 != c1))
-            {
-                Console.WriteLine("Error-81792-1 c2:{0} != c1{1} is not '{2}' as expected", c2, c1, !expectedResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(expectedResult == (c1 == c2), string.Format("c1:{0} == c2{1} is not '{2}' as expected", c1, c2, expectedResult));
+            Assert.True(expectedResult == (c2 == c1), string.Format("c2:{0} == c1{1} is not '{2}' as expected", c2, c1, expectedResult));
+            Assert.True(expectedResult != (c1 != c2), string.Format("c1:{0} != c2{1} is not '{2}' as expected", c1, c2, !expectedResult));
+            Assert.True(expectedResult != (c2 != c1), string.Format("c2:{0} != c1{1} is not '{2}' as expected", c2, c1, !expectedResult));
 
             bool result = c1.Equals(c2);
-            if (expectedResultEqual != result)
-            {
-                Console.WriteLine("Error-6172 c1:{0}.Equals(c2{1}) is not '{2}' as expected", c1, c2, expectedResultEqual);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(expectedResultEqual == result, string.Format("c1:{0}.Equals(c2{1}) is not '{2}' as expected", c1, c2, expectedResultEqual));
 
             if (result) // then verify Hash Code equality
             {
-                if (c1.GetHashCode() != c2.GetHashCode())
-                {
-                    Console.WriteLine("Error-9HaSh72 c1:{0}.GetHashCode() == c2:{1}.GetHashCode() is 'true' as expected", c1, c2);
-                    Assert.True(false, "Verification Failed");
-                }
+                Assert.True(c1.GetHashCode() == c2.GetHashCode(), string.Format("c1:{0}.GetHashCode() == c2:{1}.GetHashCode() is 'true' as expected", c1, c2));
             }
 
             result = c2.Equals(c1);
-            if (expectedResultEqual != result)
-            {
-                Console.WriteLine("Error-6172-1 c2:{0}.Equals(c1{1}) is not '{2}' as expected", c2, c1, expectedResultEqual);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(expectedResultEqual == result, string.Format("c2:{0}.Equals(c1{1}) is not '{2}' as expected", c2, c1, expectedResultEqual));
 
             if (result) // then verify Hash Code equality
             {
-                if (c2.GetHashCode() != c1.GetHashCode())
-                {
-                    Console.WriteLine("Error-9HaSh72-1 c2:{0}.GetHashCode() == c1:{1}.GetHashCode() is 'true' as expected", c2, c1);
-                    Assert.True(false, "Verification Failed");
-                }
+                Assert.True(c2.GetHashCode() == c1.GetHashCode(), string.Format("Obj c2:{0}.GetHashCode() == c1:{1}.GetHashCode() is 'true' as expected", c2, c1));
             }
 
-            if (expectedResult != c2.Equals((Object)c1))
-            {
-                Console.WriteLine("Error-6172Obj c2:{0}.Equals((object) c1{1}) is not '{2}' as expected", c2, c1, expectedResult);
-                Assert.True(false, "Verification Failed");
-            }
-
-            if (expectedResult != c1.Equals((Object)c2))
-            {
-                Console.WriteLine("Error-6172Obj-1 c1:{0}.Equals((object) c2{1}) is not '{2}' as expected", c1, c2, expectedResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(expectedResult == c2.Equals((Object)c1), string.Format("c2:{0}.Equals((object) c1{1}) is not '{2}' as expected", c2, c1, expectedResult));
+            Assert.True(expectedResult == c1.Equals((Object)c2), string.Format("c1:{0}.Equals((object) c2{1}) is not '{2}' as expected", c1, c2, expectedResult));
         }
 
         private static void VerifyComplexComparison(Complex c1, Complex c2, bool expectedResult)
@@ -89,11 +43,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_ZeroOneImaginaryOne()
         {
-            // local variables
-            bool expectedResult = false;
-
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
             Complex randomComplex = new Complex(real, imaginary);
 
             real = Support.GetRandomDoubleValue(true);
@@ -115,7 +66,7 @@ namespace System.Numerics.Tests
             VerifyComplexComparison(Complex.Zero, -Complex.ImaginaryOne, false);
             VerifyComplexComparison(Complex.Zero, -Complex.ImaginaryOne, false);
 
-            expectedResult = (randomComplex.Real == 0.0 && randomComplex.Imaginary == 0.0);
+            bool expectedResult = (randomComplex.Real == 0.0 && randomComplex.Imaginary == 0.0);
             VerifyComplexComparison(Complex.Zero, randomComplex, expectedResult);
 
             expectedResult = (randomComplexNeg.Real == 0.0 && randomComplexNeg.Imaginary == 0.0);
@@ -196,11 +147,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_MaxMinValues()
         {
-            // local variables
-            bool expectedResult;
-
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
             Complex randomComplex = new Complex(real, imaginary);
 
             real = Support.GetRandomDoubleValue(true);
@@ -215,12 +163,12 @@ namespace System.Numerics.Tests
             imaginary = Support.GetSmallRandomDoubleValue(true);
             Complex randomSmallComplexNeg = new Complex(real, imaginary);
 
-            Complex maxComplex = new Complex(Double.MaxValue, Double.MaxValue);
-            Complex minComplex = new Complex(Double.MinValue, Double.MinValue);
-            Complex maxReal = new Complex(Double.MaxValue, 0.0);
-            Complex minReal = new Complex(Double.MinValue, 0.0);
-            Complex maxImaginary = new Complex(0.0, Double.MaxValue);
-            Complex minImaginary = new Complex(0.0, Double.MinValue);
+            Complex maxComplex = new Complex(double.MaxValue, double.MaxValue);
+            Complex minComplex = new Complex(double.MinValue, double.MinValue);
+            Complex maxReal = new Complex(double.MaxValue, 0.0);
+            Complex minReal = new Complex(double.MinValue, 0.0);
+            Complex maxImaginary = new Complex(0.0, double.MaxValue);
+            Complex minImaginary = new Complex(0.0, double.MinValue);
 
             VerifyComplexComparison(maxComplex, maxComplex, true);
             VerifyComplexComparison(maxComplex, minComplex, false);
@@ -229,7 +177,7 @@ namespace System.Numerics.Tests
             VerifyComplexComparison(maxComplex, maxImaginary, false);
             VerifyComplexComparison(maxComplex, minImaginary, false);
 
-            expectedResult = (randomComplex.Real == maxComplex.Real && randomComplex.Imaginary == maxComplex.Imaginary);
+            bool expectedResult = (randomComplex.Real == maxComplex.Real && randomComplex.Imaginary == maxComplex.Imaginary);
             VerifyComplexComparison(maxComplex, randomComplex, expectedResult);
 
             expectedResult = (randomComplexNeg.Real == maxComplex.Real && randomComplexNeg.Imaginary == maxComplex.Imaginary);
@@ -329,8 +277,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_InvalidValues()
         {
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
             Complex randomComplex = new Complex(real, imaginary);
 
             foreach (double imaginaryInvalid in Support.doubleInvalidValues)
@@ -338,7 +286,7 @@ namespace System.Numerics.Tests
                 real = Support.GetRandomDoubleValue(false);
                 Complex randomInvalidComplex = new Complex(real, imaginaryInvalid);
                 VerifyComplexComparison(randomInvalidComplex, randomComplex, false);
-                VerifyComplexComparison(randomInvalidComplex, randomInvalidComplex, !Double.IsNaN(imaginaryInvalid), true);
+                VerifyComplexComparison(randomInvalidComplex, randomInvalidComplex, !double.IsNaN(imaginaryInvalid), true);
             }
 
             foreach (double realInvalid in Support.doubleInvalidValues)
@@ -346,7 +294,7 @@ namespace System.Numerics.Tests
                 imaginary = Support.GetRandomDoubleValue(false);
                 Complex randomInvalidComplex = new Complex(realInvalid, imaginary);
                 VerifyComplexComparison(randomInvalidComplex, randomComplex, false);
-                VerifyComplexComparison(randomInvalidComplex, randomInvalidComplex, !Double.IsNaN(realInvalid), true);
+                VerifyComplexComparison(randomInvalidComplex, randomInvalidComplex, !double.IsNaN(realInvalid), true);
             }
 
             foreach (double realInvalid in Support.doubleInvalidValues)
@@ -355,7 +303,7 @@ namespace System.Numerics.Tests
                 {
                     Complex randomInvalidComplex = new Complex(realInvalid, imaginaryInvalid);
                     VerifyComplexComparison(randomInvalidComplex, randomComplex, false);
-                    VerifyComplexComparison(randomInvalidComplex, randomInvalidComplex, !(Double.IsNaN(realInvalid) || Double.IsNaN(imaginaryInvalid)), true);
+                    VerifyComplexComparison(randomInvalidComplex, randomInvalidComplex, !(double.IsNaN(realInvalid) || double.IsNaN(imaginaryInvalid)), true);
                 }
             }
         }
@@ -364,40 +312,20 @@ namespace System.Numerics.Tests
         public static void RunTests_WithNonComplexObject()
         {
             // local variables
-            Double real = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
             Complex randomComplex = new Complex(real, 0.0);
 
             // verify with same double value
-
-            if (randomComplex.Equals((Object)real))
-            {
-                Console.WriteLine("Error-9674Obj randomComplex:{0}.Equals((object) real) is not 'false' as expected", randomComplex, real);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.False(randomComplex.Equals((Object)real), string.Format("Obj randomComplex:{0}.Equals((object) real) is not 'false' as expected", randomComplex, real));
 
             // verify with null
-
-            if (randomComplex.Equals((Object)null))
-            {
-                Console.WriteLine("Error-5441Obj randomComplex:{0}.Equals((object) null) is not 'false' as expected", randomComplex);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.False(randomComplex.Equals((Object)null), string.Format("Obj randomComplex:{0}.Equals((object) null) is not 'false' as expected", randomComplex));
 
             // verify with 0
-
-            if (randomComplex.Equals((Object)0))
-            {
-                Console.WriteLine("Error-5441Obj randomComplex:{0}.Equals((object) 0) is not 'false' as expected", randomComplex);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.False(randomComplex.Equals((Object)0), string.Format("Obj randomComplex:{0}.Equals((object) 0) is not 'false' as expected", randomComplex));
 
             // verify with string
-
-            if (randomComplex.Equals((Object)"0"))
-            {
-                Console.WriteLine("Error-5441Obj randomComplex:{0}.Equals((object) \"0\") is not 'false' as expected", randomComplex);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.False(randomComplex.Equals((Object)"0"), string.Format("Obj randomComplex:{0}.Equals((object) \"0\") is not 'false' as expected", randomComplex));
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Exp.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Exp.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class standardNumericalFunctions_ExpTest
     {
-        private static void VerifyExpWithAddition(Double real, Double imaginary)
+        private static void VerifyExpWithAddition(double real, double imaginary)
         {
             // verify with e(x+y) = e(x)*e(y) if xy == yx
             Complex realComplex = new Complex(real, 0.0);
@@ -29,11 +28,8 @@ namespace System.Numerics.Tests
             Complex complex = new Complex(real, imaginary);
             Complex complexExp = Complex.Exp(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(complexExp, expectedExp.Real, expectedExp.Imaginary))
-            {
-                Console.WriteLine("Error eXp-Err3521! Exp({0}):{1} != {2})", complex, complexExp, expectedExp);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(complexExp, expectedExp.Real, expectedExp.Imaginary,
+                string.Format("Exp({0}):{1} != {2})", complex, complexExp, expectedExp));
         }
 
         [Fact]
@@ -59,8 +55,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyExpWithAddition(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -84,37 +80,30 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            Complex max = new Complex(Double.MaxValue, Double.MaxValue);
+            Complex max = new Complex(double.MaxValue, double.MaxValue);
 
             Complex complexExp = Complex.Exp(max);
-            if (false == Support.VerifyRealImaginaryProperties(complexExp, Math.Cos(Double.MaxValue) * Double.PositiveInfinity, Double.PositiveInfinity)) //for IA64
-            {
-                Console.WriteLine("Error eXp-Max:Err6589! Exp(Max) is not (Infinity, Infinity))");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(complexExp, Math.Cos(double.MaxValue) * double.PositiveInfinity, double.PositiveInfinity,
+                string.Format("Exp(Max) is not (Infinity, Infinity)"));
 
             // Verify test results with MaxReal
-
-            Complex maxReal = new Complex(Double.MaxValue, 0.0);
+            Complex maxReal = new Complex(double.MaxValue, 0.0);
 
             complexExp = Complex.Exp(max);
-            if (false == Support.VerifyRealImaginaryProperties(complexExp, Math.Cos(Double.MaxValue) * Double.PositiveInfinity, Double.PositiveInfinity)) //for IA64
-            {
-                Console.WriteLine("Error eXp-MAxReal:Err697.1! Exp(MaxReal) is not (Infinity, Infinity))");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(complexExp, Math.Cos(double.MaxValue) * double.PositiveInfinity, double.PositiveInfinity, 
+                string.Format("Exp(MaxReal) is not (Infinity, Infinity))"));
 
             // Verify test results with MaxImg
-            VerifyExpWithAddition(0.0, Double.MaxValue);
+            VerifyExpWithAddition(0.0, double.MaxValue);
 
             // Verify test results with Min
-            VerifyExpWithAddition(Double.MinValue, Double.MinValue);
+            VerifyExpWithAddition(double.MinValue, double.MinValue);
 
             // Verify test results with MinReal
-            VerifyExpWithAddition(Double.MinValue, 0.0);
+            VerifyExpWithAddition(double.MinValue, 0.0);
 
             // Verify test results with MinImaginary
-            VerifyExpWithAddition(0.0, Double.MinValue);
+            VerifyExpWithAddition(0.0, double.MinValue);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Log.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Log.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -34,7 +33,7 @@ namespace System.Numerics.Tests
         private static void VerifyLogWithMultiply(Complex c1, Complex c2)
         {
             // Log(c1*c2) == Log(c1) + Log(c2), if -PI < Arg(c1) + Arg(c2) <= PI
-            Double equalityCondition = Math.Atan2(c1.Imaginary, c1.Real) + Math.Atan2(c2.Imaginary, c2.Real);
+            double equalityCondition = Math.Atan2(c1.Imaginary, c1.Real) + Math.Atan2(c2.Imaginary, c2.Real);
             if (equalityCondition <= -Math.PI || equalityCondition > Math.PI)
             {
                 return;
@@ -43,11 +42,8 @@ namespace System.Numerics.Tests
             Complex logComplex = Complex.Log(c1 * c2);
             Complex logExpectedComplex = Complex.Log(c1) + Complex.Log(c2);
 
-            if (false == Support.VerifyRealImaginaryProperties(logComplex, logExpectedComplex.Real, logExpectedComplex.Imaginary))
-            {
-                Console.WriteLine("Error LogMULT-ErrLoG8710! Log({0}*{1}):{2} != {3})", c1, c2, logComplex, logExpectedComplex);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(logComplex, logExpectedComplex.Real, logExpectedComplex.Imaginary,
+                string.Format("Log({0}*{1}):{2} != {3})", c1, c2, logComplex, logExpectedComplex));
         }
 
         private static void VerifyLogWithPowerMinusOne(Complex c)
@@ -56,11 +52,8 @@ namespace System.Numerics.Tests
             Complex logComplex = Complex.Log(c);
             Complex logPowerMinusOne = Complex.Log(1 / c);
 
-            if (false == Support.VerifyRealImaginaryProperties(logComplex, -logPowerMinusOne.Real, -logPowerMinusOne.Imaginary))
-            {
-                Console.WriteLine("Error LogPowMnsOne-ErrLoG6913! Log({0}):{1} != {2} as expected", c, logComplex, -logPowerMinusOne);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(logComplex, -logPowerMinusOne.Real, -logPowerMinusOne.Imaginary,
+                string.Format("Log({0}):{1} != {2} as expected", c, logComplex, -logPowerMinusOne));
         }
 
         private static void VerifyLogWithExp(Complex c)
@@ -69,33 +62,27 @@ namespace System.Numerics.Tests
             Complex logComplex = Complex.Log(c);
             Complex expLogComplex = Complex.Exp(logComplex);
 
-            if (false == Support.VerifyRealImaginaryProperties(expLogComplex, c.Real, c.Imaginary))
-            {
-                Console.WriteLine("Error LogEXP-Err2113! Exp(Log({0}):{1} != {2})", c, expLogComplex, c);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(expLogComplex, c.Real, c.Imaginary,
+                string.Format("Exp(Log({0}):{1} != {2})", c, expLogComplex, c));
         }
 
         private static void VerifyLogWithBase10(Complex complex)
         {
             Complex logValue = Complex.Log10(complex);
             Complex logComplex = Complex.Log(complex);
-            Double baseLog = Math.Log(10);
+            double baseLog = Math.Log(10);
             Complex expectedLog = logComplex / baseLog;
 
-            if (!Support.VerifyRealImaginaryProperties(logValue, expectedLog.Real, expectedLog.Imaginary))
-            {
-                Console.WriteLine("Error LogBase10-ErrLoG4211! Log({0}, {1}):{2} != {3} as expected", complex, 10, logValue, expectedLog);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(logValue, expectedLog.Real, expectedLog.Imaginary, 
+                string.Format("Log({0}, {1}):{2} != {3} as expected", complex, 10, logValue, expectedLog));
         }
 
         private static void VerifyLogWithBase(Complex complex)
         {
-            Double baseValue = 0.0;
-            Double baseLog;
+            double baseValue = 0.0;
+            double baseLog;
 
-            // verify with Random Int32
+            // Verify with Random Int32
             do
             {
                 baseValue = Support.GetRandomInt32Value(false);
@@ -108,14 +95,10 @@ namespace System.Numerics.Tests
             baseLog = Math.Log(baseValue);
             Complex expectedLog = logComplex / baseLog;
 
-            if (false == Support.VerifyRealImaginaryProperties(logValue, expectedLog.Real, expectedLog.Imaginary))
-            {
-                Console.WriteLine("Error LogBase-ErrLoG01571! Log({0}, {1}):{2} != {3} as expected", complex, baseValue, logValue, expectedLog);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(logValue, expectedLog.Real, expectedLog.Imaginary, 
+                string.Format("Log({0}, {1}):{2} != {3} as expected", complex, baseValue, logValue, expectedLog));
 
-            // Verify with Random Double value
-
+            // Verify with Random double value
             baseValue = 0.0;
             do
             {
@@ -128,27 +111,24 @@ namespace System.Numerics.Tests
             baseLog = Math.Log(baseValue);
             expectedLog = logComplex / baseLog;
 
-            if (!Support.VerifyRealImaginaryProperties(logValue, expectedLog.Real, expectedLog.Imaginary))
-            {
-                Console.WriteLine("Error LogBaseDbL-ErrLoG1598! Log({0}, {1}):{2} != {3} as expected", complex, baseValue, logValue, expectedLog);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(logValue, expectedLog.Real, expectedLog.Imaginary, 
+                string.Format("Log({0}, {1}):{2} != {3} as expected", complex, baseValue, logValue, expectedLog));
         }
 
         [Fact]
         public static void RunTests_ZeroOneImaginaryOne()
         {
             Complex logValue = Complex.Log(Complex.Zero);
-            Support.VerifyRealImaginaryProperties(logValue, Double.NegativeInfinity, 0.0);
+            Support.VerifyRealImaginaryProperties(logValue, double.NegativeInfinity, 0.0, "Verify log of zero");
 
-            // verify log10 with Zero
+            // Verify log10 with Zero
             logValue = Complex.Log10(Complex.Zero);
-            Support.VerifyRealImaginaryProperties(logValue, Double.NegativeInfinity, 0.0);
+            Support.VerifyRealImaginaryProperties(logValue, double.NegativeInfinity, 0.0, "Verify log10 of zero");
 
-            // verify log base with Zero
-            Double baseValue = Support.GetRandomInt32Value(false);
+            // Verify log base with Zero
+            double baseValue = Support.GetRandomInt32Value(false);
             logValue = Complex.Log(Complex.Zero, baseValue);
-            Support.VerifyRealImaginaryProperties(logValue, Double.NegativeInfinity, Double.NaN);
+            Support.VerifyRealImaginaryProperties(logValue, double.NegativeInfinity, double.NaN, "Verify log base of zero");
 
             // Verify test results with Zero - One
             VerifyLogWithProperties(Complex.One, Complex.Zero);
@@ -160,8 +140,8 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_RandomValidValues()
         {
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             Complex cFirst = new Complex(real, imaginary);
 
             real = Support.GetSmallRandomDoubleValue(true);
@@ -210,22 +190,21 @@ namespace System.Numerics.Tests
         [Fact]
         public static void RunTests_BoundaryValues()
         {
-            // local variables
-            Complex c_maxReal = new Complex(Double.MaxValue, 0.0);
-            Complex c_maxImg = new Complex(0.0, Double.MaxValue);
-            Complex c_minReal = new Complex(Double.MinValue, 0.0);
-            Complex c_minImg = new Complex(0.0, Double.MinValue);
+            Complex c_maxReal = new Complex(double.MaxValue, 0.0);
+            Complex c_maxImg = new Complex(0.0, double.MaxValue);
+            Complex c_minReal = new Complex(double.MinValue, 0.0);
+            Complex c_minImg = new Complex(0.0, double.MinValue);
 
-            // test with 'MaxReal'
+            // MaxReal
             VerifyLogWithProperties(c_maxReal, Complex.One, false);
 
-            // test with 'MaxImaginary'
+            // MaxImaginary
             VerifyLogWithProperties(c_maxImg, Complex.ImaginaryOne, false);
 
-            // test with 'MinReal'
+            // MinReal
             VerifyLogWithProperties(c_minReal, Complex.One, false);
 
-            // test with 'MinImaginary'
+            // MinImaginary
             VerifyLogWithProperties(c_minImg, Complex.ImaginaryOne, false);
         }
     }

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Pow.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Pow.cs
@@ -2,21 +2,20 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class standardNumericalFunctions_PowTest
     {
-        private static void VerifyPow(Double a, Double b, Double c, Double d)
+        private static void VerifyPow(double a, double b, double c, double d)
         {
             Complex x = new Complex(a, b);
             Complex y = new Complex(c, d);
             Complex powComplex = Complex.Pow(x, y);
 
-            Double expectedReal = 0;
-            Double expectedImaginary = 0;
+            double expectedReal = 0;
+            double expectedImaginary = 0;
             if (0 == c && 0 == d)
                 expectedReal = 1;
             else if (!(0 == a && 0 == b))
@@ -27,21 +26,17 @@ namespace System.Numerics.Tests
                 expectedImaginary = expected.Imaginary;
             }
 
-            if (false == Support.VerifyRealImaginaryProperties(powComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error pOw-Err2534! Pow (({0}, {1}), ({2}, {3}))", a, b, c, d);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(powComplex, expectedReal, expectedImaginary, 
+                string.Format("Pow (({0}, {1}), ({2}, {3}))", a, b, c, d));
         }
 
-        private static void VerifyPow(Double a, Double b, Double doubleVal)
+        private static void VerifyPow(double a, double b, double doubleVal)
         {
             Complex x = new Complex(a, b);
             Complex powComplex = Complex.Pow(x, doubleVal);
 
-            Double expectedReal = 0;
-            Double expectedImaginary = 0;
+            double expectedReal = 0;
+            double expectedImaginary = 0;
             if (0 == doubleVal)
                 expectedReal = 1;
             else if (!(0 == a && 0 == b))
@@ -53,48 +48,36 @@ namespace System.Numerics.Tests
                 expectedImaginary = expected.Imaginary;
             }
 
-            if (false == Support.VerifyRealImaginaryProperties(powComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error pOw-Err2534! Pow (({0}, {1}), {2})", a, b, doubleVal);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(powComplex, expectedReal, expectedImaginary, 
+                string.Format("Pow (({0}, {1}), {2})", a, b, doubleVal));
         }
 
-        private static void RunTests_PowDouble(Double a, Double b)
+        private static void RunTests_PowDouble(double a, double b)
         {
-            //if (!Support.IsARM || !m_randomValues)
-            //{
-            //	VerifyPow(a, b, -1.0);
-            //}
             VerifyPow(a, b, 0.0);
             VerifyPow(a, b, 1.0);
 
-            Double randomPower = Support.GetSmallRandomDoubleValue(true);
+            double randomPower = Support.GetSmallRandomDoubleValue(true);
             VerifyPow(a, b, randomPower);
 
             randomPower = Support.GetSmallRandomDoubleValue(false);
             VerifyPow(a, b, randomPower);
 
-            foreach (Double power in Support.doubleInvalidValues)
+            foreach (double power in Support.doubleInvalidValues)
             {
                 VerifyPow(a, b, power);
             }
         }
 
-        private static void RunTests_PowComplex(Double a, Double b)
+        private static void RunTests_PowComplex(double a, double b)
         {
-            //if (!Support.IsARM || !m_randomValues)
-            //{
-            //	VerifyPow(a, b, -1.0, 0.0);
-            //}
             VerifyPow(a, b, 0.0, -1.0);
             VerifyPow(a, b, 0.0, 0.0);
             VerifyPow(a, b, 0.0, 1.0);
             VerifyPow(a, b, 1.0, 0.0);
 
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyPow(a, b, real, imaginary);
 
             real = Support.GetSmallRandomDoubleValue(true);
@@ -110,7 +93,7 @@ namespace System.Numerics.Tests
             VerifyPow(a, b, real, imaginary);
         }
 
-        private static void RunTests(Double a, Double b)
+        private static void RunTests(double a, double b)
         {
             RunTests_PowDouble(a, b);
             RunTests_PowComplex(a, b);
@@ -139,8 +122,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetRandomDoubleValue(false);
-            Double imaginary = Support.GetRandomDoubleValue(false);
+            double real = Support.GetRandomDoubleValue(false);
+            double imaginary = Support.GetRandomDoubleValue(false);
             RunTests(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -163,10 +146,10 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            RunTests(Double.MaxValue, Double.MaxValue);
+            RunTests(double.MaxValue, double.MaxValue);
 
             // Verify test results with Min
-            RunTests(Double.MinValue, Double.MinValue);
+            RunTests(double.MinValue, double.MinValue);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Sqrt.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/standardNumericalFunctions_Sqrt.cs
@@ -2,31 +2,27 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class standardNumericalFunctions_SqrtTest
     {
-        private static void VerifySqrtWithRectangularForm(Double real, Double imaginary, Double expectedReal, Double expectedImaginary)
+        private static void VerifySqrtWithRectangularForm(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(real, imaginary);
             Complex sqrtComplex = Complex.Sqrt(complex);
-            if (false == Support.VerifyRealImaginaryProperties(sqrtComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error sQRt-Err2534! Sqrt({0}):{1} != ({2},{3})", complex, sqrtComplex, expectedReal, expectedImaginary);
-                Assert.True(false, "Verification Fail");
-            }
+            Support.VerifyRealImaginaryProperties(sqrtComplex, expectedReal, expectedImaginary, 
+                string.Format("Sqrt({0}):{1} != ({2},{3})", complex, sqrtComplex, expectedReal, expectedImaginary));
         }
 
-        private static void VerifySqrtWithRectangularForm(Double real, Double imaginary)
+        private static void VerifySqrtWithRectangularForm(double real, double imaginary)
         {
             // sqrt(a+bi) = +- (sqrt(r + a) + i sqrt(r - a) sign(b)) sqrt(2) / 2, unless a=-r and y = 0
             Complex complex = new Complex(real, imaginary);
 
-            Double expectedReal = 0.0;
-            Double expectedImaginary = 0.0;
+            double expectedReal = 0.0;
+            double expectedImaginary = 0.0;
 
             if (0 == imaginary)
             {
@@ -37,7 +33,7 @@ namespace System.Numerics.Tests
             }
             else
             {
-                Double scale = 1 / Math.Sqrt(2);
+                double scale = 1 / Math.Sqrt(2);
                 expectedReal = scale * Math.Sqrt(complex.Magnitude + complex.Real);
                 expectedImaginary = scale * Math.Sqrt(complex.Magnitude - complex.Real);
                 if (complex.Imaginary < 0)
@@ -69,13 +65,13 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with MaxReal
-            VerifySqrtWithRectangularForm(Double.MaxValue, 0.0, 1.34078079299426E+154, 0.0);
+            VerifySqrtWithRectangularForm(double.MaxValue, 0.0, 1.34078079299426E+154, 0.0);
 
             // Verify test results with MaxImg
-            VerifySqrtWithRectangularForm(0.0, Double.MaxValue, 9.48075190810917E+153, 9.48075190810917E+153);
+            VerifySqrtWithRectangularForm(0.0, double.MaxValue, 9.48075190810917E+153, 9.48075190810917E+153);
 
             // Verify test results with MinImaginary
-            VerifySqrtWithRectangularForm(0.0, Double.MinValue, 9.48075190810917E+153, -9.48075190810917E+153);
+            VerifySqrtWithRectangularForm(0.0, double.MinValue, 9.48075190810917E+153, -9.48075190810917E+153);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/staticConstants.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/staticConstants.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -13,280 +12,139 @@ namespace System.Numerics.Tests
         public static void RunTests_Zero()
         {
             // Verify it is zero.
-            if (0 != Complex.Zero)
-            {
-                Console.WriteLine("ErRoR ErrZero_3426! Zero does not equal to (0.0, 0.0)");
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(0 == Complex.Zero, string.Format("Zero does not equal to (0.0, 0.0)"));
 
             // Verify real and imaginary parts are 0.0
-
-            if (false == Support.VerifyRealImaginaryProperties(Complex.Zero, 0.0, 0.0))
-            {
-                Console.WriteLine("ErRoR ErrZero_3429! Verify real and imaginary parts are 0.0");
-                Assert.True(false, "Verification Failed");
-            }
-
+            Support.VerifyRealImaginaryProperties(Complex.Zero, 0.0, 0.0, "Verify real and imaginary parts are 0.0");
+            
             // verify magnitude is 0.0 and phase is NaN.
-
-            if (false == Support.VerifyMagnitudePhaseProperties(Complex.Zero, 0.0, Double.NaN))
-            {
-                Console.WriteLine("ErRoR ErrZero_3432! Verify magnitude is 0.0 and phase is NaN");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyMagnitudePhaseProperties(Complex.Zero, 0.0, double.NaN, "Verify magnitude is 0.0 and phase is NaN");
 
             // create a complex number with random real and imaginary parts
-            Double realPart = Support.GetRandomDoubleValue(false);
-            Double imaginaryPart = Support.GetRandomDoubleValue(false);
+            double realPart = Support.GetRandomDoubleValue(false);
+            double imaginaryPart = Support.GetRandomDoubleValue(false);
             Complex complexRandom = new Complex(realPart, imaginaryPart);
 
             // verify x*0 = 0
-
             Complex multResult = complexRandom * Complex.Zero;
-            if (0 != multResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_5784! Multiplication with Zero does not equal to 0: {0}", multResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(0 == multResult, string.Format("Multiplication with Zero does not equal to 0: {0}", multResult));
 
             // verify x/0 = Infinity
-
             Complex divisorZeroResult = complexRandom / Complex.Zero;
-            if (false == Support.VerifyRealImaginaryProperties(divisorZeroResult, Double.NaN, Double.NaN))
-            {
-                Console.WriteLine("ErRoR ErrZero_5787! Division with Zero does not equal to (NaN, NaN): {0}", divisorZeroResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(divisorZeroResult, double.NaN, double.NaN, 
+                string.Format("Division with Zero does not equal to (NaN, NaN): {0}", divisorZeroResult));
 
             // verify 0/x = 0
-
             Complex divZeroResult = Complex.Zero / complexRandom;
-            if (0 != divZeroResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_5791! Division of Zero does not equal to 0: {0}", divZeroResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(0 == divZeroResult, string.Format("Division of Zero does not equal to 0: {0}", divZeroResult));
 
             // verify x - 0 = 0
-
             Complex subZeroResult = complexRandom - Complex.Zero;
-            if (complexRandom != subZeroResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_5794! Zero sub does not equal to complex {0} itself: {1}", complexRandom, subZeroResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(complexRandom == subZeroResult, string.Format("Zero sub does not equal to complex {0} itself: {1}", complexRandom, subZeroResult));
 
             // verify 0 - x = -x
-
             Complex subComplexResult = Complex.Zero - complexRandom;
-            if (subComplexResult != -complexRandom)
-            {
-                Console.WriteLine("ErRoR ErrZero_5797! Sub from Zero does not equal to neg complex {0}: {1}", complexRandom, subComplexResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(subComplexResult == -complexRandom, string.Format("Sub from Zero does not equal to neg complex {0}: {1}", complexRandom, subComplexResult));
 
             // verify x + 0 = x
-
             Complex addZeroResult = complexRandom + Complex.Zero;
-            if (addZeroResult != complexRandom)
-            {
-                Console.WriteLine("ErRoR ErrZero_5701! Add Zero result does not equal to complex {0}: {1}", complexRandom, addZeroResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(addZeroResult == complexRandom, string.Format("Add Zero result does not equal to complex {0}: {1}", complexRandom, addZeroResult));
 
             // verify 0 + x = x
-
             Complex addComplexResult = Complex.Zero + complexRandom;
-            if (addComplexResult != complexRandom)
-            {
-                Console.WriteLine("ErRoR ErrZero_5701! Add to Zero result does not equal to complex {0}: {1}", complexRandom, addComplexResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(addComplexResult == complexRandom, string.Format("Add to Zero result does not equal to complex {0}: {1}", complexRandom, addComplexResult));
 
             // verify Abs(0) = 0
-
-            Double absResult = Complex.Abs(Complex.Zero);
-            if (0.0 != absResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_3887! Abs(Zero) does NoT equal to 0: {0}", absResult);
-                Assert.True(false, "Verification Failed");
-            }
+            double absResult = Complex.Abs(Complex.Zero);
+            Assert.True(0.0 == absResult, string.Format("Abs(Zero) does not equal to 0: {0}", absResult));
 
             // verify Conjugate(0) = 0
-
             Complex conjugateResult = Complex.Conjugate(Complex.Zero);
-            if (0 != conjugateResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_3891! Conjugate(Zero) does NoT equal to 0: {0}", conjugateResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(0 == conjugateResult, string.Format("Conjugate(Zero) does not equal to 0: {0}", conjugateResult));
 
             // verify Reciprocal(0) goes to 0
-
             Complex reciprocalResult = Complex.Reciprocal(Complex.Zero);
-            if (reciprocalResult != Complex.Zero)
-            {
-                Console.WriteLine("ErRoR ErrZero_3893! Reciprocal(Zero) does NoT go to Infinity: {0}", reciprocalResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(reciprocalResult == Complex.Zero, string.Format("Reciprocal(Zero) does not go to Infinity: {0}", reciprocalResult));
         }
 
         [Fact]
         public static void RunTests_One()
         {
             // Verify real part is 1.0, and imaginary part is 0.0
-
-            if (false == Support.VerifyRealImaginaryProperties(Complex.One, 1.0, 0.0))
-            {
-                Console.WriteLine("ErRoR ErrOne_2934! Verify real part is 1.0, and imaginary part is 0.0");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(Complex.One, 1.0, 0.0, "Verify real part is 1.0, and imaginary part is 0.0");
 
             // verify magnitude is 1.0 and phase is 0.0.
-
-            if (false == Support.VerifyMagnitudePhaseProperties(Complex.One, 1.0, 0.0))
-            {
-                Console.WriteLine("ErRoR ErrZero_2937!");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyMagnitudePhaseProperties(Complex.One, 1.0, 0.0, "Verify magnitude is 1.0, and phase is 0.0");
 
             // create a complex number with random real and imaginary parts
-            Double realPart = Support.GetRandomDoubleValue(false);
-            Double imaginaryPart = Support.GetRandomDoubleValue(false);
+            double realPart = Support.GetRandomDoubleValue(false);
+            double imaginaryPart = Support.GetRandomDoubleValue(false);
             Complex complexRandom = new Complex(realPart, imaginaryPart);
-
+            
             // verify x*1 = x
-
             Complex multResult = complexRandom * Complex.One;
-            if (multResult != complexRandom)
-            {
-                Console.WriteLine("ErRoR ErrOne_3135! Mult with 1 does not equal to complex:{0} itself: {1}", complexRandom, multResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(multResult == complexRandom, string.Format("Mult with 1 does not equal to complex:{0} itself: {1}", complexRandom, multResult));
 
             // verify x/1 = x
-
             Complex divisorOneResult = complexRandom / Complex.One;
-            if (divisorOneResult != complexRandom)
-            {
-                Console.WriteLine("ErRoR ErrOne_3139! Division by 1 does not equal to complex:{0} itself: {1}", complexRandom, divisorOneResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(divisorOneResult == complexRandom, string.Format("Division by 1 does not equal to complex:{0} itself: {1}", complexRandom, divisorOneResult));
 
             // verify Abs(1) = 1
-
-            Double absResult = Complex.Abs(Complex.One);
-            if (1.0 != absResult)
-            {
-                Console.WriteLine("ErRoR ErrOne_4356! Abs(One) does NoT equal to 1: {0}", absResult);
-                Assert.True(false, "Verification Failed");
-            }
+            double absResult = Complex.Abs(Complex.One);
+            Assert.True(1.0 == absResult, string.Format("Abs(One) does not equal to 1: {0}", absResult));
 
             // verify Conjugate(1) = 1
-
             Complex conjugateResult = Complex.Conjugate(Complex.One);
-            if (Complex.One != conjugateResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_4359! Conjugate(One) does NoT equal to One: {0}", conjugateResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(Complex.One == conjugateResult, string.Format("Conjugate(One) does not equal to One: {0}", conjugateResult));
 
             // verify Reciprocal(1) = 1
-
             Complex reciprocalResult = Complex.Reciprocal(Complex.One);
-            if (Complex.One != reciprocalResult)
-            {
-                Console.WriteLine("ErRoR ErrZero_4365! Reciprocal(One) does NoT equal to One: {0}", reciprocalResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(Complex.One == reciprocalResult, string.Format("Reciprocal(One) does not equal to One: {0}", reciprocalResult));
         }
 
         [Fact]
         public static void RunTests_ImaginaryOne()
         {
             // Verify real part is 0.0, and imaginary part is 1.0
-
-            if (false == Support.VerifyRealImaginaryProperties(Complex.ImaginaryOne, 0.0, 1.0))
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2563-1! Verify real part is 0.0, and imaginary part is 1.0");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(Complex.ImaginaryOne, 0.0, 1.0, "Verify real part is 0.0, and imaginary part is 1.0");
 
             // verify magnitude is 1.0 and phase is Math.PI/2.
-
-            if (false == Support.VerifyMagnitudePhaseProperties(Complex.ImaginaryOne, 1.0, (Double)(Math.PI / 2)))
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2567-1! verify magnitude is 1.0 and phase is Math.PI/2.");
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyMagnitudePhaseProperties(Complex.ImaginaryOne, 1.0, (Double)(Math.PI / 2), "Verify magnitude is 1.0 and phase is Math.PI/2.");
 
             // verify ImaginaryOne * ImaginaryOne = -1
-
             Complex multResultImgOnes = Complex.ImaginaryOne * Complex.ImaginaryOne;
-            if (-1 != multResultImgOnes)
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2973-1! Multiplication of ImaginaryOnes is not -1", multResultImgOnes);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(-1 == multResultImgOnes, string.Format("Multiplication of ImaginaryOnes is not -1", multResultImgOnes));
 
             // verify ImaginaryOne / ImaginaryOne = 1
-
             Complex divResultImgOnes = Complex.ImaginaryOne / Complex.ImaginaryOne;
-            if (1 != divResultImgOnes)
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2978-1! Division of ImaginaryOnes is not 1", divResultImgOnes);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(1 == divResultImgOnes, string.Format("Division of ImaginaryOnes is not 1", divResultImgOnes));
 
             // verify ImaginaryOne / ImaginaryOne = 1
-
-            Double absResult = Complex.Abs(Complex.ImaginaryOne);
-            if (1 != absResult)
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2981-1! Abs of ImaginaryOne is not 1", absResult);
-                Assert.True(false, "Verification Failed");
-            }
+            double absResult = Complex.Abs(Complex.ImaginaryOne);
+            Assert.True(1 == absResult, string.Format("Abs of ImaginaryOne is not 1", absResult));
 
             // verify Conjugate(1) = 1
-
             Complex conjugateResult = Complex.Conjugate(Complex.ImaginaryOne);
-            if (-Complex.ImaginaryOne != conjugateResult)
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2983-1! Conjugate of ImaginaryOne is not 1", conjugateResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(-Complex.ImaginaryOne == conjugateResult, string.Format("Conjugate of ImaginaryOne is not 1", conjugateResult));
 
             // verify Reciprocal(1) = 1
-
             Complex reciprocalResult = Complex.Reciprocal(Complex.ImaginaryOne);
-            if (-Complex.ImaginaryOne != reciprocalResult)
-            {
-                Console.WriteLine("ErRoR ErrImaginaryOne_2986-1! Reciprocal of ImaginaryOne is not 1", reciprocalResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Assert.True(-Complex.ImaginaryOne == reciprocalResult, string.Format("Reciprocal of ImaginaryOne is not 1", reciprocalResult));
 
             // create a complex number with random real and imaginary parts
-            Double realPart = Support.GetRandomDoubleValue(false);
-            Double imaginaryPart = Support.GetRandomDoubleValue(false);
+            double realPart = Support.GetRandomDoubleValue(false);
+            double imaginaryPart = Support.GetRandomDoubleValue(false);
             Complex complexRandom = new Complex(realPart, imaginaryPart);
 
             // verify x*i = Complex(-x.Imaginary, x.Real)
-
             Complex multResult = complexRandom * Complex.ImaginaryOne;
-            if (false == Support.VerifyRealImaginaryProperties(multResult, -complexRandom.Imaginary, complexRandom.Real))
-            {
-                Console.WriteLine("FAiL! ErRoR ErrImaginaryOne_2718-1! Mult with i does not equal to ({0}, {1}): {2}", -complexRandom.Imaginary, complexRandom.Real, multResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(multResult, -complexRandom.Imaginary, complexRandom.Real, 
+                string.Format("Mult with i does not equal to ({0}, {1}): {2}", -complexRandom.Imaginary, complexRandom.Real, multResult));
 
             // verify x/i = Complex(x.Imaginary, -x.Real)
-
             Complex divResult = complexRandom / Complex.ImaginaryOne;
-            if (false == Support.VerifyRealImaginaryProperties(divResult, complexRandom.Imaginary, -complexRandom.Real))
-            {
-                Console.WriteLine("FAiL! ErRoR ErrImaginaryOne_2738-1! Div by i does not equal to ({0}, {1}): {2}", complexRandom.Imaginary, -complexRandom.Real, divResult);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(divResult, complexRandom.Imaginary, -complexRandom.Real, 
+                string.Format("Div by i does not equal to ({0}, {1}): {2}", complexRandom.Imaginary, -complexRandom.Real, divResult));
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ACos.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_ACosTest
     {
-        private static void VerifyACos(Double x, Double y)
+        private static void VerifyACos(double x, double y)
         {
             // formula used in the feature: arccos(z) = -iln(z + iSqrt(value*value-1))
             // Verification is done with z = ACos(Cos(z));
@@ -20,30 +19,21 @@ namespace System.Numerics.Tests
 
             if (false == x.Equals((Double)acosComplex.Real) || false == y.Equals((Double)acosComplex.Imaginary))
             {
-                Double realDiff = Math.Abs(Math.Abs(x) - Math.Abs(acosComplex.Real));
-                Double imaginaryDiff = Math.Abs(Math.Abs(y) - Math.Abs(acosComplex.Imaginary));
-                if ((realDiff > 0.1) || (imaginaryDiff > 0.1))
-                {
-                    Console.WriteLine("Error AcOs-Err3A6C6s! ({0}) != ACos(Cos():{1}):{2}", complex, cosComplex, acosComplex);
-
-                    Assert.True(false, "Verification Failed");
-                }
+                double realDiff = Math.Abs(Math.Abs(x) - Math.Abs(acosComplex.Real));
+                double imaginaryDiff = Math.Abs(Math.Abs(y) - Math.Abs(acosComplex.Imaginary));
+                Assert.False((realDiff > 0.1) || (imaginaryDiff > 0.1), string.Format("({0}) != ACos(Cos():{1}):{2}", complex, cosComplex, acosComplex));
             }
         }
 
-        private static void VerifyACos(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyACos(double x, double y, double expectedReal, double expectedImaginary)
         {
             // for boundary values, ACos returns invalid Values
 
             Complex complex = new Complex(x, y);
             Complex acosComplex = Complex.Acos(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(acosComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error AcOs-Err3A6s1N! AcOs({0})", complex, acosComplex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(acosComplex, expectedReal, expectedImaginary, 
+                string.Format("AcOs({0}):{1}", complex, acosComplex));
         }
 
         [Fact]
@@ -69,8 +59,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyACos(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -93,43 +83,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyACos(Double.MaxValue, Double.MaxValue);
+            VerifyACos(double.MaxValue, double.MaxValue);
 
             // Verify test results with MaxReal
-            VerifyACos(Double.MaxValue, 0.0, Double.NaN, Double.NaN);
+            VerifyACos(double.MaxValue, 0.0, double.NaN, double.NaN);
 
             // Verify test results with MaxImg
-            VerifyACos(0.0, Double.MaxValue);
+            VerifyACos(0.0, double.MaxValue);
 
             // Verify test results with Min
-            VerifyACos(Double.MinValue, Double.MinValue);
+            VerifyACos(double.MinValue, double.MinValue);
 
             // Verify test results with MinReal
-            VerifyACos(Double.MinValue, 0.0, Double.NaN, Double.NaN);
+            VerifyACos(double.MinValue, 0.0, double.NaN, double.NaN);
 
             // Verify test results with MinImaginary
-            VerifyACos(0.0, Double.MinValue);
+            VerifyACos(0.0, double.MinValue);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifyACos(1.0, Double.PositiveInfinity, Double.NaN, Double.NaN);
-            VerifyACos(1.0, Double.NegativeInfinity, Double.NaN, Double.NaN);
-            VerifyACos(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifyACos(1.0, double.PositiveInfinity, double.NaN, double.NaN);
+            VerifyACos(1.0, double.NegativeInfinity, double.NaN, double.NaN);
+            VerifyACos(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifyACos(Double.PositiveInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyACos(Double.NegativeInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyACos(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifyACos(double.PositiveInfinity, 1.0, double.NaN, double.NaN);
+            VerifyACos(double.NegativeInfinity, 1.0, double.NaN, double.NaN);
+            VerifyACos(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifyACos(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifyACos(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ASin.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_ASinTest
     {
-        private static void VerifyASin(Double x, Double y)
+        private static void VerifyASin(double x, double y)
         {
             // formula used in the feature: arcsin(z) = -iln(iz + Sqrt(1-z*z))
             // Verification is done with z = ASin(Sin(z));
@@ -18,27 +17,19 @@ namespace System.Numerics.Tests
             Complex sinComplex = Complex.Sin(complex);
             Complex asinComplex = Complex.Asin(sinComplex);
 
-            if (false == Support.VerifyRealImaginaryProperties(asinComplex, x, y))
-            {
-                Console.WriteLine("Error AsIn-Err3A6s1N! ({0}) != ASin(Sin():{1}):{2}", complex, sinComplex, asinComplex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(asinComplex, x, y, 
+                string.Format("({0}) != ASin(Sin():{1}):{2}", complex, sinComplex, asinComplex));
         }
 
-        private static void VerifyASin(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyASin(double x, double y, double expectedReal, double expectedImaginary)
         {
             // if ASin verification formula returns invalid Values
 
             Complex complex = new Complex(x, y);
             Complex asinComplex = Complex.Asin(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(asinComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error AsIn-Err3A6s1N! ASin({0})", complex, asinComplex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(asinComplex, expectedReal, expectedImaginary, 
+                string.Format("ASin({0}):{1}", complex, asinComplex));
         }
 
         [Fact]
@@ -64,8 +55,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyASin(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -88,43 +79,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyASin(Double.MaxValue, Double.MaxValue, Double.NaN, Double.NaN);
+            VerifyASin(double.MaxValue, double.MaxValue, double.NaN, double.NaN);
 
             // Verify test results with MaxReal
-            VerifyASin(Double.MaxValue, 0.0, Double.NaN, Double.NaN);
+            VerifyASin(double.MaxValue, 0.0, double.NaN, double.NaN);
 
             // Verify test results with MaxImg
-            VerifyASin(0.0, Double.MaxValue, Double.NaN, Double.NaN);
+            VerifyASin(0.0, double.MaxValue, double.NaN, double.NaN);
 
             // Verify test results with Min
-            VerifyASin(Double.MinValue, Double.MinValue, Double.NaN, Double.NaN);
+            VerifyASin(double.MinValue, double.MinValue, double.NaN, double.NaN);
 
             // Verify test results with MinReal
-            VerifyASin(Double.MinValue, 0.0, Double.NaN, Double.NaN);
+            VerifyASin(double.MinValue, 0.0, double.NaN, double.NaN);
 
             // Verify test results with MinImaginary
-            VerifyASin(0.0, Double.MinValue, Double.NaN, Double.NaN);
+            VerifyASin(0.0, double.MinValue, double.NaN, double.NaN);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifyASin(1.0, Double.PositiveInfinity, Double.NaN, Double.NaN);
-            VerifyASin(1.0, Double.NegativeInfinity, Double.NaN, Double.NaN);
-            VerifyASin(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifyASin(1.0, double.PositiveInfinity, double.NaN, double.NaN);
+            VerifyASin(1.0, double.NegativeInfinity, double.NaN, double.NaN);
+            VerifyASin(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifyASin(Double.PositiveInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyASin(Double.NegativeInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyASin(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifyASin(double.PositiveInfinity, 1.0, double.NaN, double.NaN);
+            VerifyASin(double.NegativeInfinity, 1.0, double.NaN, double.NaN);
+            VerifyASin(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifyASin(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifyASin(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ATan.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_ATan.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_ATanTest
     {
-        private static void VerifyAtan(Double x, Double y)
+        private static void VerifyAtan(double x, double y)
         {
             // formula used in the feature: Atan(z) = (i/2) * (log(1-iz) - log(1+iz))
             // Verification is done with z = ATan(Tan(z));
@@ -18,26 +17,18 @@ namespace System.Numerics.Tests
             Complex tanComplex = Complex.Tan(complex);
             Complex atanComplex = Complex.Atan(tanComplex);
 
-            if (false == Support.VerifyRealImaginaryProperties(atanComplex, x, y))
-            {
-                Console.WriteLine("Error aTaN-ErraT6A81N! ({0}) != ATan(Tan():{1}):{2}", complex, tanComplex, atanComplex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(atanComplex, x, y, 
+                string.Format("({0}) != ATan(Tan():{1}):{2}", complex, tanComplex, atanComplex));
         }
 
-        private static void VerifyAtan(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyAtan(double x, double y, double expectedReal, double expectedImaginary)
         {
             // if ATan verification formula returns invalid Values
             Complex complex = new Complex(x, y);
             Complex atanComplex = Complex.Atan(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(atanComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error AtAn-Err3A6s1N! ATan({0})", complex, atanComplex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(atanComplex, expectedReal, expectedImaginary,
+                string.Format("ATan({0}):{1}", complex, atanComplex));
         }
 
         [Fact]
@@ -65,8 +56,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyAtan(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -89,43 +80,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyAtan(Double.MaxValue, Double.MaxValue, Double.NaN, Double.NaN);
+            VerifyAtan(double.MaxValue, double.MaxValue, double.NaN, double.NaN);
 
             // Verify test results with MaxReal
-            VerifyAtan(Double.MaxValue, 0, Math.PI / 2, 0);
+            VerifyAtan(double.MaxValue, 0, Math.PI / 2, 0);
 
             // Verify test results with MaxImg
-            VerifyAtan(0, Double.MaxValue, Math.PI / 2, 0);
+            VerifyAtan(0, double.MaxValue, Math.PI / 2, 0);
 
             // Verify test results with Min
-            VerifyAtan(Double.MinValue, Double.MinValue, Double.NaN, Double.NaN);
+            VerifyAtan(double.MinValue, double.MinValue, double.NaN, double.NaN);
 
             // Verify test results with MinReal
-            VerifyAtan(Double.MinValue, 0, -Math.PI / 2, 0);
+            VerifyAtan(double.MinValue, 0, -Math.PI / 2, 0);
 
             // Verify test results with MinImaginary
-            VerifyAtan(0.0, Double.MinValue, -Math.PI / 2, 0);
+            VerifyAtan(0.0, double.MinValue, -Math.PI / 2, 0);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifyAtan(1.0, Double.PositiveInfinity, Double.NaN, Double.NaN);
-            VerifyAtan(1.0, Double.NegativeInfinity, Double.NaN, Double.NaN);
-            VerifyAtan(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifyAtan(1.0, double.PositiveInfinity, double.NaN, double.NaN);
+            VerifyAtan(1.0, double.NegativeInfinity, double.NaN, double.NaN);
+            VerifyAtan(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifyAtan(Double.PositiveInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyAtan(Double.NegativeInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyAtan(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifyAtan(double.PositiveInfinity, 1.0, double.NaN, double.NaN);
+            VerifyAtan(double.NegativeInfinity, 1.0, double.NaN, double.NaN);
+            VerifyAtan(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifyAtan(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifyAtan(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cos.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cos.cs
@@ -2,26 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_CosTest
     {
-        private static void VerifyCos(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyCos(double x, double y, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(x, y);
             Complex cosComplex = Complex.Cos(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(cosComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error cOs-Err36C6s! Cos({0}):{1} != ({2},{3})", complex, cosComplex, expectedReal, expectedImaginary);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(cosComplex, expectedReal, expectedImaginary, 
+                string.Format("Cos({0}):{1} != ({2},{3})", complex, cosComplex, expectedReal, expectedImaginary));
         }
 
-        private static void VerifyCos(Double x, Double y)
+        private static void VerifyCos(double x, double y)
         {
             // the product formula: cos (x+iy) = cos(x)*cosh(y) - isin(x)sinh(y)
             // the verification formula: cos (z) = (Complex.Exp(i*z) + Complex.Exp(-i*z)) / 2
@@ -56,8 +52,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyCos(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -80,43 +76,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyCos(Double.MaxValue, Double.MaxValue, Math.Cos(Double.MaxValue) * Double.PositiveInfinity, Double.NegativeInfinity); //for IA64
+            VerifyCos(double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, double.NegativeInfinity); //for IA64
 
             // Verify test results with MaxReal
-            VerifyCos(Double.MaxValue, 0.0, Math.Cos(Double.MaxValue), 0); //for IA64
+            VerifyCos(double.MaxValue, 0.0, Math.Cos(double.MaxValue), 0); //for IA64
 
             // Verify test results with MaxImg
-            VerifyCos(0.0, Double.MaxValue, Double.PositiveInfinity, Double.NaN);
+            VerifyCos(0.0, double.MaxValue, double.PositiveInfinity, double.NaN);
 
             // Verify test results with Min
-            VerifyCos(Double.MinValue, Double.MinValue, Double.NegativeInfinity, Double.NegativeInfinity);
+            VerifyCos(double.MinValue, double.MinValue, double.NegativeInfinity, double.NegativeInfinity);
 
             // Verify test results with MinReal
-            VerifyCos(Double.MinValue, 0.0, Math.Cos(Double.MinValue), 0); //for IA64
+            VerifyCos(double.MinValue, 0.0, Math.Cos(double.MinValue), 0); //for IA64
 
             // Verify test results with MinImaginary
-            VerifyCos(0.0, Double.MinValue, Double.PositiveInfinity, Double.NaN);
+            VerifyCos(0.0, double.MinValue, double.PositiveInfinity, double.NaN);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifyCos(1.0, Double.PositiveInfinity, Double.PositiveInfinity, Double.NegativeInfinity);
-            VerifyCos(1.0, Double.NegativeInfinity, Double.PositiveInfinity, Double.PositiveInfinity);
-            VerifyCos(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifyCos(1.0, double.PositiveInfinity, double.PositiveInfinity, double.NegativeInfinity);
+            VerifyCos(1.0, double.NegativeInfinity, double.PositiveInfinity, double.PositiveInfinity);
+            VerifyCos(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifyCos(Double.PositiveInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyCos(Double.NegativeInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyCos(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifyCos(double.PositiveInfinity, 1.0, double.NaN, double.NaN);
+            VerifyCos(double.NegativeInfinity, 1.0, double.NaN, double.NaN);
+            VerifyCos(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifyCos(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifyCos(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cosh.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Cosh.cs
@@ -2,27 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_CoshTest
     {
-        private static void VerifyCosh(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyCosh(double x, double y, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(x, y);
             Complex coshComplex = Complex.Cosh(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(coshComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error Cosh-Err3H6s1N!!!! Cosh({0})", complex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(coshComplex, expectedReal, expectedImaginary, 
+                string.Format("Cosh({0})", complex));
         }
 
-        private static void VerifyCosh(Double x, Double y)
+        private static void VerifyCosh(double x, double y)
         {
             // the product formula: cosh (x+iy) = cosh(x)*cos(y) + isinh(x)*sin(y) 
             // the verification formula: Cosh (z) = (Exp(z) + Exp(-z))/2
@@ -57,8 +52,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyCosh(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -81,43 +76,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyCosh(Double.MaxValue, Double.MaxValue, Math.Cos(Double.MaxValue) * Double.PositiveInfinity, Double.PositiveInfinity); //for IA64
+            VerifyCosh(double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, double.PositiveInfinity); //for IA64
 
             // Verify test results with MaxReal
-            VerifyCosh(Double.MaxValue, 0.0, Double.PositiveInfinity, Double.NaN);
+            VerifyCosh(double.MaxValue, 0.0, double.PositiveInfinity, double.NaN);
 
             // Verify test results with MaxImg
-            VerifyCosh(0.0, Double.MaxValue, Math.Cos(Double.MaxValue), 0); //for IA64
+            VerifyCosh(0.0, double.MaxValue, Math.Cos(double.MaxValue), 0); //for IA64
 
             // Verify test results with Min
-            VerifyCosh(Double.MinValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity);
+            VerifyCosh(double.MinValue, double.MinValue, double.NegativeInfinity, double.PositiveInfinity);
 
             // Verify test results with MinReal
-            VerifyCosh(Double.MinValue, 0.0, Double.PositiveInfinity, Double.NaN);
+            VerifyCosh(double.MinValue, 0.0, double.PositiveInfinity, double.NaN);
 
             // Verify test results with MinImaginary
-            VerifyCosh(0.0, Double.MinValue, Math.Cos(Double.MinValue), 0); //for IA64
+            VerifyCosh(0.0, double.MinValue, Math.Cos(double.MinValue), 0); //for IA64
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifyCosh(1.0, Double.PositiveInfinity, Double.NaN, Double.NaN);
-            VerifyCosh(1.0, Double.NegativeInfinity, Double.NaN, Double.NaN);
-            VerifyCosh(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifyCosh(1.0, double.PositiveInfinity, double.NaN, double.NaN);
+            VerifyCosh(1.0, double.NegativeInfinity, double.NaN, double.NaN);
+            VerifyCosh(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifyCosh(Double.PositiveInfinity, 1.0, Double.PositiveInfinity, Double.PositiveInfinity);
-            VerifyCosh(Double.NegativeInfinity, 1.0, Double.PositiveInfinity, Double.NegativeInfinity);
-            VerifyCosh(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifyCosh(double.PositiveInfinity, 1.0, double.PositiveInfinity, double.PositiveInfinity);
+            VerifyCosh(double.NegativeInfinity, 1.0, double.PositiveInfinity, double.NegativeInfinity);
+            VerifyCosh(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifyCosh(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifyCosh(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sin.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sin.cs
@@ -2,27 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_SinTest
     {
-        private static void VerifySin(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifySin(double x, double y, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(x, y);
             Complex sinComplex = Complex.Sin(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(sinComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error sIn-Err36s1N! Sin({0}):{1} != ({2},{3})", complex, sinComplex, expectedReal, expectedImaginary);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(sinComplex, expectedReal, expectedImaginary,
+                string.Format("Sin({0}):{1} != ({2},{3})", complex, sinComplex, expectedReal, expectedImaginary));
         }
 
-        private static void VerifySin(Double x, Double y)
+        private static void VerifySin(double x, double y)
         {
             // the product formula: sin (x+iy) = sin(x)*cosh(y) + icos(x)sinh(y)
             // the verification formula: sin (z) = (Complex.Exp(i*z) - Complex.Exp(-i*z)) / (2*i)
@@ -57,8 +52,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifySin(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -81,43 +76,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifySin(Double.MaxValue, Double.MaxValue, Double.PositiveInfinity, Math.Cos(Double.MaxValue) * Double.PositiveInfinity); //for IA64
+            VerifySin(double.MaxValue, double.MaxValue, double.PositiveInfinity, Math.Cos(double.MaxValue) * double.PositiveInfinity); //for IA64
 
             // Verify test results with MaxReal
-            VerifySin(Double.MaxValue, 0.0, Math.Sin(Double.MaxValue), 0); //for IA64
+            VerifySin(double.MaxValue, 0.0, Math.Sin(double.MaxValue), 0); //for IA64
 
             // Verify test results with MaxImg
-            VerifySin(0.0, Double.MaxValue, Double.NaN, Double.PositiveInfinity);
+            VerifySin(0.0, double.MaxValue, double.NaN, double.PositiveInfinity);
 
             // Verify test results with Min
-            VerifySin(Double.MinValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity);
+            VerifySin(double.MinValue, double.MinValue, double.NegativeInfinity, double.PositiveInfinity);
 
             // Verify test results with MinReal
-            VerifySin(Double.MinValue, 0.0, Math.Sin(Double.MinValue), 0.0); //for IA64
+            VerifySin(double.MinValue, 0.0, Math.Sin(double.MinValue), 0.0); //for IA64
 
             // Verify test results with MinImaginary
-            VerifySin(0.0, Double.MinValue, Double.NaN, Double.NegativeInfinity);
+            VerifySin(0.0, double.MinValue, double.NaN, double.NegativeInfinity);
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifySin(1.0, Double.PositiveInfinity, Double.PositiveInfinity, Double.PositiveInfinity);
-            VerifySin(1.0, Double.NegativeInfinity, Double.PositiveInfinity, Double.NegativeInfinity);
-            VerifySin(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifySin(1.0, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity);
+            VerifySin(1.0, double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity);
+            VerifySin(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifySin(Double.PositiveInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifySin(Double.NegativeInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifySin(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifySin(double.PositiveInfinity, 1.0, double.NaN, double.NaN);
+            VerifySin(double.NegativeInfinity, 1.0, double.NaN, double.NaN);
+            VerifySin(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifySin(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifySin(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sinh.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Sinh.cs
@@ -2,27 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_SinhTest
     {
-        private static void VerifySinh(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifySinh(double x, double y, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(x, y);
             Complex sinhComplex = Complex.Sinh(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(sinhComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error Sinh-Err3H6s1N!!!! Sinh({0})", complex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(sinhComplex, expectedReal, expectedImaginary, 
+                string.Format("Sinh({0})", complex));
         }
 
-        private static void VerifySinh(Double x, Double y)
+        private static void VerifySinh(double x, double y)
         {
             // the product formula: sinh (x+iy) = sinh(x)*cos(y) + icosh(x)*sin(y)
             // the verification formula: sinh (z) = (Exp(z) - Exp(-z))/2
@@ -57,8 +52,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifySinh(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -81,43 +76,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifySinh(Double.MaxValue, Double.MaxValue, Math.Cos(Double.MaxValue) * Double.PositiveInfinity, Double.PositiveInfinity); //for IA64
+            VerifySinh(double.MaxValue, double.MaxValue, Math.Cos(double.MaxValue) * double.PositiveInfinity, double.PositiveInfinity); //for IA64
 
             // Verify test results with MaxReal
-            VerifySinh(Double.MaxValue, 0.0, Double.PositiveInfinity, Double.NaN);
+            VerifySinh(double.MaxValue, 0.0, double.PositiveInfinity, double.NaN);
 
             // Verify test results with MaxImg
-            VerifySinh(0.0, Double.MaxValue, 0, Math.Sin(Double.MaxValue)); //for IA64
+            VerifySinh(0.0, double.MaxValue, 0, Math.Sin(double.MaxValue)); //for IA64
 
             // Verify test results with Min
-            VerifySinh(Double.MinValue, Double.MinValue, Double.PositiveInfinity, Double.NegativeInfinity);
+            VerifySinh(double.MinValue, double.MinValue, double.PositiveInfinity, double.NegativeInfinity);
 
             // Verify test results with MinReal
-            VerifySinh(Double.MinValue, 0.0, Double.NegativeInfinity, Double.NaN);
+            VerifySinh(double.MinValue, 0.0, double.NegativeInfinity, double.NaN);
 
             // Verify test results with MinImaginary
-            VerifySinh(0.0, Double.MinValue, 0, Math.Sin(Double.MinValue)); //for IA64
+            VerifySinh(0.0, double.MinValue, 0, Math.Sin(double.MinValue)); //for IA64
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifySinh(1.0, Double.PositiveInfinity, Double.NaN, Double.NaN);
-            VerifySinh(1.0, Double.NegativeInfinity, Double.NaN, Double.NaN);
-            VerifySinh(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifySinh(1.0, double.PositiveInfinity, double.NaN, double.NaN);
+            VerifySinh(1.0, double.NegativeInfinity, double.NaN, double.NaN);
+            VerifySinh(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifySinh(Double.PositiveInfinity, 1.0, Double.PositiveInfinity, Double.PositiveInfinity);
-            VerifySinh(Double.NegativeInfinity, 1.0, Double.NegativeInfinity, Double.PositiveInfinity);
-            VerifySinh(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifySinh(double.PositiveInfinity, 1.0, double.PositiveInfinity, double.PositiveInfinity);
+            VerifySinh(double.NegativeInfinity, 1.0, double.NegativeInfinity, double.PositiveInfinity);
+            VerifySinh(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifySinh(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifySinh(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tan.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tan.cs
@@ -2,37 +2,37 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_TanTest
     {
-        private static void VerifyTan(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyTan(double x, double y, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(x, y);
             Complex tanComplex = Complex.Tan(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(tanComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error TaN-ErrT6A81N! Tan({0}):{1} != ({2},{3})", complex, tanComplex, expectedReal, expectedImaginary);
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(tanComplex, expectedReal, expectedImaginary,
+                string.Format("Tan({0}):{1} != ({2},{3})", complex, tanComplex, expectedReal, expectedImaginary));
 
             // The following verification can be added: tan(x) = -tan(-x)
         }
 
-        private static void VerifyTan(Double x, Double y)
+        private static void VerifyTan(double x, double y)
         {
-            Double scale = Math.Cosh(2 * y);
-            if (!Double.IsInfinity(scale))
+            double scale = Math.Cosh(2 * y);
+            if (!double.IsInfinity(scale))
+            {
                 scale += Math.Cos(2 * x);
-            Double expectedReal = Math.Sin(2 * x) / scale;
-            Double expectedImaginary = Math.Sinh(2 * y) / scale;
+            }
+            double expectedReal = Math.Sin(2 * x) / scale;
+            double expectedImaginary = Math.Sinh(2 * y) / scale;
 
-            if (Double.IsNaN(expectedImaginary))
-                expectedReal = Double.NaN;
+            if (double.IsNaN(expectedImaginary))
+            {
+                expectedReal = double.NaN;
+            }
             VerifyTan(x, y, expectedReal, expectedImaginary);
         }
 
@@ -59,8 +59,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyTan(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -83,22 +83,22 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyTan(Double.MaxValue, Double.MaxValue, Double.NaN, Double.NaN);
+            VerifyTan(double.MaxValue, double.MaxValue, double.NaN, double.NaN);
 
             // Verify test results with MaxReal
-            VerifyTan(Double.MaxValue, 0.0, Math.Sin(Double.MaxValue) / Math.Cos(Double.MaxValue), 0); //for IA64
+            VerifyTan(double.MaxValue, 0.0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue), 0); //for IA64
 
             // Verify test results with MaxImg
-            VerifyTan(0.0, Double.MaxValue, Double.NaN, Double.NaN);
+            VerifyTan(0.0, double.MaxValue, double.NaN, double.NaN);
 
             // Verify test results with Min
-            VerifyTan(Double.MinValue, Double.MinValue, Double.NaN, Double.NaN);
+            VerifyTan(double.MinValue, double.MinValue, double.NaN, double.NaN);
 
             // Verify test results with MinReal
-            VerifyTan(Double.MinValue, 0.0, Math.Sin(Double.MinValue) / Math.Cos(Double.MinValue), 0); //for IA64
+            VerifyTan(double.MinValue, 0.0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue), 0); //for IA64
 
             // Verify test results with MinImaginary
-            VerifyTan(0.0, Double.MinValue, Double.NaN, Double.NaN);
+            VerifyTan(0.0, double.MinValue, double.NaN, double.NaN);
         }
     }
 }

--- a/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tanh.cs
+++ b/src/System.Runtime.Numerics/tests/Complex/trigonometricOperations_Tanh.cs
@@ -2,27 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ComplexTestSupport;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Numerics.Tests
 {
     public class trigonometricOperations_TanhTest
     {
-        private static void VerifyTanh(Double x, Double y, Double expectedReal, Double expectedImaginary)
+        private static void VerifyTanh(double x, double y, double expectedReal, double expectedImaginary)
         {
             Complex complex = new Complex(x, y);
             Complex tanhComplex = Complex.Tanh(complex);
 
-            if (false == Support.VerifyRealImaginaryProperties(tanhComplex, expectedReal, expectedImaginary))
-            {
-                Console.WriteLine("Error TaNh-ErrT6A81Nh!!! Actual Tanh({0})", complex);
-
-                Assert.True(false, "Verification Failed");
-            }
+            Support.VerifyRealImaginaryProperties(tanhComplex, expectedReal, expectedImaginary,
+                string.Format("Tanh({0}):{1} != ({2},{3})", complex, tanhComplex, expectedReal, expectedImaginary));
         }
 
-        private static void VerifyTanh(Double x, Double y)
+        private static void VerifyTanh(double x, double y)
         {
             // the product formula: cosh (x+iy) = sinh (x+iy) / cosh (x+iy)
             // the verification formula: Tanh (z) = (Exp(2z) -1) / (Exp(2z)+1)
@@ -58,8 +53,8 @@ namespace System.Numerics.Tests
         public static void RunTests_RandomValidValues()
         {
             // Verify test results with ComplexInFirstQuad
-            Double real = Support.GetSmallRandomDoubleValue(false);
-            Double imaginary = Support.GetSmallRandomDoubleValue(false);
+            double real = Support.GetSmallRandomDoubleValue(false);
+            double imaginary = Support.GetSmallRandomDoubleValue(false);
             VerifyTanh(real, imaginary);
 
             // Verify test results with ComplexInSecondQuad
@@ -82,43 +77,43 @@ namespace System.Numerics.Tests
         public static void RunTests_BoundaryValues()
         {
             // Verify test results with Max
-            VerifyTanh(Double.MaxValue, Double.MaxValue);
+            VerifyTanh(double.MaxValue, double.MaxValue);
 
             // Verify test results with MaxReal
-            VerifyTanh(Double.MaxValue, 0.0);
+            VerifyTanh(double.MaxValue, 0.0);
 
             // Verify test results with MaxImg
-            VerifyTanh(0.0, Double.MaxValue, 0, Math.Sin(Double.MaxValue) / Math.Cos(Double.MaxValue)); //for IA64
+            VerifyTanh(0.0, double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue)); //for IA64
 
             // Verify test results with Min
-            VerifyTanh(Double.MinValue, Double.MinValue);
+            VerifyTanh(double.MinValue, double.MinValue);
 
             // Verify test results with MinReal
-            VerifyTanh(Double.MinValue, 0.0, Double.NaN, Double.NaN);
+            VerifyTanh(double.MinValue, 0.0, double.NaN, double.NaN);
 
             // Verify test results with MinImaginary
-            VerifyTanh(0.0, Double.MinValue, 0, Math.Sin(Double.MinValue) / Math.Cos(Double.MinValue)); //for IA64
+            VerifyTanh(0.0, double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue)); //for IA64
         }
 
         [Fact]
         public static void RunTests_InvalidValues()
         {
             // Verify test results with invalid Imaginary
-            VerifyTanh(1.0, Double.PositiveInfinity, Double.NaN, Double.NaN);
-            VerifyTanh(1.0, Double.NegativeInfinity, Double.NaN, Double.NaN);
-            VerifyTanh(1.0, Double.NaN, Double.NaN, Double.NaN);
+            VerifyTanh(1.0, double.PositiveInfinity, double.NaN, double.NaN);
+            VerifyTanh(1.0, double.NegativeInfinity, double.NaN, double.NaN);
+            VerifyTanh(1.0, double.NaN, double.NaN, double.NaN);
 
             // Verify test results with invalid Real
-            VerifyTanh(Double.PositiveInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyTanh(Double.NegativeInfinity, 1.0, Double.NaN, Double.NaN);
-            VerifyTanh(Double.NaN, 1.0, Double.NaN, Double.NaN);
+            VerifyTanh(double.PositiveInfinity, 1.0, double.NaN, double.NaN);
+            VerifyTanh(double.NegativeInfinity, 1.0, double.NaN, double.NaN);
+            VerifyTanh(double.NaN, 1.0, double.NaN, double.NaN);
 
             // Verify test results with invalid Real and Imaginary
-            foreach (Double invalidReal in Support.doubleInvalidValues)
+            foreach (double invalidReal in Support.doubleInvalidValues)
             {
-                foreach (Double invalidImaginary in Support.doubleInvalidValues)
+                foreach (double invalidImaginary in Support.doubleInvalidValues)
                 {
-                    VerifyTanh(invalidReal, invalidImaginary, Double.NaN, Double.NaN);
+                    VerifyTanh(invalidReal, invalidImaginary, double.NaN, double.NaN);
                 }
             }
         }


### PR DESCRIPTION
Remove Console.WriteLine from Complex tests.
More effectively use Asserts in Complex test code.

Progress against #915