### PR TITLE
Disable Unicode compression tests failing in CI

### DIFF
--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="$(CommonTestPath)\Compression\Utilities\LocalMemoryStream.cs" />
     <Compile Include="$(CommonTestPath)\Compression\Utilities\StreamHelpers.cs" />
     <Compile Include="$(CommonTestPath)\Compression\Utilities\ZipTestHelper.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <!-- Temporary until we have new work in build tools to

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -13,7 +13,10 @@ namespace System.IO.Compression.Test
         public static async Task CreateFromDirectoryNormal()
         {
             await TestCreateDirectory(zfolder("normal"), true);
-            await TestCreateDirectory(zfolder("unicode"), true);
+            if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
+            {
+                await TestCreateDirectory(zfolder("unicode"), true);
+            }
         }
 
         private static async Task TestCreateDirectory(String folderName, Boolean testWithBaseDir)
@@ -62,7 +65,10 @@ namespace System.IO.Compression.Test
         public static void ExtractToDirectoryNormal()
         {
             TestExtract(zfile("normal.zip"), zfolder("normal"));
-            TestExtract(zfile("unicode.zip"), zfolder("unicode"));
+            if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
+            {
+                TestExtract(zfile("unicode.zip"), zfolder("unicode"));
+            }
             TestExtract(zfile("empty.zip"), zfolder("empty"));
             TestExtract(zfile("explicitdir1.zip"), zfolder("explicitdir"));
             TestExtract(zfile("explicitdir2.zip"), zfolder("explicitdir"));
@@ -137,12 +143,15 @@ namespace System.IO.Compression.Test
                 DirsEqual(tempFolder, zfolder("normal"));
             }
 
-            using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
+            if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
             {
-                String tempFolder = StreamHelpers.GetTmpPath(false);
-                archive.ExtractToDirectory(tempFolder);
+                using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
+                {
+                    String tempFolder = StreamHelpers.GetTmpPath(false);
+                    archive.ExtractToDirectory(tempFolder);
 
-                DirsEqual(tempFolder, zfolder("unicode"));
+                    DirsEqual(tempFolder, zfolder("unicode"));
+                }
             }
         }
 

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -15,8 +15,11 @@ namespace System.IO.Compression.Test
             await testCreate("small", false);
             await testCreate("normal", true);
             await testCreate("normal", false);
-            await testCreate("unicode", true);
-            await testCreate("unicode", false);
+            if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
+            {
+                await testCreate("unicode", true);
+                await testCreate("unicode", false);
+            }
             await testCreate("empty", true);
             await testCreate("empty", false);
             await testCreate("emptydir", true);

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -25,8 +25,11 @@ namespace System.IO.Compression.Test
                 ZipTest.zfile("emptydir.zip"), ZipTest.zfolder("emptydir"), ZipArchiveMode.Read);
             await ZipTest.IsZipSameAsDirAsync(
                 ZipTest.zfile("small.zip"), ZipTest.zfolder("small"), ZipArchiveMode.Read);
-            await ZipTest.IsZipSameAsDirAsync(
-                ZipTest.zfile("unicode.zip"), ZipTest.zfolder("unicode"), ZipArchiveMode.Read);
+            if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
+            {
+                await ZipTest.IsZipSameAsDirAsync(
+                    ZipTest.zfile("unicode.zip"), ZipTest.zfolder("unicode"), ZipArchiveMode.Read);
+            }
         }
 
         [Fact]
@@ -36,7 +39,10 @@ namespace System.IO.Compression.Test
 
             await TestStreamingRead(ZipTest.zfile("normal.zip"), ZipTest.zfolder("normal"));
             await TestStreamingRead(ZipTest.zfile("fake64.zip"), ZipTest.zfolder("small"));
-            await TestStreamingRead(ZipTest.zfile("unicode.zip"), ZipTest.zfolder("unicode"));
+            if (Interop.IsWindows) // [ActiveIssue(846, PlatformID.Linux | PlatformID.OSX)]
+            {
+                await TestStreamingRead(ZipTest.zfile("unicode.zip"), ZipTest.zfolder("unicode"));
+            }
             await TestStreamingRead(ZipTest.zfile("empty.zip"), ZipTest.zfolder("empty"));
             await TestStreamingRead(ZipTest.zfile("appended.zip"), ZipTest.zfolder("small"));
             await TestStreamingRead(ZipTest.zfile("prepended.zip"), ZipTest.zfolder("small"));

--- a/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -15,8 +15,11 @@ namespace System.IO.Compression.Test
                 await StreamHelpers.CreateTempCopyStream(ZipTest.zfile("normal.zip")), ZipTest.zfolder("normal"), ZipArchiveMode.Update, false, false);
             ZipTest.IsZipSameAsDir(
                 await StreamHelpers.CreateTempCopyStream(ZipTest.zfile("fake64.zip")), ZipTest.zfolder("small"), ZipArchiveMode.Update, false, false);
-            ZipTest.IsZipSameAsDir(
-                await StreamHelpers.CreateTempCopyStream(ZipTest.zfile("unicode.zip")), ZipTest.zfolder("unicode"), ZipArchiveMode.Update, false, false);
+            if (Interop.IsWindows)
+            {
+                ZipTest.IsZipSameAsDir(
+                    await StreamHelpers.CreateTempCopyStream(ZipTest.zfile("unicode.zip")), ZipTest.zfolder("unicode"), ZipArchiveMode.Update, false, false);
+            }
             ZipTest.IsZipSameAsDir(
                 await StreamHelpers.CreateTempCopyStream(ZipTest.zfile("empty.zip")), ZipTest.zfolder("empty"), ZipArchiveMode.Update, false, false);
             ZipTest.IsZipSameAsDir(
@@ -49,7 +52,10 @@ namespace System.IO.Compression.Test
         {
             await testFolder("normal");
             await testFolder("empty");
-            await testFolder("unicode");
+            if (Interop.IsWindows)
+            {
+                await testFolder("unicode");
+            }
         }
 
         public static async Task testFolder(String s)


### PR DESCRIPTION
In #1523 I re-enabled several compression tests that we'd previously disabled due to the default string marshaling encoding on Linux not being UTF8, and once it was, these tests were passing for me locally.  However, there's obviously some difference between my machine setup and the CI machine setup that's causing these Unicode tests to fail during CI but not for me locally.  Since we know we need a complete globalization implementation on Linux and OSX (#846) such that it's not surprising these tests are failing (it's more surprising they're passing for me locally), I'm disabling these Unicode tests on all but Windows for now.  This commit disables not only those from #1523 but all of the tests using the unicode.zip file.