### PR TITLE
Add tests for Semaphore

### DIFF
--- a/src/System.Threading/tests/BarrierTests.cs
+++ b/src/System.Threading/tests/BarrierTests.cs
@@ -161,6 +161,30 @@ namespace Test
             RunBarrierTest4_AddParticipants(100, int.MaxValue, typeof(ArgumentOutOfRangeException));
         }
 
+        [Fact]
+        public static void TooManyParticipants()
+        {
+            Barrier b = new Barrier(Int16.MaxValue);
+            Assert.Throws<InvalidOperationException>(() => b.AddParticipant());
+        }
+
+        [Fact]
+        public static void RemovingParticipants()
+        {
+            Barrier b;
+
+            b = new Barrier(1);
+            b.RemoveParticipant();
+            Assert.Throws<ArgumentOutOfRangeException>(() => b.RemoveParticipant());
+
+            b = new Barrier(1);
+            b.RemoveParticipants(1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => b.RemoveParticipants(1));
+
+            b = new Barrier(1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => b.RemoveParticipants(2));
+        }
+
         /// <summary>
         /// Test AddParticipants
         /// </summary>
@@ -478,6 +502,20 @@ namespace Test
                     Assert.True(false, string.Format("RunBarrierTest10c:  Error: Only finished {0} iterations, before an exception was thrown.", j));
                 }
             }
+        }
+
+        [Fact]
+        public static void PostPhaseException()
+        {
+            Exception exc = new Exception("inner");
+
+            Assert.NotNull(new BarrierPostPhaseException().Message);
+            Assert.NotNull(new BarrierPostPhaseException((string)null).Message);
+            Assert.Equal("test", new BarrierPostPhaseException("test").Message);
+            Assert.NotNull(new BarrierPostPhaseException(exc).Message);
+            Assert.Same(exc, new BarrierPostPhaseException(exc).InnerException);
+            Assert.Equal("test", new BarrierPostPhaseException("test", exc).Message);
+            Assert.Same(exc, new BarrierPostPhaseException("test", exc).InnerException);
         }
 
         #region Helper Methods

