### PR TITLE
Incorporated feedback after talking to the ASP.NET team

### DIFF
--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -29,6 +29,9 @@
     <Compile Include="System\Text\Encodings\Web\IJavaScriptStringEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\IUrlEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\JavaScriptStringEncoder.cs" />
+    <Compile Include="System\Text\Encodings\Web\TextEncoderExtensions.cs" />
+    <Compile Include="System\Text\Encodings\Web\TextEncoderAdapters.cs" />
+    <Compile Include="System\Text\Encodings\Web\TextEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\UnicodeEncoderBase.cs" />
     <Compile Include="System\Text\Encodings\Web\UnicodeHelpers.cs" />
     <Compile Include="System\Text\Encodings\Web\UnicodeRange.cs" />

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedCharsBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedCharsBitmap.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 
 namespace System.Text.Internal
@@ -72,6 +73,15 @@ namespace System.Text.Internal
             uint codePoint = (uint)c;
             int index = (int)(codePoint >> 5);
             int offset = (int)(codePoint & 0x1FU);
+            return ((_allowedCharsBitmap[index] >> offset) & 0x1U) != 0;
+        }
+
+        // Determines whether the given character can be returned unencoded.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsUnicodeScalarAllowed(int unicodeScalar)
+        {
+            int index = unicodeScalar >> 5;
+            int offset = (int)(unicodeScalar & 0x1FU);
             return ((_allowedCharsBitmap[index] >> offset) & 0x1U) != 0;
         }
     }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/EncoderExtensions.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/EncoderExtensions.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// Helpful extension methods for the encoder classes.

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HexUtil.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HexUtil.cs
@@ -23,6 +23,16 @@ namespace System.Text.Encodings.Web
         }
 
         /// <summary>
+        /// Converts a number 0 - 15 to its associated hex character '0' - 'F'.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static char ToHexDigit(int value)
+        {
+            Debug.Assert(value < 16);
+            return (value < 10) ? (char)('0' + value) : (char)('A' + (value - 10));
+        }
+
+        /// <summary>
         /// Returns the integral form of this hexadecimal character.
         /// </summary>
         /// <returns>0 - 15 if the character is valid, -1 if the character is invalid.</returns>

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -5,9 +5,10 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
 using System.Threading;
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// A class which can perform HTML encoding given an allow list of characters which
@@ -18,10 +19,10 @@ namespace System.Text.Encodings.Web
     /// and &gt;), even if the filter provided in the constructor allows such characters.
     /// Once constructed, instances of this class are thread-safe for multiple callers.
     /// </remarks>
