### PR TITLE
Make System.Linq reference Private in System.Linq.Tests

### DIFF
--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\src\System.Linq.csproj">
       <Project>{ca488507-3b6e-4494-b7be-7b4eeeb2c4d1}</Project>
       <Name>System.Linq</Name>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Otherwise, the System.Linq.dll from the NuGet package ends up getting deployed instead when running tests.  This means that a) the tests aren't actually testing the current version of the source, and b) the PDB isn't deployed to the test directory such that code coverage doesn't work.

Fixes #1479