### PR TITLE
Fix failing System.IO.Pipes tests on Linux

### DIFF
--- a/src/System.IO.Pipes/tests/AnonymousPipesThrowsTests.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipesThrowsTests.cs
@@ -58,7 +58,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ServerServerPipeHandleThrows()
         {
-            SafePipeHandle pipeHandle = new SafePipeHandle((System.IntPtr)0, true);
+            SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
             using (AnonymousPipeServerStream dummyserver = new AnonymousPipeServerStream(PipeDirection.Out))
             {
                 Assert.Throws<ArgumentException>(delegate
@@ -71,7 +71,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ServerClientPipeHandleThrows()
         {
-            SafePipeHandle pipeHandle = new SafePipeHandle((System.IntPtr)0, true);
+            SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
             using (AnonymousPipeServerStream dummyserver = new AnonymousPipeServerStream(PipeDirection.Out))
             {
                 Assert.Throws<ArgumentException>(delegate
@@ -472,8 +472,6 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientPipeHandleAsNullThrows()
         {
-            SafePipeHandle pipeHandle = new SafePipeHandle((System.IntPtr)0, true);
-
             Assert.Throws<ArgumentNullException>(delegate
             {
                 AnonymousPipeClientStream client = new AnonymousPipeClientStream(PipeDirection.In, (SafePipeHandle)null);
@@ -483,7 +481,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientBadPipeHandleAsInvalidThrows()
         {
-            SafePipeHandle pipeHandle = new SafePipeHandle((System.IntPtr)0, true);
+            SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
 
             Assert.Throws<ArgumentException>(delegate
             {

--- a/src/System.IO.Pipes/tests/NamedPipesThrowsTests.cs
+++ b/src/System.IO.Pipes/tests/NamedPipesThrowsTests.cs
@@ -70,7 +70,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientInvalidPipeHandleThrows()
         {
-            SafePipeHandle pipeHandle = new SafePipeHandle((System.IntPtr)0, true);
+            SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
             Assert.Throws<ArgumentException>(delegate
             {
                 NamedPipeServerStream server = new NamedPipeServerStream(PipeDirection.InOut, false, true, pipeHandle);
@@ -162,7 +162,7 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void ClientInvalidServerHandleThrows()
         {
-            SafePipeHandle pipeHandle = new SafePipeHandle((System.IntPtr)0, true);
+            SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
             Assert.Throws<ArgumentException>(delegate
             {
                 NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.InOut, false, true, pipeHandle);


### PR DESCRIPTION
#1430 added a bunch of new tests to verify exceptional behaviors in System.IO.Pipes, including that the right exceptions get thrown when invalid handle values are provided as inputs.  But some of the tests used 0 as a handle value, which while invalid on Windows is a valid file descriptor on Unix.  -1 is invalid on both, so this commit just changes those tests to use -1 instead of 0, and all of the tests again pass on Unix.