### PR TITLE
added unit test for ScaffoldColumnAttribute

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/ScaffoldColumnAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/ScaffoldColumnAttributeTests.cs
@@ -1,0 +1,14 @@
+﻿using Xunit;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    public class ScaffoldColumnAttributeTests
+    {
+        [Fact]
+        public static void Can_construct_and_get_Scaffold()
+        {
+            var attribute = new ScaffoldColumnAttribute(true);
+            Assert.Equal(true, attribute.Scaffold);
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="RangeAttributeTests.cs" />
     <Compile Include="RegularExpressionAttributeTests.cs" />
     <Compile Include="RequiredAttributeTests.cs" />
+    <Compile Include="ScaffoldColumnAttributeTests.cs" />
     <Compile Include="Schema\ColumnAttributeTests.cs" />
     <Compile Include="Schema\DatabaseGeneratedAttributeTests.cs" />
     <Compile Include="Schema\ForeignKeyAttributeTests.cs" />


### PR DESCRIPTION
This progresses issue #921 - "Improve code coverage for System.ComponentModel.Annotations" and is my first contribution to corefx. :tada: 

![unit-test](https://cloud.githubusercontent.com/assets/127353/7427699/b95c75d8-f024-11e4-9a53-0d35c72862be.png)

Question: I've noticed that throughout the codebase unit tests generally do not test the attribute contract `AttributeUsage` - why would we not test `AllowMultiple = false` or `AttributeTargets.Field`?