### PR TITLE
Workarounds for building with Roslyn/MSBuild on Unix.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="CheckRoslyn" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
 
   <!--
@@ -15,6 +15,8 @@
     <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta5-11624</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
+    <RoslynVersion>1.0.0-rc2-20150421-01</RoslynVersion>
+    <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
   </PropertyGroup>
 
   <!-- Common repo directories -->
@@ -27,7 +29,7 @@
     <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
     <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
-    
+
     <!-- Input Directories -->
     <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir)packages/</PackagesDir>
     <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)/lib/</ToolsDir>
@@ -58,6 +60,53 @@
     <!-- Current version of DNX does not support all semantics used in our packages, 
          so we ignore the pre-calculation in the lock file and calculate asset applicability in the build task -->
     <NuGetIngoreLockFile>true</NuGetIngoreLockFile>
+  </PropertyGroup>
+
+  <!--
+    Set up Roslyn predefines
+  -->
+  <PropertyGroup>
+    <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName).$(RoslynVersion)/</RoslynPackageDir>
+    <RoslynPropsFile>$(RoslynPackageDir)build/Microsoft.Net.ToolsetCompilers.props</RoslynPropsFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OsEnvironment)'=='Unix' and '$(UseRoslynCompiler)'=='true'">
+    <!--
+      PDB support isn't implemented yet. https://github.com/dotnet/roslyn/issues/2449
+      Note that both DebugSymbols and DebugType need set or project references will assume they need to copy pdbs and fail.
+    -->
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <!--
+      Delay signing with the ECMA key currently doesn't work.
+      https://github.com/dotnet/roslyn/issues/2444
+    -->
+    <UseECMAKey>false</UseECMAKey>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(OsEnvironment)'=='Unix' and '$(UseRoslynCompiler)'=='true'">
+    <!--
+      System.Diagnostics.Debug.Tests currently fails trying to resolve types against System.Runtime
+      https://github.com/dotnet/corefx/issues/1609
+    -->
+    <ExcludeProjects Include="System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj" />
+    <!--
+      The OpenSourceSign target complains about System.Diagnostics.FileVersionInfo.TestAssembly.dll not being delay signed.
+      https://github.com/dotnet/corefx/issues/1610
+    -->
+    <ExcludeProjects Include="System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(OsEnvironment)'=='Unix'">
+    <!--
+      Mono currently doesn't include VB targets for portable, notably /lib/mono/xbuild/Microsoft/Portable/v4.5/Microsoft.Portable.VisualBasic.targets.
+      Fixed in https://github.com/mono/mono/pull/1726.
+    -->
+    <IncludeVbProjects>false</IncludeVbProjects>
+    <!--
+      Building packages fails for two reasons.
+      First, nuget doesn't like the paths in the nuspec having backslashes as directory separators.
+      Second, we aren't yet building pdbs, which the nuspecs specify.
+    -->
+    <SkipBuildPackages>true</SkipBuildPackages>
   </PropertyGroup>
 
   <!-- 
@@ -151,4 +200,13 @@
     <MakePriExtensionPath>$(_WindowsPhoneKitBinPath)\x86\MrmEnvironmentExtDl.dll</MakePriExtensionPath>
     <MakePriExtensionPath_x64>$(_WindowsPhoneKitBinPath)\x64\MrmEnvironmentExtDl.dll</MakePriExtensionPath_x64>
   </PropertyGroup>
+
+  <Import Project="$(RoslynPropsFile)"
+          Condition="'$(UseRoslynCompiler)'=='true' and Exists('$(RoslynPropsFile)')" />
+
+  <!-- Building the build.proj should restore successfully, so ignore in that case -->
+  <Target Name="CheckRoslyn" Condition="'$(UseRoslynCompiler)'=='true' and '$(MSBuildProjectFile)'!='build.proj'">
+    <Warning Condition="!Exists('$(RoslynPropsFile)')"
+             Text="The Roslyn targets do not exist- Roslyn will not be used for this build, but the package should be restored if you build again." />
+  </Target>
 </Project>

--- a/dir.targets
+++ b/dir.targets
@@ -88,11 +88,13 @@
     <Copy Condition="Exists('$(NuGetConfigFile)')" SourceFiles="$(NuGetConfigFile)" DestinationFolder="$(PackagesDir)" SkipUnchangedFiles="true" />
     <Copy Condition="Exists('$(NuGetConfigFile)')" SourceFiles="$(NuGetConfigFile)" DestinationFolder="$(IntermediateOutputRootPath)" SkipUnchangedFiles="true" />
 
