### PR TITLE
Use x86 clrcompression.dll rather than x64

### DIFF
--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -66,7 +66,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(PackagesDir)\System.IO.Compression.clrcompression-x64\4.0.0-beta-22819\native\win\x64\clrcompression.dll">
+    <Content Include="$(PackagesDir)\System.IO.Compression.clrcompression-x86\4.0.0-beta-22819\native\win\x86\clrcompression.dll">
       <Link>clrcompression.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/System.IO.Compression/src/project.json
+++ b/src/System.IO.Compression/src/project.json
@@ -6,7 +6,7 @@
     "System.Diagnostics.Tools": "4.0.0-beta-22809",
     "System.Globalization": "4.0.10-beta-22809",
     "System.IO": "4.0.10-beta-22809",
-    "System.IO.Compression.clrcompression-x64": "4.0.0-beta-22819",
+    "System.IO.Compression.clrcompression-x86": "4.0.0-beta-22819",
     "System.Reflection": "4.0.10-beta-22809",
     "System.Resources.ResourceManager": "4.0.0-beta-22809",
     "System.Runtime": "4.0.20-beta-22809",


### PR DESCRIPTION
We currently use an x86 version of coreclr.dll.  The bitness of
clrcompression.dll needs to match.  When we begin deploying different
bitnesses of coreclr.dll, we will need to ensure clrcompression.dll
matches.