### PR TITLE
Fix a few more FileSystem tests on Unix

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -107,22 +107,25 @@ public class Directory_GetFileSystemEntries_str
 
             //TODO:: Add UNC path testcase.
 
-            //With wild character's
-            iCountTestcases++;
-            try
+            if (Interop.IsWindows)
             {
-                String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 2);
-                Directory.GetFileSystemEntries(strTempDir);
-                iCountErrors++;
-                printerr("Error_1003! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_1004! Unexpected exceptiont thrown: " + exc.ToString());
+                //With wild character's
+                iCountTestcases++;
+                try
+                {
+                    String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 2);
+                    Directory.GetFileSystemEntries(strTempDir);
+                    iCountErrors++;
+                    printerr("Error_1003! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_1004! Unexpected exceptiont thrown: " + exc.ToString());
+                }
             }
 
             //With lot's of \'s at the end

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -85,22 +85,25 @@ public class Directory_GetFileSystemEntries_str_str
                 printerr("Error_1002! Unexpected exceptiont thrown: " + exc.ToString());
             }
 
-            //With wild character's as file name
-            iCountTestcases++;
-            try
+            if (Interop.IsWindows)
             {
-                String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 3);
-                Directory.GetFileSystemEntries(strTempDir, "*");
-                iCountErrors++;
-                printerr("Error_1003! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_1004! Unexpected exceptiont thrown: " + exc.ToString());
+                //With wild character's as file name
+                iCountTestcases++;
+                try
+                {
+                    String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 3);
+                    Directory.GetFileSystemEntries(strTempDir, "*");
+                    iCountErrors++;
+                    printerr("Error_1003! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_1004! Unexpected exceptiont thrown: " + exc.ToString());
+                }
             }
 
             //With spaces as file name
@@ -160,22 +163,25 @@ public class Directory_GetFileSystemEntries_str_str
                 printerr("Error_9005! Unexpected exceptiont thrown: " + exc.ToString());
             }
 
-            //With wild character's as search pattern
-            iCountTestcases++;
-            try
+            if (Interop.IsWindows)
             {
-                String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 3);
-                Directory.GetFileSystemEntries(dirName, strTempDir);
-                iCountErrors++;
-                printerr("Error_3003! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_3004! Unexpected exceptiont thrown: " + exc.ToString());
+                //With wild character's as search pattern
+                iCountTestcases++;
+                try
+                {
+                    String strTempDir = Path.Combine("dls;d", "442349-0", "v443094(*)(+*$#$*") + new string(Path.DirectorySeparatorChar, 3);
+                    Directory.GetFileSystemEntries(dirName, strTempDir);
+                    iCountErrors++;
+                    printerr("Error_3003! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_3004! Unexpected exceptiont thrown: " + exc.ToString());
+                }
             }
 
             //Valid characters for search pattern

--- a/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move_str_str.cs
@@ -260,45 +260,51 @@ public class Directory_Move_str_str
 
             //-----------------------------------------------------------------
 
