### PR TITLE
Fix #1487:  Three XPath tests failing in Debug.Assert #1487

### DIFF
--- a/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
+++ b/src/Common/tests/System.Xml.XPath/FuncLocation/PathAxeCombinationsTests.cs
@@ -44935,7 +44935,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS59: //namespace::node()//@*
         /// </summary>
         [Fact]
-        [ActiveIssue(1487)]
         public static void AxesCombinationsTest2142()
         {
             var xml = "ns_prefixes.xml";
@@ -44951,7 +44950,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS60: //namespace::node()//self::*
         /// </summary>
         [Fact]
-        [ActiveIssue(1487)]
         public static void AxesCombinationsTest2143()
         {
             var xml = "ns_prefixes.xml";
@@ -44967,7 +44965,6 @@ namespace XPathTests.FunctionalTests.Location.Paths
         /// NS61: //namespace::node()//namespace::node()
         /// </summary>
         [Fact]
-        [ActiveIssue(1487)]
         public static void AxesCombinationsTest2144()
         {
             var xml = "ns_prefixes.xml";

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/BaseAxisQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/BaseAxisQuery.cs
@@ -106,7 +106,6 @@ namespace MS.Internal.Xml.XPath
             ResetCount();
             Reset();
             qyInput.Evaluate(nodeIterator);
-            AssertQuery(qyInput);
             return this;
         }
 

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/CacheChildrenQuery.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/CacheChildrenQuery.cs
@@ -90,17 +90,7 @@ namespace MS.Internal.Xml.XPath
                         continue;
                     }
                 }
-#if DEBUG
-                if (_lastNode != null)
-                {
-                    if (currentNode.GetType().ToString() == "Microsoft.VisualStudio.Modeling.StoreNavigator")
-                    {
-                        XmlNodeOrder order = CompareNodes(_lastNode, currentNode);
-                        System.Diagnostics.Debug.Assert(order == XmlNodeOrder.Before, "Algorithm error. Nodes expected to be DocOrderDistinct");
-                    }
-                }
-                _lastNode = currentNode.Clone();
-#endif
+
                 if (matches(currentNode))
                 {
                     position++;

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/Query.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/Query.cs
@@ -134,7 +134,6 @@ namespace MS.Internal.Xml.XPath
                         break;
                 }
             }
-            AssertDOD(buffer, nav, l);
             buffer.Insert(l, nav.Clone());
             return true;
         }
@@ -167,60 +166,6 @@ namespace MS.Internal.Xml.XPath
                 );
             }
             return cmp;
-        }
-
-        [Conditional("DEBUG")]
-        private static void AssertDOD(List<XPathNavigator> buffer, XPathNavigator nav, int pos)
-        {
-            if (nav.GetType().ToString() == "Microsoft.VisualStudio.Modeling.StoreNavigator") return;
-            if (nav.GetType().ToString() == "System.Xml.DataDocumentXPathNavigator") return;
-            Debug.Assert(0 <= pos && pos <= buffer.Count, "Algorithm error: Insert()");
-            XmlNodeOrder cmp;
-            if (0 < pos)
-            {
-                cmp = CompareNodes(buffer[pos - 1], nav);
-                Debug.Assert(cmp == XmlNodeOrder.Before, "Algorithm error: Insert()");
-            }
-            if (pos < buffer.Count)
-            {
-                cmp = CompareNodes(nav, buffer[pos]);
-                Debug.Assert(cmp == XmlNodeOrder.Before, "Algorithm error: Insert()");
-            }
-        }
-
-        [Conditional("DEBUG")]
-        public static void AssertQuery(Query query)
-        {
-            Debug.Assert(query != null, "AssertQuery(): query == null");
-            if (query is FunctionQuery) return; // Temp Fix. Functions (as document()) return now unordered sequences
-            query = Clone(query);
-            XPathNavigator last = null;
-            XPathNavigator curr;
-            int querySize = query.Clone().Count;
-            int actualSize = 0;
-            while ((curr = query.Advance()) != null)
-            {
-                if (curr.GetType().ToString() == "Microsoft.VisualStudio.Modeling.StoreNavigator") return;
-                if (curr.GetType().ToString() == "System.Xml.DataDocumentXPathNavigator") return;
-                Debug.Assert(curr == query.Current, "AssertQuery(): query.Advance() != query.Current");
-                if (last != null)
-                {
-                    if (last.NodeType == XPathNodeType.Namespace && curr.NodeType == XPathNodeType.Namespace)
-                    {
-                        // NamespaceQuery reports namespaces in mixed order.
-                        // Ignore this for now. 
-                        // It seams that this doesn't break other queries because NS can't have children
-                    }
-                    else
-                    {
-                        XmlNodeOrder cmp = CompareNodes(last, curr);
-                        Debug.Assert(cmp == XmlNodeOrder.Before, "AssertQuery(): Wrong node order");
-                    }
-                }
-                last = curr.Clone();
-                actualSize++;
-            }
-            Debug.Assert(actualSize == querySize, "AssertQuery(): actualSize != querySize");
         }
 
         // =================== XPathResultType_Navigator ======================


### PR DESCRIPTION
Some Debug.Assert in XPath code are assuming that attributes/namespaces are sorted which is invalid for some implementations of XPath. Since that checks are only made on debug builds I'm removing them.