### PR TITLE
exclude Visual Studio 2015 `.vs` working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,10 @@ bld/
 [Oo]bj/
 msbuild.log
 
-# Roslyn stuff
+# Visual Studio 2015
+.vs/
+
+# Visual Studio 2015 Pre-CTP6
 *.sln.ide
 *.ide/
 


### PR DESCRIPTION
"The .vs directory is the new location where per-user solution-specific items are saved. Previously there was no directory where this information could be placed, so the IDE kept adding files alongside the
solution. It's finally a solution to a problem that's been here for a very long time." - @sharwell