### PR TITLE
Augment System.Runtime tests

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -36,6 +36,8 @@
     <Compile Include="System\Collections\ObjectModel\Collection.cs" />
     <Compile Include="System\Collections\ObjectModel\CollectionTestBase.cs" />
     <Compile Include="System\Collections\ObjectModel\ReadOnlyCollection.cs" />
+    <Compile Include="System\ComponentModel\EditorBrowsableAttribute.cs" />
+    <Compile Include="System\ComponentModel\DefaultValueAttribute.cs" />
     <Compile Include="System\DateTime.cs" />
     <Compile Include="System\DateTimeOffset.cs" />
     <Compile Include="System\DateTimeOffset.UnixTimeConversions.cs" />
@@ -59,12 +61,14 @@
     <Compile Include="System\IO\PathTooLongException.cs" />
     <Compile Include="System\IO\PathTooLongException.Interop.cs" />
     <Compile Include="System\Lazy.cs" />
+    <Compile Include="System\LazyOfTMetadata.cs" />
     <Compile Include="System\MethodAccessException.cs" />
     <Compile Include="System\MissingFieldException.cs" />
     <Compile Include="System\MissingMethodException.cs" />
     <Compile Include="System\MulticastDelegate.cs" />
     <Compile Include="System\Nullable.cs" />
     <Compile Include="System\Object.cs" />
+    <Compile Include="System\Runtime\CompilerServices\StrongBox.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="System\SByte.cs" />
     <Compile Include="System\Single.cs" />

