### PR TITLE
Fix NullReferenceException in FileSystemWatcher.

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -71,7 +71,6 @@ namespace System.IO
             // thus freeing the pinned buffer.
             _stopListening = true;
             _directoryHandle.Dispose();
-            _directoryHandle = null;
 
             // Start ignoring all events occurring after this.
             Interlocked.Increment(ref _currentSession);


### PR DESCRIPTION
This change is to address the NullReferenceException reported in Issue #1556.  See that issue for additional details.  

I was able to repro this by creating a unit test which creates two threads.

Thread 1: Create and delete a file
Thread 2: Enable and disable raising events

I then ran thread 1 and thread 2 using the same FileSystemWatcher for 30 seconds.  On average, it took less than 10 seconds for a NullReferenceException to fire.  

I have a local fix for this, which is to remove the "_directoryHandle=null" statement.  Not setting _directoryHandle to null means the GC won't collect it.  Whenever we start raising events, we initialize "_directoryHandle" to refer to the directory being monitored.  An alternative solution would be to use a lock, but that is a bit heavy handed and not necessary unless setting _directoryHandle to null is a requirement.
