### PR TITLE
Update S.IO.Comp.clrcompression-x64 nupkg to version 4.0.0-beta-22819

### DIFF
--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -64,6 +64,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="$(PackagesDir)\System.IO.Compression.clrcompression-x64\4.0.0-beta-22819\native\win\x64\clrcompression.dll">
+      <Link>clrcompression.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression/src/project.json
+++ b/src/System.IO.Compression/src/project.json
@@ -6,6 +6,7 @@
     "System.Diagnostics.Tools": "4.0.0-beta-22809",
     "System.Globalization": "4.0.10-beta-22809",
     "System.IO": "4.0.10-beta-22809",
+    "System.IO.Compression.clrcompression-x64": "4.0.0-beta-22819",
     "System.Reflection": "4.0.10-beta-22809",
     "System.Resources.ResourceManager": "4.0.0-beta-22809",
     "System.Runtime": "4.0.20-beta-22809",

--- a/src/System.IO.Compression/tests/packages.config
+++ b/src/System.IO.Compression/tests/packages.config
@@ -1,6 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.IO.Compression.clrcompression-x64" version="1.0.0-prerelease" />
   <package id="System.IO.Compression.TestData" version="1.0.0-prerelease" />
   <package id="xunit" version="2.0.0-beta5-build2785" />
   <package id="xunit.abstractions.netcore" version="1.0.0-prerelease" />


### PR DESCRIPTION
Update S.IO.Comp.clrcompression-x64 nupkg to version 4.0.0-beta-22819
and copy native binary from new package location to output directory.