### PR TITLE
Fix #284: XPath AxesCombination tests are failing on debug builds

### DIFF
--- a/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
+++ b/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
@@ -44939,7 +44939,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS59: //namespace::node()//@*
         /// </summary>
         [Fact]
-        [ActiveIssue(284)]
         public static void AxesCombinationsTest2142()
         {
             var xml = "ns_prefixes.xml";
@@ -44955,7 +44954,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS60: //namespace::node()//self::*
         /// </summary>
         [Fact]
-        [ActiveIssue(284)]
         public static void AxesCombinationsTest2143()
         {
             var xml = "ns_prefixes.xml";
@@ -44971,7 +44969,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS61: //namespace::node()//namespace::node()
         /// </summary>
         [Fact]
-        [ActiveIssue(284)]
         public static void AxesCombinationsTest2144()
         {
             var xml = "ns_prefixes.xml";

--- a/src/System.Xml.XPath.XDocument/System.Xml.XPath.XDocument.sln
+++ b/src/System.Xml.XPath.XDocument/System.Xml.XPath.XDocument.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22310.1
+VisualStudioVersion = 14.0.22609.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XDocument", "src\System.Xml.XPath.XDocument.csproj", "{DAA1EA56-C318-4D2E-AB8D-1AB87D9F98F5}"
 EndProject
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DAB
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XmlDocument", "..\System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj", "{17CB2E3C-2904-4241-94DB-3894D24F35DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath", "..\System.Xml.XPath\src\System.Xml.XPath.csproj", "{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +39,10 @@ Global
 		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17CB2E3C-2904-4241-94DB-3894D24F35DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
+++ b/src/System.Xml.XPath.XDocument/src/System.Xml.XPath.XDocument.csproj
@@ -28,5 +28,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Xml.XPath\src\System.Xml.XPath.csproj">
+      <Project>{be28323e-327a-4e0f-b7f9-16ab7eab59dd}</Project>
+      <Name>System.Xml.XPath</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XPath.XDocument/src/project.json
+++ b/src/System.Xml.XPath.XDocument/src/project.json
@@ -10,7 +10,6 @@
     "System.Runtime.Extensions": "4.0.10-beta-22809",
     "System.Threading": "4.0.10-beta-22809",
     "System.Xml.ReaderWriter": "4.0.10-beta-22809",
-    "System.Xml.XDocument": "4.0.10-beta-22809",
-    "System.Xml.XPath": "4.0.0-beta-22809"
+    "System.Xml.XDocument": "4.0.10-beta-22809"
   }
 }

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -217,6 +217,10 @@
       <Project>{17cb2e3c-2904-4241-94db-3894d24f35da}</Project>
       <Name>System.Xml.XPath.XmlDocument</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Xml.XPath\src\System.Xml.XPath.csproj">
+      <Project>{be28323e-327a-4e0f-b7f9-16ab7eab59dd}</Project>
+      <Name>System.Xml.XPath</Name>
+    </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.XDocument.csproj">
       <Project>{daa1ea56-c318-4d2e-ab8d-1ab87d9f98f5}</Project>
       <Name>System.Xml.XPath.XDocument</Name>

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -10,7 +10,6 @@
     "System.Threading.Tasks": "4.0.10-beta-22809",
     "System.Xml.ReaderWriter": "4.0.10-beta-22809",
     "System.Xml.XDocument": "4.0.10-beta-22809",
-    "System.Xml.XmlDocument": "4.0.0-beta-22809",
-    "System.Xml.XPath": "4.0.0-beta-22809"
+    "System.Xml.XmlDocument": "4.0.0-beta-22809"
   }
 }

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -53,5 +53,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Xml.XPath\src\System.Xml.XPath.csproj">
+      <Project>{be28323e-327a-4e0f-b7f9-16ab7eab59dd}</Project>
+      <Name>System.Xml.XPath</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XPath.XmlDocument/src/project.json
+++ b/src/System.Xml.XPath.XmlDocument/src/project.json
@@ -11,7 +11,6 @@
     "System.Runtime.Extensions": "4.0.10-beta-22809",
     "System.Threading": "4.0.10-beta-22809",
     "System.Xml.ReaderWriter": "4.0.10-beta-22809",
-    "System.Xml.XmlDocument": "4.0.0-beta-22809",
-    "System.Xml.XPath": "4.0.0-beta-22809"
+    "System.Xml.XmlDocument": "4.0.0-beta-22809"
   }
 }

--- a/src/System.Xml.XPath/src/System/Xml/XPath/XPathNavigator.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/XPathNavigator.cs
@@ -706,10 +706,6 @@ namespace System.Xml.XPath
 
                 if (parent1.IsSamePosition(parent2))
                 {
-                    if (n1.GetType().ToString() != "Microsoft.VisualStudio.Modeling.StoreNavigator")
-                    {
-                        Debug.Assert(CompareSiblings(n1.Clone(), n2.Clone()) != CompareSiblings(n2.Clone(), n1.Clone()), "IsSamePosition() on custom navigator returns inconsistent results");
-                    }
                     return CompareSiblings(n1, n2);
                 }
 


### PR DESCRIPTION
Explanation on removed Debug.Assert:
Currently Debug.Assert is checking if:
CompareSiblings(n1, n2) == CompareSiblings(n2, n1)

the assumption is incorrect.
The easiest example of why is: If CompareSiblings(n1, n2) returns "XmlNodeOrder.After" the expected CompareSiblings(n2, n1) is "XmlNodeOrder.Before" and not After.

I couldn't find why did we have such assumption (behavior seems to be present since one of the first versions of .NET). My guess is that at one point CompareSiblings used to return Same/NotSame and after changing that to be more accurate the Debug.Assert stayed and somehow we never tested this path.