-            // [] wildchars in src directory
-            //-----------------------------------------------------------------
-            strLoc = "Loc_00032";
+            if (Interop.IsWindows)
+            {
+                // [] wildchars in src directory
+                //-----------------------------------------------------------------
+                strLoc = "Loc_00032";
 
-            iCountTestcases++;
-            try
-            {
-                Directory.Move("*", tempDirName);
-                iCountErrors++;
-                printerr("Error_00033! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_00035! Incorrect exception thrown, exc==" + exc.ToString());
+                iCountTestcases++;
+                try
+                {
+                    Directory.Move("*", tempDirName);
+                    iCountErrors++;
+                    printerr("Error_00033! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_00035! Incorrect exception thrown, exc==" + exc.ToString());
+                }
             }
             //-----------------------------------------------------------------
 
-            // [] wildchars in dest directory
-            //-----------------------------------------------------------------
-            strLoc = "Loc_00036";
+            if (Interop.IsWindows)
+            {
+                // [] wildchars in dest directory
+                //-----------------------------------------------------------------
+                strLoc = "Loc_00036";
 
-            iCountTestcases++;
-            try
-            {
-                Directory.Move(TestInfo.CurrentDirectory, "Temp*");
-                iCountErrors++;
-                printerr("Error_00037! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_00039! Incorrect exception thrown, exc==" + exc.ToString());
+                iCountTestcases++;
+                try
+                {
+                    Directory.Move(TestInfo.CurrentDirectory, "Temp*");
+                    iCountErrors++;
+                    printerr("Error_00037! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_00039! Incorrect exception thrown, exc==" + exc.ToString());
+                }
             }
             //-----------------------------------------------------------------
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo_str.cs
@@ -381,7 +381,7 @@ public class DirectoryInfo_Move_str
             iCountTestcases++;
             try
             {
-                dir2.MoveTo("******.***");
+                dir2.MoveTo("\0\0\0**\0.*\0\0");
                 iCountErrors++;
                 printerr("Error_298hv! Expected exception not thrown");
             }

--- a/src/System.IO.FileSystem/tests/File/Copy_str_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy_str_str.cs
@@ -206,7 +206,7 @@ public class File_Copy_str_str
             iCountTestcases++;
             try
             {
-                File.Copy(fil2.FullName, "**");
+                File.Copy(fil2.FullName, "*\0*");
                 iCountErrors++;
                 printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
                 fil1.Delete();
@@ -360,7 +360,7 @@ public class File_Copy_str_str
             iCountTestcases++;
             try
             {
-                File.Copy("**", fil2.FullName, false);
+                File.Copy("*\0*", fil2.FullName, false);
                 iCountErrors++;
                 printerr("Error_43987! Expected exception not thrown, fil2==" + fil1.FullName);
                 fil1.Delete();

--- a/src/System.IO.FileSystem/tests/File/Copy_str_str_b.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy_str_str_b.cs
@@ -211,7 +211,7 @@ public class File_Copy_str_str_b
             iCountTestcases++;
             try
             {
-                File.Copy(fil2.FullName, "**", false);
+                File.Copy(fil2.FullName, "*\0*", false);
                 iCountErrors++;
                 printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
                 fil1.Delete();

--- a/src/System.IO.FileSystem/tests/File/CreateText_str.cs
+++ b/src/System.IO.FileSystem/tests/File/CreateText_str.cs
@@ -130,24 +130,27 @@ public class File_CreateText_str
             //-----------------------------------------------------------------
 
 
-            // [] Wildcard in filename should throw
-            //-----------------------------------------------------------------
-            strLoc = "Loc_48yv8";
+            if (Interop.IsWindows)
+            {
+                // [] Wildcard in filename should throw
+                //-----------------------------------------------------------------
+                strLoc = "Loc_48yv8";
 
-            iCountTestcases++;
-            try
-            {
-                File.CreateText("Test*");
-                iCountErrors++;
-                printerr("Error_4y8vv! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_489v7! Incorrect exception thrown, exc==" + exc.ToString());
+                iCountTestcases++;
+                try
+                {
+                    File.CreateText("Test*");
+                    iCountErrors++;
+                    printerr("Error_4y8vv! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_489v7! Incorrect exception thrown, exc==" + exc.ToString());
+                }
             }
 
             //-----------------------------------------------------------------

--- a/src/System.IO.FileSystem/tests/File/Delete_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete_str.cs
@@ -61,24 +61,27 @@ public class File_Delete_str
                 printerr("Error_19d4b! Incorrect exception thrown, exc==" + exc.ToString());
             }
 
-            // [] ArgumentException if argument is *.*
-            //-----------------------------------------------------------------
-            strLoc = "Loc_32453";
+            if (Interop.IsWindows)
+            {
+                // [] ArgumentException if argument is *.*
+                //-----------------------------------------------------------------
+                strLoc = "Loc_32453";
 
-            iCountTestcases++;
-            try
-            {
-                File.Delete("*.*");
-                iCountErrors++;
-                printerr("Error_4342! Expected exception not thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_7777! Incorrect exception thrown, exc==" + exc.ToString());
+                iCountTestcases++;
+                try
+                {
+                    File.Delete("*.*");
+                    iCountErrors++;
+                    printerr("Error_4342! Expected exception not thrown");
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_7777! Incorrect exception thrown, exc==" + exc.ToString());
+                }
             }
 
             // [] Exception for "."

--- a/src/System.IO.FileSystem/tests/File/Move_str_str.cs
+++ b/src/System.IO.FileSystem/tests/File/Move_str_str.cs
@@ -199,7 +199,7 @@ public class File_Move_str_str
             iCountTestcases++;
             try
             {
-                File.Move(fil2.FullName, "**");
+                File.Move(fil2.FullName, "*\0*");
                 iCountErrors++;
                 printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
                 fil2.Delete();

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str.cs
@@ -194,7 +194,7 @@ public class FileInfo_CopyTo_str
             iCountTestcases++;
             try
             {
-                fil1 = fil2.CopyTo("**");
+                fil1 = fil2.CopyTo("*\0*");
                 iCountErrors++;
                 printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
                 fil1.Delete();

--- a/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str_b.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/CopyTo_str_b.cs
@@ -188,7 +188,7 @@ public class FileInfo_CopyTo_str_b
             iCountTestcases++;
             try
             {
-                fil1 = fil2.CopyTo("**", false);
+                fil1 = fil2.CopyTo("*\0*", false);
                 iCountErrors++;
                 printerr("Error_298xh! Expected exception not thrown, fil2==" + fil1.FullName);
                 fil1.Delete();

--- a/src/System.IO.FileSystem/tests/FileInfo/MoveTo_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/MoveTo_str.cs
@@ -183,7 +183,7 @@ public class FileInfo_MoveTo_str
             iCountTestcases++;
             try
             {
-                fil2.MoveTo("**");
+                fil2.MoveTo("*\0*");
                 iCountErrors++;
                 printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
                 fil2.Delete();

--- a/src/System.IO.FileSystem/tests/FileInfo/ctor_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/ctor_str.cs
@@ -183,26 +183,28 @@ public class FileInfo_ctor_str
             }
 
 
-
-            // [] Filename with wildchar characters
-
-
-            strLoc = "Loc_984hg";
-
-            iCountTestcases++;
-            try
+            if (Interop.IsWindows)
             {
-                fil2 = new FileInfo("**");
-                iCountErrors++;
-                printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception exc)
-            {
-                iCountErrors++;
-                printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+                // [] Filename with wildchar characters
+
+
+                strLoc = "Loc_984hg";
+
+                iCountTestcases++;
+                try
+                {
+                    fil2 = new FileInfo("**");
+                    iCountErrors++;
+                    printerr("Error_298xh! Expected exception not thrown, fil2==" + fil2.FullName);
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (Exception exc)
+                {
+                    iCountErrors++;
+                    printerr("Error_2091s! Incorrect exception thrown, exc==" + exc.ToString());
+                }
             }
 
 


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/823 fixes an where ```'*'``` and ```'?'``` are treated as invalid path characters.  Once that's fixed, some additional FileSystem tests that were expecting ```'*'``` and ```'?'``` to be invalid start failing on Unix.  This commit fixes those tests.

The fixes are all of either two flavors: using Interop.IsWindows to only run the test on Windows, or changing the path to include characters also invalid on Unix (namely ```'\0'```).  A bit arbitrary, but I used the former when there was a comment saying that wildcards were being tested, and I used the latter when there was a comment saying that illegal characters were being tested.