### PR TITLE
Add tests for System.Collection's debugger attributes

### DIFF
--- a/src/System.Collections/tests/Generic/Common/TestDebugger.cs
+++ b/src/System.Collections/tests/Generic/Common/TestDebugger.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
+
+namespace TestSupport.Collections
+{
+    public class DebuggerTests
+    {
+        [Theory]
+        [MemberData("TestDebuggerAttributes_Inputs")]
+        public static void TestDebuggerAttributes(object obj)
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(obj);
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(obj);
+        }
+
+        public static IEnumerable<object[]> TestDebuggerAttributes_Inputs()
+        {
+            yield return new object[] { new Dictionary<int, string>() };
+            yield return new object[] { new HashSet<string>() };
+            yield return new object[] { new LinkedList<object>() };
+            yield return new object[] { new List<int>() };
+            yield return new object[] { new Queue<double>() };
+            yield return new object[] { new SortedDictionary<string, int>() };
+            yield return new object[] { new SortedList<int, string>() };
+            yield return new object[] { new SortedSet<int>() };
+            yield return new object[] { new Stack<object>() };
+
+            yield return new object[] { new Dictionary<double, float>().Keys };
+            yield return new object[] { new Dictionary<float, double>().Values };
+            yield return new object[] { new SortedDictionary<Guid, string>().Keys };
+            yield return new object[] { new SortedDictionary<long, Guid>().Values };
+            yield return new object[] { new SortedList<string, int>().Keys };
+            yield return new object[] { new SortedList<float, long>().Values };
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -124,7 +124,11 @@
     <Compile Include="Generic\SortedList\Values.cs" />
     <Compile Include="Generic\SortedSet\SortedSetSpecificTests.cs" />
     <Compile Include="Generic\SortedSet\SortedSetTest.cs" />
+    <Compile Include="Generic\Common\TestDebugger.cs" />
     <Compile Include="Generic\Stack\Stack_GetEnumerator.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- References are resolved from packages.config -->
   <ItemGroup>

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -4,6 +4,7 @@
     "System.Console": "4.0.0-beta-22809",
     "System.Globalization": "4.0.10-beta-22809",
     "System.IO": "4.0.10-beta-22809",
+    "System.Linq": "4.0.0-beta-22809",
     "System.Runtime": "4.0.20-beta-22809",
     "System.Runtime.Extensions": "4.0.10-beta-22809",
     "System.Threading": "4.0.10-beta-22809",


### PR DESCRIPTION
As we've done in other projects, using reflection to verify that the collection types have DebuggerDisplay/DebuggerTypeProxy attributes and to do basic validation of them.