### PR TITLE
added EditableAttribute construction test

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EditableAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EditableAttribute.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.DataAnnotations
     /// <remarks>
     ///     This attribute neither enforces nor guarantees editability; the underlying data
     ///     store might allow changing the data regardless of this attribute.  The presence
-    ///     of this attribute signals intent to the consumer of the attribute whethere or not
+    ///     of this attribute signals intent to the consumer of the attribute whether or not
     ///     the end user should be allowed to change the value via the client application.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/src/System.ComponentModel.Annotations/tests/EditableAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/EditableAttributeTests.cs
@@ -1,0 +1,17 @@
+﻿using Xunit;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    public class EditableAttributeTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void Can_construct_and_both_AllowEdit_and_AllowInitialValue_are_set(bool value)
+        {
+            var attribute = new EditableAttribute(value);
+            Assert.Equal(value, attribute.AllowEdit);
+            Assert.Equal(value, attribute.AllowInitialValue);
+        }
+    }
+}

--- a/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="CreditCardAttributeTests.cs" />
     <Compile Include="CustomValidationAttributeTests.cs" />
     <Compile Include="DataTypeAttributeTests.cs" />
+    <Compile Include="EditableAttributeTests.cs" />
     <Compile Include="EmailAddressAttributeTests.cs" />
     <Compile Include="EnumDataTypeAttributeTests.cs" />
     <Compile Include="FileExtensionsAttributeTests.cs" />


### PR DESCRIPTION
+5 covered - from 0% to 100% coverage.

progresses issue #921

[x] When the value passed to EditableAttribute's ctor is false?
[ ] When AllowInitialValue is changed, making sure AllowEdit isn't also changed?


	# Ignore - WIP notes.

	The actual intent vs implementation of
	https://github.com/dotnet/corefx/blob/master/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EditableAttribute.cs

	It makes minimal sense that public bool AllowEdit { get; private set; } has a
	private setter and public bool AllowInitialValue { get; set; } does not.

	InitialValue imho should be private/immutable whilst AllowEdit should be
	mutable.

	ellismg 23 minutes ago :

	@ghuntley if I had to wager a guess, I would think the intention is that you
	must always set a value for AllowEdit, but you don't for AllowInitialValue
	(since it inherits the value from the .ctor. I don't think people expected
	folks to new up these attributes at runtime and start calling the setters on
	them, instead just set their values in metadata But that's just my guess from
	looking at the surface area and docs. Looking into the internal history, it
	seems like previously we had an "ImmutableAttribute" which had the
	AllowInitialValue property (but not AllowEdit) and it was replaced with
	EditableAttribute. Jeff Handley may have been responsible for the creation of
	this type.

	waynd: @ghuntley the problem with making AllowInitialValue’s setter private is that
	you can no longer do [Editable(true, AllowInitialValue = false)] i dont think
	the intent for usage is to ever change AllowInitialValue after creation, but to
	allow it to be set by name on application, it has to have a public setter
	otherwise you need to add a new ctor with two parameters — which may be a
	better solution, but can also be an anti pattern. easy to miss the difference
	between [Editable(true, false)] and [Editable(false, true)]

