### PR TITLE
Replace some empty array allocations with Array.Empty

### DIFF
--- a/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Compiler
 
             // mark the assembly transparent so that it works in partial trust:
             var attributes = new[] {
-                new CustomAttributeBuilder(typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes), new object[0])
+                new CustomAttributeBuilder(typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>())
             };
 
             _myAssembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run, attributes);

--- a/src/Common/src/System/Xml/XmlConvertEx.cs
+++ b/src/Common/src/System/Xml/XmlConvertEx.cs
@@ -171,7 +171,7 @@ namespace System.Xml
 
         private static Exception CreateException(string res, ExceptionType exceptionType, int lineNo, int linePos)
         {
-            return CreateException(res, new string[] { }, exceptionType, lineNo, linePos);
+            return CreateException(res, Array.Empty<string>(), exceptionType, lineNo, linePos);
         }
 
         public static Exception CreateInvalidCharException(string data, int invCharPos, ExceptionType exceptionType)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     {
         bool ICSharpInvokeOrInvokeMemberBinder.StaticCall { get { return _argumentInfo[0] != null && _argumentInfo[0].IsStaticType; } }
         string ICSharpInvokeOrInvokeMemberBinder.Name { get { return "Invoke"; } }
-        IList<Type> ICSharpInvokeOrInvokeMemberBinder.TypeArguments { get { return new Type[0]; } }
+        IList<Type> ICSharpInvokeOrInvokeMemberBinder.TypeArguments { get { return Array.Empty<Type>(); } }
 
         CSharpCallFlags ICSharpInvokeOrInvokeMemberBinder.Flags { get { return _flags; } }
         private CSharpCallFlags _flags;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         private List<CSharpArgumentInfo> _argumentInfo;
 
         public bool StaticCall { get { return true; } }
-        public IList<Type> TypeArguments { get { return new Type[0]; } }
+        public IList<Type> TypeArguments { get { return Array.Empty<Type>(); } }
         public string Name { get { return ".ctor"; } }
 
         bool ICSharpInvokeOrInvokeMemberBinder.ResultDiscarded { get { return false; } }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private const int LOG2_SYMTBL_INITIAL_BUCKET_CNT = 13;    // Initial local size: 8192 buckets.
 
-        private static readonly TypeArray s_taEmpty = new TypeArray(new CType[] { });
+        private static readonly TypeArray s_taEmpty = new TypeArray(Array.Empty<CType>());
 
         public BSYMMGR(NameManager nameMgr, TypeManager typeManager)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 
@@ -18,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _items = types;
             if (_items == null)
             {
-                _items = new CType[0];
+                _items = Array.Empty<CType>();
             }
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         private IEnumerable<MemberInfo> AddNamesInInheritanceHierarchy(string name, List<Type> inheritance)
         {
-            IEnumerable<MemberInfo> result = new MemberInfo[0];
+            IEnumerable<MemberInfo> result = Array.Empty<MemberInfo>();
 
             foreach (Type t in inheritance)
             {

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObject.cs
@@ -287,7 +287,7 @@ namespace System.Dynamic
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         public virtual IEnumerable<string> GetDynamicMemberNames()
         {
-            return new string[0];
+            return Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/UpdateDelegates.Generated.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/UpdateDelegates.Generated.cs
@@ -106,7 +106,7 @@ namespace System.Dynamic
             //
 
             rule = null;
-            var args = new object[] { };
+            var args = Array.Empty<object>();
 
             for (; ; )
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions.Compiler
             if (typeof(LambdaExpression).IsAssignableFrom(expr.Type))
             {
                 // if the invoke target is a lambda expression tree, first compile it into a delegate
-                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", new Type[0]));
+                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>()));
             }
             expr = Expression.Call(expr, expr.Type.GetMethod("Invoke"), node.Arguments);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2392,7 +2392,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (typeof(LambdaExpression).IsAssignableFrom(node.Expression.Type))
             {
-                var compMethod = node.Expression.Type.GetMethod("Compile", new Type[0]);
+                var compMethod = node.Expression.Type.GetMethod("Compile", Array.Empty<Type>());
                 CompileMethodCallExpression(
                     Expression.Call(
                         Expression.Call(

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -264,8 +264,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private readonly LightCompiler _parent;
 
-        private static LocalDefinition[] s_emptyLocals = new LocalDefinition[0];
-
         public LightCompiler()
         {
             _instructions = new InstructionList();
@@ -522,7 +520,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                locals = s_emptyLocals;
+                locals = Array.Empty<LocalDefinition>();
             }
 
             for (int i = 0; i < node.Expressions.Count - 1; i++)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -863,7 +863,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, "type");
             ContractUtils.RequiresNotNull(methodName, "methodName");
 
-            if (arguments == null) arguments = new Expression[] { };
+            if (arguments == null) arguments = Array.Empty<Expression>();
             BindingFlags flags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
             return Expression.Call(null, FindMethod(type, methodName, typeArguments, arguments, flags), arguments);
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -394,7 +394,7 @@ namespace System.Runtime.Serialization
             else
             {
                 return (type.GetTypeInfo().IsVisible &&
-                    type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Globals.EmptyTypeArray) != null);
+                    type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>()) != null);
             }
         }
 
@@ -1320,7 +1320,7 @@ namespace System.Runtime.Serialization
                 if (type.GetTypeInfo().IsValueType)
                     return null;
 
-                ConstructorInfo ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Globals.EmptyTypeArray);
+                ConstructorInfo ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>());
                 if (ctor == null)
                     throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.NonAttributedSerializableTypesMustHaveDefaultConstructor, DataContract.GetClrTypeFullName(type))));
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -725,7 +725,7 @@ namespace System.Runtime.Serialization
                     XmlDictionary dictionary = new XmlDictionary(2);
                     this.Name = dictionary.Add(StableName.Name);
                     this.Namespace = dictionary.Add(StableName.Namespace);
