### PR TITLE
Use Thread.Sleep in System.Threading's Helpers.Sleep on CoreCLR

### DIFF
--- a/src/System.Threading/src/System/Threading/Helpers.CoreCLR.cs
+++ b/src/System.Threading/src/System/Threading/Helpers.CoreCLR.cs
@@ -8,11 +8,9 @@ namespace System.Threading
     /// </summary>
     internal static class Helpers
     {
-        private static readonly WaitHandle s_sleepHandle = new System.Threading.ManualResetEvent(false);
-
-        internal static void Sleep(uint milliseconds)
+        internal static void Sleep(int milliseconds)
         {
-            s_sleepHandle.WaitOne((int)milliseconds);
+            Thread.Sleep(milliseconds);
         }
 
         internal static void Spin(int iterations)


### PR DESCRIPTION
Helpers.Sleep (used by ReaderWriterLockSlim) is currently coded to call WaitOne on a static WaitHandle as an approximation for Thread.Sleep.  This is a holdover from when Thread.Sleep was unavailable.  Now that it is available, it's better to simply use it, rather than constructing and caching a never-set ManualResetEvent purely for the purposes of waiting on it to put the thread to sleep.