### PR TITLE
Add test for System.Threading ETW provider

### DIFF
--- a/src/System.Threading/tests/EtwTests.cs
+++ b/src/System.Threading/tests/EtwTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Threading;
+using Xunit;
+
+namespace Test
+{
+    public class EtwTests
+    {
+        [Fact]
+        public void TestEtw()
+        {
+            using (var listener = new TestEventListener("System.Threading.SynchronizationEventSource", EventLevel.Verbose))
+            {
+                const int BarrierPhaseFinishedId = 3;
+                const int ExpectedInvocations = 5;
+                int eventsRaised = 0;
+                int delegateInvocations = 0;
+                listener.RunWithCallback(ev => {
+                        Assert.Equal(expected: BarrierPhaseFinishedId, actual: ev.EventId);
+                        eventsRaised++;
+                    },
+                    () => {
+                        Barrier b = new Barrier(1, _ => delegateInvocations++);
+                        for (int i = 0; i < ExpectedInvocations; i++)
+                            b.SignalAndWait();
+                    });
+                Assert.Equal(ExpectedInvocations, delegateInvocations);
+                Assert.Equal(ExpectedInvocations, eventsRaised);
+            }
+        }
+    }
+}

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -6,6 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tests</AssemblyName>
+    <ProjectGuid>{33F5A50E-B823-4FDD-8571-365C909ACEAE}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -16,6 +17,7 @@
     <Compile Include="BarrierTests.cs" />
     <Compile Include="CountdownEventCancellationTests.cs" />
     <Compile Include="CountdownEventTests.cs" />
+    <Compile Include="EtwTests.cs" />
     <Compile Include="ManualResetEventSlimCancellationTests.cs" />
     <Compile Include="ManualResetEventSlimTests.cs" />
     <Compile Include="SemaphoreSlimCancellationTests.cs" />
@@ -23,6 +25,9 @@
     <Compile Include="SpinLockTests.cs" />
     <Compile Include="ThreadLocalTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -3,6 +3,7 @@
     "System.Collections": "4.0.0-beta-22809",
     "System.Console": "4.0.0-beta-22809",
     "System.Diagnostics.Debug": "4.0.0-beta-22809",
+    "System.Diagnostics.Tracing": "4.0.20-beta-22809",
     "System.Globalization": "4.0.10-beta-22809",
     "System.Reflection": "4.0.10-beta-22809",
     "System.Runtime": "4.0.20-beta-22809",


### PR DESCRIPTION
This adds a test for the synchronization ETW provider and one of its events.  The other two events are used by .NET Native.