### PR TITLE
Remove testcategories from csproj, in relation to the recent changes in buildtools.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,8 +2,8 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00033</BuildToolsVersion>
-    <DnxVersion>1.0.0-beta5-11562</DnxVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00037</BuildToolsVersion>
+    <DnxVersion>1.0.0-beta5-11580</DnxVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00033" />
-  <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11562" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00037" />
+  <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11580" />
 </packages>

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Collections.Concurrent.Tests</AssemblyName>
     <RootNamespace>System.Collections.Concurrent.Tests</RootNamespace>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>System.Collections.NonGeneric.Tests</RootNamespace>
     <AssemblyName>System.Collections.NonGeneric.Tests</AssemblyName>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Console/tests/System.Console.Tests.csproj
+++ b/src/System.Console/tests/System.Console.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Console.Tests</AssemblyName>
     <RootNamespace>System.Console.Tests</RootNamespace>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>System.IO.FileSystem.DriveInfo.Tests</RootNamespace>
     <AssemblyName>System.IO.FileSystem.DriveInfo.Tests</AssemblyName>
     <ProjectGuid>{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -7,7 +7,6 @@
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -13,7 +13,6 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>8be98411</NuGetPackageImportStamp>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>System.Numerics.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Numerics.Tests</AssemblyName>
     <ProjectGuid>{28AE24F8-BEF4-4358-B612-ADD9D587C8E1}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System.Security.SecureString.Tests</RootNamespace>
     <AssemblyName>System.Security.SecureString.Tests</AssemblyName>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.Threading.Tasks.Dataflow.Tests</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>bcca2a00</NuGetPackageImportStamp>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Parallel.Tests</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Parallel.Tests</AssemblyName>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/System.Xml.RW.CharCheckingReader.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/System.Xml.RW.CharCheckingReader.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.CharCheckingReader.Tests</AssemblyName>
     <RootNamespace>XmlReaderTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/System.Xml.RW.CustomReader.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/System.Xml.RW.CustomReader.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.CustomReader.Tests</AssemblyName>
     <RootNamespace>XmlReaderTest.CustomReaderTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/System.Xml.RW.FactoryReader.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/System.Xml.RW.FactoryReader.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.FactoryReader.Tests</AssemblyName>
     <RootNamespace>XmlReaderTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/System.Xml.RW.NameTable.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/System.Xml.RW.NameTable.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.NameTable.Tests</AssemblyName>
     <RootNamespace>NameTableTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.ReaderSettings.Tests</AssemblyName>
     <RootNamespace>XmlReaderTest.ReaderSettingsTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/System.Xml.RW.SubtreeReader.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/System.Xml.RW.SubtreeReader.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.SubtreeReader.Tests</AssemblyName>
     <RootNamespace>XmlReaderTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/System.Xml.RW.WrappedReader.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/System.Xml.RW.WrappedReader.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.WrappedReader.Tests</AssemblyName>
     <RootNamespace>XmlReaderTest</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/System.Xml.RW.RwFactory.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/System.Xml.RW.RwFactory.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.RwFactory.Tests</AssemblyName>
     <RootNamespace>RWFactory</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.XmlWriterApiTests</AssemblyName>
     <RootNamespace>XmlWriterAPI.Test</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/System.Xml.RW.XmlConvert.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/System.Xml.RW.XmlConvert.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.RW.XmlConvert.Tests</AssemblyName>
     <RootNamespace>XmlConvertTests</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/Properties/System.Xml.XDocument.Properties.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/Properties/System.Xml.XDocument.Properties.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Properties.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/SDMSample/System.Xml.XDocument.SDMSample.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/SDMSample/System.Xml.XDocument.SDMSample.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.SDMSample.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/Streaming/System.Xml.XDocument.Streaming.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/Streaming/System.Xml.XDocument.Streaming.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Streaming.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.TreeManipulation.Tests</AssemblyName>
     <RootNamespace>XLinqTests</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/events/System.Xml.XDocument.Events.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/events/System.Xml.XDocument.Events.Tests.csproj
@@ -9,7 +9,6 @@
     <AssemblyName>System.Xml.XDocument.Events.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
     <ProjectGuid>{C560E194-5B14-4112-ABC6-3208491E53E6}</ProjectGuid>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/misc/System.Xml.XDocument.Misc.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/misc/System.Xml.XDocument.Misc.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.Misc.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/System.Xml.XDocument.xNodeBuilder.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/System.Xml.XDocument.xNodeBuilder.Tests.csproj
@@ -13,7 +13,6 @@
       Disable running tests for this project as most of them are failing because of the infrastructure issue
       https://github.com/dotnet/corefx/issues/641
     -->
-    <TestCategories>OuterLoop</TestCategories>
     <RunTestsForProject>False</RunTestsForProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Xml.XDocument/tests/xNodeReader/System.Xml.XDocument.xNodeReader.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/xNodeReader/System.Xml.XDocument.xNodeReader.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.xNodeReader.Tests</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
-    <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XDocument/tests/System.Xml.XPath.XDocument.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XPath.XDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XPath.XDocument.Tests</RootNamespace>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XPath.XmlDocument/tests/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>System.Xml.XPath.XmlDocument.Tests</AssemblyName>
     <DefineConstants>$(DefineConstants);FEATURE_XML_XPATH_ID</DefineConstants>
     <RootNamespace>System.Xml.XPath.XmlDocument.Tests</RootNamespace>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
+++ b/src/System.Xml.XPath/tests/System.Xml.XPath.Tests.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>System.Xml.XPath.Tests</AssemblyName>
     <DefineConstants>$(DefineConstants);FEATURE_XML_XPATH_ID</DefineConstants>
     <RootNamespace>System.Xml.XPath.Tests</RootNamespace>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
   </PropertyGroup>

--- a/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
+++ b/src/System.Xml.XmlDocument/tests/System.Xml.XmlDocument.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XmlDocument.Tests</AssemblyName>
     <RootNamespace>System.Xml.XmlDocument.UnitTests</RootNamespace>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Refer dotnet/buildtools@71577daf8e39778fecb5720752fe9e4247a376c8