### PR TITLE
Remove Progress from System.Threading, and add tests

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="System\Environment.GetEnvironmentVariable.cs" />
     <Compile Include="System\Environment.SetEnvironmentVariable.cs" />
     <Compile Include="System\Math.cs" />
+    <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
     <Compile Include="System\StringComparer.cs" />
     <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />

--- a/src/System.Runtime.Extensions/tests/System/Progress.cs
+++ b/src/System.Runtime.Extensions/tests/System/Progress.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class ProgressTests
+{
+    [Fact]
+    public void Ctor()
+    {
+        new Progress<int>();
+        new Progress<int>(i => { });
+        Assert.Throws<ArgumentNullException>(() => new Progress<int>(null));
+    }
+
+    [Fact]
+    public void NoWorkQueuedIfNoHandlers()
+    {
+        RunWithoutSyncCtx(() =>
+        {
+            var tsc = new TrackingSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(tsc);
+            Progress<int> p = new Progress<int>();
+            for (int i = 0; i < 3; i++)
+                ((IProgress<int>)p).Report(i);
+            Assert.Equal(0, tsc.Posts);
+            SynchronizationContext.SetSynchronizationContext(null);
+        });
+    }
+
+    [Fact]
+    public void TargetsCurrentSynchronizationContext()
+    {
+        RunWithoutSyncCtx(() =>
+        {
+            var tsc = new TrackingSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(tsc);
+            Progress<int> p = new Progress<int>(i => { });
+            for (int i = 0; i < 3; i++)
+                ((IProgress<int>)p).Report(i);
+            Assert.Equal(3, tsc.Posts);
+            SynchronizationContext.SetSynchronizationContext(null);
+        });
+    }
+
+    [Fact]
+    public void EventRaisedWithActionHandler()
+    {
+        RunWithoutSyncCtx(() =>
+        {
+            Barrier b = new Barrier(2);
+            Progress<int> p = new Progress<int>(i =>
+            {
+                Assert.Equal(b.CurrentPhaseNumber, i);
+                b.SignalAndWait();
+            });
+            for (int i = 0; i < 3; i++)
+            {
+                ((IProgress<int>)p).Report(i);
+                b.SignalAndWait();
+            }
+        });
+    }
+
+    [Fact]
+    public void EventRaisedWithEventHandler()
+    {
+        RunWithoutSyncCtx(() =>
+        {
+            Barrier b = new Barrier(2);
+            Progress<int> p = new Progress<int>();
+            p.ProgressChanged += (s, i) =>
+            {
+                Assert.Same(s, p);
+                Assert.Equal(b.CurrentPhaseNumber, i);
+                b.SignalAndWait();
+            };
+            for (int i = 0; i < 3; i++)
+            {
+                ((IProgress<int>)p).Report(i);
+                b.SignalAndWait();
+            }
+        });
+    }
+
+    private static void RunWithoutSyncCtx(Action action)
+    {
+        Task.Run(action).GetAwaiter().GetResult();
+    }
+
+    private sealed class TrackingSynchronizationContext : SynchronizationContext
+    {
+        internal int Posts = 0;
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            Posts++;
+            base.Post(d, state);
+        }
+    }
+
+}

--- a/src/System.Threading/src/System.Threading.CoreCLR.csproj
+++ b/src/System.Threading/src/System.Threading.CoreCLR.csproj
@@ -22,13 +22,10 @@
   <ItemGroup>
     <Compile Include="System\Threading\Semaphore.cs" />
     <Compile Include="System\Threading\Helpers.CoreCLR.cs" />
-    <Compile Include="System\Collections\Concurrent\LowLevelConcurrentQueue.cs" />
-    <Compile Include="System\Progress.cs" />
     <Compile Include="System\Threading\Barrier.cs" />
     <Compile Include="System\Threading\CDSsyncETWBCLProvider.cs" />
     <Compile Include="System\Threading\CountdownEvent.cs" />
     <Compile Include="System\Threading\ReaderWriterLockSlim.cs" />
-    <Compile Include="System\Threading\TimeoutHelper.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Threading\Semaphore.Windows.cs" />


### PR DESCRIPTION
I started out trying to increase the code coverage for System.Threading, starting with Progress<T>.  While all of my tests ran successfully, the results didn't show up in code coverage at all for the Progress.cs file.  This led me to realize that, although we're compiling Progress.cs as a public type into System.Threading.dll, it's actually exposed from the System.Runtime.Extensions.dll contract, where the facade just type forwards it to the implementation in mscorlib.

I've removed Progress.cs from the .csproj, and since I'd already written tests, I moved those over to the System.Runtime.Extensions tests project.

I've also removed from the .csproj a few others that aren't being used, but I've left the all of these files in the repo as they're being used by the .NET Native implementation.  We'll reorganize separately.