### PR TITLE
Improve performance of BigInteger.Multiply

### DIFF
--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -19,6 +19,8 @@
   </PropertyGroup>
   <!-- References are resolved from packages.config -->
   <ItemGroup>
+    <Compile Include="System\Numerics\BigIntegerCalculator.AddSub.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.SquMul.cs" />
     <Compile Include="System\Numerics\BigInteger.cs" />
     <Compile Include="System\Numerics\BigIntegerBuilder.cs" />
     <Compile Include="System\Numerics\BigNumber.cs" />

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1618,12 +1618,46 @@ namespace System.Numerics
             left.AssertValid();
             right.AssertValid();
 
-            int sign = +1;
-            BigIntegerBuilder reg1 = new BigIntegerBuilder(left, ref sign);
-            BigIntegerBuilder reg2 = new BigIntegerBuilder(right, ref sign);
+            uint[] result;
 
-            reg1.Mul(ref reg2);
-            return reg1.GetInteger(sign);
+            if (left._bits != null)
+            {
+                if (right._bits != null)
+                {
+                    if (left._bits == right._bits)
+                    {
+                        result = BigIntegerCalculator.Square(left._bits);
+                    }
+                    else
+                    {
+                        if (left._bits.Length < right._bits.Length)
+                        {
+                            result = BigIntegerCalculator.Multiply(right._bits, left._bits);
+                        }
+                        else
+                        {
+                            result = BigIntegerCalculator.Multiply(left._bits, right._bits);
+                        }
+                    }
+                }
+                else
+                {
+                    result = BigIntegerCalculator.Multiply(left._bits, NumericsHelpers.Abs(right._sign));
+                }
+            }
+            else
+            {
+                if (right._bits != null)
+                {
+                    result = BigIntegerCalculator.Multiply(right._bits, NumericsHelpers.Abs(left._sign));
+                }
+                else
+                {
+                    result = BigIntegerCalculator.Multiply(NumericsHelpers.Abs(left._sign), NumericsHelpers.Abs(right._sign));
+                }
+            }
+
+            return new BigInteger(result, (left._sign < 0) ^ (right._sign < 0));
         }
 
         public static BigInteger operator /(BigInteger dividend, BigInteger divisor)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
