### PR TITLE
Disable another XPath globalization test on Unix

### DIFF
--- a/src/Common/tests/System.Xml.XPath/MiscellaneousCases/GlobalizationTests.cs
+++ b/src/Common/tests/System.Xml.XPath/MiscellaneousCases/GlobalizationTests.cs
@@ -19,6 +19,7 @@ namespace XPathTests.FunctionalTests
         /// </summary>
         [Fact]
         [OuterLoop]
+        [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
         public static void GlobalizationTest566()
         {
             var xml = "Surrogates_1.xml";


### PR DESCRIPTION
Another of the XPath outer loop tests depends on globalization support not yet implemented on Unix.  Disabling for now so that we can run all of the XML tests (inner and outer loops) without failure on Unix.