### PR TITLE
Re-enable tests now that UTF8 is default string marshaling encoding on Linux

### DIFF
--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace System.IO.Compression.Test
 {
     public class zip_CreateTests 
-    {        
+    {
         [Fact]
         public static async Task CreateNormal()
         {
@@ -15,11 +15,8 @@ namespace System.IO.Compression.Test
             await testCreate("small", false);
             await testCreate("normal", true);
             await testCreate("normal", false);
-            if (!Interop.IsLinux) // TODO [ActiveIssue("https://github.com/dotnet/coreclr/issues/333")].  Remove this once libcoreclrpal uses UTF8 for marshaling.
-            {
-                await testCreate("unicode", true);
-                await testCreate("unicode", false);
-            }
+            await testCreate("unicode", true);
+            await testCreate("unicode", false);
             await testCreate("empty", true);
             await testCreate("empty", false);
             await testCreate("emptydir", true);

--- a/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -49,10 +49,7 @@ namespace System.IO.Compression.Test
         {
             await testFolder("normal");
             await testFolder("empty");
-            if (!Interop.IsLinux) // TODO [ActiveIssue("https://github.com/dotnet/coreclr/issues/333")].  Remove this once libcoreclrpal uses UTF8 for marshaling.
-            {
-                await testFolder("unicode");
-            }
+            await testFolder("unicode");
         }
 
         public static async Task testFolder(String s)


### PR DESCRIPTION
A few of the compression tests had been disabled due to asserts in the runtime related to default string marshaling encoding.  These are no longer an issue now that https://github.com/dotnet/coreclr/issues/333 has been fixed.