@@ -1,0 +1,72 @@
+﻿using System.Diagnostics;
+using System.Security;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        [SecuritySafeCritical]
+        private unsafe static void Add(uint* left, int leftLength,
+                                       uint* right, int rightLength,
+                                       uint* bits, int bitsLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+            Debug.Assert(leftLength >= rightLength);
+            Debug.Assert(bitsLength == leftLength + 1);
+
+            // Executes the "grammar-school" algorithm for computing z = a + b.
+            // While calculating z_i = a_i + b_i we take care of overflow:
+            // Since a_i + b_i + c <= 2(2^32 - 1) + 1 = 2^33 - 1, our carry c
+            // has always the value 1 or 0; hence, we're safe here.
+
+            int i = 0;
+            long carry = 0L;
+
+            // adds the bits
+            for (; i < rightLength; i++)
+            {
+                long digit = (left[i] + carry) + right[i];
+                bits[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            for (; i < leftLength; i++)
+            {
+                long digit = left[i] + carry;
+                bits[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            bits[i] = (uint)carry;
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void AddSelf(uint* left, int leftLength,
+                                           uint* right, int rightLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+            Debug.Assert(leftLength >= rightLength);
+
+            // Executes the "grammar-school" algorithm for computing z = a + b.
+            // Same as above, but we're writing the result directly to a and
+            // stop execution, if we're out of b and c is already 0.
+
+            int i = 0;
+            long carry = 0L;
+
+            // adds the bits
+            for (; i < rightLength; i++)
+            {
+                long digit = (left[i] + carry) + right[i];
+                left[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            for (; carry != 0 && i < leftLength; i++)
+            {
+                long digit = left[i] + carry;
+                left[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -1,0 +1,364 @@
+﻿using System.Diagnostics;
+using System.Security;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        [SecuritySafeCritical]
+        public unsafe static uint[] Square(uint[] value)
+        {
+            Debug.Assert(value != null);
+
+            // Switching to unsafe pointers helps sparing
+            // some nasty index calculations...
+
+            uint[] bits = new uint[value.Length + value.Length];
+
+            fixed (uint* v = value, b = bits)
+            {
+                Square(v, value.Length,
+                       b, bits.Length);
+            }
+
+            return bits;
+        }
+
+#if DEBUG
+        private const int SquareThreshold = 8;
+#else
+        private const int SquareThreshold = 32;
+#endif
+
+        [SecuritySafeCritical]
+        private unsafe static void Square(uint* value, int valueLength,
+                                          uint* bits, int bitsLength)
+        {
+            Debug.Assert(valueLength >= 0);
+            Debug.Assert(bitsLength == valueLength + valueLength);
+
+            // Executes different algorithms for computing z = a * a
+            // based on the actual length of a. If a is "small" enough
+            // we stick to the classic "grammar-school" method; for the
+            // rest we switch to implementations with less complexity
+            // albeit more overhead (which needs to pay off!).
+
+            // NOTE: useful thresholds needs some "empirical" testing,
+            // which are smaller in DEBUG mode for testing purpose.
+
+            if (valueLength < SquareThreshold)
+            {
+                // Squares the bits using the "grammar-school" method.
+                // Envisioning the "rhombus" of a pen-and-paper calculation
+                // we see that computing z_i+j += a_j * a_i can be optimized
+                // since a_j * a_i = a_i * a_j (we're squaring after all!).
+                // Thus, we directly get z_i+j += 2 * a_j * a_i + c.
+
+                // ATTENTION: an ordinary multiplication is safe, because
+                // z_i+j + a_j * a_i + c <= 2(2^32 - 1) + (2^32 - 1)^2 =
+                // = 2^64 - 1 (which perfectly matches with ulong!). But
+                // here we would need an UInt65... Hence, we split these
+                // operation and do some extra shifts.
+
+                for (int i = 0; i < valueLength; i++)
+                {
+                    ulong carry = 0UL;
+                    for (int j = 0; j < i; j++)
+                    {
+                        ulong digit1 = bits[i + j] + carry;
+                        ulong digit2 = (ulong)value[j] * value[i];
+                        bits[i + j] = (uint)(digit1 + (digit2 << 1));
+                        carry = (digit2 + (digit1 >> 1)) >> 31;
+                    }
+                    ulong digits = (ulong)value[i] * value[i] + carry;
+                    bits[i + i] = (uint)digits;
+                    bits[i + i + 1] = (uint)(digits >> 32);
+                }
+            }
+            else
+            {
+                // Based on the Toom-Cook multiplication we split value
+                // into two smaller values, doing recursive squaring.
+                // The special form of this multiplication, where we
+                // split both operands into two operands, is also known
+                // as the Karatsuba algorithm...
+
+                // https://en.wikipedia.org/wiki/Toom-Cook_multiplication
+                // https://en.wikipedia.org/wiki/Karatsuba_algorithm
+
+                // Say we want to compute z = a * a ...
+
+                // ... we need to determine our new length (just the half)
+                int n = valueLength >> 1;
+                int n2 = n << 1;
+
+                // ... split value like a = (a_1 << n) + a_0
+                uint* valueLow = value;
+                int valueLowLength = n;
+                uint* valueHigh = value + n;
+                int valueHighLength = valueLength - n;
+
+                // ... prepare our result array (to reuse its memory)
+                uint* bitsLow = bits;
+                int bitsLowLength = n2;
+                uint* bitsHigh = bits + n2;
+                int bitsHighLength = bitsLength - n2;
+
+                // ... compute z_0 = a_0 * a_0 (squaring again!)
+                Square(valueLow, valueLowLength,
+                       bitsLow, bitsLowLength);
+
+                // ... compute z_2 = a_1 * a_1 (squaring again!)
+                Square(valueHigh, valueHighLength,
+                       bitsHigh, bitsHighLength);
+
+                // ... compute z_a = a_1 + a_0 (call it fold...)
+                int foldLength = valueHighLength + 1;
+                uint* fold = stackalloc uint[foldLength];
+
+                Add(valueHigh, valueHighLength,
+                    valueLow, valueLowLength,
+                    fold, foldLength);
+
+                // ... compute z_1 = z_a * z_a - z_0 - z_2
+                int coreLength = foldLength + foldLength;
+                uint* core = stackalloc uint[coreLength];
+
+                Square(fold, foldLength,
+                       core, coreLength);
+                SubtractCore(bitsHigh, bitsHighLength,
+                             bitsLow, bitsLowLength,
+                             core, coreLength);
+
+                // ... and finally merge the result! :-)
+                AddSelf(bits + n, bitsLength - n, core, coreLength);
+            }
+        }
+
+        public static uint[] Multiply(uint left, uint right)
+        {
+            // Executes the trivial multiplication for two 32-bit integers.
+            // Since the caller is working with uint[] objects, we're
+            // doing him a favor with already providing it that way.
+
+            uint[] bits = new uint[2];
+
+            ulong digits = (ulong)left * right;
+            bits[0] = (uint)digits;
+            bits[1] = (uint)(digits >> 32);
+
+            return bits;
+        }
+
+        public static uint[] Multiply(uint[] left, uint right)
+        {
+            Debug.Assert(left != null);
+
+            // Executes the multiplication for one big and one 32-bit integer.
+            // Since every step holds the already slightly familiar equation
+            // a_i * b + c <= 2^32 - 1 + (2^32 - 1)^2 < 2^64 - 1,
+            // we are safe regarding to overflows.
+
+            int i = 0;
+            ulong carry = 0UL;
+            uint[] bits = new uint[left.Length + 1];
+
+            for (; i < left.Length; i++)
+            {
+                ulong digits = (ulong)left[i] * right + carry;
+                bits[i] = (uint)digits;
+                carry = digits >> 32;
+            }
+            bits[i] = (uint)carry;
+
+            return bits;
+        }
+
+        [SecuritySafeCritical]
+        public unsafe static uint[] Multiply(uint[] left, uint[] right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+            Debug.Assert(left.Length >= right.Length);
+
+            // Switching to unsafe pointers helps sparing
+            // some nasty index calculations...
+
+            uint[] bits = new uint[left.Length + right.Length];
+
+            fixed (uint* l = left, r = right, b = bits)
+            {
+                Multiply(l, left.Length,
+                         r, right.Length,
+                         b, bits.Length);
+            }
+
+            return bits;
+        }
+
+#if DEBUG
+        private const int MultiplyThreshold = 8;
+#else
+        private const int MultiplyThreshold = 32;
+#endif
+
+        [SecuritySafeCritical]
+        private unsafe static void Multiply(uint* left, int leftLength,
+                                            uint* right, int rightLength,
+                                            uint* bits, int bitsLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+            Debug.Assert(leftLength >= rightLength);
+            Debug.Assert(bitsLength == leftLength + rightLength);
+
+            // Executes different algorithms for computing z = a * b
+            // based on the actual length of b. If b is "small" enough
+            // we stick to the classic "grammar-school" method; for the
+            // rest we switch to implementations with less complexity
+            // albeit more overhead (which needs to pay off!).
+
+            // NOTE: useful thresholds needs some "empirical" testing,
+            // which are smaller in DEBUG mode for testing purpose.
+
+            if (rightLength < MultiplyThreshold)
+            {
+                // Multiplies the bits using the "grammar-school" method.
+                // Envisioning the "rhombus" of a pen-and-paper calculation
+                // should help getting the idea of these two loops...
+                // The inner multiplication operations are safe, because
+                // z_i+j + a_j * b_i + c <= 2(2^32 - 1) + (2^32 - 1)^2 =
+                // = 2^64 - 1 (which perfectly matches with ulong!).
+
+                for (int i = 0; i < rightLength; i++)
+                {
+                    ulong carry = 0UL;
+                    for (int j = 0; j < leftLength; j++)
+                    {
+                        ulong digits = bits[i + j] + carry
+                            + (ulong)left[j] * right[i];
+                        bits[i + j] = (uint)digits;
+                        carry = digits >> 32;
+                    }
+                    bits[i + leftLength] = (uint)carry;
+                }
+            }
+            else
+            {
+                // Based on the Toom-Cook multiplication we split left/right
+                // into two smaller values, doing recursive multiplication.
+                // The special form of this multiplication, where we
+                // split both operands into two operands, is also known
+                // as the Karatsuba algorithm...
+
+                // https://en.wikipedia.org/wiki/Toom-Cook_multiplication
+                // https://en.wikipedia.org/wiki/Karatsuba_algorithm
+
+                // Say we want to compute z = a * b ...
+
+                // ... we need to determine our new length (just the half)
+                int n = rightLength >> 1;
+                int n2 = n << 1;
+
+                // ... split left like a = (a_1 << n) + a_0
+                uint* leftLow = left;
+                int leftLowLength = n;
+                uint* leftHigh = left + n;
+                int leftHighLength = leftLength - n;
+
+                // ... split right like b = (b_1 << n) + b_0
+                uint* rightLow = right;
+                int rightLowLength = n;
+                uint* rightHigh = right + n;
+                int rightHighLength = rightLength - n;
+
+                // ... prepare our result array (to reuse its memory)
+                uint* bitsLow = bits;
+                int bitsLowLength = n2;
+                uint* bitsHigh = bits + n2;
+                int bitsHighLength = bitsLength - n2;
+
+                // ... compute z_0 = a_0 * b_0 (multiply again)
+                Multiply(leftLow, leftLowLength,
+                         rightLow, rightLowLength,
+                         bitsLow, bitsLowLength);
+
+                // ... compute z_2 = a_1 * b_1 (multiply again)
+                Multiply(leftHigh, leftHighLength,
+                         rightHigh, rightHighLength,
+                         bitsHigh, bitsHighLength);
+
+                // ... compute z_a = a_1 + a_0 (call it fold...)
+                int leftFoldLength = leftHighLength + 1;
+                uint* leftFold = stackalloc uint[leftFoldLength];
+
+                Add(leftHigh, leftHighLength,
+                    leftLow, leftLowLength,
+                    leftFold, leftFoldLength);
+
+                // ... compute z_b = b_1 + b_0 (call it fold...)
+                int rightFoldLength = rightHighLength + 1;
+                uint* rightFold = stackalloc uint[rightFoldLength];
+
+                Add(rightHigh, rightHighLength,
+                    rightLow, rightLowLength,
+                    rightFold, rightFoldLength);
+
+                // ... compute z_1 = z_a * z_b - z_0 - z_2
+                int coreLength = leftFoldLength + rightFoldLength;
+                uint* core = stackalloc uint[coreLength];
+
+                Multiply(leftFold, leftFoldLength,
+                         rightFold, rightFoldLength,
+                         core, coreLength);
+                SubtractCore(bitsHigh, bitsHighLength,
+                             bitsLow, bitsLowLength,
+                             core, coreLength);
+
+                // ... and finally merge the result! :-)
+                AddSelf(bits + n, bitsLength - n, core, coreLength);
+            }
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void SubtractCore(uint* left, int leftLength,
+                                                uint* right, int rightLength,
+                                                uint* core, int coreLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+            Debug.Assert(coreLength >= 0);
+            Debug.Assert(leftLength >= rightLength);
+            Debug.Assert(coreLength >= leftLength);
+
+            // Executes a special subtraction algorithm for the multiplication,
+            // which needs to subtract two different values from a core value,
+            // while core is always bigger than the sum of these values.
+
+            // NOTE: we could do an ordinary subtraction of course, but we spare
+            // one "run", if we do this computation within a single one...
+
+            int i = 0;
+            long carry = 0L;
+
+            for (; i < rightLength; i++)
+            {
+                long digit = (core[i] + carry) - left[i] - right[i];
+                core[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            for (; i < leftLength; i++)
+            {
+                long digit = (core[i] + carry) - left[i];
+                core[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            for (; carry != 0 && i < coreLength; i++)
+            {
+                long digit = core[i] + carry;
+                core[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -84,6 +84,9 @@ namespace Tools
                     return new BigInteger(Negate(bytes1).ToArray());
                 case "u+":
                     return num1;
+                case "uMultiply":
+                case "u*":
+                    return new BigInteger(Multiply(bytes1, bytes1).ToArray());
                 default:
                     Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;

--- a/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -18,6 +18,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
+            // Multiply Method - One Large BigInteger
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(random);
+                VerifyMultiplyString(Print(tempByteArray1) + "uMultiply");
+            }
+
             // Multiply Method - Two Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
@@ -18,6 +18,13 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
 
+            // Multiply Method - One Large BigInteger
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                VerifyMultiplyString(Print(tempByteArray1) + "u*");
+            }
+
             // Multiply Method - Two Large BigIntegers
             for (int i = 0; i < s_samples; i++)
             {
@@ -158,6 +165,13 @@ namespace System.Numerics.Tests
         {
             byte[] tempByteArray1 = new byte[0];
             byte[] tempByteArray2 = new byte[0];
+
+            // Multiply Method - One Large BigInteger
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                VerifyMultiplyString(Print(tempByteArray1) + "u*");
+            }
 
             // Multiply Method - Two Large BigIntegers
             for (int i = 0; i < s_samples; i++)

--- a/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -176,6 +176,10 @@ namespace Tools
                     return (-(num1));
                 case "u+":
                     return (+(num1));
+                case "uMultiply":
+                    return BigInteger.Multiply(num1, num1);
+                case "u*":
+                    return num1 * num1;
                 default:
                     Assert.True(false, String.Format("Invalid operation found: {0}", op));
                     break;


### PR DESCRIPTION
To introduce performance tweaks for BigInteger's operations a new static class `BigCalc` implements those algorithms based on raw uint[] objects, partially switching even to pointer arithmetic to spare some index calculations. First of all a multiplication implementation is included, furthermore an optimized version for squaring.

A basic performance comparison based on [this code](https://gist.github.com/axelheer/3b701c91271b7c762586) unveils the following results:

**Multiply**

| # of bits | # of vals | before ms | after ms |
|----------:|----------:|----------:|---------:|
|        16 | 1,000,000 |        41 |       35 |
|        64 | 1,000,000 |       127 |       89 |
|       256 | 1,000,000 |       284 |      182 |
|     1,024 |   100,000 |       236 |      147 |
|     4,096 |    10,000 |       323 |      142 |
|    16,384 |     1,000 |       495 |      132 |
|    65,536 |       100 |       785 |      121 |

**Square**

| # of bits | # of vals | before ms | after ms |
|----------:|----------:|----------:|---------:|
|        16 | 1,000,000 |        41 |       42 |
|        64 | 1,000,000 |       127 |       78 |
|       256 | 1,000,000 |       284 |      147 |
|     1,024 |   100,000 |       236 |      102 |
|     4,096 |    10,000 |       323 |       98 |
|    16,384 |     1,000 |       495 |       92 |
|    65,536 |       100 |       785 |       84 |

*Note:* the performance gain is not as big as expected based on my previous work (as mentioned within the issue), but I'd still call it significant. I actually had some difficulties executing a custom build of *System.Runtime.Numerics* though, since just dropping in the *dll* as described [here](https://github.com/dotnet/corefx/wiki/Open-Source-Signing) does not work 'cause of some "type forwards". I finally managed to execute it using *kre-coreclr-win-x64.1.0.0-beta3* and some hacks... :flushed:

#1307