-                    this.ContractNamespaces = this.MemberNames = this.MemberNamespaces = new XmlDictionaryString[] { };
+                    this.ContractNamespaces = this.MemberNames = this.MemberNamespaces = Array.Empty<XmlDictionaryString>();
                     EnsureMethodsImported();
                     return;
                 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -1009,7 +1009,7 @@ namespace System.Runtime.Serialization
             ConstructorInfo defaultCtor = null;
             if (!type.GetTypeInfo().IsValueType)
             {
-                defaultCtor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Globals.EmptyTypeArray);
+                defaultCtor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Array.Empty<Type>());
                 if (defaultCtor == null && constructorRequired)
                 {
                     return HandleIfInvalidCollection(type, tryCreate, hasCollectionDataContract, isBaseTypeCollection/*createContractWithException*/,
@@ -1184,7 +1184,7 @@ namespace System.Runtime.Serialization
 
             if (getEnumeratorMethod == null)
             {
-                getEnumeratorMethod = type.GetMethod(Globals.GetEnumeratorMethodName, BindingFlags.Instance | BindingFlags.Public, Globals.EmptyTypeArray);
+                getEnumeratorMethod = type.GetMethod(Globals.GetEnumeratorMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
                 if (getEnumeratorMethod == null || !Globals.TypeOfIEnumerator.IsAssignableFrom(getEnumeratorMethod.ReturnType))
                 {
                     Type ienumerableInterface = interfaceType.GetInterfaces().Where(t => t.FullName.StartsWith("System.Collections.Generic.IEnumerable")).FirstOrDefault();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1804,14 +1804,14 @@ namespace System.Runtime.Serialization
                             if (methodName.Length == 0)
                                 DataContract.ThrowInvalidDataContractException(SR.Format(SR.KnownTypeAttributeEmptyString, DataContract.GetClrTypeFullName(type)), type);
 
-                            MethodInfo method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public, Globals.EmptyTypeArray);
+                            MethodInfo method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>());
                             if (method == null)
                                 DataContract.ThrowInvalidDataContractException(SR.Format(SR.KnownTypeAttributeUnknownMethod, methodName, DataContract.GetClrTypeFullName(type)), type);
 
                             if (!Globals.TypeOfTypeEnumerable.IsAssignableFrom(method.ReturnType))
                                 DataContract.ThrowInvalidDataContractException(SR.Format(SR.KnownTypeAttributeReturnType, DataContract.GetClrTypeFullName(type), methodName), type);
 
-                            object types = method.Invoke(null, Globals.EmptyObjectArray);
+                            object types = method.Invoke(null, Array.Empty<object>());
                             if (types == null)
                             {
                                 DataContract.ThrowInvalidDataContractException(SR.Format(SR.KnownTypeAttributeMethodNull, DataContract.GetClrTypeFullName(type)), type);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -143,7 +143,7 @@ namespace System.Runtime.Serialization
                     }
                     else
                     {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(Globals.EmptyTypeArray);
+                        _knownTypeCollection = new ReadOnlyCollection<Type>(Array.Empty<Type>());
                     }
                 }
                 return _knownTypeCollection;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -535,35 +535,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-
-        [SecurityCritical]
-        private static object[] s_emptyObjectArray;
-        internal static object[] EmptyObjectArray
-        {
-            [SecuritySafeCritical]
-            get
-            {
-                if (s_emptyObjectArray == null)
-                    s_emptyObjectArray = new object[0];
-                return s_emptyObjectArray;
-            }
-        }
-
-        [SecurityCritical]
-        private static Type[] s_emptyTypeArray;
-        internal static Type[] EmptyTypeArray
-        {
-            [SecuritySafeCritical]
-            get
-            {
-                if (s_emptyTypeArray == null)
-                    s_emptyTypeArray = new Type[0];
-                return s_emptyTypeArray;
-            }
-        }
-
-
         [SecurityCritical]
         private static Type s_typeOfNullable;
         internal static Type TypeOfNullable

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -82,7 +82,7 @@ namespace System.Runtime.Serialization.Json
                     }
                     else
                     {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(Globals.EmptyTypeArray);
+                        _knownTypeCollection = new ReadOnlyCollection<Type>(Array.Empty<Type>());
                     }
                 }
                 return _knownTypeCollection;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractToObjectConverter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractToObjectConverter.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.Serialization.Json
             List<object> serializedList = new List<object>();
             MethodInfo getEnumeratorMethod = dataContract.GetEnumeratorMethod;
 
-            IEnumerator enumerator = (getEnumeratorMethod == null) ? value.GetEnumerator() : (IEnumerator)getEnumeratorMethod.Invoke(value, Globals.EmptyTypeArray);
+            IEnumerator enumerator = (getEnumeratorMethod == null) ? value.GetEnumerator() : (IEnumerator)getEnumeratorMethod.Invoke(value, Array.Empty<Type>());
             while (enumerator.MoveNext())
             {
                 if (enumerator.Current == null || enumerator.Current.GetType().GetTypeInfo().IsPrimitive)
@@ -63,7 +63,7 @@ namespace System.Runtime.Serialization.Json
             Type[] declaredTypes = dataContract.ItemType.GetGenericArguments();
             MethodInfo getEnumeratorMethod = dataContract.GetEnumeratorMethod;
 
-            IDictionaryEnumerator enumerator = (IDictionaryEnumerator)((getEnumeratorMethod == null) ? value.GetEnumerator() : (IDictionaryEnumerator)getEnumeratorMethod.Invoke(value, Globals.EmptyTypeArray));
+            IDictionaryEnumerator enumerator = (IDictionaryEnumerator)((getEnumeratorMethod == null) ? value.GetEnumerator() : (IDictionaryEnumerator)getEnumeratorMethod.Invoke(value, Array.Empty<Type>()));
             while (enumerator.MoveNext())
             {
                 DictionaryEntry current = enumerator.Entry;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
@@ -60,7 +60,7 @@ namespace System.Runtime.Serialization.Json
             DataContractJsonSerializer.InvokeOnDeserialized(o, dataContract, context);
             if (dataContract.IsKeyValuePairAdapter)
             {
-                return dataContract.GetKeyValuePairMethodInfo.Invoke(o, Globals.EmptyTypeArray);
+                return dataContract.GetKeyValuePairMethodInfo.Invoke(o, Array.Empty<Type>());
             }
             return o;
         }
@@ -176,7 +176,7 @@ namespace System.Runtime.Serialization.Json
                 return ConvertDictionary(serializer, contract, valueAsDictionary, context);
             }
 
