### PR TITLE
Make Globalization.Extensions work for ASCII input

### DIFF
--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -9,14 +9,31 @@ namespace System.Globalization
         // managed implementation as is available in mscorlib for pre-Windows 8.  This would require including 
         // the relevant data tables.
 
+        // NOTE: The "implementation" here actually fails for IDN'd names, but will pass ASCII stuff along just fine
+        // that's by design, since this code is hit in some common paths but the data is usually ASCII and we can do
+        // the right thing there.
+
         private string GetAsciiCore(string unicode)
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            for (int i = 0; i < unicode.Length; i++)
+            {
+                if (unicode[i] > 0x7F)
+                {
+                    throw NotImplemented.ByDesign;
+                }
+            }
+
+            return unicode;
         }
 
         private string GetUnicodeCore(string ascii)
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            if (ascii.Contains("xn--"))
+            {
+                throw NotImplemented.ByDesign;
+            }
+
+            return ascii;
         }
     }
 }

--- a/src/Common/src/System/StringNormalizationExtensions.Unix.cs
+++ b/src/Common/src/System/StringNormalizationExtensions.Unix.cs
@@ -6,18 +6,34 @@ using System.Text;
 
 namespace System
 {
+    // TODO: We need an actual implementation here, but since all ASCII strings are normalized under all normalization forms
+    // we can handle the simple cases, which will actually allow a lot of code to just work.
+
     static partial class StringNormalizationExtensions
     {
         [SecurityCritical]
         public static bool IsNormalized(this string value, NormalizationForm normalizationForm)
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (value[i] > 0x7F)
+                {
+                    throw NotImplemented.ByDesign;
+                }
+            }
+
+            return true;
         }
 
         [SecurityCritical]
         public static string Normalize(this string value, NormalizationForm normalizationForm)
         {
-            throw NotImplemented.ByDesign; // TODO: Implement this
+            if (IsNormalized(value, normalizationForm))
+            {
+                return value;
+            }
+
+            throw NotImplemented.ByDesign;
         }
     }
 }


### PR DESCRIPTION
We can provide reasonable implementations of the Unix versions of these
functions when the input data in ASCII.  Doing so is helpful for
bringing up parts of the ASP.NET stack