-    <!-- Add DNU execute rights -->
+    <!-- Add DNU and Roslyn tool execute rights -->
     <Exec Condition="'$(OsEnvironment)'=='Unix'"
           Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnu&quot;" />
     <Exec Condition="'$(OsEnvironment)'=='Unix'"
           Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnx&quot;" />
+    <Exec Condition="'$(OsEnvironment)'=='Unix'"
+          Command="find '$(RoslynPackageDir)tools' -name &quot;*.exe&quot; -exec chmod &quot;+x&quot; '{}' ';'" /> 
 
     <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
@@ -110,5 +112,4 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
 
   <Target Name="Test" />
-
 </Project>

--- a/override.targets
+++ b/override.targets
@@ -4,4 +4,5 @@
   -->
 
   <Import Project="mono.targets" Condition="'$(OsEnvironment)'=='Unix'" />
+  <Import Project="roslyn.xplat.targets" Condition="'$(OsEnvironment)'=='Unix' and '$(UseRoslynCompiler)'=='true'" />
 </Project>

--- a/roslyn.xplat.targets
+++ b/roslyn.xplat.targets
@@ -1,0 +1,14 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Overrides for Roslyn on Unix
+  -->
+
+  <PropertyGroup>
+    <!-- PDB support isn't implemented yet. -->
+    <!-- Some .csproj files override the settings coming from dir.props so we have to set again here to trump them. -->
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+
+  <!-- This target in the build tools partialfacades.targets assumes that a pdb exists. -->
+  <Target Name="FillPartialFacade" />
+</Project>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -4,4 +4,5 @@
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11580" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-11624" />
+  <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc2-20150421-01" />
 </packages>

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <ProjectGuid>{5471BFE8-8071-466F-838E-5ADAA779E742}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)'==''">true</UseECMAKey>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />

--- a/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.CoreCLR.csproj
@@ -55,7 +55,7 @@
     <Compile Include="System\UriBuilder.cs" />
     <Compile Include="System\UriEnumTypes.cs" />
     <Compile Include="System\UriExt.cs" />
-    <Compile Include="System\URIFormatException.cs" />
+    <Compile Include="System\UriFormatException.cs" />
     <Compile Include="System\UriHelper.cs" />
     <Compile Include="System\UriHostNameType.cs" />
     <Compile Include="System\UriPartial.cs" />

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.CoreCLR.csproj
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.CoreCLR.csproj
@@ -23,15 +23,15 @@
     <Compile Include="System\Runtime\InteropServices\HandleCollector.CoreCLR.cs" />
     <Compile Include="System\Runtime\InteropServices\DefaultParameterValueAttribute.cs" />
     <Compile Include="System\Runtime\InteropServices\HandleCollector.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\ADVF.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\DATADIR.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\DVASPECT.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\FORMATETC.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\advf.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\datadir.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\dvaspect.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\formatetc.cs" />
     <Compile Include="System\Runtime\InteropServices\ComTypes\IAdviseSink.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\IEnumFORMATETC.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\STATDATA.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\STGMEDIUM.cs" />
-    <Compile Include="System\Runtime\InteropServices\ComTypes\TYMED.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\IEnumFormatETC.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\statdata.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\stgmedium.cs" />
+    <Compile Include="System\Runtime\InteropServices\ComTypes\tymed.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -3,10 +3,10 @@
   <Import Project="BuildValues.props" />
 
   <ItemGroup>
-    <Project Include="*\src\*.csproj" Exclude="$(ExcludeProjects)" />
-    <Project Include="*\src\*.vbproj" Exclude="$(ExcludeProjects)" />
-    <Project Include="*\tests\**\*.csproj" Exclude="$(ExcludeProjects)" />
-    <Project Include="*\tests\**\*.vbproj" Exclude="$(ExcludeProjects)" />
+    <Project Include="*\src\*.csproj" Exclude="@(ExcludeProjects)" />
+    <Project Include="*\src\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'" Exclude="@(ExcludeProjects)" />
+    <Project Include="*\tests\**\*.csproj" Exclude="@(ExcludeProjects)" />
+    <Project Include="*\tests\**\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'" Exclude="@(ExcludeProjects)" />
   </ItemGroup>
 
   <Import Project="..\dir.targets" />


### PR DESCRIPTION
Allows a successful compile with xplat MSBuild branch and Roslyn on Mono.

Adds the Roslyn package and UseRoslynCompiler property to use Roslyn.
Disable PDB generation (NYI), skip packaging, disables ECMA delay signing.
Also temporarily disables two test projects and VB.
Fixes casing for a few source file includes.