### PR TITLE
Disable several XPath tests

### DIFF
--- a/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
+++ b/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
@@ -44935,6 +44935,7 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS59: //namespace::node()//@*
         /// </summary>
         [Fact]
+        [ActiveIssue(1487)]
         public static void AxesCombinationsTest2142()
         {
             var xml = "ns_prefixes.xml";
@@ -44950,6 +44951,7 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS60: //namespace::node()//self::*
         /// </summary>
         [Fact]
+        [ActiveIssue(1487)]
         public static void AxesCombinationsTest2143()
         {
             var xml = "ns_prefixes.xml";
@@ -44965,6 +44967,7 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS61: //namespace::node()//namespace::node()
         /// </summary>
         [Fact]
+        [ActiveIssue(1487)]
         public static void AxesCombinationsTest2144()
         {
             var xml = "ns_prefixes.xml";


### PR DESCRIPTION
These were enabled in #1444, but even though they're passing on Windows, they're failing on Unix
Issue #1487