-            object returnValue = (contract.Constructor != null) ? contract.Constructor.Invoke(Globals.EmptyTypeArray) : null;
+            object returnValue = (contract.Constructor != null) ? contract.Constructor.Invoke(Array.Empty<Type>()) : null;
 
             bool isCollectionDataContractDictionary = contract.IsDictionary;
             MethodInfo addMethod = contract.AddMethod;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -296,7 +296,7 @@ namespace System.Runtime.Serialization
             if (type.GetTypeInfo().IsValueType)
                 return null;
 
-            ConstructorInfo ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Globals.EmptyTypeArray);
+            ConstructorInfo ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>());
             if (ctor == null)
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.IXmlSerializableMustHaveDefaultConstructor, DataContract.GetClrTypeFullName(type))));
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -190,7 +190,7 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_hashtableCtor == null)
-                    s_hashtableCtor = Globals.TypeOfHashtable.GetConstructor(Globals.ScanAllMembers, Globals.EmptyTypeArray);
+                    s_hashtableCtor = Globals.TypeOfHashtable.GetConstructor(Globals.ScanAllMembers, Array.Empty<Type>());
                 return s_hashtableCtor;
             }
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -55,7 +55,7 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_writeEndElementMethod == null)
-                    s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, new Type[] { });
+                    s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Array.Empty<Type>());
                 return s_writeEndElementMethod;
             }
         }
@@ -147,7 +147,7 @@ namespace System.Runtime.Serialization
             get
             {
                 if (s_isStartElementMethod0 == null)
-                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, new Type[] { });
+                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Array.Empty<Type>());
                 return s_isStartElementMethod0;
             }
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -510,7 +510,7 @@ namespace System.Runtime.Serialization
                     {
                         case CollectionKind.GenericDictionary:
                             type = Globals.TypeOfDictionaryGeneric.MakeGenericType(itemType.GetGenericArguments());
-                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Globals.EmptyTypeArray);
+                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
                             break;
                         case CollectionKind.Dictionary:
                             type = Globals.TypeOfHashtable;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -379,8 +379,8 @@ namespace System.Runtime.Serialization
                     {
                         enumeratorType = collectionContract.GetEnumeratorMethod.ReturnType;
                     }
-                    MethodInfo moveNextMethod = enumeratorType.GetMethod(Globals.MoveNextMethodName, BindingFlags.Instance | BindingFlags.Public, Globals.EmptyTypeArray);
-                    MethodInfo getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Globals.EmptyTypeArray);
+                    MethodInfo moveNextMethod = enumeratorType.GetMethod(Globals.MoveNextMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                    MethodInfo getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
                     if (moveNextMethod == null || getCurrentMethod == null)
                     {
                         if (enumeratorType.GetTypeInfo().IsInterface)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -36,8 +36,7 @@ namespace System.Xml
         private int _windowOffset;
         private int _windowOffsetMax;
         private ValueHandle _listValue;
-        private static byte[] s_emptyByteArray = new byte[0];
-        private static XmlBufferReader s_empty = new XmlBufferReader(s_emptyByteArray);
+        private static XmlBufferReader s_empty = new XmlBufferReader(Array.Empty<byte>());
 
         public XmlBufferReader(XmlDictionaryReader reader)
         {
@@ -113,7 +112,7 @@ namespace System.Xml
                 _stream.Dispose();
                 _stream = null;
             }
-            _buffer = s_emptyByteArray;
+            _buffer = Array.Empty<byte>();
             _offset = 0;
             _offsetMax = 0;
             _windowOffset = 0;

--- a/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -680,7 +680,7 @@ namespace System.ServiceProcess
         /// Starts the service.
         public void Start()
         {
-            Start(new string[0]);
+            Start(Array.Empty<string>());
         }
 
         /// Starts a service in the machine specified.

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/CodeGenerator.cs
@@ -36,8 +36,6 @@ namespace System.Xml.Serialization
         internal static MethodAttributes PublicOverrideMethodAttributes = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig;
         internal static MethodAttributes ProtectedOverrideMethodAttributes = MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig;
         internal static MethodAttributes PrivateMethodAttributes = MethodAttributes.Private | MethodAttributes.HideBySig;
-        internal static Type[] EmptyTypeArray = new Type[] { };
-        internal static string[] EmptyStringArray = new string[] { };
 
         private TypeBuilder _typeBuilder;
         private MethodBuilder _methodBuilder;
@@ -323,7 +321,7 @@ namespace System.Xml.Serialization
                     MethodInfo ICollection_get_Count = typeof(ICollection).GetMethod(
                           "get_Count",
                           CodeGenerator.InstanceBindingFlags,
-                          CodeGenerator.EmptyTypeArray
+                          Array.Empty<Type>()
                           );
                     Call(ICollection_get_Count);
                 }

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -208,7 +208,7 @@ namespace System.Xml.Serialization
                 }
             }
 
-            Type[] arguments = t.GetTypeInfo().IsGenericType || t.GetTypeInfo().ContainsGenericParameters ? t.GetGenericArguments() : new Type[0];
+            Type[] arguments = t.GetTypeInfo().IsGenericType || t.GetTypeInfo().ContainsGenericParameters ? t.GetGenericArguments() : Array.Empty<Type>();
             GetCSharpName(t, arguments, 0, sb);
             for (int i = 0; i < rank; i++)
             {

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Compilation.cs
@@ -110,7 +110,7 @@ namespace System.Xml.Serialization
                 CodeGenerator.InstanceBindingFlags,
                 CodeGenerator.EmptyTypeArray
                 );
-            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(SecurityTransparentAttribute_ctor, new Object[0]));
+            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(SecurityTransparentAttribute_ctor, Array.Empty<Object>()));
             CodeIdentifiers classes = new CodeIdentifiers();
             classes.AddUnique("XmlSerializationWriter", "XmlSerializationWriter");
             classes.AddUnique("XmlSerializationReader", "XmlSerializationReader");

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Compilation.cs
@@ -35,7 +35,6 @@ namespace System.Xml.Serialization
         private IDictionary _writerMethods;
         private IDictionary _readerMethods;
         private TempMethodDictionary _methods;