--- a/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttribute.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Xunit;
+
+namespace System.Runtime.Tests
+{
+    public static class DefaultValueAttributeTests
+    {
+        [Fact]
+        public static void TestCtor()
+        {
+            Assert.Equal(true, new DefaultValueAttribute(true).Value);
+            Assert.Equal(false, new DefaultValueAttribute(false).Value);
+            Assert.Equal((byte)1, new DefaultValueAttribute((byte)1).Value);
+            Assert.Equal('c', new DefaultValueAttribute('c').Value);
+            Assert.Equal(3.14, new DefaultValueAttribute(3.14).Value);
+            Assert.Equal(3.14f, new DefaultValueAttribute(3.14f).Value);
+            Assert.Equal(42, new DefaultValueAttribute(42).Value);
+            Assert.Equal(42L, new DefaultValueAttribute(42L).Value);
+            Assert.Equal("test", new DefaultValueAttribute((object)"test").Value);
+            Assert.Equal((short)42, new DefaultValueAttribute((short)42).Value);
+            Assert.Equal("test", new DefaultValueAttribute("test").Value);
+            Assert.Equal(DayOfWeek.Monday, new DefaultValueAttribute(typeof(DayOfWeek), "Monday").Value);
+            Assert.Equal(TimeSpan.FromHours(1), new DefaultValueAttribute(typeof(TimeSpan), "1:00:00").Value);
+            Assert.Equal(42, new DefaultValueAttribute(typeof(int), "42").Value);
+            Assert.Equal(null, new DefaultValueAttribute(typeof(int), "caughtException").Value);
+        }
+
+        [Fact]
+        public static void TestEqual()
+        {
+            DefaultValueAttribute attr;
+
+            attr = new DefaultValueAttribute(42);
+            Assert.Equal(attr, attr);
+            Assert.True(attr.Equals(attr));
+            Assert.Equal(attr.GetHashCode(), attr.GetHashCode());
+            Assert.Equal(attr, new DefaultValueAttribute(42));
+            Assert.Equal(attr.GetHashCode(), new DefaultValueAttribute(42).GetHashCode());
+            Assert.NotEqual(new DefaultValueAttribute(43), attr);
+            Assert.NotEqual(new DefaultValueAttribute(null), attr);
+            Assert.False(attr.Equals(null));
+
+            attr = new DefaultValueAttribute(null);
+            Assert.Equal(new DefaultValueAttribute(null), attr);
+            Assert.Equal(attr.GetHashCode(), new DefaultValueAttribute(null).GetHashCode());
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/ComponentModel/EditorBrowsableAttribute.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/EditorBrowsableAttribute.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using Xunit;
+
+namespace System.Runtime.Tests
+{
+    public static class EditorBrowsableAttributeTests
+    {
+        [Fact]
+        public static void TestCtor()
+        {
+            Assert.Equal(EditorBrowsableState.Advanced, new EditorBrowsableAttribute(EditorBrowsableState.Advanced).State);
+            Assert.Equal(EditorBrowsableState.Always, new EditorBrowsableAttribute(EditorBrowsableState.Always).State);
+            Assert.Equal(EditorBrowsableState.Never, new EditorBrowsableAttribute(EditorBrowsableState.Never).State);
+            Assert.Equal((EditorBrowsableState)12345, new EditorBrowsableAttribute((EditorBrowsableState)12345).State);
+        }
+
+        [Fact]
+        public static void TestEqual()
+        {
+            var attr = new EditorBrowsableAttribute(EditorBrowsableState.Advanced);
+            Assert.Equal(attr, attr);
+            Assert.True(attr.Equals(attr));
+            Assert.Equal(attr.GetHashCode(), attr.GetHashCode());
+
+            Assert.Equal(new EditorBrowsableAttribute(EditorBrowsableState.Advanced), attr);
+            Assert.Equal(new EditorBrowsableAttribute(EditorBrowsableState.Advanced).GetHashCode(), attr.GetHashCode());
+
+            Assert.NotEqual(new EditorBrowsableAttribute(EditorBrowsableState.Always), attr);
+            Assert.NotEqual(new EditorBrowsableAttribute(EditorBrowsableState.Never).GetHashCode(), attr.GetHashCode());
+            Assert.False(attr.Equals(null));
+        }
+
+        [Fact]
+        public static void TestEnumValues()
+        {
+            Assert.Equal(0, (int)EditorBrowsableState.Always);
+            Assert.Equal(1, (int)EditorBrowsableState.Never);
+            Assert.Equal(2, (int)EditorBrowsableState.Advanced);
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/Lazy.cs
+++ b/src/System.Runtime/tests/System/Lazy.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Runtime.Tests
 {
-    public static class LazyInitializerTests
+    public static class LazyTests
     {
         [Fact]
         public static void TestConstructor()

--- a/src/System.Runtime/tests/System/LazyOfTMetadata.cs
+++ b/src/System.Runtime/tests/System/LazyOfTMetadata.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Xunit;
+
+namespace System.Runtime.Tests
+{
+    public static class LazyOfTMetadataTests
+    {
+        [Fact]
+        public static void TestCtor()
+        {
+            new Lazy<int, string>(null);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Lazy<int, string>("test", (LazyThreadSafetyMode)12345));
+            Assert.Throws<ArgumentNullException>(() => new Lazy<int, string>(null, "test"));
+            Assert.Throws<ArgumentNullException>(() => new Lazy<int, string>(null, "test", false));
+            Assert.Throws<ArgumentNullException>(() => new Lazy<int, string>(null, "test", LazyThreadSafetyMode.PublicationOnly));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Lazy<int, string>(() => 42, "test", (LazyThreadSafetyMode)12345));
+        }
+
+        [Fact]
+        public static void TestMetadataProperty()
+        {
+            Assert.Equal("metadata1", new Lazy<int, string>("metadata1").Metadata);
+            Assert.Equal("metadata2", new Lazy<int, string>("metadata2", false).Metadata);
+            Assert.Equal("metadata3", new Lazy<int, string>("metadata3", LazyThreadSafetyMode.PublicationOnly).Metadata);
+            Assert.Equal(4, new Lazy<object, int>(() => new object(), 4).Metadata);
+            Assert.Equal(5, new Lazy<object, int>(() => new object(), 5, false).Metadata);
+            Assert.Equal(6, new Lazy<object, int>(() => new object(), 6, LazyThreadSafetyMode.None).Metadata);
+        }
+
+        [Fact]
+        public static void TestBasicInitialization()
+        {
+            Lazy<int, string> lazy;
+
+            lazy = new Lazy<int, string>("test1");
+            Assert.False(lazy.IsValueCreated);
+            Assert.Equal("test1", lazy.Metadata);
+            Assert.False(lazy.IsValueCreated);
+            Assert.Equal(0, lazy.Value);
+            Assert.True(lazy.IsValueCreated);
+
+            lazy = new Lazy<int, string>(() => 42, "test2");
+            Assert.False(lazy.IsValueCreated);
+            Assert.Equal("test2", lazy.Metadata);
+            Assert.False(lazy.IsValueCreated);
+            Assert.Equal(42, lazy.Value);
+            Assert.True(lazy.IsValueCreated);
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/StrongBox.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/StrongBox.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Runtime.Tests
+{
+    public static class StrongBoxTests
+    {
+        [Fact]
+        public static void TestCtor()
+        {
+            StrongBox<int> boxedInt32 = new StrongBox<int>();
+            Assert.Equal(default(int), boxedInt32.Value);
+            boxedInt32 = new StrongBox<int>(42);
+            Assert.Equal(42, boxedInt32.Value);
+
+            StrongBox<string> boxedString = new StrongBox<string>();
+            Assert.Equal(default(string), boxedString.Value);
+            boxedString = new StrongBox<string>("test");
+            Assert.Equal("test", boxedString.Value);
+        }
+
+        [Fact]
+        public static void TestValue()
+        {
+            StrongBox<int> sb = new StrongBox<int>();
+            Assert.Equal(0, sb.Value);
+            sb.Value = 42;
+            Assert.Equal(42, sb.Value);
+
+            IStrongBox isb = sb;
+            Assert.Equal(42, (int)isb.Value);
+            isb.Value = 84;
+            Assert.Equal(84, sb.Value);
+            Assert.Equal(84, (int)isb.Value);
+
+            Assert.Throws<InvalidCastException>(() => isb.Value = "test");
+        }
+    }
+}


### PR DESCRIPTION
System.Runtime is a partial facade, with most of the types exposed from it type forwarded to mscorlib, but with a few actually implemented in it.  While there are a fair number of tests for System.Runtime already in the repo, none of them cover the types in System.Runtime.dll itself.  This commit brings the code coverage for those types in System.Runtime.dll itself up from 0% to 100%.