### PR TITLE
Fixes #54 (Remove always true "if" and unreachable code in System.Xml.Linq.XObject.SkipNotify method.)

### DIFF
--- a/src/System.Xml.XDocument/src/System/Xml/Linq/XObject.cs
+++ b/src/System.Xml.XDocument/src/System/Xml/Linq/XObject.cs
@@ -479,7 +479,7 @@ namespace System.Xml.Linq
                     o = o.parent;
                 }
                 if (o == null) return true;
-                if (o.Annotations<XObjectChangeAnnotation>() != null) return false;
+                if (o.Annotation<XObjectChangeAnnotation>() != null) return false;
                 o = o.parent;
             }
         }

--- a/src/System.Xml.XDocument/tests/TreeManipulation/XObjectsTests.cs
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/XObjectsTests.cs
@@ -13,7 +13,6 @@ namespace XLinqTests
         public class SkipNotifyTests
         {
             [Fact]
-            [ActiveIssue(54)]
             public void NoXObjectChangeAnnotation()
             {
                 var sut = new FakeXObject();


### PR DESCRIPTION
Fixes #54 (Remove always true "if" and unreachable code in System.Xml.Linq.XObject.SkipNotify method.)

Uses XObject.Annotation<T>() method to check XObjectChangeAnnotation is present in XObject.annotations list.