### PR TITLE
Add a failing test for XObject.SkipNotify()

### DIFF
--- a/src/System.Xml.XDocument/src/Properties/InternalsVisibleTo.cs
+++ b/src/System.Xml.XDocument/src/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//------------------------------------------------------------
+
+//------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("System.Xml.XDocument.TreeManipulation.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/src/System.Xml.XDocument.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>System\StringBuilderCache.cs</Link>
     </Compile>
+    <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="System\Xml\Linq\BaseUriAnnotation.cs" />
     <Compile Include="System\Xml\Linq\Extensions.cs" />
     <Compile Include="System\Xml\Linq\LineInfoAnnotation.cs" />

--- a/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="XNodeReplaceOnDocument3.cs" />
     <Compile Include="XNodeReplaceOnElement.cs" />
     <Compile Include="XNodeSequenceRemove.cs" />
+    <Compile Include="XObjectsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\SystemXml\ModuleCore\ModuleCore.csproj">

--- a/src/System.Xml.XDocument/tests/TreeManipulation/XObjectsTests.cs
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/XObjectsTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml;
+using System.Xml.Linq;
+
+using Xunit;
+
+namespace XLinqTests
+{
+    public class XObjectTests
+    {
+        public class SkipNotifyTests
+        {
+            [Fact]
+            [ActiveIssue(54)]
+            public void NoXObjectChangeAnnotation()
+            {
+                var sut = new FakeXObject();
+                sut.AddAnnotation(new object());
+                sut.AddAnnotation(new object());
+                Assert.True(sut.SkipNotify());
+            }
+
+            [Fact]
+            public void XObjectChangeAnnotation()
+            {
+                var sut = new FakeXObject();
+                sut.AddAnnotation(new object());
+                sut.AddAnnotation(new object());
+                sut.AddAnnotation(new XObjectChangeAnnotation());
+                Assert.False(sut.SkipNotify());
+            }
+        }
+
+        private class FakeXObject : XObject
+        {
+            public override XmlNodeType NodeType
+            {
+                get
+                {
+                    return XmlNodeType.None;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added tests for #54 (Remove always true "if" and unreachable code in System.Xml.Linq.XObject.SkipNotify method.)
Tests fails because XObject.Annotations() returns an enumerator object which is always not null.