### PR TITLE
Update DNX to fix Win7 build break

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -3,7 +3,7 @@
   <!-- Build Tools Version -->
   <PropertyGroup>
     <BuildToolsVersion>1.0.25-prerelease-00033</BuildToolsVersion>
-    <DnxVersion>1.0.0-beta5-11562</DnxVersion>
+    <DnxVersion>1.0.0-beta5-11580</DnxVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00033" />
-  <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11562" />
+  <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11580" />
 </packages>


### PR DESCRIPTION
The version of DNX we use to restore packages from project.json has a
bug which prevents it from running on Windows 7 machines.  This has been
fixed in newer versions.

Update our LKG.  Now the build works fine on Windows 7.

Fixes #1438