### PR TITLE
Improve performance of BigInteger.Add/Sub/Div/Rem

### DIFF
--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -20,6 +20,7 @@
   <!-- References are resolved from packages.config -->
   <ItemGroup>
     <Compile Include="System\Numerics\BigIntegerCalculator.AddSub.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.DivRem.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.SquMul.cs" />
     <Compile Include="System\Numerics\BigInteger.cs" />
     <Compile Include="System\Numerics\BigIntegerBuilder.cs" />

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerBuilder.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerBuilder.cs
@@ -160,23 +160,11 @@ namespace System.Numerics
 
             int cuExtra = _rgu.Length - _iuLast - 1;
             Debug.Assert(cuExtra >= 0);
-            if (cuExtra <= 1)
+            if (cuExtra == 0)
             {
-                if (cuExtra == 0 || _rgu[_iuLast + 1] == 0)
-                {
-                    _fWritable = false;
-                    bits = _rgu;
-                    return;
-                }
-                if (_fWritable)
-                {
-                    _rgu[_iuLast + 1] = 0;
-                    _fWritable = false;
-                    bits = _rgu;
-                    return;
-                }
-                // The buffer isn't writable, but has an extra uint that is non-zero,
-                // so we have to allocate a new buffer.
+                _fWritable = false;
+                bits = _rgu;
+                return;
             }
 
             // Keep the bigger buffer (if it is writable), but create a smaller one for the BigInteger.

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
@@ -5,6 +5,54 @@ namespace System.Numerics
 {
     internal static partial class BigIntegerCalculator
     {
+        public static uint[] Add(uint[] left, uint right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(left.Length >= 1);
+
+            // Executes the addition for one big and one 32-bit integer.
+            // Thus, we've similar code than below, but there is no loop for
+            // processing the 32-bit integer, since it's a single element.
+
+            uint[] bits = new uint[left.Length + 1];
+
+            long digit = (long)left[0] + right;
+            bits[0] = (uint)digit;
+            long carry = digit >> 32;
+
+            for (int i = 1; i < left.Length; i++)
+            {
+                digit = left[i] + carry;
+                bits[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            bits[left.Length] = (uint)carry;
+
+            return bits;
+        }
+
+        [SecuritySafeCritical]
+        public unsafe static uint[] Add(uint[] left, uint[] right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+            Debug.Assert(left.Length >= right.Length);
+
+            // Switching to unsafe pointers helps sparing
+            // some nasty index calculations...
+
+            uint[] bits = new uint[left.Length + 1];
+
+            fixed (uint* l = left, r = right, b = bits)
+            {
+                Add(l, left.Length,
+                    r, right.Length,
+                    b, bits.Length);
+            }
+
+            return bits;
+        }
+
         [SecuritySafeCritical]
         private unsafe static void Add(uint* left, int leftLength,
                                        uint* right, int rightLength,
@@ -23,7 +71,6 @@ namespace System.Numerics
             int i = 0;
             long carry = 0L;
 
-            // adds the bits
             for (; i < rightLength; i++)
             {
                 long digit = (left[i] + carry) + right[i];
@@ -54,7 +101,6 @@ namespace System.Numerics
             int i = 0;
             long carry = 0L;
 
-            // adds the bits
             for (; i < rightLength; i++)
             {
                 long digit = (left[i] + carry) + right[i];
@@ -67,6 +113,167 @@ namespace System.Numerics
                 left[i] = (uint)digit;
                 carry = digit >> 32;
             }
+
+            Debug.Assert(carry == 0);
+        }
+
+        public static uint[] Subtract(uint[] left, uint right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(left.Length >= 1);
+            Debug.Assert(left[0] >= right || left.Length >= 2);
+
+            // Executes the subtraction for one big and one 32-bit integer.
+            // Thus, we've similar code than below, but there is no loop for
+            // processing the 32-bit integer, since it's a single element.
+
+            uint[] bits = new uint[left.Length];
+
+            long digit = (long)left[0] - right;
+            bits[0] = (uint)digit;
+            long carry = digit >> 32;
+
+            for (int i = 1; i < left.Length; i++)
+            {
+                digit = left[i] + carry;
+                bits[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+
+            return bits;
+        }
+
+        [SecuritySafeCritical]
+        public unsafe static uint[] Subtract(uint[] left, uint[] right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+            Debug.Assert(left.Length >= right.Length);
+            Debug.Assert(Compare(left, right) >= 0);
+
+            // Switching to unsafe pointers helps sparing
+            // some nasty index calculations...
+
+            uint[] bits = new uint[left.Length];
+
+            fixed (uint* l = left, r = right, b = bits)
+            {
+                Subtract(l, left.Length,
+                         r, right.Length,
+                         b, bits.Length);
+            }
+
+            return bits;
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void Subtract(uint* left, int leftLength,
+                                            uint* right, int rightLength,
+                                            uint* bits, int bitsLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+            Debug.Assert(leftLength >= rightLength);
+            Debug.Assert(Compare(left, leftLength, right, rightLength) >= 0);
+            Debug.Assert(bitsLength == leftLength);
+
+            // Executes the "grammar-school" algorithm for computing z = a - b.
+            // While calculating z_i = a_i - b_i we take care of overflow:
+            // Since a_i - b_i doesn't need any additional bit, our carry c
+            // has always the value -1 or 0; hence, we're safe here.
+
+            int i = 0;
+            long carry = 0L;
+
+            for (; i < rightLength; i++)
+            {
+                long digit = (left[i] + carry) - right[i];
+                bits[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            for (; i < leftLength; i++)
+            {
+                long digit = left[i] + carry;
+                bits[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            bits[i] = (uint)carry;
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void SubtractSelf(uint* left, int leftLength,
+                                                uint* right, int rightLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+            Debug.Assert(leftLength >= rightLength);
+            Debug.Assert(Compare(left, leftLength, right, rightLength) >= 0);
+
+            // Executes the "grammar-school" algorithm for computing z = a - b.
+            // Same as above, but we're writing the result directly to a and
+            // stop execution, if we're out of b and c is already 0.
+
+            int i = 0;
+            long carry = 0L;
+
+            for (; i < rightLength; i++)
+            {
+                long digit = (left[i] + carry) - right[i];
+                left[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+            for (; carry != 0 && i < leftLength; i++)
+            {
+                long digit = left[i] + carry;
+                left[i] = (uint)digit;
+                carry = digit >> 32;
+            }
+
+            Debug.Assert(carry == 0);
+        }
+
+        public static int Compare(uint[] left, uint[] right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+
+            if (left.Length < right.Length)
+                return -1;
+            if (left.Length > right.Length)
+                return 1;
+
+            for (int i = left.Length - 1; i >= 0; i--)
+            {
+                if (left[i] < right[i])
+                    return -1;
+                if (left[i] > right[i])
+                    return 1;
+            }
+
+            return 0;
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static int Compare(uint* left, int leftLength,
+                                          uint* right, int rightLength)
+        {
+            Debug.Assert(leftLength >= 0);
+            Debug.Assert(rightLength >= 0);
+
+            if (leftLength < rightLength)
+                return -1;
+            if (leftLength > rightLength)
+                return 1;
+
+            for (int i = leftLength - 1; i >= 0; i--)
+            {
+                if (left[i] < right[i])
+                    return -1;
+                if (left[i] > right[i])
+                    return 1;
+            }
+
+            return 0;
         }
     }
 }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
@@ -1,0 +1,364 @@
+﻿using System.Diagnostics;
+using System.Security;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        public static uint[] Divide(uint[] left, uint right,
+                                    out uint[] remainder)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(left.Length >= 1);
+
+            // Executes the division for one big and one 32-bit integer.
+            // Thus, we've similar code than below, but there is no loop for
+            // processing the 32-bit integer, since it's a single element.
+
+            uint[] quotient = new uint[left.Length];
+
+            ulong carry = 0UL;
+            for (int i = left.Length - 1; i >= 0; i--)
+            {
+                ulong value = (carry << 32) | left[i];
+                quotient[i] = (uint)(value / right);
+                carry = value % right;
+            }
+            remainder = new uint[] { (uint)carry };
+
+            return quotient;
+        }
+
+        public static uint[] Divide(uint[] left, uint right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(left.Length >= 1);
+
+            // Same as above, but only computing the quotient.
+
+            uint[] quotient = new uint[left.Length];
+
+            ulong carry = 0UL;
+            for (int i = left.Length - 1; i >= 0; i--)
+            {
+                ulong value = (carry << 32) | left[i];
+                quotient[i] = (uint)(value / right);
+                carry = value % right;
+            }
+
+            return quotient;
+        }
+
+        public static uint[] Remainder(uint[] left, uint right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(left.Length >= 1);
+
+            // Same as above, but only computing the remainder.
+
+            ulong carry = 0UL;
+            for (int i = left.Length - 1; i >= 0; i--)
+            {
+                ulong value = (carry << 32) | left[i];
+                carry = value % right;
+            }
+
+            return new uint[] { (uint)carry };
+        }
+
+        [SecuritySafeCritical]
+        public unsafe static uint[] Divide(uint[] left, uint[] right,
+                                           out uint[] remainder)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+            Debug.Assert(left.Length >= 1);
+            Debug.Assert(right.Length >= 1);
+            Debug.Assert(left.Length >= right.Length);
+
+            // Switching to unsafe pointers helps sparing
+            // some nasty index calculations...
+
+            uint[] quotient = new uint[left.Length - right.Length + 1];
+            remainder = new uint[right.Length];
+
+            fixed(uint* l = left, r = right, q = quotient, e = remainder)
+            {
+                Divide(l, left.Length,
+                       r, right.Length,
+                       q, quotient.Length,
+                       e, remainder.Length);
+            }
+
+            return quotient;
+        }
+
+        [SecuritySafeCritical]
+        public unsafe static uint[] Divide(uint[] left, uint[] right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+            Debug.Assert(left.Length >= 1);
+            Debug.Assert(right.Length >= 1);
+            Debug.Assert(left.Length >= right.Length);
+
+            // Same as above, but only returning the quotient.
+
+            uint[] quotient = new uint[left.Length - right.Length + 1];
+
+            fixed (uint* l = left, r = right, q = quotient)
+            {
+                Divide(l, left.Length,
+                       r, right.Length,
+                       q, quotient.Length,
+                       null, 0);
+            }
+
+            return quotient;
+        }
+
+        [SecuritySafeCritical]
+        public unsafe static uint[] Remainder(uint[] left, uint[] right)
+        {
+            Debug.Assert(left != null);
+            Debug.Assert(right != null);
+            Debug.Assert(left.Length >= 1);
+            Debug.Assert(right.Length >= 1);
+            Debug.Assert(left.Length >= right.Length);
+
+            // Same as above, but only returning the remainder.
+
+            uint[] remainder = new uint[right.Length];
+
+            fixed (uint* l = left, r = right, e = remainder)
+            {
+                Divide(l, left.Length,
+                       r, right.Length,
+                       null, 0,
+                       e, remainder.Length);
+            }
+
+            return remainder;
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void Divide(uint* left, int leftLength,
+                                          uint* right, int rightLength,
+                                          uint* quotient, int quotientLength,
+                                          uint* remainder, int remainderLength)
+        {
+            Debug.Assert(leftLength >= 1);
+            Debug.Assert(rightLength >= 1);
+            Debug.Assert(leftLength >= rightLength);
+            Debug.Assert(quotientLength == leftLength - rightLength + 1
+                || quotientLength == 0);
+            Debug.Assert(remainderLength == rightLength
+                || remainderLength == 0);
+
+            // Executes the "grammar-school" algorithm for computing q = a / b.
+            // Before calculating q_i, we get more bits into the highest bit
+            // block of the divisor. Thus, guessing digits of the quotient
+            // will be more precise. Additionally we'll get r = a % b.
+
+            int dividendLength = leftLength + 1;
+            int divisorLength = rightLength;
+            fixed (uint* dividend = new uint[dividendLength],
+                         divisor = new uint[divisorLength],
+                         guess = new uint[divisorLength])
+            {
+                // This will create private copies of left and right, so we can
+                // modify the actual values of the dividend during computation
+                // without breaking immutability of the calling structure!
+                int shift = LeadingZeros(right[rightLength - 1]);
+                LeftShift(left, leftLength, dividend, dividendLength, shift);
+                LeftShift(right, rightLength, divisor, divisorLength, shift);
+
+                // Measure dividend again; maybe there aren't any additional
+                // bits resulting of our shift above to the left?
+                if (dividend[dividendLength - 1] == 0)
+                    --dividendLength;
+
+                // These values will come in handy
+                uint divHi = divisor[divisorLength - 1];
+                uint divLo = divisorLength > 1 ? divisor[divisorLength - 2] : 0;
+                int guessLength = 0;
+                int delta = 0;
+
+                // First, we subtract the divisor until our dividend is smaller,
+                // if we shift the divisor so they have equal length. This will
+                // ensure that the highest digit of the dividend is smaller or
+                // equal to the highest digit of the divisor...
+                do
+                {
+                    int n = dividendLength - divisorLength;
+                    delta = Compare(dividend + n, divisorLength,
+                                    divisor, divisorLength);
+                    if (delta >= 0)
+                    {
+                        if (quotientLength != 0)
+                            ++quotient[n];
+                        SubtractSelf(dividend + n, divisorLength,
+                                     divisor, divisorLength);
+                    }
+                }
+                while (delta > 0);
+
+                // Then, we divide the rest of the bits as we would do it using
+                // pen and paper: guessing the next digit, subtracting, ...
+                for (int i = dividendLength - 1; i >= divisorLength; i--)
+                {
+                    int n = i - divisorLength;
+
+                    // First guess for the current digit of the quotient,
+                    // which naturally must have only 32 bits...
+                    ulong valHi = ((ulong)dividend[i] << 32) | dividend[i - 1];
+                    ulong digit = valHi / divHi;
+                    if (digit > 0xFFFFFFFF)
+                        digit = 0xFFFFFFFF;
+
+                    // Our first guess may be a little bit to big
+                    ulong check = divHi * digit + ((divLo * digit) >> 32);
+                    if (check > valHi)
+                        --digit;
+
+                    // Our guess may be still a little bit to big
+                    do
+                    {
+                        MultiplyDivisor(divisor, divisorLength, digit, guess);
+                        guessLength = guess[divisorLength] == 0
+                                    ? divisorLength : divisorLength + 1;
+                        delta = Compare(dividend + n, guessLength,
+                                        guess, guessLength);
+                        if (delta < 0)
+                            --digit;
+                    }
+                    while (delta < 0);
+
+                    // We have the digit!
+                    SubtractSelf(dividend + n, guessLength,
+                                 guess, guessLength);
+                    if (quotientLength != 0)
+                        quotient[n] = (uint)digit;
+                }
+
+                if (remainderLength != 0)
+                {
+                    // Repairing the remaining dividend gets the remainder
+                    RightShift(dividend, divisorLength,
+                               remainder, remainderLength,
+                               shift);
+                }
+            }
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void LeftShift(uint* value, int valueLength,
+                                             uint* target, int targetLength,
+                                             int shift)
+        {
+            Debug.Assert(valueLength >= 1);
+            Debug.Assert(targetLength == valueLength ||
+                         targetLength == valueLength + 1);
+            Debug.Assert(shift >= 0 && shift < 32);
+
+            if (shift > 0)
+            {
+                int backShift = 32 - shift;
+                target[0] = value[0] << shift;
+                for (int i = 1; i < valueLength; i++)
+                {
+                    target[i] = (value[i] << shift)
+                        | (value[i - 1] >> backShift);
+                }
+                if (targetLength > valueLength)
+                {
+                    target[valueLength] =
+                        value[valueLength - 1] >> backShift;
+                }
+            }
+            else
+            {
+                for (int i = 0; i < valueLength; i++)
+                    target[i] = value[i];
+            }
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void RightShift(uint* value, int valueLength,
+                                              uint* target, int targetLength,
+                                              int shift)
+        {
+            Debug.Assert(valueLength >= 1);
+            Debug.Assert(targetLength == valueLength);
+            Debug.Assert(shift >= 0 && shift < 32);
+
+            if (shift > 0)
+            {
+                int backShift = 32 - shift;
+                for (int i = 0; i < valueLength - 1; i++)
+                {
+                    target[i] = (value[i] >> shift)
+                        | (value[i + 1] << backShift);
+                }
+                target[valueLength - 1] =
+                    (value[valueLength - 1] >> shift);
+            }
+            else
+            {
+                for (int i = 0; i < valueLength; i++)
+                    target[i] = value[i];
+            }
+        }
+
+        [SecuritySafeCritical]
+        private unsafe static void MultiplyDivisor(uint* left, int leftLength,
+                                                   ulong right, uint* bits)
+        {
+            Debug.Assert(leftLength >= 1);
+            Debug.Assert(right <= 0xFFFFFFFF);
+
+            ulong carry = 0UL;
+            for (int i = 0; i < leftLength; i++)
+            {
+                ulong digits = left[i] * right + carry;
+                bits[i] = (uint)digits;
+                carry = digits >> 32;
+            }
+            bits[leftLength] = (uint)carry;
+        }
+
+        private static int LeadingZeros(uint value)
+        {
+            if (value == 0)
+                return 32;
+
+            var count = 0;
+            if ((value & 0xFFFF0000) == 0)
+            {
+                count += 16;
+                value = value << 16;
+            }
+            if ((value & 0xFF000000) == 0)
+            {
+                count += 8;
+                value = value << 8;
+            }
+            if ((value & 0xF0000000) == 0)
+            {
+                count += 4;
+                value = value << 4;
+            }
+            if ((value & 0xC0000000) == 0)
+            {
+                count += 2;
+                value = value << 2;
+            }
+            if ((value & 0x80000000) == 0)
+            {
+                count += 1;
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -112,42 +112,27 @@ namespace System.Numerics
                 Square(valueHigh, valueHighLength,
                        bitsHigh, bitsHighLength);
 
-                // ... compute z_a = a_1 + a_0 (call it fold...)
                 int foldLength = valueHighLength + 1;
-                uint* fold = stackalloc uint[foldLength];
-
-                Add(valueHigh, valueHighLength,
-                    valueLow, valueLowLength,
-                    fold, foldLength);
-
-                // ... compute z_1 = z_a * z_a - z_0 - z_2
                 int coreLength = foldLength + foldLength;
-                uint* core = stackalloc uint[coreLength];
+                fixed (uint* fold = new uint[foldLength],
+                             core = new uint[coreLength])
+                {
+                    // ... compute z_a = a_1 + a_0 (call it fold...)
+                    Add(valueHigh, valueHighLength,
+                        valueLow, valueLowLength,
+                        fold, foldLength);
 
-                Square(fold, foldLength,
-                       core, coreLength);
-                SubtractCore(bitsHigh, bitsHighLength,
-                             bitsLow, bitsLowLength,
-                             core, coreLength);
+                    // ... compute z_1 = z_a * z_a - z_0 - z_2
+                    Square(fold, foldLength,
+                           core, coreLength);
+                    SubtractCore(bitsHigh, bitsHighLength,
+                                 bitsLow, bitsLowLength,
+                                 core, coreLength);
 
-                // ... and finally merge the result! :-)
-                AddSelf(bits + n, bitsLength - n, core, coreLength);
+                    // ... and finally merge the result! :-)
+                    AddSelf(bits + n, bitsLength - n, core, coreLength);
+                }
             }
-        }
-
-        public static uint[] Multiply(uint left, uint right)
-        {
-            // Executes the trivial multiplication for two 32-bit integers.
-            // Since the caller is working with uint[] objects, we're
-            // doing him a favor with already providing it that way.
-
-            uint[] bits = new uint[2];
-
-            ulong digits = (ulong)left * right;
-            bits[0] = (uint)digits;
-            bits[1] = (uint)(digits >> 32);
-
-            return bits;
         }
 
         public static uint[] Multiply(uint[] left, uint right)
@@ -288,35 +273,34 @@ namespace System.Numerics
                          rightHigh, rightHighLength,
                          bitsHigh, bitsHighLength);
 
-                // ... compute z_a = a_1 + a_0 (call it fold...)
                 int leftFoldLength = leftHighLength + 1;
-                uint* leftFold = stackalloc uint[leftFoldLength];
-
-                Add(leftHigh, leftHighLength,
-                    leftLow, leftLowLength,
-                    leftFold, leftFoldLength);
-
-                // ... compute z_b = b_1 + b_0 (call it fold...)
                 int rightFoldLength = rightHighLength + 1;
-                uint* rightFold = stackalloc uint[rightFoldLength];
-
-                Add(rightHigh, rightHighLength,
-                    rightLow, rightLowLength,
-                    rightFold, rightFoldLength);
-
-                // ... compute z_1 = z_a * z_b - z_0 - z_2
                 int coreLength = leftFoldLength + rightFoldLength;
-                uint* core = stackalloc uint[coreLength];
+                fixed (uint* leftFold = new uint[leftFoldLength],
+                             rightFold = new uint[rightFoldLength],
+                             core = new uint[coreLength])
+                {
+                    // ... compute z_a = a_1 + a_0 (call it fold...)
+                    Add(leftHigh, leftHighLength,
+                        leftLow, leftLowLength,
+                        leftFold, leftFoldLength);
 
-                Multiply(leftFold, leftFoldLength,
-                         rightFold, rightFoldLength,
-                         core, coreLength);
-                SubtractCore(bitsHigh, bitsHighLength,
-                             bitsLow, bitsLowLength,
+                    // ... compute z_b = b_1 + b_0 (call it fold...)
+                    Add(rightHigh, rightHighLength,
+                        rightLow, rightLowLength,
+                        rightFold, rightFoldLength);
+
+                    // ... compute z_1 = z_a * z_b - z_0 - z_2
+                    Multiply(leftFold, leftFoldLength,
+                             rightFold, rightFoldLength,
                              core, coreLength);
+                    SubtractCore(bitsHigh, bitsHighLength,
+                                 bitsLow, bitsLowLength,
+                                 core, coreLength);
 
-                // ... and finally merge the result! :-)
-                AddSelf(bits + n, bitsLength - n, core, coreLength);
+                    // ... and finally merge the result! :-)
+                    AddSelf(bits + n, bitsLength - n, core, coreLength);
+                }
             }
         }
 

--- a/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divide.cs
@@ -150,6 +150,18 @@ namespace System.Numerics.Tests
             VerifyDivideString(Math.Pow(2, 33) + " 2 bDivide");
         }
 
+        [Fact]
+        public static void RunOverflow()
+        {
+            // these values lead to an "overflow", if dividing digit by digit
+            // we need to ensure that this case is being handled accordingly...
+            var x = new BigInteger(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 });
+            var y = new BigInteger(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 });
+            var z = new BigInteger(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 });
+
+            Assert.Equal(z, BigInteger.Divide(x, y));
+        }
+
         private static void VerifyDivideString(string opstring)
         {
             StackCalc sc = new StackCalc(opstring);

--- a/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/op_divide.cs
@@ -129,6 +129,17 @@ namespace System.Numerics.Tests
             VerifyDivideString(Math.Pow(2, 33) + " 2 b/");
         }
 
+        [Fact]
+        public static void RunOverflow()
+        {
+            // these values lead to an "overflow", if dividing digit by digit
+            // we need to ensure that this case is being handled accordingly...
+            var x = new BigInteger(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 });
+            var y = new BigInteger(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 });
+            var z = new BigInteger(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0 });
+
+            Assert.Equal(z, x / y);
+        }
 
         private static void VerifyDivideString(string opstring)
         {


### PR DESCRIPTION
To introduce further performance tweaks, some minor improvements are added to `BigIntegerCalculator`, which cover all the basic operations. Having these algorithms based on raw uint[] objects will lead to more interesting tweaks of the more fancy stuff (`ModPow`).

A basic performance comparison based on [this code](https://gist.github.com/axelheer/3b701c91271b7c762586) unveils the following results:

**Add**

| # of bits | # of vals | before ms | after ms |
|----------:|----------:|----------:|---------:|
|        16 | 1,000,000 |        40 |       37 |
|        64 | 1,000,000 |        97 |       94 |
|       256 | 1,000,000 |       110 |      107 |
|     1,024 | 1,000,000 |       163 |      152 |
|     4,096 |   100,000 |        40 |       37 |
|    16,384 |   100,000 |       147 |      122 |
|    65,536 |   100,000 |       515 |      440 |

**Subtract**

| # of bits | # of vals | before ms | after ms |
|----------:|----------:|----------:|---------:|
|        16 | 1,000,000 |        44 |       38 |
|        64 | 1,000,000 |       106 |       95 |
|       256 | 1,000,000 |       128 |      111 |
|     1,024 | 1,000,000 |       182 |      164 |
|     4,096 |   100,000 |        42 |       38 |
|    16,384 |   100,000 |       143 |      131 |
|    65,536 |   100,000 |       511 |      444 |

**Divide**

| # of bits | # of vals | before ms | after ms |
|----------:|----------:|----------:|---------:|
|        16 | 1,000,000 |        49 |       29 |
|        64 | 1,000,000 |       125 |      110 |
|       256 | 1,000,000 |       349 |      287 |
|     1,024 |   100,000 |       215 |      119 |
|     4,096 |    10,000 |       254 |      124 |
|    16,384 |     1,000 |       378 |      172 |
|    65,536 |       100 |       595 |      263 |

*Note:* during making this pull request I noted that all the `Debug.Assert` aren't doing anything... (?)

*Attention:* because of using `stackalloc` I had to reduce an unit test value, which is currently very high and leads to a stack overflow. Would it be better to switch to `fixed` or should the actual stack size be increased, if someone really needs that huge numbers?

#1307
