### PR TITLE
Fix incorrect documentation about parallel dispose

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -216,8 +216,8 @@ namespace System.Reflection.PortableExecutable
         /// Disposes all memory allocated by the reader.
         /// </summary>
         /// <remarks>
-        /// <see cref="Dispose"/>  can be called multiple times (even in parallel). 
-        /// However, it is not safe to call <see cref="Dispose"/> in parallel with any other operation on the <see cref="PEReader"/>
+        /// <see cref="Dispose"/>  can be called multiple times (but not in parallel).
+        /// It is not safe to call <see cref="Dispose"/> in parallel with any other operation on the <see cref="PEReader"/>
         /// or reading from <see cref="PEMemoryBlock"/>s retrieved from the reader.
         /// </remarks>
         public void Dispose()


### PR DESCRIPTION
Previously, PEReader allowed mutliple calls to Dispose in parallel, but
that was removed because the caller must not Dispose the PEReader in
parallel to any other non-Dispose operation and the caller's
synchronization required to guarantee that can also guarantee that
Dispose is not called in parallel.