### PR TITLE
Fix UnixFileStream.Seek buffering with SeekOrigin.Current

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -945,11 +945,15 @@ namespace System.IO
             VerifyOSHandlePosition();
 
             // Flush our write/read buffer.  FlushWrite will output any write buffer we have and reset _bufferWritePos.
-            // We don't call FlushRead or FlushInternalBuffer, as that will do an unnecessary seek to rewind the read
-            // buffer, and since we're about to seek and update our position, we can simply dump the buffer and reset
-            // our read position. In the future, for some simple cases we could potentially add an optimization here to just 
-            // move data around in the buffer for short jumps, to avoid re-reading the data from disk.
+            // We don't call FlushRead, as that will do an unnecessary seek to rewind the read buffer, and since we're 
+            // about to seek and update our position, we can simply update the offset as necessary and reset our read 
+            // position and length to 0. (In the future, for some simple cases we could potentially add an optimization 
+            // here to just move data around in the buffer for short jumps, to avoid re-reading the data from disk.)
             FlushWriteBuffer();
+            if (origin == SeekOrigin.Current)
+            {
+                offset -= (_readLength - _readPos);
+            }
             _readPos = _readLength = 0;
 
             // Keep track of where we were, in case we're in append mode and need to verify

--- a/src/System.IO.FileSystem/tests/FileStream/Seek.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Seek.cs
@@ -207,7 +207,7 @@ namespace System.IO.FileSystem.Tests
 
             Assert.Equal(position, stream.Seek(0, SeekOrigin.Current));
             Assert.Equal(position, stream.Position);
-            
+
             Assert.Equal(position, stream.Seek(position - stream.Length, SeekOrigin.End));
             Assert.Equal(position, stream.Position);
         }
@@ -256,5 +256,57 @@ namespace System.IO.FileSystem.Tests
                 Assert.Equal(0x2A, fs.ReadByte());
             }
         }
+
+        [Fact]
+        public void RandomSeekReadConsistency()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
+            {
+                var rand = new Random(1); // fixed seed to enable repeatable runs
+                const int Trials = 1000;
+                const int FileLength = 0x4000;
+                const int MaxBytesToRead = 21;
+
+                // Write data to the file
+                var buffer = new byte[FileLength];
+                for (int i = 0; i < buffer.Length; i++)
+                    buffer[i] = (byte)i;
+                fs.Write(buffer, 0, buffer.Length);
+                fs.Position = 0;
+
+                // Repeatedly jump around, reading, and making sure we get the right data back
+                for (int trial = 0; trial < Trials; trial++)
+                {
+                    // Pick some number of bytes to read
+                    int bytesToRead = rand.Next(1, MaxBytesToRead);
+
+                    // Jump to a random position, seeking either from one of the possible origins
+                    SeekOrigin origin = (SeekOrigin)rand.Next(3);
+                    int offset = 0;
+                    switch (origin)
+                    {
+                        case SeekOrigin.Begin:
+                            offset = rand.Next(0, (int)fs.Length - bytesToRead);
+                            break;
+                        case SeekOrigin.Current:
+                            offset = rand.Next(-(int)fs.Position + bytesToRead, (int)fs.Length - (int)fs.Position - bytesToRead);
+                            break;
+                        case SeekOrigin.End:
+                            offset = -rand.Next(bytesToRead, (int)fs.Length);
+                            break;
+                    }
+                    long pos = fs.Seek(offset, origin);
+                    Assert.InRange(pos, 0, fs.Length - bytesToRead - 1);
+
+                    // Read the requested number of bytes, and verify each is correct
+                    for (int i = 0; i < bytesToRead; i++)
+                    {
+                        int byteRead = fs.ReadByte();
+                        Assert.Equal(buffer[pos + i], byteRead);
+                    }
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
UnixFileStream.Seek was dumping the read buffer as desired, but with a SeekOrigin of Current, it wasn't factoring in the read buffer information into the offset (the fact that we have a read buffer means that the caller's definition of "Current" doesn't match the actual underlying file descriptor's position).  This fix just updates the offset (as is correctly done in similar code in the Win32FileStream implementation) based on how much data we have in the read buffer.

I've also added a seek test that repeatedly seeks around and reads data.  It blows up without the fix and passes with it.