--- a/src/System.Threading/tests/SemaphoreTests.cs
+++ b/src/System.Threading/tests/SemaphoreTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace Test
+{
+    public class SemaphoreTests
+    {
+        [Fact]
+        public void Ctor()
+        {
+            new Semaphore(0, 1).Dispose();
+            new Semaphore(1, 1).Dispose();
+            new Semaphore(1, 2).Dispose();
+            new Semaphore(Int32.MaxValue, Int32.MaxValue).Dispose();
+            new Semaphore(1, 1, null).Dispose();
+
+            new Semaphore(0, 1, "SemaphoreTestsName").Dispose();
+
+            bool createdNew;
+            new Semaphore(0, 1, "SemaphoreTestsName", out createdNew).Dispose();
+            Assert.True(createdNew);
+
+            Assert.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-2, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("maximumCount", () => new Semaphore(0, 0));
+            Assert.Throws<ArgumentException>(() => new Semaphore(2, 1));
+
+            Assert.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-1, 1, null));
+            Assert.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-2, 1, null));
+            Assert.Throws<ArgumentOutOfRangeException>("maximumCount", () => new Semaphore(0, 0, null));
+            Assert.Throws<ArgumentException>(() => new Semaphore(2, 1, null));
+            Assert.Throws<ArgumentException>(() => new Semaphore(0, 1, new string('a', 10000)));
+
+            Assert.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-1, 1, "CtorSemaphoreTest", out createdNew));
+            Assert.Throws<ArgumentOutOfRangeException>("initialCount", () => new Semaphore(-2, 1, "CtorSemaphoreTest", out createdNew));
+            Assert.Throws<ArgumentOutOfRangeException>("maximumCount", () => new Semaphore(0, 0, "CtorSemaphoreTest", out createdNew));
+            Assert.Throws<ArgumentException>(() => new Semaphore(2, 1, "CtorSemaphoreTest", out createdNew));
+            Assert.Throws<ArgumentException>(() => new Semaphore(0, 1, new string('a', 10000)));
+            Assert.Throws<ArgumentException>(() => new Semaphore(0, 1, new string('a', 10000), out createdNew));
+        }
+
+        [Fact]
+        public void CanWaitWithoutBlockingUntilNoCount()
+        {
+            const int InitialCount = 5;
+            using (Semaphore s = new Semaphore(InitialCount, InitialCount))
+            {
+                for (int i = 0; i < InitialCount; i++)
+                    Assert.True(s.WaitOne(0));
+                Assert.False(s.WaitOne(0));
+            }
+        }
+
+        [Fact]
+        public void CanWaitWithoutBlockingForReleasedCount()
+        {
+            using (Semaphore s = new Semaphore(0, Int32.MaxValue))
+            {
+                for (int counts = 1; counts < 5; counts++)
+                {
+                    Assert.False(s.WaitOne(0));
+
+                    if (counts % 2 == 0)
+                    {
+                        for (int i = 0; i < counts; i++)
+                            s.Release();
+                    }
+                    else
+                    {
+                        s.Release(counts);
+                    }
+
+                    for (int i = 0; i < counts; i++)
+                    {
+                        Assert.True(s.WaitOne(0));
+                    }
+
+                    Assert.False(s.WaitOne(0));
+                }
+            }
+        }
+
+        [Fact]
+        public void Release()
+        {
+            using (Semaphore s = new Semaphore(1, 1))
+            {
+                Assert.Throws<SemaphoreFullException>(() => s.Release());
+            }
+
+            using (Semaphore s = new Semaphore(0, 10))
+            {
+                Assert.Throws<SemaphoreFullException>(() => s.Release(11));
+                Assert.Throws<ArgumentOutOfRangeException>("releaseCount", () => s.Release(-1));
+            }
+
+            using (Semaphore s = new Semaphore(0, 10))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    Assert.Equal(i, s.Release());
+                }
+            }
+        }
+
+        [Fact]
+        public void AnonymousProducerConsumer()
+        {
+            using (Semaphore s = new Semaphore(0, Int32.MaxValue))
+            {
+                const int NumItems = 5;
+                Task.WaitAll(
+                    Task.Factory.StartNew(() =>
+                    {
+                        for (int i = 0; i < NumItems; i++)
+                            s.WaitOne();
+                        Assert.False(s.WaitOne(0));
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
+                    Task.Factory.StartNew(() =>
+                    {
+                        for (int i = 0; i < NumItems; i++)
+                            s.Release();
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
+        }
+        }
+
+        [Fact]
+        public void NamedProducerConsumer()
+        {
+            const string Name = "NamedProducerConsumerSemaphoreTest";
+            const int NumItems = 5;
+            Task.WaitAll(
+                Task.Factory.StartNew(() =>
+                {
+                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, Name))
+                    {
+                        for (int i = 0; i < NumItems; i++)
+                            s.WaitOne();
+                        Assert.False(s.WaitOne(0));
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
+                Task.Factory.StartNew(() =>
+                {
+                    using (Semaphore s = new Semaphore(0, Int32.MaxValue, Name))
+                    {
+                        for (int i = 0; i < NumItems; i++)
+                            s.Release();
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
+        }
+
+        [Fact]
+        public void OpenExisting()
+        {
+            const string Name = "OpenExistingSemaphoreTestName";
+            Semaphore ignored;
+
+            Assert.Throws<ArgumentNullException>("name", () => Semaphore.OpenExisting(null));
+            Assert.Throws<ArgumentException>(() => Semaphore.OpenExisting(string.Empty));
+            Assert.Throws<WaitHandleCannotBeOpenedException>(() => Semaphore.OpenExisting(Name));
+            Assert.Throws<ArgumentException>(() => Semaphore.OpenExisting(new string('a', 10000)));
+            Assert.False(Semaphore.TryOpenExisting(Name, out ignored));
+
+            using (Mutex mtx = new Mutex(true, Name))
+            {
+                Assert.Throws<WaitHandleCannotBeOpenedException>(() => Semaphore.OpenExisting(Name));
+                Assert.False(Semaphore.TryOpenExisting(Name, out ignored));
+            }
+
+            bool createdNew;
+            using (Semaphore s1 = new Semaphore(0, Int32.MaxValue, Name, out createdNew))
+            {
+                Assert.True(createdNew);
+
+                using (Semaphore s2 = Semaphore.OpenExisting(Name))
+                {
+                    Assert.False(s1.WaitOne(0));
+                    Assert.False(s2.WaitOne(0));
+                    s1.Release();
+                    Assert.True(s2.WaitOne(0));
+                    Assert.False(s2.WaitOne(0));
+                    s2.Release();
+                    Assert.True(s1.WaitOne(0));
+                    Assert.False(s1.WaitOne(0));
+                }
+
+                Semaphore s3;
+                Assert.True(Semaphore.TryOpenExisting(Name, out s3));
+                using (s3)
+                {
+                    Assert.False(s1.WaitOne(0));
+                    Assert.False(s3.WaitOne(0));
+                    s1.Release();
+                    Assert.True(s3.WaitOne(0));
+                    Assert.False(s3.WaitOne(0));
+                    s3.Release();
+                    Assert.True(s1.WaitOne(0));
+                    Assert.False(s1.WaitOne(0));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Threading/tests/SpinLockTests.cs
+++ b/src/System.Threading/tests/SpinLockTests.cs
@@ -14,6 +14,34 @@ namespace Test
     /// </summary>
     public class SpinLockTests
     {
+        [Fact]
+        public static void EnterExit()
+        {
+            var sl = new SpinLock();
+            Assert.True(sl.IsThreadOwnerTrackingEnabled);
+
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.False(sl.IsHeld);
+                Assert.False(sl.IsHeldByCurrentThread);
+
+                bool lockTaken = false;
+                if (i % 2 == 0)
+                    sl.Enter(ref lockTaken);
+                else
+                    sl.TryEnter(ref lockTaken);
+                Assert.True(lockTaken);
+                Assert.True(sl.IsHeld);
+                Assert.True(sl.IsHeldByCurrentThread);
+                Task.Factory.StartNew(() =>
+                {
+                    Assert.True(sl.IsHeld);
+                    Assert.False(sl.IsHeldByCurrentThread);
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).GetAwaiter().GetResult();
+                sl.Exit();
+            }
+        }
+
         /// <summary>
         /// Run all SpinLock tests
         /// </summary>

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -6,6 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tests</AssemblyName>
+    <ProjectGuid>{33F5A50E-B823-4FDD-8571-365C909ACEAE}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -20,6 +21,7 @@
     <Compile Include="ManualResetEventSlimTests.cs" />
     <Compile Include="SemaphoreSlimCancellationTests.cs" />
     <Compile Include="SemaphoreSlimTests.cs" />
+    <Compile Include="SemaphoreTests.cs" />
     <Compile Include="SpinLockTests.cs" />
     <Compile Include="ThreadLocalTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />


### PR DESCRIPTION
We have some platform-specific code in Semaphore, but no tests for it.  This adds a bunch of Semaphore tests (plus a few additional ones for Barrier and SpinLock).