-        private static object[] s_emptyObjectArray = new object[0];
 
         internal class TempMethod
         {
@@ -108,7 +107,7 @@ namespace System.Xml.Serialization
             AssemblyBuilder assemblyBuilder = CodeGenerator.CreateAssemblyBuilder(assemblyName);
             ConstructorInfo SecurityTransparentAttribute_ctor = typeof(SecurityTransparentAttribute).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(SecurityTransparentAttribute_ctor, Array.Empty<Object>()));
             CodeIdentifiers classes = new CodeIdentifiers();
@@ -229,7 +228,7 @@ namespace System.Xml.Serialization
                     }
                     _methods[mapping.Key].readMethod = GetMethodFromType(reader.GetType(), methodName);
                 }
-                return _methods[mapping.Key].readMethod.Invoke(reader, s_emptyObjectArray);
+                return _methods[mapping.Key].readMethod.Invoke(reader, Array.Empty<object>());
             }
             catch (SecurityException e)
             {

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Models.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Models.cs
@@ -283,7 +283,7 @@ namespace System.Xml.Serialization
             _fieldType = fieldType;
             _fieldTypeDesc = fieldTypeDesc;
             _memberInfo = memberInfo;
-            _checkShouldPersistMethodInfo = memberInfo.DeclaringType.GetMethod("ShouldSerialize" + memberInfo.Name, new Type[0]);
+            _checkShouldPersistMethodInfo = memberInfo.DeclaringType.GetMethod("ShouldSerialize" + memberInfo.Name, Array.Empty<Type>());
             _checkShouldPersist = _checkShouldPersistMethodInfo != null;
 
             FieldInfo specifiedField = memberInfo.DeclaringType.GetField(memberInfo.Name + "Specified");

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/SourceInfo.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/SourceInfo.cs
@@ -204,7 +204,7 @@ namespace System.Xml.Serialization
                 MethodInfo Nullable_get_Value = nullableType.GetMethod(
                     "get_Value",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ILG.Call(Nullable_get_Value);
                 if (targetType != null)

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Types.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Types.cs
@@ -1060,7 +1060,7 @@ namespace System.Xml.Serialization
 
         private static TypeFlags GetConstructorFlags(Type type, ref Exception exception)
         {
-            ConstructorInfo ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, new Type[0]);
+            ConstructorInfo ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Array.Empty<Type>());
             if (ctor != null)
             {
                 TypeFlags flags = TypeFlags.HasDefaultConstructor;
@@ -1087,7 +1087,7 @@ namespace System.Xml.Serialization
         {
             if (typeof(IEnumerable).IsAssignableFrom(type))
             {
-                MethodInfo enumerator = type.GetMethod("GetEnumerator", new Type[0]);
+                MethodInfo enumerator = type.GetMethod("GetEnumerator", Array.Empty<Type>());
 
                 if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
                 {
@@ -1111,7 +1111,7 @@ namespace System.Xml.Serialization
                     {
                         // and finally private interface implementation
                         flags |= TypeFlags.UsePrivateImplementation;
-                        enumerator = type.GetMethod("System.Collections.IEnumerable.GetEnumerator", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, new Type[0]);
+                        enumerator = type.GetMethod("System.Collections.IEnumerable.GetEnumerator", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Array.Empty<Type>());
                     }
                 }
                 if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationILGen.cs
@@ -163,8 +163,8 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(IDictionary),
                 "get_" + publicName,
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.PublicOverrideMethodAttributes | MethodAttributes.SpecialName);
             propertyBuilder.SetGetMethod(ilg.MethodBuilder);
 
@@ -176,7 +176,7 @@ namespace System.Xml.Serialization
 
             ConstructorInfo Hashtable_ctor = typeof(Hashtable).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             LocalBuilder _tmpLoc = ilg.DeclareLocal(typeof(Hashtable), "_tmp");
             ilg.New(Hashtable_ctor);
@@ -278,29 +278,29 @@ namespace System.Xml.Serialization
                 CodeIdentifier.GetCSharpName(baseSerializer),
                 TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializer),
-                CodeGenerator.EmptyTypeArray);
+                Array.Empty<Type>());
 
             ConstructorInfo readerCtor = CreatedTypes[readerClass].GetConstructor(
                CodeGenerator.InstanceBindingFlags,
-               CodeGenerator.EmptyTypeArray
+               Array.Empty<Type>()
                );
             ilg = new CodeGenerator(baseSerializerTypeBuilder);
             ilg.BeginMethod(typeof(XmlSerializationReader),
                 "CreateReader",
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.New(readerCtor);
             ilg.EndMethod();
 
             ConstructorInfo writerCtor = CreatedTypes[writerClass].GetConstructor(
                CodeGenerator.InstanceBindingFlags,
-               CodeGenerator.EmptyTypeArray
+               Array.Empty<Type>()
                );
             ilg.BeginMethod(typeof(XmlSerializationWriter),
                 "CreateWriter",
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.New(writerCtor);
             ilg.EndMethod();
@@ -323,7 +323,7 @@ namespace System.Xml.Serialization
                 CodeIdentifier.GetCSharpName(serializerName),
                 TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
                 CreatedTypes[baseSerializer],
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
 
             ilg = new CodeGenerator(typedSerializerTypeBuilder);
@@ -395,7 +395,7 @@ namespace System.Xml.Serialization
                 MethodInfo readerType_readMethod = CreatedTypes[readerClass].GetMethod(
                     readMethod,
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg("reader");
                 ilg.Castclass(CreatedTypes[readerClass]);
@@ -423,7 +423,7 @@ namespace System.Xml.Serialization
             {
                 ConstructorInfo ctor = CreatedTypes[(string)serializers[key]].GetConstructor(
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldloc(typeof(Hashtable), "_tmp");
                 ilg.Ldstr(GetCSharpString(key));
@@ -463,7 +463,7 @@ namespace System.Xml.Serialization
                     {
                         ConstructorInfo ctor = CreatedTypes[(string)serializers[xmlMappings[i].Key]].GetConstructor(
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.New(ctor);
                         ilg.Stloc(ilg.ReturnLocal);
@@ -487,7 +487,7 @@ namespace System.Xml.Serialization
                 "XmlSerializerContract",
                 TypeAttributes.Public | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializerImplementation),
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
 
             ilg = new CodeGenerator(serializerContractTypeBuilder);
@@ -499,13 +499,13 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(XmlSerializationReader),
                 "get_Reader",
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.PublicOverrideMethodAttributes | MethodAttributes.SpecialName);
             propertyBuilder.SetGetMethod(ilg.MethodBuilder);
             ConstructorInfo ctor = CreatedTypes[readerType].GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.New(ctor);
             ilg.EndMethod();
@@ -519,13 +519,13 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(XmlSerializationWriter),
                 "get_Writer",
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.PublicOverrideMethodAttributes | MethodAttributes.SpecialName);
             propertyBuilder.SetGetMethod(ilg.MethodBuilder);
             ctor = CreatedTypes[writerType].GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.New(ctor);
             ilg.EndMethod();
@@ -539,14 +539,14 @@ namespace System.Xml.Serialization
             // Default ctor
             ConstructorInfo baseCtor = typeof(XmlSerializerImplementation).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg = new CodeGenerator(serializerContractTypeBuilder);
             ilg.BeginMethod(
                 typeof(void),
                 ".ctor",
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.PublicMethodAttributes | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName
                 );
             ilg.Ldarg(0);

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -206,7 +206,7 @@ namespace System.Xml.Serialization
                 ClassName,
                 TypeAttributes | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializationReader),
-                CodeGenerator.EmptyTypeArray);
+                Array.Empty<Type>());
             foreach (TypeScope scope in Scopes)
             {
                 foreach (TypeMapping mapping in scope.TypeMappings)
@@ -244,17 +244,17 @@ namespace System.Xml.Serialization
             GenerateInitCallbacksMethod();
 
             ilg = new CodeGenerator(this.typeBuilder);
-            ilg.BeginMethod(typeof(void), "InitIDs", CodeGenerator.EmptyTypeArray, CodeGenerator.EmptyStringArray,
+            ilg.BeginMethod(typeof(void), "InitIDs", Array.Empty<Type>(), Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                  "get_Reader",
                  CodeGenerator.InstanceBindingFlags,
-                 CodeGenerator.EmptyTypeArray
+                 Array.Empty<Type>()
                  );
             MethodInfo XmlReader_get_NameTable = typeof(XmlReader).GetMethod(
                 "get_NameTable",
                 CodeGenerator.InstanceBindingFlags,
-                 CodeGenerator.EmptyTypeArray
+                 Array.Empty<Type>()
                 );
             MethodInfo XmlNameTable_Add = typeof(XmlNameTable).GetMethod(
                 "Add",
@@ -301,7 +301,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                  "get_Reader",
                  CodeGenerator.InstanceBindingFlags,
-                 CodeGenerator.EmptyTypeArray
+                 Array.Empty<Type>()
                  );
             MethodInfo XmlReader_IsStartElement = typeof(XmlReader).GetMethod(
                  "IsStartElement",
@@ -359,7 +359,7 @@ namespace System.Xml.Serialization
         private void GenerateInitCallbacksMethod()
         {
             ilg = new CodeGenerator(this.typeBuilder);
-            ilg.BeginMethod(typeof(void), "InitCallbacks", CodeGenerator.EmptyTypeArray, CodeGenerator.EmptyStringArray,
+            ilg.BeginMethod(typeof(void), "InitCallbacks", Array.Empty<Type>(), Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
 
             string dummyArrayMethodName = NextMethodName("Array");
@@ -371,8 +371,8 @@ namespace System.Xml.Serialization
                 ilg.BeginMethod(
                     typeof(object),
                     GetMethodBuilder(dummyArrayMethodName),
-                    CodeGenerator.EmptyTypeArray,
-                    CodeGenerator.EmptyStringArray,
+                    Array.Empty<Type>(),
+                    Array.Empty<string>(),
                     CodeGenerator.PrivateMethodAttributes);
                 MethodInfo XmlSerializationReader_UnknownNode1 = typeof(XmlSerializationReader).GetMethod(
                       "UnknownNode",
@@ -432,8 +432,8 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(object[]),
                 methodName,
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.PublicMethodAttributes
                 );
             ilg.Load(null);
@@ -441,12 +441,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                "MoveToContent",
                CodeGenerator.InstanceBindingFlags,
-               CodeGenerator.EmptyTypeArray
+               Array.Empty<Type>()
                );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -562,7 +562,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_MoveToElement = typeof(XmlReader).GetMethod(
                     "MoveToElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -577,7 +577,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                     "get_IsEmptyElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -587,7 +587,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -602,7 +602,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                     "ReadStartElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -631,7 +631,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                     "ReadEndElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -676,8 +676,8 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(object),
                 methodName,
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 CodeGenerator.PublicMethodAttributes
                 );
             LocalBuilder oLoc = ilg.DeclareLocal(typeof(object), "o");
@@ -691,12 +691,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                "MoveToContent",
                CodeGenerator.InstanceBindingFlags,
-               CodeGenerator.EmptyTypeArray
+               Array.Empty<Type>()
                );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -744,12 +744,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_ReadXXXString = typeof(XmlReader).GetMethod(
                         source == "Reader.ReadElementString()" ? "ReadElementContentAsString" : "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -760,12 +760,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                           "get_Value",
                           CodeGenerator.InstanceBindingFlags,
-                          CodeGenerator.EmptyTypeArray
+                          Array.Empty<Type>()
                           );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -794,12 +794,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_ReadXXXString = typeof(XmlReader).GetMethod(
                         source == "Reader.ReadElementString()" ? "ReadElementContentAsString" : "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -810,12 +810,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                           "get_Value",
                           CodeGenerator.InstanceBindingFlags,
-                          CodeGenerator.EmptyTypeArray
+                          Array.Empty<Type>()
                           );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -838,12 +838,12 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                      "get_Reader",
                      CodeGenerator.InstanceBindingFlags,
-                     CodeGenerator.EmptyTypeArray
+                     Array.Empty<Type>()
                      );
                 MethodInfo XmlReader_method = typeof(XmlReader).GetMethod(
                     source == "Reader.Value" ? "get_Value" : "ReadElementContentAsString",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 if (mapping.TypeDesc.CollapseWhitespace)
                     ilg.Ldarg(0);
@@ -902,12 +902,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_ReadXXXString = typeof(XmlReader).GetMethod(
                         source == "Reader.ReadElementString()" ? "ReadElementContentAsString" : "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -918,12 +918,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                           "get_Value",
                           CodeGenerator.InstanceBindingFlags,
-                          CodeGenerator.EmptyTypeArray
+                          Array.Empty<Type>()
                           );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -1003,8 +1003,8 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(Hashtable),
                 "get_" + propName,
-                CodeGenerator.EmptyTypeArray,
-                CodeGenerator.EmptyStringArray,
+                Array.Empty<Type>(),
+                Array.Empty<string>(),
                 MethodAttributes.Assembly | MethodAttributes.HideBySig | MethodAttributes.SpecialName);
 
             ilg.Ldarg(0);
@@ -1014,7 +1014,7 @@ namespace System.Xml.Serialization
 
             ConstructorInfo Hashtable_ctor = typeof(Hashtable).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             LocalBuilder hLoc = ilg.DeclareLocal(typeof(Hashtable), "h");
             ilg.New(Hashtable_ctor);
@@ -1223,12 +1223,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                             "get_Reader",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                             "ReadStartElement",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_get_Reader);
@@ -1253,7 +1253,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlReader_ReadString = typeof(XmlReader).GetMethod(
                             "ReadContentAsString",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Ldarg(0);
@@ -1267,7 +1267,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                             "ReadEndElement",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -1332,7 +1332,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                 "ReadNull",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray);
+                Array.Empty<Type>());
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadNull);
             ilg.If();
@@ -1389,12 +1389,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_GetXsiType = typeof(XmlSerializationReader).GetMethod(
                 "GetXsiType",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                  "ReadNull",
                  CodeGenerator.InstanceBindingFlags,
-                 CodeGenerator.EmptyTypeArray
+                 Array.Empty<Type>()
                  );
             Label labelTrue = ilg.DefineLabel();
             Label labelEnd = ilg.DefineLabel();
@@ -1653,12 +1653,12 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                     "get_Reader",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 MethodInfo XmlReader_MoveToElement = typeof(XmlReader).GetMethod(
                     "MoveToElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1668,7 +1668,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                     "get_IsEmptyElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1677,7 +1677,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                     "Skip",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1691,7 +1691,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                     "ReadStartElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1707,7 +1707,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                     "MoveToContent",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1720,7 +1720,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                     "ReadEndElement",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -1741,12 +1741,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlQualifiedName_get_Name = typeof(XmlQualifiedName).GetMethod(
                 "get_Name",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlQualifiedName_get_Namespace = typeof(XmlQualifiedName).GetMethod(
                 "get_Namespace",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             Label labelEnd = ilg.DefineLabel();
             Label labelFalse = ilg.DefineLabel();
@@ -1784,17 +1784,17 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_" + source,
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_get_LocalName = typeof(XmlReader).GetMethod(
                 "get_LocalName",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_get_NamespaceURI = typeof(XmlReader).GetMethod(
                 "get_NamespaceURI",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
 
             Label labelFalse = ilg.DefineLabel();
@@ -1855,12 +1855,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_MoveToNextAttribute = typeof(XmlReader).GetMethod(
                 "MoveToNextAttribute",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.WhileBegin();
 
@@ -1918,17 +1918,17 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_Name = typeof(XmlReader).GetMethod(
                     "get_Name",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 MethodInfo XmlReader_get_LocalName = typeof(XmlReader).GetMethod(
                     "get_LocalName",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                     "get_Value",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Ldarg(0);
@@ -1944,7 +1944,7 @@ namespace System.Xml.Serialization
                 WriteSourceBegin(xmlnsMember.Source);
                 ConstructorInfo ctor = xmlnsMember.Mapping.TypeDesc.Type.GetConstructor(
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.New(ctor);
                 WriteSourceEnd(xmlnsMember.Source, xmlnsMember.Mapping.TypeDesc.Type);
@@ -1960,7 +1960,7 @@ namespace System.Xml.Serialization
                 MethodInfo String_get_Length = typeof(String).GetMethod(
                     "get_Length",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ILGenLoad(xmlnsMember.ArraySource, xmlnsMember.Mapping.TypeDesc.Type);
                 ilg.Ldarg(0);
@@ -1993,7 +1993,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_Name = typeof(XmlReader).GetMethod(
                     "get_Name",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 ilg.Ldarg(0);
                 ilg.Ldarg(0);
@@ -2009,7 +2009,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Document = typeof(XmlSerializationReader).GetMethod(
                     "get_Document",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 MethodInfo XmlDocument_ReadNode = typeof(XmlDocument).GetMethod(
                     "ReadNode",
@@ -2124,12 +2124,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                         "get_Reader",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                         "get_Value",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -2283,12 +2283,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_get_NodeType = typeof(XmlReader).GetMethod(
                  "get_NodeType",
                  CodeGenerator.InstanceBindingFlags,
-                 CodeGenerator.EmptyTypeArray
+                 Array.Empty<Type>()
                  );
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             int XmlNodeType_Element = 1;
             ilg.Ldarg(0);
@@ -2315,12 +2315,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_get_NodeType = typeof(XmlReader).GetMethod(
                 "get_NodeType",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2391,12 +2391,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     MethodInfo XmlReader_ReadString = typeof(XmlReader).GetMethod(
                         "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -2531,7 +2531,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_get_IsReturnValue = typeof(XmlSerializationReader).GetMethod(
                             "get_IsReturnValue",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_get_IsReturnValue);
@@ -2865,7 +2865,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                 "ReadNull",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadNull);
@@ -2900,12 +2900,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                 "get_IsEmptyElement",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2921,7 +2921,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                 "Skip",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2931,7 +2931,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                 "ReadStartElement",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2943,7 +2943,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                 "MoveToContent",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2954,7 +2954,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                 "ReadEndElement",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -3011,7 +3011,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                          "ReadNull",
                          CodeGenerator.InstanceBindingFlags,
-                         CodeGenerator.EmptyTypeArray
+                         Array.Empty<Type>()
                          );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_ReadNull);
@@ -3034,12 +3034,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                         "get_Reader",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                         "get_IsEmptyElement",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -3048,7 +3048,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -3066,7 +3066,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_ReadElementQualifiedName = typeof(XmlSerializationReader).GetMethod(
                            "ReadElementQualifiedName",
                            CodeGenerator.InstanceBindingFlags,
-                           CodeGenerator.EmptyTypeArray
+                           Array.Empty<Type>()
                            );
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_ReadElementQualifiedName);
@@ -3105,12 +3105,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                         "get_Reader",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     ilg.Ldloc(arrayName);
                     ilg.Load(null);
@@ -3171,7 +3171,7 @@ namespace System.Xml.Serialization
                             MethodInfo XmlSerializationReader_GetXsiType = typeof(XmlSerializationReader).GetMethod(
                                 "GetXsiType",
                                 CodeGenerator.InstanceBindingFlags,
-                                CodeGenerator.EmptyTypeArray
+                                Array.Empty<Type>()
                                 );
                             Label labelTrue = ilg.DefineLabel();
                             Label labelEnd = ilg.DefineLabel();
@@ -3324,12 +3324,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                 "MoveToContent",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -3352,12 +3352,12 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                     "get_Reader",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 MethodInfo XmlReader_get_NodeType = typeof(XmlReader).GetMethod(
                     "get_NodeType",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 Label labelFalse = ilg.DefineLabel();
                 Label labelEnd = ilg.DefineLabel();
@@ -3385,7 +3385,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_ReaderCount = typeof(XmlSerializationReader).GetMethod(
                 "get_ReaderCount",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldc(0);
             ilg.Stloc(typeof(Int32), String.Format(CultureInfo.InvariantCulture, "whileIterations{0}", _nextWhileLoopIndex));
@@ -3621,7 +3621,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_CreateUnknownNodeException = typeof(XmlSerializationReader).GetMethod(
                        "CreateUnknownNodeException",
                        CodeGenerator.InstanceBindingFlags,
-                       CodeGenerator.EmptyTypeArray
+                       Array.Empty<Type>()
                        );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_CreateUnknownNodeException);

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -32,7 +32,7 @@ namespace System.Xml.Serialization
                 ClassName,
                 TypeAttributes | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializationWriter),
-                CodeGenerator.EmptyTypeArray);
+                Array.Empty<Type>());
 
             foreach (TypeScope scope in Scopes)
             {
@@ -88,7 +88,7 @@ namespace System.Xml.Serialization
         private void GenerateInitCallbacksMethod()
         {
             ilg = new CodeGenerator(this.typeBuilder);
-            ilg.BeginMethod(typeof(void), "InitCallbacks", CodeGenerator.EmptyTypeArray, CodeGenerator.EmptyStringArray,
+            ilg.BeginMethod(typeof(void), "InitCallbacks", Array.Empty<Type>(), Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.EndMethod();
         }
@@ -319,7 +319,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_WriteEndElement = typeof(XmlSerializationWriter).GetMethod(
                 "WriteEndElement",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_WriteEndElement);
@@ -367,7 +367,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_WriteStartDocument = typeof(XmlSerializationWriter).GetMethod(
                 "WriteStartDocument",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_WriteStartDocument);
@@ -375,7 +375,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_TopLevelElement = typeof(XmlSerializationWriter).GetMethod(
                 "TopLevelElement",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_TopLevelElement);
@@ -560,7 +560,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_WriteStartDocument = typeof(XmlSerializationWriter).GetMethod(
                 "WriteStartDocument",
                 CodeGenerator.InstanceBindingFlags,
-                CodeGenerator.EmptyTypeArray
+                Array.Empty<Type>()
                 );
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_WriteStartDocument);
@@ -580,7 +580,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationWriter_TopLevelElement = typeof(XmlSerializationWriter).GetMethod(
                       "TopLevelElement",
                       CodeGenerator.InstanceBindingFlags,
-                      CodeGenerator.EmptyTypeArray
+                      Array.Empty<Type>()
                       );
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationWriter_TopLevelElement);
@@ -704,7 +704,7 @@ namespace System.Xml.Serialization
                     MethodInfo CultureInfo_get_InvariantCulture = typeof(CultureInfo).GetMethod(
                         "get_InvariantCulture",
                         CodeGenerator.StaticBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     MethodInfo Int64_ToString = typeof(Int64).GetMethod(
                         "ToString",
@@ -805,7 +805,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlWriter_WriteStartElement = typeof(XmlWriter).GetMethod(
                             "WriteStartElement",
@@ -848,7 +848,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlWriter_WriteEndElement = typeof(XmlWriter).GetMethod(
                             "WriteEndElement",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationWriter_get_Writer);
@@ -871,7 +871,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlWriter_WriteStartElement = typeof(XmlWriter).GetMethod(
                             "WriteStartElement",
@@ -898,7 +898,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlWriter_WriteEndElement = typeof(XmlWriter).GetMethod(
                             "WriteEndElement",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationWriter_get_Writer);
@@ -962,7 +962,7 @@ namespace System.Xml.Serialization
             MethodInfo Object_GetType = typeof(object).GetMethod(
                     "GetType",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
             ArgBuilder oArg = ilg.GetArg("o");
             ilg.LdargAddress(oArg);
@@ -1176,7 +1176,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlWriter_WriteStartAttribute = typeof(XmlWriter).GetMethod(
                             "WriteStartAttribute",
@@ -1195,7 +1195,7 @@ namespace System.Xml.Serialization
                         LocalBuilder sbLoc = ilg.DeclareOrGetLocal(typeof(StringBuilder), "sb");
                         ConstructorInfo StringBuilder_ctor = typeof(StringBuilder).GetConstructor(
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.New(StringBuilder_ctor);
                         ilg.Stloc(sbLoc);
@@ -1235,7 +1235,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlWriter_WriteString = typeof(XmlWriter).GetMethod(
                             "WriteString",
@@ -1299,12 +1299,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlWriter_WriteEndAttribute = typeof(XmlWriter).GetMethod(
                             "WriteEndAttribute",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationWriter_get_Writer);
@@ -1315,7 +1315,7 @@ namespace System.Xml.Serialization
                         MethodInfo StringBuilder_get_Length = typeof(StringBuilder).GetMethod(
                             "get_Length",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldloc("sb");
                         ilg.Call(StringBuilder_get_Length);
@@ -1335,7 +1335,7 @@ namespace System.Xml.Serialization
                         MethodInfo Object_ToString = typeof(Object).GetMethod(
                             "ToString",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldloc("sb");
                         ilg.Call(Object_ToString);
@@ -1477,7 +1477,7 @@ namespace System.Xml.Serialization
                     getEnumeratorMethod = typeIEnumerable.GetMethod(
                         "GetEnumerator",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray);
+                        Array.Empty<Type>());
 
                     ilg.ConvertValue(arrayTypeDesc.Type, typeIEnumerable);
                 }
@@ -1488,7 +1488,7 @@ namespace System.Xml.Serialization
                     getEnumeratorMethod = typeIEnumerable.GetMethod(
                         "GetEnumerator",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray);
+                        Array.Empty<Type>());
 
                     ilg.ConvertValue(arrayTypeDesc.Type, typeIEnumerable);
                 }
@@ -1496,7 +1496,7 @@ namespace System.Xml.Serialization
                 {
                     getEnumeratorMethod = arrayTypeDesc.Type.GetMethod(
                         "GetEnumerator",
-                        CodeGenerator.EmptyTypeArray);
+                        Array.Empty<Type>());
                 }
                 ilg.Call(getEnumeratorMethod);
                 ilg.ConvertValue(getEnumeratorMethod.ReturnType, typeof(IEnumerator));
@@ -1515,7 +1515,7 @@ namespace System.Xml.Serialization
                 MethodInfo IEnumerator_MoveNext = typeof(IEnumerator).GetMethod(
                     "MoveNext",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray);
+                    Array.Empty<Type>());
                 ilg.Ldloc(eLoc);
                 ilg.Call(IEnumerator_MoveNext);
                 ilg.WhileEndCondition();
@@ -1701,12 +1701,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlNode_get_Name = typeof(XmlNode).GetMethod(
                             "get_Name",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlNode_get_NamespaceURI = typeof(XmlNode).GetMethod(
                             "get_NamespaceURI",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Ldloc(elemLoc);
                         ilg.Call(XmlNode_get_Name);
@@ -1771,12 +1771,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlNode_get_Name = typeof(XmlNode).GetMethod(
                             "get_Name",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         MethodInfo XmlNode_get_NamespaceURI = typeof(XmlNode).GetMethod(
                             "get_NamespaceURI",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         ilg.Call(XmlNode_get_Name);
                         ilg.Ldloc(elemLoc);
@@ -1873,7 +1873,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            CodeGenerator.EmptyTypeArray
+                            Array.Empty<Type>()
                             );
                         source.Load(source.Type);
                         ilg.Ldarg(0);
@@ -1897,7 +1897,7 @@ namespace System.Xml.Serialization
                     MethodInfo Nullable_get_HasValue = element.Mapping.TypeDesc.Type.GetMethod(
                         "get_HasValue",
                         CodeGenerator.InstanceBindingFlags,
-                        CodeGenerator.EmptyTypeArray
+                        Array.Empty<Type>()
                         );
                     source.LoadAddress(element.Mapping.TypeDesc.Type);
                     ilg.Call(Nullable_get_HasValue);
@@ -2096,7 +2096,7 @@ namespace System.Xml.Serialization
                 MethodInfo String_get_Length = typeof(string).GetMethod(
                     "get_Length",
                     CodeGenerator.InstanceBindingFlags,
-                    CodeGenerator.EmptyTypeArray
+                    Array.Empty<Type>()
                     );
                 source.Load(typeof(string));
                 ilg.Call(String_get_Length);
@@ -2362,7 +2362,7 @@ namespace System.Xml.Serialization
             {
                 ConstructorInfo ctor = type.GetConstructor(
                        CodeGenerator.InstanceBindingFlags,
-                       CodeGenerator.EmptyTypeArray
+                       Array.Empty<Type>()
                        );
                 if (ctor != null)
                     ilg.New(ctor);

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
@@ -98,7 +98,7 @@ namespace System.Xml.Serialization
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public XmlSerializer(Type type, XmlRootAttribute root) : this(type, null, new Type[0], root, null, null, null)
+        public XmlSerializer(Type type, XmlRootAttribute root) : this(type, null, Array.Empty<Type>(), root, null, null, null)
         {
         }
 
@@ -114,7 +114,7 @@ namespace System.Xml.Serialization
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public XmlSerializer(Type type, XmlAttributeOverrides overrides) : this(type, overrides, new Type[0], null, null, null, null)
+        public XmlSerializer(Type type, XmlAttributeOverrides overrides) : this(type, overrides, Array.Empty<Type>(), null, null, null, null)
         {
         }
 


### PR DESCRIPTION
Just a small cleanup...

We'd previously done a pass through the CoreFX libraries to replace most empty array allocations with "Array.Empty<SomeType>()".  But in browsing through the code, I noticed a few more, either that we previously missed or that have crept in since.

This PR addresses those. There are still some remaining which I didn't replace, in particular ones that are returning new arrays from methods like ToArray, some of which are documented to return new arrays.

There were also some additional places I noticed that were doing their own caching of empty arrays, allocating a new array and storing it into a static. I've removed those fields and replaced the call sites with usage of Array.Empty, too.