### PR TITLE
Fix decoding of multi-mod types in signatures

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -391,7 +391,7 @@ namespace System.Reflection.Metadata.Decoding
 
                 do
                 {
-                    type = DecodeType(ref blobReader, typeCode, provider);
+                    type = DecodeTypeHandle(ref blobReader, provider);
                     modifier = new CustomModifier<TType>(type, isRequired);
                     builder.Add(modifier);
                     typeCode = blobReader.ReadSignatureTypeCode();

--- a/src/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Decoding;
+using Xunit;
+
+namespace System.Reflection.Metadata.Tests
+{
+    public class SignatureDecoderTests
+    {
+        [Fact]
+        public unsafe void VerifyMultipleOptionalModifiers()
+        {
+            // Type 1: int32 modopt([mscorlib]System.Runtime.CompilerServices.IsLong) modopt([mscorlib]System.Runtime.CompilerServices.CallConvCdecl)
+            // Type 2: char* 
+            // Type 3: uint32 
+            // Type 4: char modopt([mscorlib]System.Runtime.CompilerServices.IsConst)*
+            var testSignature = new byte[] { 0x20, 0x45, 0x20, 0x69, 0x08, 0x0F, 0x03, 0x09, 0x0F, 0x20, 0x55, 0x03 };
+            var types = new string[]
+            {
+                "11 1A Int32",  // This has multiple modifiers, which exercises different code paths than single modifiers
+                "Char*",
+                "UInt32",
+                "15 Char*"
+            };
+
+            fixed (byte* testSignaturePtr = &testSignature[0])
+            {
+                var signatureBlob = new BlobReader(testSignaturePtr, testSignature.Length);
+                var sigTypeProvider = new TestSignatureTypeProvider();
+
+                foreach (string typeString in types)
+                {
+                    // Verify that each type is decoded as expected
+                    Assert.Equal(typeString, SignatureDecoder.DecodeType(ref signatureBlob, sigTypeProvider));
+                }
+                // And that nothing is left over to decode
+                Assert.Throws<BadImageFormatException>(() => SignatureDecoder.DecodeType(ref signatureBlob, sigTypeProvider));
+            }
+        }
+
+        // Simple test implementation of ISignatureTypeProvider to check that the right types are decoded
+        private class TestSignatureTypeProvider : ISignatureTypeProvider<string>
+        {
+            public string GetModifiedType(string unmodifiedType, ImmutableArray<CustomModifier<string>> customModifiers)
+            {
+                return string.Join(" ", customModifiers.Select(c => c.Type)) + " " + unmodifiedType;
+            }
+
+            public string GetPrimitiveType(PrimitiveTypeCode typeCode) { return typeCode.ToString(); }
+            public string GetTypeFromDefinition(TypeDefinitionHandle handle) { return handle.RowId.ToString("X"); }
+            public string GetTypeFromReference(TypeReferenceHandle handle) { return handle.RowId.ToString("X"); }
+            public string GetByReferenceType(string elemenstring) { return elemenstring + "&"; }
+            public string GetSZArrayType(string elemenstring) { return elemenstring + "[]"; }
+            public string GetPointerType(string elemenstring) { return elemenstring + "*"; }
+
+            public MetadataReader Reader { get { return null; } } // Not needed, currently
+            public string GetFunctionPointerType(MethodSignature<string> signature) { return null; } // Not needed, currently
+            public string GetGenericMethodParameter(int index) { return null; } // Not needed, currently
+            public string GetGenericTypeParameter(int index) { return null; } // Not needed, currently
+            public string GetGenericInstance(string genericType, ImmutableArray<string> typeArguments) { return null; } // Not needed, currently
+            public string GetArrayType(string elemenstring, ArrayShape shape) { return null; } // Not needed, currently
+            public string GetPinnedType(string elemenstring) { return null; } // Not needed, currently
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="Metadata\ClassLayoutRow.cs" />
     <Compile Include="Metadata\Decoding\MethodSignatureTests.cs" />
+    <Compile Include="Metadata\Decoding\SignatureDecoderTests.cs" />
     <Compile Include="Metadata\Ecma335\MetadataAggregatorTests.cs" />
     <Compile Include="Metadata\Ecma335\MetadataTokensTests.cs" />
     <Compile Include="Metadata\HandleComparerTests.cs" />


### PR DESCRIPTION
Address issue #1535 by updating the metadata reader's signature decoder to correctly decode types with multiple modifiers.