### PR TITLE
Add nuget/myget version badges to library components

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,206 +45,86 @@ Want to chat with other members of the CoreFX community?
 
 ## .NET Core Library Components
 
-The repo contains the following components. More libraries are coming soon. ['Watch'](https://github.com/dotnet/corefx/subscription) the repo to be notified.
-
-* **System.Collections**. Provides classes that define generic collections, which allow developers to create 
-  strongly-typed collections.
-
-* **System.Collections.Concurrent**.  Provides a set of thread-safe collection types, instances of which may be used 
-  concurrently from multiple threads.
-
-* **System.Collections.Immutable**. Provides a set of immutable collection types that make it easy to keep
-  mutable state under control without sacrificing performance or memory
-  footprint. You can read more about them on [MSDN][immutable-msdn].
-
-* **System.Collections.NonGeneric**.  Provides classes that define various collections of objects, such as ArrayList, 
-  Hashtable, SortedList, Stack, and Queue. These collections exist in .NET Core primarily for backwards compatibility
-  and generally should be avoided when writing new code.
-
-* **System.Collections.Specialized**. Provides classes that define specialized collections of objects, for example, 
-  a linked list dictionary, a bit vector, and collections that contain only strings. These collections exist in 
-  .NET Core primarily for backwards compatibility and generally should be avoided when writing new code.
-
-* **System.ComponentModel**. Provides interfaces for the editing and change tracking of objects used as data sources.
-
-* **System.ComponentModel.Annotations**. Provides attributes that are used to define metadata for objects used as data sources.
-
-* **System.ComponentModel.EventBasedAsync**. Provides support classes and delegates for the event-based asynchronous pattern. 
-  This pattern and these supporting types exist in .NET Core primarily for backwards compatibility and generally should be
-  avoided when writing new code.
-  
-* **System.ComponentModel.Primitives**. Provides interfaces that are used to implement the run-time and design-time behavior 
-  of components.
-
-* **System.ComponentModel.TypeConverter**. Provides the System.ComponentModel.TypeConverter class, which represents a unified 
-  way of converting types of values to other types.
-
-* **System.Console**. Provides the Console class, which enables access to the standard input,
-  output, and error streams for console-based applications.
-
-* **System.Diagnostics.Contracts**. Provides types and methods for representing program contracts such as preconditions, 
-  postconditions, and invariants.
-
-* **System.Diagnostics.Debug**. Provides a class to interact with the debugger as well as methods for performing runtime assertions.
-
-* **System.Diagnostics.FileVersionInfo**. Provides useful functionality for querying
-  and examining the version information of physical files on disk.
-
-* **System.Diagnostics.Process**. Provides access to local and remote processes, and enables the starting and
-  stopping of local system processes.
-
-* **System.Diagnostics.TextWriterTraceListener**. Provides trace listeners for directing tracing output to a text writer, 
-  such as System.IO.StreamWriter.
-
-* **System.Diagnostics.Tools**. Provides attributes, such as GeneratedCodeAttribute, that are emitted or consumed by 
-  analysis tools.
-
-* **System.Diagnostics.TraceSource**. Provides classes that help you trace the execution of your code.
-
-* **System.Dynamic.Runtime**. Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
-
-* **System.Globalization.Extensions**. Provides classes for performing unicode string normalization, culture-specific string 
-  comparisons and support the use of non-ASCII characters for Internet domain names.
-
-* **System.IO**. Provides base input and output (I/O) types that enable reading and writing data streams
-
-* **System.IO.Compression**. Provides classes that support the compression and decompression of streams.
-
-* **System.IO.Compression.ZipFile**. Provides static methods for creating and using Zip files.
-
-* **System.IO.FileSystem**. Provides access to the file system, including support for enumerating and manipulating 
-  file system objects and for reading and writing files via streams.
-
-* **System.IO.FileSystem.DriveInfo**. Provides the System.IO.DriveInfo class, which enables developers to query 
-  local drive information.
-
-* **System.IO.FileSystem.Primitives**. Provides common enumerations and exceptions for path-based I/O libraries.
-
-* **System.IO.FileSystem.Watcher**. Provides the System.IO.Watcher class, which listens to the system directory change 
-  notifications and raises events when a directory or file within a directory changes.
-
-* **System.IO.MemoryMappedFiles**. Provides access to memory-mapped files, enabling code to read and write files by
-  reading and writing memory.
-
-* **System.IO.Pipes**. Provides types that enable a means for interprocess communication through anonymous 
-  and/or named pipes.
-
-* **System.IO.UnmanagedMemoryStream**. Provides a stream for accessing unmanaged memory as represented by a pointer, 
-  as well as an accessor for reading and writing primitive types from unmanaged memory.
-
-* **System.Linq**. Provides the foundation of Language-Integrated Query (LINQ), including LINQ standard query operators 
-  that operate on objects that implement ```IEnumerable<T>```.
-
-* **System.Linq.Expressions**. Provides classes, interfaces, and enumerations that enable language-level code expressions
-  to be represented as objects in the form of expression trees.
-
-* **System.Linq.Parallel**.  Provides a parallelized implementation of LINQ to Objects. "Parallel LINQ" (PLINQ) 
-  implements the full set of LINQ standard query operators as well as additional operators specific to parallel operations.
-
-* **System.Linq.Queryable**. Provides LINQ standard query operators that operate on objects that implement ```IQueryable<T>```.
-
-* **System.Net.Http**. Provides a programming interface for modern HTTP applications. This includes HTTP client components that allow applications to consume modern web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers, for example. This provides a consistent programming model on both the client and the server side for modern web services over HTTP.
-
-* **System.Numerics.Vectors**. Provides a set of basic vector types that leverage single instruction, 
-  multiple data (SIMD) CPU instructions. See our [recent][simd-post-1] [announcements][simd-post-2] for more details.
-
-* **System.ObjectModel**. Provides types and interfaces that enable the creation of observable types that provide
-  notifications to clients when changes are made.
-
-* **System.Reflection.DispatchProxy**. Provides a mechanism for dynamically creating proxy types that implement a 
-  specified interface and derive from a specified DispatchProxy type.
-
-* **System.Reflection.Metadata**. Provides a highly-tuned, low-level ECMA-335 metadata reader.  This is the same
-  reader used by "[Roslyn]" C# and Visual Basic compilers to parse assemblies.
-
-* **System.Reflection.TypeExtensions**. Provides extension methods for types in the System.Reflection namespace.
-  These extensions are designed to be source-compatible with older reflection-based APIs.
-
-* **System.Resources.ReaderWriter**. Provides classes for reading and writing resources in the system-default format.
-
-* **System.Runtime**. Provides the fundamental primitives, classes, and base classes that define commonly-used value 
-  and reference data types, events and event handlers, interfaces, attributes, and exceptions.
-
-* **System.Runtime.Environment**. Provides types that expose information about the runtime and operating system
-  environment in which code is executing.
-
-* **System.Runtime.Extensions**. Provides commonly-used classes for performing mathematical functions, conversions, 
-  string comparisons, and querying environment information
-
-* **System.Runtime.Handles**. Provides base classes, including CriticalHandle and SafeHandle, for types that 
-  represent operating system handles.
-
-* **System.Runtime.InteropServices**. Provides types that support platform invoke (P/Invoke) and COM interop.
-
-* **System.Runtime.Numerics**. Provides two useful numeric structures, BigInteger and Complex.
-
-* **System.Runtime.Serialization.Json**. Provides classes for serializing objects to the JavaScript Object 
-  Notation (JSON) and for deserializing JSON data to objects.
-
-* **System.Runtime.Serialization.Primitives**. Provides common types, including System.Runtime.Serialization.DataContractAttribute, 
-  for libraries that support data contract serialization.
-
-* **System.Runtime.Serialization.Xml**. Provides classes for serializing objects to the Extensible Markup Language (XML) 
-  and deserializing XML data to objects.
-
-* **System.Security.Principal**. Provides the base interfaces for principal and identity objects that represent the 
-  security context under which code is running.
-
-* **System.Security.Principal.Windows**. Provides classes for retrieving the current Windows user and for interacting 
-  with Windows users and groups.
-
-* **System.Security.SecureString**. Provides support for accessing and modifying text that should be kept confidential.
-
-* **System.ServiceProcess.ServiceController**. Provides the ServiceController class that represents a Windows service
-  and allows you to connect to a running or stopped service, manipulate it, or get information about it.
-
-* **System.Text.Encoding.CodePages**. Provides the ability to access existing encoding types for string manipulation 
-  across common cultural standards, as well as support to create custom Encoding Providers.
-
-* **System.Text.Encodings.Web**.  Provides support for encodings related to HTML, JavaScript, and URLs.
-
-* **System.Text.RegularExpressions**. Provides a regular expression engine. The types in this library provide useful 
-  functionality for running common operations using regular expressions.
-
-* **System.Threading**. Provides synchronization primitives used when writing multi-threaded and asynchronous code. 
-
-* **System.Threading.Tasks**. Provides types that simplify the work of writing concurrent and asynchronous code.
-
-* **System.Threading.Tasks.Dataflow**.  Provides a set of types that support actor/agent-oriented designs through 
-  primitives for in-process message passing, dataflow, and pipelining.
-    
-* **System.Threading.Tasks.Parallel**.  Provides library-based data parallel replacements for common
-  operations such as for loops, for each loops, and execution of a set of statements.
-
-* **System.Xml.ReaderWriter**. Provides types for reading and writing streams of XML.
-
-* **System.Xml.XDocument**. Provides XML-related types for querying XML documents using LINQ.
-
-* **System.Xml.XmlDocument**.  Provides types for manipulating an XML Document Object Model (DOM).
-
-* **System.Xml.XmlSerializer**. Provides classes for serializing objects to XML and for deserializing XML data to objects.
-
-* **System.Xml.XPath**.  Provides classes that define a cursor model for navigating and editing XML information items 
-  as instances of the XQuery 1.0 and XPath 2.0 Data Model.
-
-* **System.Xml.XPath.XDocument**. Provides extension methods that add System.Xml.XPath support to the System.Xml.XDocument package.
-
-* **System.Xml.XPath.XmlDocument**. Provides extension methods that add System.Xml.XPath support to the System.Xml.XmlDocument package.
-
-* **Microsoft.CSharp**. Provides support for compilation and code generation, including dynamic, using the C# language.
-
-* **Microsoft.VisualBasic**. Provides types that support the Visual Basic runtime.
-
-* **Microsoft.Win32.Primitives**. Provides common types supporting the implementation of Win32-based libraries.
-
-* **Microsoft.Win32.Registry**. Provides support for accessing and modifying the Windows Registry.
-
-* The overall list of items we currently plan to move onto GitHub is [here][typelist].
+The repo currently contains the source for the following components.
+More libraries are coming soon (the overall list of items we currently plan to move onto GitHub is [here][typelist]).
+['Watch'](https://github.com/dotnet/corefx/subscription) the repo to be notified.
+
+|Component|Description|
+|---------|-----------|
+|**System.Collections**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Collections.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes that define generic collections, which allow developers to create strongly-typed collections.</sub>|
+|**System.Collections.Concurrent**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Collections.Concurrent.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides a set of thread-safe collection types, instances of which may be used concurrently from multiple threads.</sub>|
+|**System.Collections.Immutable**<br/>[![MyGet Package](https://img.shields.io/nuget/vpre/System.Collections.Immutable.svg)](http://www.nuget.org/packages/System.Collections.Immutable/)|<sub>Provides a set of immutable collection types that are safe to use concurrently.</sub>|
+|**System.Collections.NonGeneric**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Collections.NonGeneric.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes that define various collections of objects, such as ArrayList and Hashtable. _These collections exist in .NET Core primarily for backwards compatibility and generally should be avoided when writing new code_.</sub>|
+|**System.Collections.Specialized**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Collections.Specialized.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes that define specialized collections of objects, for example, a linked list dictionary and collections that contain only strings. _These collections exist in .NET Core primarily for backwards compatibility and generally should be avoided when writing new code_.</sub>|
+|**System.ComponentModel**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ComponentModel.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides interfaces for the editing and change tracking of objects used as data sources.</sub>|
+|**System.ComponentModel.Annotations**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ComponentModel.Annotations.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides attributes that are used to define metadata for objects used as data sources.</sub>|
+|**System.ComponentModel.EventBasedAsync**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ComponentModel.EventBasedAsync.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides support classes and delegates for the event-based asynchronous pattern. _This pattern and these supporting types exist in .NET Core primarily for backwards compatibility and generally should be avoided when writing new code_.</sub>|
+|**System.ComponentModel.Primitives**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ComponentModel.Primitives.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides interfaces that are used to implement the run-time and design-time behavior of components.</sub>|
+|**System.ComponentModel.TypeConverter**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ComponentModel.TypeConverter.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the System.ComponentModel.TypeConverter class, which represents a unified way of converting types of values to other types.</sub>|
+|**System.Console**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Console.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the Console class, which enables access to the standard input, output, and error streams for console-based applications.</sub>|
+|**System.Diagnostics.Contracts**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.Contracts.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types and methods for representing program contracts such as preconditions, postconditions, and invariants.</sub>|
+|**System.Diagnostics.Debug**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.Debug.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides a class to interact with the debugger as well as methods for performing runtime assertions.</sub>|
+|**System.Diagnostics.FileVersionInfo**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.FileVersionInfo.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides useful functionality for querying and examining the version information of physical files on disk.</sub>|
+|**System.Diagnostics.Process**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.Process.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides access to local and remote processes, and enables the starting and stopping of local system processes.</sub>|
+|**System.Diagnostics.TextWriterTraceListener**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.TextWriterTraceListener.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides trace listeners for directing tracing output to a text writer, such as System.IO.StreamWriter.</sub>|
+|**System.Diagnostics.Tools**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.Tools.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides attributes, such as GeneratedCodeAttribute, that are emitted or consumed by analysis tools.</sub>|
+|**System.Diagnostics.TraceSource**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Diagnostics.TraceSource.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes that help you trace the execution of your code.</sub>|
+|**System.Dynamic.Runtime**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Dynamic.Runtime.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes and interfaces that support the Dynamic Language Runtime (DLR).</sub>|
+|**System.Globalization.Extensions**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Globalization.Extensions.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes for performing unicode string normalization, culture-specific string comparisons and support the use of non-ASCII characters for Internet domain names.</sub>|
+|**System.IO**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides base input and output (I/O) types that enable reading and writing data streams.</sub>|
+|**System.IO.Compression**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.Compression.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes that support the compression and decompression of streams.</sub>|
+|**System.IO.Compression.ZipFile**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.Compression.ZipFile.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides static methods for creating and using Zip files.</sub>|
+|**System.IO.FileSystem**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.FileSystem.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides access to the file system, including support for enumerating and manipulating file system objects and for reading and writing files via streams.</sub>|
+|**System.IO.FileSystem.DriveInfo**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.FileSystem.DriveInfo.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the System.IO.DriveInfo class, which enables developers to query local drive information.</sub>|
+|**System.IO.FileSystem.Primitives**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.FileSystem.Primitives.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides common enumerations and exceptions for path-based I/O libraries.</sub>|
+|**System.IO.FileSystem.Watcher**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.FileSystem.Watcher.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the System.IO.Watcher class, which listens to the system directory change notifications and raises events when a directory or file within a directory changes.</sub>|
+|**System.IO.MemoryMappedFiles**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.MemoryMappedFiles.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides access to memory-mapped files, enabling code to read and write files by reading and writing memory.</sub>|
+|**System.IO.Pipes**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.Pipes.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types that enable a means for interprocess communication through anonymous and/or named pipes.</sub>|
+|**System.IO.UnmanagedMemoryStream**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.IO.UnmanagedMemoryStream.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides a stream for accessing unmanaged memory as represented by a pointer, as well as an accessor for reading and writing primitive types from unmanaged memory.</sub>|
+|**System.Linq**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Linq.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the foundation of Language-Integrated Query (LINQ), including LINQ standard query operators that operate on objects that implement ```IEnumerable<T>```.</sub>|
+|**System.Linq.Expressions**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Linq.Expressions.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes, interfaces, and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.</sub>|
+|**System.Linq.Parallel**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Linq.Parallel.svg)](https://www.myget.org/gallery/dotnet-core)|<sub> Provides a parallelized implementation of LINQ to Objects. "Parallel LINQ" (PLINQ) implements the full set of LINQ standard query operators as well as additional operators specific to parallel operations.</sub>|
+|**System.Linq.Queryable**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Linq.Queryable.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides LINQ standard query operators that operate on objects that implement ```IQueryable<T>```.</sub>|
+|**System.Net.Http**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Net.Http.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.</sub>|
+|**System.Numerics.Vectors**<br/>[![MyGet Package](https://img.shields.io/nuget/vpre/System.Numerics.Vectors.svg)](http://www.nuget.org/packages/System.Numerics.Vectors/)|<sub>Provides a set of basic vector types that leverage single instruction, multiple data (SIMD) CPU instructions.</sub>|
+|**System.ObjectModel**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ObjectModel.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types and interfaces that enable the creation of observable types that provide notifications to clients when changes are made.</sub>|
+|**System.Reflection.DispatchProxy**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Reflection.DispatchProxy.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides a mechanism for dynamically creating proxy types that implement a specified interface and derive from a specified DispatchProxy type.</sub>|
+|**System.Reflection.Metadata**<br/>[![MyGet Package](https://img.shields.io/nuget/vpre/System.Reflection.Metadata.svg)](http://www.nuget.org/packages/System.Reflection.Metadata/)|<sub>Provides a highly-tuned, low-level ECMA-335 metadata reader.  This is the same reader used by "[Roslyn]" C# and Visual Basic compilers to parse assemblies.</sub>|
+|**System.Reflection.TypeExtensions**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Reflection.TypeExtensions.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides extension methods for types in the System.Reflection namespace. _These extensions are designed to be source-compatible with older reflection-based APIs_.</sub>|
+|**System.Resources.ReaderWriter**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Resources.ReaderWriter.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes for reading and writing resources in the system-default format.</sub>|
+|**System.Runtime**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the fundamental primitives, classes, and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions.</sub>|
+|**System.Runtime.Environment**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Environment.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types that expose information about the runtime and operating system environment in which code is executing.</sub>|
+|**System.Runtime.Extensions**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Extensions.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides commonly-used classes for performing mathematical functions, conversions, string comparisons, and querying environment information.</sub>|
+|**System.Runtime.Handles**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Handles.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides base classes, including CriticalHandle and SafeHandle, for types that represent operating system handles.</sub>|
+|**System.Runtime.InteropServices**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.InteropServices.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types that support platform invoke (P/Invoke) and COM interop.</sub>|
+|**System.Runtime.Numerics**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Numerics.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides two useful numeric structures, BigInteger and Complex.</sub>|
+|**System.Runtime.Serialization.Json**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Serialization.Json.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes for serializing objects to the JavaScript Object Notation (JSON) and for deserializing JSON data to objects.</sub>|
+|**System.Runtime.Serialization.Primitives**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Serialization.Primitives.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides common types, including System.Runtime.Serialization.DataContractAttribute, for libraries that support data contract serialization.</sub>|
+|**System.Runtime.Serialization.Xml**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Runtime.Serialization.Xml.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes for serializing objects to the Extensible Markup Language (XML) and deserializing XML data to objects.</sub>|
+|**System.Security.Principal**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Security.Principal.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the base interfaces for principal and identity objects that represent the security context under which code is running.</sub>|
+|**System.Security.Principal.Windows**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Security.Principal.Windows.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes for retrieving the current Windows user and for interacting with Windows users and groups.</sub>|
+|**System.Security.SecureString**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Security.SecureString.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides support for accessing and modifying text that should be kept confidential.</sub>|
+|**System.ServiceProcess.ServiceController**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.ServiceProcess.ServiceController.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the ServiceController class that represents a Windows service and allows you to connect to a running or stopped service, manipulate it, or get information about it.</sub>|
+|**System.Text.Encoding.CodePages**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Text.Encoding.CodePages.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides the ability to access existing encoding types for string manipulation across common cultural standards, as well as support to create custom Encoding Providers.</sub>|
+|**System.Text.Encodings.Web**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Text.Encodings.Web.svg)](https://www.myget.org/gallery/dotnet-core)|<sub> Provides support for encodings related to HTML, JavaScript, and URLs.</sub>|
+|**System.Text.RegularExpressions**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Text.RegularExpressions.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides a regular expression engine. The types in this library provide useful functionality for running common operations using regular expressions.</sub>|
+|**System.Threading**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Threading.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides synchronization primitives used when writing multi-threaded and asynchronous code.</sub>|
+|**System.Threading.Tasks**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Threading.Tasks.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types that simplify the work of writing concurrent and asynchronous code.</sub>|
+|**System.Threading.Tasks.Dataflow**<br/>[![MyGet Package](https://img.shields.io/nuget/vpre/Microsoft.Tpl.Dataflow.svg)](http://www.nuget.org/packages/Microsoft.Tpl.Dataflow/)|<sub> Provides a set of types that support actor/agent-oriented designs through primitives for in-process message passing, dataflow, and pipelining.</sub>|
+|**System.Threading.Tasks.Parallel**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Threading.Tasks.Parallel.svg)](https://www.myget.org/gallery/dotnet-core)|<sub> Provides library-based data parallel replacements for common operations such as for loops, for each loops, and execution of a set of statements.</sub>|
+|**System.Xml.ReaderWriter**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.ReaderWriter.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types for reading and writing streams of XML.</sub>|
+|**System.Xml.XDocument**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.XDocument.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides XML-related types for querying XML documents using LINQ.</sub>|
+|**System.Xml.XmlDocument**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.XmlDocument.svg)](https://www.myget.org/gallery/dotnet-core)|<sub> Provides types for manipulating an XML Document Object Model (DOM).</sub>|
+|**System.Xml.XmlSerializer**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.XmlSerializer.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides classes for serializing objects to XML and for deserializing XML data to objects.</sub>|
+|**System.Xml.XPath**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.XPath.svg)](https://www.myget.org/gallery/dotnet-core)|<sub> Provides classes that define a cursor model for navigating and editing XML information items as instances of the XQuery 1.0 and XPath 2.0 Data Model.</sub>|
+|**System.Xml.XPath.XDocument**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.XPath.XDocument.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides extension methods that add System.Xml.XPath support to the System.Xml.XDocument package.</sub>|
+|**System.Xml.XPath.XmlDocument**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/System.Xml.XPath.XmlDocument.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides extension methods that add System.Xml.XPath support to the System.Xml.XmlDocument package.</sub>|
+|**Microsoft.CSharp**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/Microsoft.CSharp.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides support for compilation and code generation, including dynamic, using the C# language.</sub>|
+|**Microsoft.VisualBasic**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/Microsoft.VisualBasic.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides types that support the Visual Basic runtime.</sub>|
+|**Microsoft.Win32.Primitives**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/Microsoft.Win32.Primitives.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides common types supporting the implementation of Win32-based libraries.</sub>|
+|**Microsoft.Win32.Registry**<br/>[![MyGet Package](https://img.shields.io/myget/dotnet-core/v/Microsoft.Win32.Registry.svg)](https://www.myget.org/gallery/dotnet-core)|<sub>Provides support for accessing and modifying the Windows Registry.</sub>|
 
 [roslyn]: https://github.com/dotnet/roslyn
-[immutable-msdn]: http://msdn.microsoft.com/en-us/library/dn385366(v=vs.110).aspx
-[simd-post-1]: http://blogs.msdn.com/b/dotnet/archive/2014/04/07/the-jit-finally-proposed-jit-and-simd-are-getting-married.aspx
-[simd-post-2]: http://blogs.msdn.com/b/dotnet/archive/2014/05/13/update-to-simd-support.aspx
 [typelist]: https://github.com/dotnet/corefx-progress/blob/master/src-diff/README.md
 
 ## License


### PR DESCRIPTION
Experimenting with including badges for each library, highlighting the latest published dev version of the component and providing a link to where it can be downloaded.

"View" the README.md as rendered markdown to see all of the badges, courtesy of shields.io.  The majority of these are from the dotnet-core myget gallery; when components weren't available there, they were usually on NuGet.  The remaining few that show up as "invalid" don't yet have a published package, but as soon as they're published to myget, these badges will be updated automatically.