### PR TITLE
Remove a few unnecessary dictionary lookups

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
@@ -124,12 +124,8 @@ namespace System.Collections.ObjectModel
 
             if (_dict != null)
             {
-                if (_dict.ContainsKey(key))
-                {
-                    return Remove(_dict[key]);
-                }
-
-                return false;
+                TItem item;
+                return _dict.TryGetValue(key, out item) && Remove(item);
             }
 
             if (key != null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ObjectToDataContractConverterHelper.cs
@@ -47,9 +47,10 @@ namespace System.Runtime.Serialization.Json
                 return dto.ToOffset(new TimeSpan(0, (int)deserialzedValue["OffsetMinutes"], 0));
             }
 
-            if (deserialzedValue.ContainsKey(JsonGlobals.ServerTypeString))
+            object serverTypeStringValue;
+            if (deserialzedValue.TryGetValue(JsonGlobals.ServerTypeString, out serverTypeStringValue))
             {
-                dataContract = ResolveDataContractFromTypeInformation(deserialzedValue[JsonGlobals.ServerTypeString].ToString(), dataContract, context);
+                dataContract = ResolveDataContractFromTypeInformation(serverTypeStringValue.ToString(), dataContract, context);
             }
 
             object o = CreateInstance(dataContract);
@@ -270,10 +271,11 @@ namespace System.Runtime.Serialization.Json
         {
             System.Diagnostics.Debug.Assert(obj is IDictionary, "obj is IDictionary");
             Dictionary<string, object> dictOfStringObject = obj as Dictionary<string, object>;
-            if (dictOfStringObject.ContainsKey(JsonGlobals.ServerTypeString))
+            object serverTypeStringValue;
+            if (dictOfStringObject.TryGetValue(JsonGlobals.ServerTypeString, out serverTypeStringValue))
             {
                 return ConvertDictionaryToClassDataContract(serializer,
-                    ResolveDataContractFromTypeInformation(dictOfStringObject[JsonGlobals.ServerTypeString].ToString(), null, context),
+                    ResolveDataContractFromTypeInformation(serverTypeStringValue.ToString(), null, context),
                     dictOfStringObject, context);
             }
             else if (dictOfStringObject.ContainsKey("DateTime") && dictOfStringObject.ContainsKey("OffsetMinutes"))


### PR DESCRIPTION
I was considering writing a Roslyn analyzer to look for unnecessary dictionary lookups, and searched across corefx for patterns like:
```
if (dict.ContainsKey(key))
    Use(dict[key]);
```
and
```
if (dict.ContainsKey(key))
    dict.Remove(key);
```
where there's an extra dictionary lookup that can be removed trivially. I only found a few such occurrences, not enough to warrant spending time on an analyzer at present.  But since fixing those I did find is quick and easy, this commit does so.