### PR TITLE
Bring TypeExtensions code coverage to 100%

### DIFF
--- a/src/System.Reflection.TypeExtensions/System.Reflection.TypeExtensions.sln
+++ b/src/System.Reflection.TypeExtensions/System.Reflection.TypeExtensions.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions.CoreCLR", "src\System.Reflection.TypeExtensions.CoreCLR.csproj", "{1E689C1B-690C-4799-BDE9-6E7990585894}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions.Tests", "tests\System.Reflection.TypeExtensions.Tests.csproj", "{089444FE-8FF5-4D8F-A51B-32D026425F6B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.Build.0 = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.CoreCLR.csproj
+++ b/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.CoreCLR.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NuGetTargetFrameworkMoniker>ASP.NetCore, version=v5.0</NuGetTargetFrameworkMoniker>
+    <ProjectGuid>{1e689c1b-690c-4799-bde9-6e7990585894}</ProjectGuid>
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Reflection.TypeExtensions/tests/Type/GetMembers.cs
+++ b/src/System.Reflection.TypeExtensions/tests/Type/GetMembers.cs
@@ -123,5 +123,11 @@ namespace System.Reflection.Compatibility.UnitTests.TypeTests
             BindingFlags allBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
             TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1[System.String]", allBindingFlags, new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "System.String get_Item(Int32)", "Void set_Item(Int32, System.String)", "Void .ctor(System.String[])", "Int32 myProperty", "System.String Item [Int32]", "System.String[] _field", "Int32 _field1" });
         }
+
+        [Fact]
+        public void Test7()
+        {
+            TryGetMembers("System.Reflection.Compatibility.UnitTests.TypeTests.GenericArrayWrapperClass`1[System.String]", new string[] { "Int32 get_myProperty()", "Void set_myProperty(Int32)", "System.String get_Item(Int32)", "Void set_Item(Int32, System.String)", "Void .ctor(System.String[])", "Int32 myProperty", "System.String Item [Int32]", "System.String ToString()", "Boolean Equals(System.Object)", "Int32 GetHashCode()", "System.Type GetType()" });
+        }
     }
 }


### PR DESCRIPTION
Scratching an itch; the System.Reflection.TypeExtensions.dll tests were one method short of 100% code coverage... adding that test case.

Also adding a .sln for System.Reflection.TypeExtensions