### PR TITLE
Cleanup more Contract.Asserts

### DIFF
--- a/src/Common/src/System/Collections/HashHelpers.cs
+++ b/src/Common/src/System/Collections/HashHelpers.cs
@@ -93,7 +93,7 @@ namespace System.Collections
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
             if ((uint)newSize > MaxPrimeArrayLength && MaxPrimeArrayLength > oldSize)
             {
-                Contract.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
+                Debug.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
                 return MaxPrimeArrayLength;
             }
 

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -915,9 +915,9 @@ namespace System.Collections.Generic
         /// </summary>
         private void SetCapacity(int newSize, bool forceNewHashCodes)
         {
-            Contract.Assert(HashHelpers.IsPrime(newSize), "New size is not prime!");
+            Debug.Assert(HashHelpers.IsPrime(newSize), "New size is not prime!");
 
-            Contract.Assert(_buckets != null, "SetCapacity called on a set with no elements");
+            Debug.Assert(_buckets != null, "SetCapacity called on a set with no elements");
 
             Slot[] newSlots;
             if (_slots == null)


### PR DESCRIPTION
A few more snuck in as part of System.Collections.  Replacing with Debug.Asserts, for consistency across repo.