### PR TITLE
Reimplement TaskExtensions.Unwrap

### DIFF
--- a/src/System.Threading.Tasks/src/System/Threading/Tasks/TaskExtensions.CoreCLR.cs
+++ b/src/System.Threading.Tasks/src/System/Threading/Tasks/TaskExtensions.CoreCLR.cs
@@ -29,6 +29,13 @@ namespace System.Threading.Tasks
         {
             if (task == null)
                 throw new ArgumentNullException("task");
+            
+            // Fast path for an already successfully completed outer task: just return the inner one.
+            // As in the subsequent slower path, a null inner task is special-cased to mean cancellation.
+            if (task.Status == TaskStatus.RanToCompletion && (task.CreationOptions & TaskCreationOptions.AttachedToParent) == 0)
+            {
+                return task.Result ?? Task.FromCanceled(new CancellationToken(true));
+            }
 
             // Create a new Task to serve as a proxy for the actual inner task.  Attach it
             // to the parent if the original was attached to the parent.
@@ -55,6 +62,13 @@ namespace System.Threading.Tasks
         {
             if (task == null)
                 throw new ArgumentNullException("task");
+
+            // Fast path for an already successfully completed outer task: just return the inner one.
+            // As in the subsequent slower path, a null inner task is special-cased to mean cancellation.
+            if (task.Status == TaskStatus.RanToCompletion && (task.CreationOptions & TaskCreationOptions.AttachedToParent) == 0)
+            {
+                return task.Result ?? Task.FromCanceled<TResult>(new CancellationToken(true));
+            }
 
             // Create a new Task to serve as a proxy for the actual inner task.  Attach it
             // to the parent if the original was attached to the parent.

--- a/src/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -28,8 +28,8 @@ namespace System.Threading.Tasks.Tests
         {
             Task<Task> outer = Task.FromResult(inner);
             Task unwrappedInner = outer.Unwrap();
-            // Assert.True(unwrappedInner.IsCompleted); // TODO: uncomment once we have implementation with this optimization
-            // Assert.Same(inner, unwrappedInner); // TODO: uncomment once we have implementation with this optimization
+            Assert.True(unwrappedInner.IsCompleted);
+            Assert.Same(inner, unwrappedInner);
             AssertTasksAreEqual(inner, unwrappedInner);
         }
 
@@ -43,8 +43,8 @@ namespace System.Threading.Tasks.Tests
         {
             Task<Task<string>> outer = Task.FromResult(inner);
             Task<string> unwrappedInner = outer.Unwrap();
-            // Assert.True(unwrappedInner.IsCompleted); // TODO: uncomment once we have implementation with this optimization
-            // Assert.Same(inner, unwrappedInner); // TODO: uncomment once we have implementation with this optimization
+            Assert.True(unwrappedInner.IsCompleted);
+            Assert.Same(inner, unwrappedInner);
             AssertTasksAreEqual(inner, unwrappedInner);
         }
 
@@ -407,7 +407,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test that Unwrap with a non-generic task doesn't use TaskScheduler.Current.
         /// </summary>
-        // [Fact] // TODO: Uncomment once new implementation matches mscorlib behavior and guarantees TaskScheduler.Default is used
+        [Fact]
         public void NonGeneric_DefaultSchedulerUsed()
         {
             var scheduler = new CountingScheduler();
@@ -427,7 +427,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test that Unwrap with a generic task doesn't use TaskScheduler.Current.
         /// </summary>
-        // [Fact] // TODO: Uncomment once new implementation matches mscorlib behavior and guarantees TaskScheduler.Default is used
+        [Fact]
         public void Generic_DefaultSchedulerUsed()
         {
             var scheduler = new CountingScheduler();
@@ -479,8 +479,7 @@ namespace System.Threading.Tasks.Tests
                     Assert.Equal((IEnumerable<Exception>)expected.Exception.InnerExceptions, actual.Exception.InnerExceptions);
                     break;
                 case TaskStatus.Canceled:
-                    // TODO: Uncomment once we have new implementation that guarantees this
-                    //Assert.Equal(GetCanceledTaskToken(expected), GetCanceledTaskToken(actual));
+                    Assert.Equal(GetCanceledTaskToken(expected), GetCanceledTaskToken(actual));
                     break;
             }
         }


### PR DESCRIPTION
The currently checked in implementation of TaskExtensions.Unwrap isn't what's in .NET 4.5/6 desktop.  Rather, it's a slight improvement over what was shipped in .NET 4, before a bunch of optimizations were made to it for .NET 4.5.  In .NET 4.5, we effectively built the implementation into Task itself, taking advantage of Task internals to minimize allocations and other overheads; the Unwrap extension methods then had internals access and could delegate to that implementation in mscorlib.  For the separate implementation now in System.Threading.Tasks.dll in .NET Core, we don't have that internals access, and need to implement Unwrap on top of Task's public surface area.

Even so, we can do much better than the checked in implementation, and this PR overhauls it.  In the common case, the current implementation incurs 17 allocations (!) per Unwrap, whereas mscorlib's implementation incurs only 1 (along with a commensurate reduction in the number of bytes allocated).  This implementation gets the number down from 17 to 4, again with a commensurate size reduction.  It also gets the single-threaded speed of the implementation (i.e. not taking into account the GC impact of the extra allocations) to effectively the same as the implementation in mscorlib, whereas the old implementation is measurably worse.

It also addresses an inconsistency between the implementations.  In .NET 4.5/6, when the inner task has a CancellationToken that causes the task to be canceled, that CancellationToken is stored into the proxy task, a fact visible due to that token propagating out of any OperationCanceledException thrown when await'ing the proxy task.  The current implementation doesn't have that, but rather the pre-.NET 4.5 behavior where the token wasn't marshaled.  This PR brings it back.

I will hold off on merging this until the System.Threading.Tasks tests are up in the repo and I can validate this against them.