### PR TITLE
Closed #228: Test failures because of lacking System.String.Format overload

### DIFF
--- a/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateElementTests.cs
+++ b/src/System.Xml.XmlDocument/tests/XmlDocumentTests/CreateElementTests.cs
@@ -86,7 +86,6 @@ namespace XmlDocumentTests.XmlDocumentTests
         }
 
         [Fact]
-        [ActiveIssue(228)]
         public static void NameWithWhitespace()
         {
             var xmlDocument = new XmlDocument();


### PR DESCRIPTION
Issue got resolved when we started using CoreRun.exe