### PR TITLE
Fix IImmutableList documentation issue

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -78,7 +78,7 @@ namespace System.Collections.Immutable
         /// Adds the specified value to this list.
         /// </summary>
         /// <param name="value">The value to add.</param>
-        /// <returns>A new list with the element added, or this list if the element is already in this list.</returns>
+        /// <returns>A new list with the element added.</returns>
         [Pure]
         IImmutableList<T> Add(T value);
 


### PR DESCRIPTION
Remove incorrect part of description for IImmutableList.Add

The documentation for IImmutableList.Add incorrectly stated that the method would return the current list if the item being added is already present in the list. This is not correct for an IImmutableList (but would be correct for an ImmutableSet). The implementation of this method in ImmutableList<T>.Add is correct, and in fact has a contract that ensures the resulting list has an additional element added.