### PR TITLE
Cleanup a few more empty array allocations and Contract.Asserts

### DIFF
--- a/src/Common/src/System/Collections/Generic/LowLevelList.cs
+++ b/src/Common/src/System/Collections/Generic/LowLevelList.cs
@@ -49,14 +49,12 @@ namespace System.Collections.Generic
         protected int _size;
         protected int _version;
 
-        private static readonly T[] s_emptyArray = new T[0];
-
         // Constructs a List. The list is initially empty and has a capacity
         // of zero. Upon adding the first element to the list the capacity is
         // increased to 16, and then increased in multiples of two as required.
         public LowLevelList()
         {
-            _items = s_emptyArray;
+            _items = Array.Empty<T>();
         }
 
         // Constructs a List with a given initial capacity. The list is
@@ -69,7 +67,7 @@ namespace System.Collections.Generic
             Contract.EndContractBlock();
 
             if (capacity == 0)
-                _items = s_emptyArray;
+                _items = Array.Empty<T>();
             else
                 _items = new T[capacity];
         }
@@ -90,7 +88,7 @@ namespace System.Collections.Generic
                 int count = c.Count;
                 if (count == 0)
                 {
-                    _items = s_emptyArray;
+                    _items = Array.Empty<T>();
                 }
                 else
                 {
@@ -102,7 +100,7 @@ namespace System.Collections.Generic
             else
             {
                 _size = 0;
-                _items = s_emptyArray;
+                _items = Array.Empty<T>();
                 // This enumerable could be empty.  Let Add allocate a new array, if needed.
                 // Note it will also go to _defaultCapacity first, not 1, then 2, etc.
 
@@ -150,7 +148,7 @@ namespace System.Collections.Generic
                     }
                     else
                     {
-                        _items = s_emptyArray;
+                        _items = Array.Empty<T>();
                     }
                 }
             }

--- a/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -22,14 +22,12 @@ namespace System.Runtime.CompilerServices
 
         private Object _syncRoot;
 
-        private static readonly T[] s_emptyArray = new T[0];
-
         /// <summary>
         /// Constructs a ReadOnlyCollectionBuilder.
         /// </summary>
         public ReadOnlyCollectionBuilder()
         {
-            _items = s_emptyArray;
+            _items = Array.Empty<T>();
         }
 
         /// <summary>
@@ -97,7 +95,7 @@ namespace System.Runtime.CompilerServices
                     }
                     else
                     {
-                        _items = s_emptyArray;
+                        _items = Array.Empty<T>();
                     }
                 }
             }
@@ -471,7 +469,7 @@ namespace System.Runtime.CompilerServices
             {
                 items = ToArray();
             }