-    public unsafe sealed class HtmlEncoder : IHtmlEncoder
+    public unsafe sealed class HtmlEncoderOld : IHtmlEncoder
     {
         // The default HtmlEncoder (Basic Latin), instantiated on demand
-        private static HtmlEncoder _defaultEncoder;
+        private static HtmlEncoderOld _defaultEncoder;
 
         // The inner encoder, responsible for the actual encoding routines
         private readonly HtmlUnicodeEncoder _innerUnicodeEncoder;
@@ -30,7 +31,7 @@ namespace System.Text.Encodings.Web
         /// Instantiates an encoder using <see cref="UnicodeRanges.BasicLatin"/> as its allow list.
         /// Any character not in the <see cref="UnicodeRanges.BasicLatin"/> range will be escaped.
         /// </summary>
-        public HtmlEncoder()
+        public HtmlEncoderOld()
             : this(HtmlUnicodeEncoder.BasicLatin)
         {
         }
@@ -40,7 +41,7 @@ namespace System.Text.Encodings.Web
         /// pass through the encoder unescaped. Any character not in the set of ranges specified
         /// by <paramref name="allowedRanges"/> will be escaped.
         /// </summary>
-        public HtmlEncoder(params UnicodeRange[] allowedRanges)
+        public HtmlEncoderOld(params UnicodeRange[] allowedRanges)
             : this(new HtmlUnicodeEncoder(new CodePointFilter(allowedRanges)))
         {
         }
@@ -50,25 +51,25 @@ namespace System.Text.Encodings.Web
         /// set returned by <paramref name="filter"/>'s <see cref="ICodePointFilter.GetAllowedCodePoints"/>
         /// method will be escaped.
         /// </summary>
-        public HtmlEncoder(ICodePointFilter filter)
+        public HtmlEncoderOld(ICodePointFilter filter)
             : this(new HtmlUnicodeEncoder(CodePointFilter.Wrap(filter)))
         {
         }
 
-        private HtmlEncoder(HtmlUnicodeEncoder innerEncoder)
+        private HtmlEncoderOld(HtmlUnicodeEncoder innerEncoder)
         {
             Debug.Assert(innerEncoder != null);
             _innerUnicodeEncoder = innerEncoder;
         }
 
         /// <summary>
-        /// A default instance of <see cref="HtmlEncoder"/>.
+        /// A default instance of <see cref="HtmlEncoderOld"/>.
         /// </summary>
         /// <remarks>
         /// This normally corresponds to <see cref="UnicodeRanges.BasicLatin"/>. However, this property is
         /// settable so that a developer can change the default implementation application-wide.
         /// </remarks>
-        public static HtmlEncoder Default
+        public static HtmlEncoderOld Default
         {
             get
             {
@@ -85,9 +86,9 @@ namespace System.Text.Encodings.Web
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // the JITter can attempt to inline the caller itself without worrying about us
-        private static HtmlEncoder CreateDefaultEncoderSlow()
+        private static HtmlEncoderOld CreateDefaultEncoderSlow()
         {
-            var onDemandEncoder = new HtmlEncoder();
+            var onDemandEncoder = new HtmlEncoderOld();
             return Interlocked.CompareExchange(ref _defaultEncoder, onDemandEncoder, null) ?? onDemandEncoder;
         }
 

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/IHtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/IHtmlEncoder.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// Provides services for HTML-encoding input.

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/IJavaScriptStringEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/IJavaScriptStringEncoder.cs
@@ -4,7 +4,7 @@
 using System.IO;
 
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// Provides services for JavaScript-escaping strings.

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/IUrlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/IUrlEncoder.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// Provides services for URL-escaping strings.

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptStringEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptStringEncoder.cs
@@ -5,9 +5,10 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
 using System.Threading;
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// A class which can perform JavaScript string escaping given an allow list of characters which
@@ -18,10 +19,10 @@ namespace System.Text.Encodings.Web
     /// and "), even if the filter provided in the constructor allows such characters.
     /// Once constructed, instances of this class are thread-safe for multiple callers.
     /// </remarks>
-    public sealed class JavaScriptStringEncoder : IJavaScriptStringEncoder
+    public sealed class JavaScriptStringEncoderOld : IJavaScriptStringEncoder
     {
         // The default JavaScript string encoder (Basic Latin), instantiated on demand
-        private static JavaScriptStringEncoder _defaultEncoder;
+        private static JavaScriptStringEncoderOld _defaultEncoder;
 
         // The inner encoder, responsible for the actual encoding routines
         private readonly JavaScriptStringUnicodeEncoder _innerUnicodeEncoder;
@@ -30,7 +31,7 @@ namespace System.Text.Encodings.Web
         /// Instantiates an encoder using <see cref="UnicodeRanges.BasicLatin"/> as its allow list.
         /// Any character not in the <see cref="UnicodeRanges.BasicLatin"/> range will be escaped.
         /// </summary>
-        public JavaScriptStringEncoder()
+        public JavaScriptStringEncoderOld()
             : this(JavaScriptStringUnicodeEncoder.BasicLatin)
         {
         }
@@ -40,7 +41,7 @@ namespace System.Text.Encodings.Web
         /// pass through the encoder unescaped. Any character not in the set of ranges specified
         /// by <paramref name="allowedRanges"/> will be escaped.
         /// </summary>
-        public JavaScriptStringEncoder(params UnicodeRange[] allowedRanges)
+        public JavaScriptStringEncoderOld(params UnicodeRange[] allowedRanges)
             : this(new JavaScriptStringUnicodeEncoder(new CodePointFilter(allowedRanges)))
         {
         }
@@ -50,25 +51,25 @@ namespace System.Text.Encodings.Web
         /// set returned by <paramref name="filter"/>'s <see cref="ICodePointFilter.GetAllowedCodePoints"/>
         /// method will be escaped.
         /// </summary>
-        public JavaScriptStringEncoder(ICodePointFilter filter)
+        public JavaScriptStringEncoderOld(ICodePointFilter filter)
             : this(new JavaScriptStringUnicodeEncoder(CodePointFilter.Wrap(filter)))
         {
         }
 
-        private JavaScriptStringEncoder(JavaScriptStringUnicodeEncoder innerEncoder)
+        private JavaScriptStringEncoderOld(JavaScriptStringUnicodeEncoder innerEncoder)
         {
             Debug.Assert(innerEncoder != null);
             _innerUnicodeEncoder = innerEncoder;
         }
 
         /// <summary>
-        /// A default instance of <see cref="JavaScriptStringEncoder"/>.
+        /// A default instance of <see cref="JavaScriptStringEncoderOld"/>.
         /// </summary>
         /// <remarks>
         /// This normally corresponds to <see cref="UnicodeRanges.BasicLatin"/>. However, this property is
         /// settable so that a developer can change the default implementation application-wide.
         /// </remarks>
-        public static JavaScriptStringEncoder Default
+        public static JavaScriptStringEncoderOld Default
         {
             get
             {
@@ -85,9 +86,9 @@ namespace System.Text.Encodings.Web
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // the JITter can attempt to inline the caller itself without worrying about us
-        private static JavaScriptStringEncoder CreateDefaultEncoderSlow()
+        private static JavaScriptStringEncoderOld CreateDefaultEncoderSlow()
         {
-            var onDemandEncoder = new JavaScriptStringEncoder();
+            var onDemandEncoder = new JavaScriptStringEncoderOld();
             return Interlocked.CompareExchange(ref _defaultEncoder, onDemandEncoder, null) ?? onDemandEncoder;
         }
 

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -1,0 +1,475 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Internal;
+
+namespace System.Text.Encodings.Web
+{
+    public abstract class TextEncoder
+    {
+        public abstract bool TryEncodeUnicodeScalar(int unicodeScalar, char[] buffer, int index, out int writtenChars);
+        public abstract bool Encodes(int unicodeScalar);
+
+        // all subclasses have the same implementation of this method.
+        // but this cannot be made virtual, because it will cause a virtual call to Encodes, and it destroys perf, i.e. makes common scenario 2x slower 
+        public abstract int FindFirstCharacterToEncode(string text);
+
+        // this could be a field, but I am trying to make the abstraction pure.
+        public abstract int MaxOutputCharsPerInputChar { get; }
+
+        /* The following two methods would improve perf, but complicate the API */
+
+        //public unsafe abstract bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int length, out int writtenChars);
+        //public unsafe abstract int FindFirstCharacterToEncode(char* text, int charCount);
+    }
+
+    public abstract class HtmlEncoder : TextEncoder
+    {
+        public static HtmlEncoder Default
+        {
+            get { return HtmlTextEncoder.Default; }
+        }
+        public static HtmlEncoder Create(CodePointFilter filter)
+        {
+            return new HtmlTextEncoder(filter);
+        }
+        public static HtmlEncoder Create(params UnicodeRange[] allowedRanges)
+        {
+            return new HtmlTextEncoder(allowedRanges);
+        }
+    }
+
+    public abstract class JavaScriptEncoder : TextEncoder
+    {
+        public static JavaScriptEncoder Default
+        {
+            get { return JavaScriptTextEncoder.Default; }
+        }
+        public static JavaScriptEncoder Create(CodePointFilter filter)
+        {
+            return new JavaScriptTextEncoder(filter);
+        }
+        public static JavaScriptEncoder Create(params UnicodeRange[] allowedRanges)
+        {
+            return new JavaScriptTextEncoder(allowedRanges);
+        }
+    }
+
+    public abstract class UrlEncoder : TextEncoder
+    {
+        public static UrlEncoder Default
+        {
+            get { return UrlTextEncoder.Default; }
+        }
+        public static UrlEncoder Create(CodePointFilter filter)
+        {
+            return new UrlTextEncoder(filter);
+        }
+        public static UrlEncoder Create(params UnicodeRange[] allowedRanges)
+        {
+            return new UrlTextEncoder(allowedRanges);
+        }
+    }
+
+    internal sealed class HtmlTextEncoder : HtmlEncoder
+    {
+        private AllowedCharsBitmap _allowedCharsBitmap;
+
+        public readonly static HtmlTextEncoder Default = new HtmlTextEncoder(new CodePointFilter(UnicodeRanges.BasicLatin));
+
+        public HtmlTextEncoder(CodePointFilter filter)
+        {
+            _allowedCharsBitmap = filter.GetAllowedCharsBitmap();
+
+            // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
+            // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
+            _allowedCharsBitmap.ForbidUndefinedCharacters();
+
+            // Forbid characters that are special in HTML.
+            // Even though this is a common encoder used by everybody (including URL
+            // and JavaScript strings), it's unfortunately common for developers to
+            // forget to HTML-encode a string once it has been URL-encoded or
+            // JavaScript string-escaped, so this offers extra protection.
+            _allowedCharsBitmap.ForbidCharacter('<');
+            _allowedCharsBitmap.ForbidCharacter('>');
+            _allowedCharsBitmap.ForbidCharacter('&');
+            _allowedCharsBitmap.ForbidCharacter('\''); // can be used to escape attributes
+            _allowedCharsBitmap.ForbidCharacter('\"'); // can be used to escape attributes
+            _allowedCharsBitmap.ForbidCharacter('+'); // technically not HTML-specific, but can be used to perform UTF7-based attacks
+        }
+
+        public HtmlTextEncoder(params UnicodeRange[] allowedRanges) : this(new CodePointFilter(allowedRanges))
+        { }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Encodes(int unicodeScalar)
+        {
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar)) return true;            
+            return !_allowedCharsBitmap.IsUnicodeScalarAllowed(unicodeScalar);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override int FindFirstCharacterToEncode(string text)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                var character = text[i];
+                if (!_allowedCharsBitmap.IsCharacterAllowed(character)) { return i; }
+            }
+            return -1;
+        }
+
+        public override int MaxOutputCharsPerInputChar
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return 8;
+            }
+        }
+
+        static readonly char[] quote = "&quot;".ToCharArray();
+        static readonly char[] ampersand = "&amp;".ToCharArray();
+        static readonly char[] lessthan = "&lt;".ToCharArray();
+        static readonly char[] greaterthan = "&gt;".ToCharArray();
+
+        public override bool TryEncodeUnicodeScalar(int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\"') { return quote.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '&') { return ampersand.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '<') { return lessthan.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '>') { return greaterthan.TryCopyCharacters(buffer, index, out writtenChars); }
+            else { return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, index, out writtenChars); }
+        }
+
+        // Writes a scalar value as an HTML-encoded numeric entity.
+        private unsafe static bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            // We're building the characters up in reverse
+            char* chars = stackalloc char[8 /* "FFFFFFFF" */];
+            int numCharsWritten = 0;
+            do
+            {
+                Debug.Assert(numCharsWritten < 8, "Couldn't have written 8 characters out by this point.");
+                // Pop off the last nibble
+                chars[numCharsWritten++] = HexUtil.ToHexDigit((int)(unicodeScalar & 0xFU));
+                unicodeScalar >>= 4;
+            } while (unicodeScalar != 0);
+
+            writtenChars = numCharsWritten + 4; // four chars are &, #, x, and ;
+            Debug.Assert(numCharsWritten > 0, "At least one character should've been written.");
+
+            if (numCharsWritten + 4 > buffer.Length)
+            {
+                writtenChars = 0;
+                return false;
+            }
+            // Finally, write out the HTML-encoded scalar value.
+            buffer[index++] = '&';
+            buffer[index++] = '#';
+            buffer[index++] = 'x';
+            do
+            {
+                buffer[index++] = chars[--numCharsWritten];
+            }
+            while (numCharsWritten != 0);
+
+            buffer[index++] = ';';
+            return true;
+        }
+    } 
+
+    internal sealed class JavaScriptTextEncoder : JavaScriptEncoder
+    {
+        private AllowedCharsBitmap _allowedCharsBitmap;
+
+        public readonly static JavaScriptTextEncoder Default = new JavaScriptTextEncoder(new CodePointFilter(UnicodeRanges.BasicLatin));
+
+        public JavaScriptTextEncoder(CodePointFilter filter)
+        {
+            _allowedCharsBitmap = filter.GetAllowedCharsBitmap();
+
+            // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
+            // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
+            _allowedCharsBitmap.ForbidUndefinedCharacters();
+
+            // Forbid characters that are special in HTML.
+            // Even though this is a common encoder used by everybody (including URL
+            // and JavaScript strings), it's unfortunately common for developers to
+            // forget to HTML-encode a string once it has been URL-encoded or
+            // JavaScript string-escaped, so this offers extra protection.
+            _allowedCharsBitmap.ForbidCharacter('<');
+            _allowedCharsBitmap.ForbidCharacter('>');
+            _allowedCharsBitmap.ForbidCharacter('&');
+            _allowedCharsBitmap.ForbidCharacter('\''); // can be used to escape attributes
+            _allowedCharsBitmap.ForbidCharacter('\"'); // can be used to escape attributes
+            _allowedCharsBitmap.ForbidCharacter('+'); // technically not HTML-specific, but can be used to perform UTF7-based attacks
+
+            _allowedCharsBitmap.ForbidCharacter('\\');
+            _allowedCharsBitmap.ForbidCharacter('/');
+        }
+
+        public JavaScriptTextEncoder(params UnicodeRange[] allowedRanges) : this(new CodePointFilter(allowedRanges))
+        { }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Encodes(int unicodeScalar)
+        {
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar)) return true;
+            return !_allowedCharsBitmap.IsUnicodeScalarAllowed(unicodeScalar);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override int FindFirstCharacterToEncode(string text)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                var character = text[i];
+                if (!_allowedCharsBitmap.IsCharacterAllowed(character)) { return i; }
+            }
+            return -1;
+        }
+
+        // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
+        // We don't need to worry about astral code points since they're represented as encoded
+        // surrogate pairs in the output.
+        public override int MaxOutputCharsPerInputChar
+        {
+            get
+            {
+                return 6;
+            }
+        }
+
+        static readonly char[] b = @"\b".ToCharArray();
+        static readonly char[] t = @"\t".ToCharArray();
+        static readonly char[] n = @"\n".ToCharArray();
+        static readonly char[] f = @"\f".ToCharArray();
+        static readonly char[] r = @"\r".ToCharArray();
+        static readonly char[] forward = @"\/".ToCharArray();
+        static readonly char[] back = @"\\".ToCharArray();
+
+        // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
+        // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
+        // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
+        // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+        public override bool TryEncodeUnicodeScalar(int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            // ECMA-262 allows encoding U+000B as "\v", but ECMA-404 does not.
+            // Both ECMA-262 and ECMA-404 allow encoding U+002F SOLIDUS as "\/".
+            // (In ECMA-262 this character is a NonEscape character.)
+            // HTML-specific characters (including apostrophe and quotes) will
+            // be written out as numeric entities for defense-in-depth.
+            // See UnicodeEncoderBase ctor comments for more info.
+
+            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\b') { return b.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\t') { return t.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\n') { return n.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\f') { return f.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\r') { return r.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '/') { return forward.TryCopyCharacters(buffer, index, out writtenChars); }
+            else if (unicodeScalar == '\\') { return back.TryCopyCharacters(buffer, index, out writtenChars); }
+            else { return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, index, out writtenChars); }
+        }
+
+        // Writes a scalar value as an JavaScript-escaped character (or sequence of characters).
+        private unsafe static bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
+            {
+                // Convert this back to UTF-16 and write out both characters.
+                char leadingSurrogate, trailingSurrogate;
+                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out leadingSurrogate, out trailingSurrogate);
+                int leadingSurrogateCharactersWritten;
+                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, index, out leadingSurrogateCharactersWritten) &&
+                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer, index + leadingSurrogateCharactersWritten, out writtenChars)
+                )
+                {
+                    writtenChars += leadingSurrogateCharactersWritten;
+                    return true;
+                }
+                else
+                {
+                    writtenChars = 0;
+                    return false;
+                }
+            }
+            else
+            {
+                // This is only a single character.
+                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, index, out writtenChars);
+            }
+        }
+
+        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
+        private static bool TryWriteEncodedSingleCharacter(int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
+            if (buffer.Length - index < 6)
+            {
+                writtenChars = 0;
+                return false;
+            }
+
+            // Encode this as 6 chars "\uFFFF".
+            buffer[index++] = '\\';
+            buffer[index++] = 'u';
+            buffer[index++] = HexUtil.ToHexDigit(unicodeScalar >> 12);
+            buffer[index++] = HexUtil.ToHexDigit((int)((unicodeScalar >> 8) & 0xFU));
+            buffer[index++] = HexUtil.ToHexDigit((int)((unicodeScalar >> 4) & 0xFU));
+            buffer[index++] = HexUtil.ToHexDigit((int)(unicodeScalar & 0xFU));
+
+            writtenChars = 6;
+            return true;
+        }
+    }
+
+    internal sealed class UrlTextEncoder : UrlEncoder
+    {
+        private AllowedCharsBitmap _allowedCharsBitmap;
+
+        public readonly static UrlTextEncoder Default = new UrlTextEncoder(new CodePointFilter(UnicodeRanges.BasicLatin));
+
+        // We perform UTF8 conversion of input, which means that the worst case is
+        // 9 output chars per input char: [input] U+FFFF -> [output] "%XX%YY%ZZ".
+        // We don't need to worry about astral code points since they consume 2 input
+        // chars to produce 12 output chars "%XX%YY%ZZ%WW", which is 6 output chars per input char.
+        public override int MaxOutputCharsPerInputChar
+        {
+            get
+            {
+                return 9;
+            }
+        }
+
+        public UrlTextEncoder(CodePointFilter filter)
+        {
+            _allowedCharsBitmap = filter.GetAllowedCharsBitmap();
+
+            // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
+            // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
+            _allowedCharsBitmap.ForbidUndefinedCharacters();
+
+            // Forbid characters that are special in HTML.
+            // Even though this is a common encoder used by everybody (including URL
+            // and JavaScript strings), it's unfortunately common for developers to
+            // forget to HTML-encode a string once it has been URL-encoded or
+            // JavaScript string-escaped, so this offers extra protection.
+            _allowedCharsBitmap.ForbidCharacter('<');
+            _allowedCharsBitmap.ForbidCharacter('>');
+            _allowedCharsBitmap.ForbidCharacter('&');
+            _allowedCharsBitmap.ForbidCharacter('\''); // can be used to escape attributes
+            _allowedCharsBitmap.ForbidCharacter('\"'); // can be used to escape attributes
+            _allowedCharsBitmap.ForbidCharacter('+'); // technically not HTML-specific, but can be used to perform UTF7-based attacks
+
+            // Per RFC 3987, Sec. 2.2, we want encodings that are safe for
+            // four particular components: 'isegment', 'ipath-noscheme',
+            // 'iquery', and 'ifragment'. The relevant definitions are below.
+            //
+            //    ipath-noscheme = isegment-nz-nc *( "/" isegment )
+            // 
+            //    isegment       = *ipchar
+            // 
+            //    isegment-nz-nc = 1*( iunreserved / pct-encoded / sub-delims
+            //                         / "@" )
+            //                   ; non-zero-length segment without any colon ":"
+            //
+            //    ipchar         = iunreserved / pct-encoded / sub-delims / ":"
+            //                   / "@"
+            // 
+            //    iquery         = *( ipchar / iprivate / "/" / "?" )
+            // 
+            //    ifragment      = *( ipchar / "/" / "?" )
+            // 
+            //    iunreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~" / ucschar
+            // 
+            //    ucschar        = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
+            //                   / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
+            //                   / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
+            //                   / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
+            //                   / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
+            //                   / %xD0000-DFFFD / %xE1000-EFFFD
+            // 
+            //    pct-encoded    = "%" HEXDIG HEXDIG
+            // 
+            //    sub-delims     = "!" / "$" / "&" / "'" / "(" / ")"
+            //                   / "*" / "+" / "," / ";" / "="
+            //
+            // The only common characters between these four components are the
+            // intersection of 'isegment-nz-nc' and 'ipchar', which is really
+            // just 'isegment-nz-nc' (colons forbidden).
+            // 
+            // From this list, the base encoder already forbids "&", "'", "+",
+            // and we'll additionally forbid "=" since it has special meaning
+            // in x-www-form-urlencoded representations.
+            //
+            // This means that the full list of allowed characters from the
+            // Basic Latin set is:
+            // ALPHA / DIGIT / "-" / "." / "_" / "~" / "!" / "$" / "(" / ")" / "*" / "," / ";" / "@"
+
+            const string forbiddenChars = @" #%/:=?[\]^`{|}"; // chars from Basic Latin which aren't already disallowed by the base encoder
+            foreach (char c in forbiddenChars)
+            {
+                _allowedCharsBitmap.ForbidCharacter(c);
+            }
+
+            // Specials (U+FFF0 .. U+FFFF) are forbidden by the definition of 'ucschar' above
+            for (int i = 0; i < 16; i++)
+            {
+                _allowedCharsBitmap.ForbidCharacter((char)(0xFFF0 | i));
+            }
+
+            // Supplementary characters are forbidden anyway by the base encoder //TODO: make sure it's true after the changes
+        }
+
+        public UrlTextEncoder(params UnicodeRange[] allowedRanges) : this(new CodePointFilter(allowedRanges))
+        { }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Encodes(int unicodeScalar)
+        {
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar)) return true;
+            return !_allowedCharsBitmap.IsUnicodeScalarAllowed(unicodeScalar);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override int FindFirstCharacterToEncode(string text)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                var character = text[i];
+                if (!_allowedCharsBitmap.IsCharacterAllowed(character)) { return i; }
+            }
+            return -1;
+        }
+
+        public override bool TryEncodeUnicodeScalar(int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, index, out writtenChars); }
+
+            writtenChars = 0;
+            uint asUtf8 = (uint)UnicodeHelpers.GetUtf8RepresentationForScalarValue((uint)unicodeScalar);
+            do
+            {
+                char highNibble, lowNibble;
+                HexUtil.WriteHexEncodedByte((byte)asUtf8, out highNibble, out lowNibble);
+                if (buffer.Length - index < 3)
+                {
+                    writtenChars = 0;
+                    return false;
+                }
+                buffer[index++] = '%';
+                buffer[index++] = highNibble;
+                buffer[index++] = lowNibble;
+
+                writtenChars += 3;
+            }
+            while ((asUtf8 >>= 8) != 0);
+            return true;
+        }
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoderAdapters.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoderAdapters.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text.Encodings.Web;
+
+namespace Microsoft.Framework.WebEncoders
+{
+    // These implement ASP.NET interfaces
+    public sealed class HtmlEncoder : IHtmlEncoder
+    {
+        System.Text.Encodings.Web.HtmlTextEncoder _encoder;
+        static HtmlEncoder s_default;
+
+        /// <summary>
+        /// A default instance of <see cref="HtmlEncoder"/>.
+        /// </summary>
+        /// <remarks>
+        /// This normally corresponds to <see cref="UnicodeRanges.BasicLatin"/>. However, this property is
+        /// settable so that a developer can change the default implementation application-wide.
+        /// </remarks>
+        public static HtmlEncoder Default
+        {
+            get
+            {
+                if (s_default == null)
+                {
+                    s_default = new HtmlEncoder();
+                }
+                return s_default;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+                s_default = value;
+            }
+        }
+
+        public HtmlEncoder()
+        {
+            _encoder = System.Text.Encodings.Web.HtmlTextEncoder.Default;
+        }
+        public HtmlEncoder(CodePointFilter filter)
+        {
+            _encoder = new System.Text.Encodings.Web.HtmlTextEncoder(filter);
+        }
+
+        public HtmlEncoder(UnicodeRange allowedRange) : this(new CodePointFilter(allowedRange))
+        { }
+
+        public HtmlEncoder(params UnicodeRange[] allowedRanges) : this(new CodePointFilter(allowedRanges))
+        { }
+
+        public void HtmlEncode(char[] value, int startIndex, int charCount, TextWriter output)
+        {
+            _encoder.Encode(value, startIndex, charCount, output);
+        }
+
+        public string HtmlEncode(string value)
+        {
+            return _encoder.Encode(value);
+        }
+
+        public void HtmlEncode(string value, int startIndex, int charCount, TextWriter output)
+        {
+            _encoder.Encode(value, startIndex, charCount, output);
+        }
+    }
+
+    public sealed class JavaScriptStringEncoder : IJavaScriptStringEncoder
+    {
+        System.Text.Encodings.Web.JavaScriptTextEncoder _encoder;
+        static JavaScriptStringEncoder s_default;
+
+        /// <summary>
+        /// A default instance of <see cref="JavaScriptEncoder"/>.
+        /// </summary>
+        /// <remarks>
+        /// This normally corresponds to <see cref="UnicodeRanges.BasicLatin"/>. However, this property is
+        /// settable so that a developer can change the default implementation application-wide.
+        /// </remarks>
+        public static JavaScriptStringEncoder Default
+        {
+            get
+            {
+                if (s_default == null)
+                {
+                    s_default = new JavaScriptStringEncoder();
+                }
+                return s_default;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+                s_default = value;
+            }
+        }
+
+        public JavaScriptStringEncoder()
+        {
+            _encoder = System.Text.Encodings.Web.JavaScriptTextEncoder.Default;
+        }
+        public JavaScriptStringEncoder(CodePointFilter filter)
+        {
+            _encoder = new System.Text.Encodings.Web.JavaScriptTextEncoder(filter);
+        }
+
+        public JavaScriptStringEncoder(UnicodeRange allowedRange) : this(new CodePointFilter(allowedRange))
+        { }
+
+        public JavaScriptStringEncoder(params UnicodeRange[] allowedRanges) : this(new CodePointFilter(allowedRanges))
+        { }
+
+        public void JavaScriptStringEncode(char[] value, int startIndex, int charCount, TextWriter output)
+        {
+            _encoder.Encode(value, startIndex, charCount, output);
+        }
+
+        public string JavaScriptStringEncode(string value)
+        {
+            return _encoder.Encode(value);
+        }
+
+        public void JavaScriptStringEncode(string value, int startIndex, int charCount, TextWriter output)
+        {
+            _encoder.Encode(value, startIndex, charCount, output);
+        }
+    }
+
+    public sealed class UrlEncoder : IUrlEncoder
+    {
+        System.Text.Encodings.Web.UrlTextEncoder _encoder;
+        static UrlEncoder s_default;
+
+        /// <summary>
+        /// A default instance of <see cref="UrlEncoder"/>.
+        /// </summary>
+        /// <remarks>
+        /// This normally corresponds to <see cref="UnicodeRanges.BasicLatin"/>. However, this property is
+        /// settable so that a developer can change the default implementation application-wide.
+        /// </remarks>
+        public static UrlEncoder Default
+        {
+            get
+            {
+                if (s_default == null)
+                {
+                    s_default = new UrlEncoder();
+                }
+                return s_default;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+                s_default = value;
+            }
+        }
+
+        public UrlEncoder()
+        {
+            _encoder = System.Text.Encodings.Web.UrlTextEncoder.Default;
+        }
+        public UrlEncoder(CodePointFilter filter)
+        {
+            _encoder = new System.Text.Encodings.Web.UrlTextEncoder(filter);
+        }
+
+        public UrlEncoder(UnicodeRange allowedRange) : this(new CodePointFilter(allowedRange))
+        { }
+
+        public UrlEncoder(params UnicodeRange[] allowedRanges) : this(new CodePointFilter(allowedRanges))
+        { }
+
+        public void UrlEncode(char[] value, int startIndex, int charCount, TextWriter output)
+        {
+            _encoder.Encode(value, startIndex, charCount, output);
+        }
+
+        public string UrlEncode(string value)
+        {
+            return _encoder.Encode(value); ;
+        }
+
+        public void UrlEncode(string value, int startIndex, int charCount, TextWriter output)
+        {
+            _encoder.Encode(value, startIndex, charCount, output);
+        }
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoderExtensions.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoderExtensions.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Encodings.Web
+{
+    public static class TextEncoderExtensions
+    {
+        public static void Encode(this TextEncoder encoder, string value, TextWriter output)
+        {
+            Encode(encoder, value, 0, value.Length, output);
+        }
+
+        public static string Encode(this TextEncoder encoder, string value)
+        {
+            if (value == null) {
+                return value;
+            }
+
+            int valueIndex = encoder.FindFirstCharacterToEncode(value);
+
+            if (valueIndex == -1) 
+            {
+                return value;
+            }
+
+            int bufferSize = encoder.MaxOutputCharsPerInputChar * value.Length;
+            char[] buffer = new char[bufferSize];
+
+            if (valueIndex > 0)
+            {
+                var firstCharacterToEncode = valueIndex;
+                value.CopyTo(0, buffer, 0, firstCharacterToEncode);                
+            }
+
+            int bufferIndex = valueIndex;
+
+            char firstChar = value[valueIndex];
+            char secondChar = firstChar;
+            bool wasSurrogatePair = false;
+            int charsWritten;
+
+            // this loop processes character pairs (in case they are surrogates).
+            // there is an if block below to process single last character.
+            for (int secondCharIndex = valueIndex + 1; secondCharIndex < value.Length; secondCharIndex++) {
+                if (!wasSurrogatePair) {
+                    firstChar = secondChar;
+                }
+                else {
+                    firstChar = value[secondCharIndex - 1];
+                }
+                secondChar = value[secondCharIndex];
+
+                if (!encoder.Encodes(firstChar))
+                {
+                    wasSurrogatePair = false;
+                    if (bufferIndex < buffer.Length)
+                    {
+                        buffer[bufferIndex++] = firstChar;
+                    }               
+                }
+                else
+                {
+                    int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, secondChar, out wasSurrogatePair);
+                    if (!encoder.TryEncodeUnicodeScalar(nextScalar, buffer, bufferIndex, out charsWritten))
+                    {
+                        throw new NotImplementedException("this should never happen");
+                    }
+
+                    bufferIndex += charsWritten;
+                    if (wasSurrogatePair)
+                    {
+                        secondCharIndex++;
+                    } 
+                }
+            }
+
+            if (!wasSurrogatePair)
+            {
+                firstChar = value[value.Length - 1];
+                int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, null, out wasSurrogatePair);
+                if (!encoder.TryEncodeUnicodeScalar(nextScalar, buffer, bufferIndex, out charsWritten)) {
+                    throw new NotImplementedException("this should never happen");
+                }
+
+                bufferIndex += charsWritten;
+            }
+
+            var result = new String(buffer, 0, bufferIndex);
+            return result;
+        }
+
+        public static void Encode(this TextEncoder encoder, string value, int startIndex, int charCount, TextWriter output)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            if (output == null)
+            {
+                throw new ArgumentNullException("output");
+            }
+            ValidateRanges(startIndex, charCount, actualInputLength: value.Length);
+
+            int valueIndex = encoder.FindFirstCharacterToEncode(value); // TODO (Pri 0): this does not work with substrings, and so causes an inefficiency
+
+            if (valueIndex == -1)
+            {
+                output.Write(value.ToCharArray(startIndex, charCount)); // TODO: this could be optimized for small substrings. Same below
+                return;
+            }
+
+            if (valueIndex > 0 && valueIndex > startIndex)
+            {
+                output.Write(value.ToCharArray(startIndex, valueIndex - startIndex));
+            }
+
+            unsafe
+            {
+                fixed (char* valuePointer = value)
+                {
+                    var subrangePointer = valuePointer + valueIndex;
+                    EncodeCore(encoder, subrangePointer, charCount - (valueIndex - startIndex), output);
+                }
+            }
+        }
+
+        public static void Encode(this TextEncoder encoder, char[] value, int startIndex, int charCount, TextWriter output)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            if (output == null)
+            {
+                throw new ArgumentNullException("output");
+            }
+            ValidateRanges(startIndex, charCount, actualInputLength: value.Length);
+
+            int valueIndex = encoder.FindFirstCharacterToEncode(new string(value, 0, charCount + startIndex));
+
+            if (valueIndex == -1)
+            {
+                output.Write(value, startIndex, charCount);
+                return;
+            }
+
+            if (valueIndex > 0 && valueIndex > startIndex)
+            {
+                output.Write(value, startIndex, valueIndex - startIndex);
+            }
+
+            unsafe
+            {
+                fixed (char* valuePointer = value)
+                {
+                    var subrangePointer = valuePointer + valueIndex;
+                    EncodeCore(encoder, subrangePointer, charCount - (valueIndex - startIndex), output);
+                }
+            }
+        }
+
+        private static unsafe void EncodeCore(this TextEncoder encoder, char* value, int charCount, TextWriter output)
+        {
+            char[] buffer = new char[encoder.MaxOutputCharsPerInputChar];  // TODO (Pri 0): it's very unfortunate we cannot stackalloc this. 
+
+            char firstChar = *value;
+            char secondChar = firstChar;
+            bool wasSurrogatePair = false;
+            int charsWritten;
+
+            // this loop processes character pairs (in case they are surrogates).
+            // there is an if block below to process single last character.
+            for (int secondCharIndex = 1; secondCharIndex < charCount; secondCharIndex++)
+            {
+                if (!wasSurrogatePair)
+                {
+                    firstChar = secondChar;
+                }
+                else
+                {
+                    firstChar = value[secondCharIndex - 1];
+                }
+                secondChar = value[secondCharIndex];
+
+                if (!encoder.Encodes(firstChar))
+                {
+                    wasSurrogatePair = false;
+                    output.Write(firstChar); 
+                }
+                else
+                {
+                    int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, secondChar, out wasSurrogatePair);
+                    if (!encoder.TryEncodeUnicodeScalar(nextScalar, buffer, 0, out charsWritten))
+                    {
+                        throw new NotImplementedException("this should never happen");
+                    }
+                    output.Write(buffer, 0, charsWritten); // TODO: We could make the buffer larger and write to output only if buffer is close to full
+
+                    if (wasSurrogatePair)
+                    {
+                        secondCharIndex++;
+                    }
+                }
+            }
+
+            if (!wasSurrogatePair)
+            {
+                firstChar = value[charCount - 1];
+                int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, null, out wasSurrogatePair);
+                if (!encoder.TryEncodeUnicodeScalar(nextScalar, buffer, 0, out charsWritten))
+                {
+                    throw new NotImplementedException("this should never happen");
+                }
+                output.Write(buffer, 0, charsWritten);
+            }
+        }
+
+        private static void ValidateRanges(int startIndex, int charCount, int actualInputLength)
+        {
+            if (startIndex < 0 || startIndex > actualInputLength)
+            {
+                throw new ArgumentOutOfRangeException("startIndex");
+            }
+            if (charCount < 0 || charCount > (actualInputLength - startIndex))
+            {
+                throw new ArgumentOutOfRangeException("charCount");
+            }
+        }
+
+        internal static bool TryCopyCharacters(this char[] source, char[] destination, int destinationIndex, out int writtenChars)
+        {
+            if (destination.Length - destinationIndex < source.Length)
+            {
+                writtenChars = 0;
+                return false;
+            }
+
+            if (source.Length < 8)
+            {
+                for (int i = 0; i < source.Length; i++)
+                {
+                    destination[destinationIndex + i] = source[i];
+                }
+            }
+            else
+            {
+                source.CopyTo(destination, destinationIndex);
+            }
+            writtenChars = source.Length;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryWriteScalarAsChar(this int unicodeScalar, char[] buffer, int index, out int writtenChars)
+        {
+            if (buffer.Length - index < 1)
+            {
+                writtenChars = 0;
+                return false;
+            }
+            buffer[index] = (char)unicodeScalar; // TODO: this assumes allowed scalars are chars; is that ok in all cases?
+            writtenChars = 1;
+            return true;
+        }
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
@@ -5,9 +5,10 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
 using System.Threading;
 
-namespace System.Text.Encodings.Web
+namespace Microsoft.Framework.WebEncoders
 {
     /// <summary>
     /// A class which can perform URL string escaping given an allow list of characters which
@@ -18,10 +19,10 @@ namespace System.Text.Encodings.Web
     /// and ?), even if the filter provided in the constructor allows such characters.
     /// Once constructed, instances of this class are thread-safe for multiple callers.
     /// </remarks>
-    public sealed class UrlEncoder : IUrlEncoder
+    public sealed class UrlEncoderOld : IUrlEncoder
     {
         // The default URL string encoder (Basic Latin), instantiated on demand
-        private static UrlEncoder _defaultEncoder;
+        private static UrlEncoderOld _defaultEncoder;
 
         // The inner encoder, responsible for the actual encoding routines
         private readonly UrlUnicodeEncoder _innerUnicodeEncoder;
@@ -30,7 +31,7 @@ namespace System.Text.Encodings.Web
         /// Instantiates an encoder using <see cref="UnicodeRanges.BasicLatin"/> as its allow list.
         /// Any character not in the <see cref="UnicodeRanges.BasicLatin"/> range will be escaped.
         /// </summary>
-        public UrlEncoder()
+        public UrlEncoderOld()
             : this(UrlUnicodeEncoder.BasicLatin)
         {
         }
@@ -40,7 +41,7 @@ namespace System.Text.Encodings.Web
         /// pass through the encoder unescaped. Any character not in the set of ranges specified
         /// by <paramref name="allowedRanges"/> will be escaped.
         /// </summary>
-        public UrlEncoder(params UnicodeRange[] allowedRanges)
+        public UrlEncoderOld(params UnicodeRange[] allowedRanges)
             : this(new UrlUnicodeEncoder(new CodePointFilter(allowedRanges)))
         {
         }
@@ -50,25 +51,25 @@ namespace System.Text.Encodings.Web
         /// set returned by <paramref name="filter"/>'s <see cref="ICodePointFilter.GetAllowedCodePoints"/>
         /// method will be escaped.
         /// </summary>
-        public UrlEncoder(ICodePointFilter filter)
+        public UrlEncoderOld(ICodePointFilter filter)
             : this(new UrlUnicodeEncoder(CodePointFilter.Wrap(filter)))
         {
         }
 
-        private UrlEncoder(UrlUnicodeEncoder innerEncoder)
+        private UrlEncoderOld(UrlUnicodeEncoder innerEncoder)
         {
             Debug.Assert(innerEncoder != null);
             _innerUnicodeEncoder = innerEncoder;
         }
 
         /// <summary>
-        /// A default instance of <see cref="UrlEncoder"/>.
+        /// A default instance of <see cref="UrlEncoderOld"/>.
         /// </summary>
         /// <remarks>
         /// This normally corresponds to <see cref="UnicodeRanges.BasicLatin"/>. However, this property is
         /// settable so that a developer can change the default implementation application-wide.
         /// </remarks>
-        public static UrlEncoder Default
+        public static UrlEncoderOld Default
         {
             get
             {
@@ -85,9 +86,9 @@ namespace System.Text.Encodings.Web
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // the JITter can attempt to inline the caller itself without worrying about us
-        private static UrlEncoder CreateDefaultEncoderSlow()
+        private static UrlEncoderOld CreateDefaultEncoderSlow()
         {
-            var onDemandEncoder = new UrlEncoder();
+            var onDemandEncoder = new UrlEncoderOld();
             return Interlocked.CompareExchange(ref _defaultEncoder, onDemandEncoder, null) ?? onDemandEncoder;
         }
 

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Framework.WebEncoders;
 using System;
 using System.IO;
 using Xunit;
@@ -19,11 +20,11 @@ namespace System.Text.Encodings.Web
         public void HtmlEncode_PositiveTestCase()
         {
             // Arrange
-            IHtmlEncoder encoder = new HtmlEncoder(UnicodeRanges.All);
+            HtmlEncoder encoder = HtmlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act
-            encoder.HtmlEncode("Hello+there!", writer);
+            encoder.Encode("Hello+there!", writer);
 
             // Assert
             Assert.Equal("Hello&#x2B;there!", writer.ToString());
@@ -59,11 +60,11 @@ namespace System.Text.Encodings.Web
         public void UrlEncode_PositiveTestCase()
         {
             // Arrange
-            IUrlEncoder encoder = new UrlEncoder(UnicodeRanges.All);
+            UrlEncoder encoder = UrlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act
-            encoder.UrlEncode("Hello+there!", writer);
+            encoder.Encode("Hello+there!", writer);
 
             // Assert
             Assert.Equal("Hello%2Bthere!", writer.ToString());

--- a/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
+++ b/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Framework.WebEncoders
+{
+    public class PerformanceTests
+    {
+        const int SmallItterations = 500000;
+        const string SmallString = "<Hello World";
+
+        const int LargeItterations = 150000;
+        const string LargeString = "<Hello World aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        const string LargeStringThatIsNotEncoded = "Hello World aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const string LargeStringWithOnlyEndEncoded = "Hello World aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<aaa>";
+
+        private readonly ITestOutputHelper output;
+
+        public PerformanceTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void JavaScriptEncodeStringToString()
+        {
+            IJavaScriptStringEncoder oldEncoder = JavaScriptStringEncoderOld.Default;
+            IJavaScriptStringEncoder newEncoder = JavaScriptStringEncoder.Default;
+            Stopwatch timer = new Stopwatch();
+
+            // warmup
+            EncodeJavaScript(oldEncoder, SmallString, timer, SmallItterations);
+            EncodeJavaScript(newEncoder, SmallString, timer, SmallItterations);
+
+            var oldTime = EncodeJavaScript(oldEncoder, SmallString, timer, SmallItterations);
+            var newTime = EncodeJavaScript(newEncoder, SmallString, timer, SmallItterations);
+            var message = String.Format("JavaScriptEncodeStringToStringSmall: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeJavaScript(oldEncoder, LargeString, timer, LargeItterations);
+            newTime = EncodeJavaScript(newEncoder, LargeString, timer, LargeItterations);
+            message = String.Format("JavaScriptEncodeStringToStringLarge: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeJavaScript(oldEncoder, LargeStringThatIsNotEncoded, timer, LargeItterations);
+            newTime = EncodeJavaScript(newEncoder, LargeStringThatIsNotEncoded, timer, LargeItterations);
+            message = String.Format("JavaScriptEncodeStringToStringLargeNoEncoding: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeJavaScript(oldEncoder, LargeStringWithOnlyEndEncoded, timer, LargeItterations);
+            newTime = EncodeJavaScript(newEncoder, LargeStringWithOnlyEndEncoded, timer, LargeItterations);
+            message = String.Format("JavaScriptEncodeStringToStringLargeEndEncoding: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+        }
+
+        private TimeSpan EncodeJavaScript(IJavaScriptStringEncoder encoder, string text, Stopwatch timer, int itterations)
+        {
+            timer.Restart();
+            for (int itteration = 0; itteration < itterations; itteration++)
+            {
+                Ignore(encoder.JavaScriptStringEncode(text));
+            }
+            return timer.Elapsed;
+        }
+
+        [Fact]
+        public void HtmlEncodeStringToStringSmall()
+        {
+            IHtmlEncoder oldEncoder = HtmlEncoderOld.Default;
+            IHtmlEncoder newEncoder = HtmlEncoder.Default;
+            Stopwatch timer = new Stopwatch();
+
+            // warmup
+            EncodeHtml(oldEncoder, SmallString, timer, SmallItterations);
+            EncodeHtml(newEncoder, SmallString, timer, SmallItterations);
+
+            var oldTime = EncodeHtml(oldEncoder, SmallString, timer, SmallItterations);
+            var newTime = EncodeHtml(newEncoder, SmallString, timer, SmallItterations);
+            var message = String.Format("HtmlEncodeStringToStringSmall: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeHtml(oldEncoder, LargeString, timer, LargeItterations);
+            newTime = EncodeHtml(newEncoder, LargeString, timer, LargeItterations);
+            message = String.Format("HtmlEncodeStringToStringLarge: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeHtml(oldEncoder, LargeStringThatIsNotEncoded, timer, LargeItterations);
+            newTime = EncodeHtml(newEncoder, LargeStringThatIsNotEncoded, timer, LargeItterations);
+            message = String.Format("HtmlEncodeStringToStringLargeNoEncoding: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeHtml(oldEncoder, LargeStringWithOnlyEndEncoded, timer, LargeItterations);
+            newTime = EncodeHtml(newEncoder, LargeStringWithOnlyEndEncoded, timer, LargeItterations);
+            message = String.Format("HtmlEncodeStringToStringLargeEndEncoding: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+        }
+
+        private TimeSpan EncodeHtml(IHtmlEncoder encoder, string text, Stopwatch timer, int itterations)
+        {
+            timer.Restart();
+            for(int itteration=0; itteration<itterations; itteration++)
+            {
+                Ignore(encoder.HtmlEncode(text));
+            }
+            return timer.Elapsed;
+        }
+
+        [Fact]
+        public void HtmlEncodeTextWriter()
+        {
+            IHtmlEncoder oldEncoder = HtmlEncoderOld.Default;
+            IHtmlEncoder newEncoder = HtmlEncoder.Default;
+            Stopwatch timer = new Stopwatch();
+
+            // warmup
+            EncodeHtmlToTextWriter(oldEncoder, SmallString, timer, SmallItterations);
+            EncodeHtmlToTextWriter(newEncoder, SmallString, timer, SmallItterations);
+
+            var oldTime = EncodeHtmlToTextWriter(oldEncoder, SmallString, timer, SmallItterations);
+            var newTime = EncodeHtmlToTextWriter(newEncoder, SmallString, timer, SmallItterations);
+            var message = String.Format("HtmlEncodeToTextWriter: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeHtmlToTextWriter(oldEncoder, LargeString, timer, LargeItterations);
+            newTime = EncodeHtmlToTextWriter(newEncoder, LargeString, timer, LargeItterations);
+            message = String.Format("HtmlEncodeToTextWriterLarge: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeHtmlToTextWriter(oldEncoder, LargeStringThatIsNotEncoded, timer, LargeItterations);
+            newTime = EncodeHtmlToTextWriter(newEncoder, LargeStringThatIsNotEncoded, timer, LargeItterations);
+            message = String.Format("HtmlEncodeToTextWriterLargeNoEncoding: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+
+            oldTime = EncodeHtmlToTextWriter(oldEncoder, LargeStringWithOnlyEndEncoded, timer, LargeItterations);
+            newTime = EncodeHtmlToTextWriter(newEncoder, LargeStringWithOnlyEndEncoded, timer, LargeItterations);
+            message = String.Format("HtmlEncodeToTextWriterLargeEndEncoding: Old={0}ms, New={1}ms, Delta={2:G}%", (ulong)oldTime.TotalMilliseconds, (ulong)newTime.TotalMilliseconds, (int)((newTime.TotalMilliseconds - oldTime.TotalMilliseconds) / oldTime.TotalMilliseconds * 100));
+            output.WriteLine(message);
+        }
+
+        private static TimeSpan EncodeHtmlToTextWriter(IHtmlEncoder encoder, string text, Stopwatch timer, int itterations)
+        {
+            var stream = new MemoryStream(text.Length * 2 * HtmlTextEncoder.Default.MaxOutputCharsPerInputChar);
+            var writer = new StreamWriter(stream);
+            timer.Restart();
+            for (int itteration = 0; itteration < itterations; itteration++)
+            {
+                encoder.HtmlEncode(text, writer);
+            }
+            writer.Flush();
+            writer.Dispose();
+            return timer.Elapsed;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Ignore<T>(T value)
+        { }
+    }
+}
+

--- a/src/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj
+++ b/src/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="HtmlEncoderTests.cs" />
     <Compile Include="JavaScriptStringEncoderTests.cs" />
+    <Compile Include="PerformanceTests.cs" />
     <Compile Include="UnicodeEncoderBaseTests.cs" />
     <Compile Include="UnicodeHelpersTests.cs" />
     <Compile Include="UnicodeRangesTests.cs" />


### PR DESCRIPTION
There are scenarios where a reusable component wants a specific encoder (not just TextEncoder).
To enable these scenarios, I created abstractions for HTML, JS, and URL encoders.
I made the concrete classes internal.