### PR TITLE
Improve Path test coverage

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -37,6 +37,11 @@ public static class StopwatchTests
         var e2 = watch.Elapsed;
         Assert.Equal(e1, e2);
         Assert.Equal((long)e1.TotalMilliseconds, watch.ElapsedMilliseconds);
+
+        var t1 = watch.ElapsedTicks;
+        Sleep();
+        var t2 = watch.ElapsedTicks;
+        Assert.Equal(t1, t2);
     }
 
     [Fact]

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -10,6 +11,8 @@ public static class PathTests
     [Fact]
     public static void ChangeExtension()
     {
+        Assert.Null(Path.ChangeExtension(null, null));
+        Assert.Equal("file", Path.ChangeExtension("file.exe", null));
         Assert.Equal("file.exe", Path.ChangeExtension("file.txt", "exe"));
     }
 
@@ -25,8 +28,18 @@ public static class PathTests
     {
         Assert.Equal(".exe", Path.GetExtension("file.exe"));
         Assert.True(Path.HasExtension("file.exe"));
+
         Assert.Equal(string.Empty, Path.GetExtension("file"));
         Assert.False(Path.HasExtension("file"));
+
+        Assert.Null(Path.GetExtension(null));
+        Assert.False(Path.HasExtension(null));
+
+        Assert.Equal("", Path.GetExtension("file."));
+        Assert.False(Path.HasExtension("file."));
+
+        Assert.Equal("", Path.GetExtension(Path.Combine("test", "file")));
+        Assert.False(Path.HasExtension(Path.Combine("test", "file")));
     }
 
     [Fact]
@@ -41,6 +54,7 @@ public static class PathTests
     {
         Assert.Equal("file", Path.GetFileNameWithoutExtension(Path.Combine("bar","baz","file.exe")));
         Assert.Equal(string.Empty, Path.GetFileNameWithoutExtension(Path.Combine("bar","baz") + Path.DirectorySeparatorChar));
+        Assert.Null(Path.GetFileNameWithoutExtension(null));
     }
 
     [Fact]
@@ -63,4 +77,62 @@ public static class PathTests
             Assert.Equal(s[8], '.');
         }
     }
+
+    [Fact]
+    public static void GetInvalidPathChars()
+    {
+        Assert.NotNull(Path.GetInvalidPathChars());
+        Assert.NotSame(Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
+        Assert.Equal((IEnumerable<char>)Path.GetInvalidPathChars(), (IEnumerable<char>)Path.GetInvalidPathChars());
+        Assert.True(Path.GetInvalidPathChars().Length > 0);
+    }
+
+    [Fact]
+    public static void GetInvalidFileNameChars()
+    {
+        Assert.NotNull(Path.GetInvalidFileNameChars());
+        Assert.NotSame(Path.GetInvalidFileNameChars(), Path.GetInvalidFileNameChars());
+        Assert.Equal((IEnumerable<char>)Path.GetInvalidFileNameChars(), (IEnumerable<char>)Path.GetInvalidFileNameChars());
+        Assert.True(Path.GetInvalidFileNameChars().Length > 0);
+    }
+
+    [Fact]
+    public static void GetTempPath()
+    {
+        string tmpPath = Path.GetTempPath();
+        Assert.False(string.IsNullOrEmpty(tmpPath));
+        Assert.Equal(tmpPath, Path.GetTempPath());
+        Assert.Equal(Path.DirectorySeparatorChar, tmpPath[tmpPath.Length - 1]);
+        Assert.True(Directory.Exists(tmpPath));
+    }
+
+    [Fact]
+    public static void GetTempFileName()
+    {
+        string tmpFile = Path.GetTempFileName();
+        try
+        {
+            Assert.True(File.Exists(tmpFile));
+            Assert.Equal(".tmp", Path.GetExtension(tmpFile), ignoreCase: true);
+            using (FileStream fs = File.OpenRead(tmpFile))
+                Assert.Equal(0, fs.Length);
+            Assert.Equal(Path.Combine(Path.GetTempPath(), Path.GetFileName(tmpFile)), tmpFile);
+        }
+        finally
+        {
+            File.Delete(tmpFile);
+        }
+    }
+
+    [Fact]
+    public static void GetFullPath()
+    {
+        Assert.Throws<ArgumentNullException>(() => Path.GetFullPath(null));
+
+        string curDir = Directory.GetCurrentDirectory();
+        Assert.Equal(curDir, Path.GetFullPath(Path.Combine(curDir, ".", ".", ".", ".", ".")));
+        Assert.Equal(curDir, Path.GetFullPath(curDir + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar + "."));
+        Assert.Equal(curDir, Path.GetFullPath(Path.Combine(curDir, "..", Path.GetFileName(curDir), ".", "..", Path.GetFileName(curDir))));
+    }
+
 }


### PR DESCRIPTION
Adding some more tests for System.IO.Path, in particular for its functions that access OS functionality.

(Also adding one more test case for Stopwatch, for one of its members that didn't have any coverage.)