### PR TITLE
Fix security exception with private serialization event methods in DCJS

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -634,15 +634,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        private static void DisallowMemberAccess(bool memberAccess)
-        {
-            if (memberAccess)
-            {
-                // the exception will be wrapped with an appropriate message
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityException());
-            }
-        }
-
         static internal void InvokeOnSerializing(Object value, DataContract contract, XmlObjectSerializerWriteContextComplexJson context)
         {
             if (contract is ClassDataContract)
@@ -656,7 +647,6 @@ namespace System.Runtime.Serialization.Json
                     bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null, JsonGlobals.JsonSerializationPatterns);
                     try
                     {
-                        DisallowMemberAccess(memberAccessFlag);
                         classContract.OnSerializing.Invoke(value, new object[] { context.GetStreamingContext() });
                     }
                     catch (SecurityException securityException)
@@ -695,7 +685,6 @@ namespace System.Runtime.Serialization.Json
                     bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null, JsonGlobals.JsonSerializationPatterns);
                     try
                     {
-                        DisallowMemberAccess(memberAccessFlag);
                         classContract.OnSerialized.Invoke(value, new object[] { context.GetStreamingContext() });
                     }
                     catch (SecurityException securityException)
@@ -734,7 +723,6 @@ namespace System.Runtime.Serialization.Json
                     bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null, JsonGlobals.JsonSerializationPatterns);
                     try
                     {
-                        DisallowMemberAccess(memberAccessFlag);
                         classContract.OnDeserializing.Invoke(value, new object[] { context.GetStreamingContext() });
                     }
                     catch (SecurityException securityException)
@@ -773,7 +761,6 @@ namespace System.Runtime.Serialization.Json
                     bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null, JsonGlobals.JsonSerializationPatterns);
                     try
                     {
-                        DisallowMemberAccess(memberAccessFlag);
                         classContract.OnDeserialized.Invoke(value, new object[] { context.GetStreamingContext() });
                     }
                     catch (SecurityException securityException)

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1259,6 +1259,18 @@ public static class DataContractJsonSerializerTests
         Assert.StrictEqual("Bar Summary", deserializedValue.Articles[0].Title);
     }
 
+    [Fact]
+    public static void DCJS_SerializationEvents()
+    {
+        var input = new MyType() { Value = "string value" };
+        var output = SerializeAndDeserialize<MyType>(input, "{\"Value\":\"string value\"}");
+
+        Assert.True(input.OnSerializingMethodInvoked, "input.OnSerializingMethodInvoked is false");
+        Assert.True(input.OnSerializedMethodInvoked, "input.OnSerializedMethodInvoked is false");
+        Assert.True(output.OnDeserializingMethodInvoked, "output.OnDeserializingMethodInvoked is false");
+        Assert.True(output.OnDeserializedMethodInvoked, "output.OnDeserializedMethodInvoked is false");
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1178,25 +1178,25 @@ namespace SerializationTypes
         public object Value;
 
         [OnSerializing()]
-        internal void OnSerializingMethod(StreamingContext context)
+        private void OnSerializingMethod(StreamingContext context)
         {
             OnSerializingMethodInvoked = true;
         }
 
         [OnSerialized()]
-        internal void OnSerializedMethod(StreamingContext context)
+        private void OnSerializedMethod(StreamingContext context)
         {
             OnSerializedMethodInvoked = true;
         }
 
         [OnDeserializing()]
-        internal void OnDeserializingMethod(StreamingContext context)
+        private void OnDeserializingMethod(StreamingContext context)
         {
             OnDeserializingMethodInvoked = true;
         }
 
         [OnDeserialized()]
-        internal void OnDeserializedMethod(StreamingContext context)
+        private void OnDeserializedMethod(StreamingContext context)
         {
             OnDeserializedMethodInvoked = true;
         }


### PR DESCRIPTION
Fix security exception in the deserialization scenario of type with serialization event method marked as private, such as:
``` csharp
 [DataContract]
 public class Data
 {
    [OnDeserialized]
    private void OnDeserialized(StreamingContext context) { }
    [DataMember]
    public int Property1 { get; set; }
 }
 …
 string json = "{\"Property1\":1}";
 DataContractJsonSerializer s = new DataContractJsonSerializer(typeof(Data));
 Data obj = s.ReadObject(new MemoryStream(Encoding.UTF8.GetBytes(json))) as Data;  //Crashes
 ```
Actual behavior: SecurityException: The data contract type 'DataContractInternalRepro.Data' cannot be deserialized because the OnDeserialized method 'OnDeserialized' is not public. Making the method public will fix this error. 
Expected behavior: no exception

This scenario is working in DCS. It looks like the exception in DCJS is thrown at the wrong place.