### PR TITLE
Fix code coverage for partial facades

### DIFF
--- a/src/System.Runtime.Handles/tests/System.Runtime.Handles.Tests.csproj
+++ b/src/System.Runtime.Handles/tests/System.Runtime.Handles.Tests.csproj
@@ -20,6 +20,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -99,6 +99,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
pdb files weren't be copied over to the tests directory along with the dll files, breaking code coverage, which depends on having pdbs.

Thanks to @KirillOsenkov and @ljcollins25 for suggesting the fix.

Fixes #1528.