### PR TITLE
System.IO.Compression should use ECMA key

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,7 +2,7 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00039</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00040</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-11580</DnxVersion>
   </PropertyGroup>
 

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00039" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00040" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11580" />
 </packages>

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <ProjectGuid>{5471BFE8-8071-466F-838E-5ADAA779E742}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseECMAKey>true</UseECMAKey>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />


### PR DESCRIPTION
System.IO.Compression needs to use the same public key token that it uses on desktop: b77a5c561934e089.

Update the build tools with support for using this key and set the property in System.IO.Compression.csproj to use it.