-            _items = s_emptyArray;
+            _items = Array.Empty<T>();
             _size = 0;
             _version++;
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/QueryAggregationOptions.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/QueryAggregationOptions.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Parallel
     {
         // This helper is a workaround for the fact that Enum.Defined() does not work on non-public enums.
         // There is a custom attribute in System.Reflection.Metadata.Controls that would make it work
-        // but we don't want to introduce a dependency on that contract just to support two Contract.Asserts.
+        // but we don't want to introduce a dependency on that contract just to support two asserts.
         public static bool IsValidQueryAggregationOption(this QueryAggregationOptions value)
         {
             return value == QueryAggregationOptions.None

--- a/src/System.Threading/src/System/Collections/Concurrent/LowLevelConcurrentQueue.cs
+++ b/src/System.Threading/src/System/Collections/Concurrent/LowLevelConcurrentQueue.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
@@ -385,7 +384,7 @@ namespace System.Collections.Concurrent
                 m_array = new T[SEGMENT_SIZE];
                 m_state = new VolatileBool[SEGMENT_SIZE]; //all initialized to false
                 _high = -1;
-                Contract.Assert(index >= 0);
+                Debug.Assert(index >= 0);
                 m_index = index;
                 _source = source;
             }
@@ -417,7 +416,7 @@ namespace System.Collections.Concurrent
             /// <param name="value"></param>
             internal void UnsafeAdd(T value)
             {
-                Contract.Assert(_high < SEGMENT_SIZE - 1);
+                Debug.Assert(_high < SEGMENT_SIZE - 1);
                 _high++;
                 m_array[_high] = value;
                 m_state[_high].m_value = true;
@@ -433,7 +432,7 @@ namespace System.Collections.Concurrent
             /// <returns>the reference to the new Segment</returns>
             internal Segment UnsafeGrow()
             {
-                Contract.Assert(_high >= SEGMENT_SIZE - 1);
+                Debug.Assert(_high >= SEGMENT_SIZE - 1);
                 Segment newSegment = new Segment(m_index + 1, _source); //m_index is Int64, we don't need to worry about overflow
                 _next = newSegment;
                 return newSegment;
@@ -449,7 +448,7 @@ namespace System.Collections.Concurrent
                 //no CAS is needed, since there is no contention (other threads are blocked, busy waiting)
                 Segment newSegment = new Segment(m_index + 1, _source);  //m_index is Int64, we don't need to worry about overflow
                 _next = newSegment;
-                Contract.Assert(_source._tail == this);
+                Debug.Assert(_source._tail == this);
                 _source._tail = _next;
             }
 
@@ -556,7 +555,7 @@ namespace System.Collections.Concurrent
                             {
                                 spinLocal.SpinOnce();
                             }
-                            Contract.Assert(_source._head == this);
+                            Debug.Assert(_source._head == this);
                             _source._head = _next;
                         }
                         return true;

--- a/src/System.Threading/src/System/Progress.cs
+++ b/src/System.Threading/src/System/Progress.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 
 namespace System
 {
@@ -34,7 +33,7 @@ namespace System
             // Capture the current synchronization context.
             // If there is no current context, we use a default instance targeting the ThreadPool.
             _synchronizationContext = SynchronizationContext.Current ?? ProgressStatics.DefaultContext;
-            Contract.Assert(_synchronizationContext != null);
+            Debug.Assert(_synchronizationContext != null);
             _invokeHandlers = new SendOrPostCallback(InvokeHandlers);
         }
 

--- a/src/System.Threading/src/System/Threading/CountdownEvent.cs
+++ b/src/System.Threading/src/System/Threading/CountdownEvent.cs
@@ -11,7 +11,6 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Diagnostics.Contracts;
 
 namespace System.Threading
 {
@@ -180,7 +179,7 @@ namespace System.Threading
         public bool Signal()
         {
             ThrowIfDisposed();
-            Contract.Assert(_event != null);
+            Debug.Assert(_event != null);
 
             if (_currentCount <= 0)
             {
@@ -227,7 +226,7 @@ namespace System.Threading
             }
 
             ThrowIfDisposed();
-            Contract.Assert(_event != null);
+            Debug.Assert(_event != null);
 
             int observedCount;
             SpinWait spin = new SpinWait();
@@ -261,7 +260,7 @@ namespace System.Threading
                 return true;
             }
 
-            Contract.Assert(_currentCount >= 0, "latch was decremented below zero");
+            Debug.Assert(_currentCount >= 0, "latch was decremented below zero");
             return false;
         }
 

--- a/src/System.Threading/src/System/Threading/TimeoutHelper.cs
+++ b/src/System.Threading/src/System/Threading/TimeoutHelper.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 
 namespace System.Threading
 {
@@ -30,7 +30,7 @@ namespace System.Threading
         public static int UpdateTimeOut(uint startTime, int originalWaitMillisecondsTimeout)
         {
             // The function must be called in case the time out is not infinite
-            Contract.Assert(originalWaitMillisecondsTimeout != Timeout.Infinite);
+            Debug.Assert(originalWaitMillisecondsTimeout != Timeout.Infinite);
 
             uint elapsedMilliseconds = (GetTime() - startTime);
 

--- a/src/System.Xml.XPath.XmlDocument/src/System/Xml/XPathNodeList.cs
+++ b/src/System.Xml.XPath.XmlDocument/src/System/Xml/XPathNodeList.cs
@@ -32,8 +32,6 @@ namespace System.Xml
             }
         }
 
-        private static readonly object[] s_nullparams = { };
-
         private XmlNode GetNode(XPathNavigator n)
         {
             return (XmlNode)n.UnderlyingObject;

--- a/src/System.Xml.XPath/src/System/Xml/XPath/Internal/XPathParser.cs
+++ b/src/System.Xml.XPath/src/System/Xml/XPath/Internal/XPathParser.cs
@@ -786,7 +786,7 @@ namespace MS.Internal.Xml.XPath
         }
 
         // ----------------------------------------------------------------
-        private static readonly XPathResultType[] s_temparray1 = { };
+        private static readonly XPathResultType[] s_temparray1 = Array.Empty<XPathResultType>();
         private static readonly XPathResultType[] s_temparray2 = { XPathResultType.NodeSet };
         private static readonly XPathResultType[] s_temparray3 = { XPathResultType.Any };
         private static readonly XPathResultType[] s_temparray4 = { XPathResultType.String };


### PR DESCRIPTION
Two search-and-replace changes:
1. Replaced two more ```private static readonly T[] s_emptyArray = new T[0];``` occurrences with usage of ```Array.Empty<T>()```.
2. Replaced some more ```Contract.Assert```s that snuck in with ```Debug.Assert```s, continuing with our policy of standardizing on ```Debug.Assert``` for asserts.