### PR TITLE
Replace a few more asserts with Debug.Assert

### DIFF
--- a/src/Common/tests/XunitTraitsDiscoverers/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Common/tests/XunitTraitsDiscoverers/Discoverers/ActiveIssueDiscoverer.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -23,7 +23,7 @@ namespace Xunit.TraitDiscoverers
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             IEnumerable<object> ctorArgs = traitAttribute.GetConstructorArguments();
-            Contract.Assert(ctorArgs.Count() >= 2);
+            Debug.Assert(ctorArgs.Count() >= 2);
 
             string issue = ctorArgs.First().ToString();
             PlatformID platforms = (PlatformID)ctorArgs.Last();

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -105,7 +105,7 @@ namespace System
         private static Encoding GetEncoding(int codePage)
         {
             Encoding enc = EncodingHelper.GetSupportedConsoleEncoding(codePage);
-            Contract.Assert(!(enc is UnicodeEncoding)); // if this ever changes, will need to update how we read/write Windows console stream
+            Debug.Assert(!(enc is UnicodeEncoding)); // if this ever changes, will need to update how we read/write Windows console stream
 
             return new ConsoleEncoding(enc); // ensure encoding doesn't output a preamble
         }

--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Text;
 
 namespace System.IO.Compression
@@ -501,7 +501,7 @@ namespace System.IO.Compression
                     directoryIsEmpty = false;
 
                     Int32 entryNameLength = file.FullName.Length - basePath.Length;
-                    Contract.Assert(entryNameLength > 0);
+                    Debug.Assert(entryNameLength > 0);
 
                     String entryName = file.FullName.Substring(basePath.Length, entryNameLength);
 

--- a/src/System.Resources.ReaderWriter/src/System/Resources/ResourceReader.cs
+++ b/src/System.Resources.ReaderWriter/src/System/Resources/ResourceReader.cs
@@ -10,7 +10,7 @@ namespace System.Resources
     using System.Text;
     using System.Threading;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
+    using System.Diagnostics;
     public sealed class ResourceReader : IDisposable
     {
 
@@ -79,7 +79,7 @@ namespace System.Resources
 
         private unsafe int GetNamePosition(int index)
         {
-            Contract.Assert(index >= 0 && index < _numResources, "Bad index into name position array.  index: " + index);
+            Debug.Assert(index >= 0 && index < _numResources, "Bad index into name position array.  index: " + index);
 
             int r;
 
@@ -100,7 +100,7 @@ namespace System.Resources
 
         private unsafe String AllocateStringForNameIndex(int index, out int dataOffset)
         {
-            Contract.Assert(_store != null, "ResourceReader is closed!");
+            Debug.Assert(_store != null, "ResourceReader is closed!");
             byte[] bytes;
             int byteLen;
             long nameVA = GetNamePosition(index);
@@ -139,7 +139,7 @@ namespace System.Resources
 
         private string GetValueForNameIndex(int index)
         {
-            Contract.Assert(_store != null, "ResourceReader is closed!");
+            Debug.Assert(_store != null, "ResourceReader is closed!");
             long nameVA = GetNamePosition(index);
             lock (this)
             {
@@ -198,7 +198,7 @@ namespace System.Resources
 
         private void ReadResources()
         {
-            Contract.Assert(_store != null, "ResourceReader is closed!");
+            Debug.Assert(_store != null, "ResourceReader is closed!");
 
             try
             {
@@ -363,7 +363,7 @@ namespace System.Resources
                     _store.BaseStream.Position = oldPos;
                 }
             }
-            Contract.Assert(_typeTable[typeIndex] != null, "Should have found a type!");
+            Debug.Assert(_typeTable[typeIndex] != null, "Should have found a type!");
             return _typeTable[typeIndex];
         }
 


### PR DESCRIPTION
Some more Contract.Assert calls have snuck in.  As with the others and for consistency across corefx, replacing them with Debug.Assert.

Eventually we'll want a Roslyn analyzer to flag these.