### PR TITLE
Update comments on Safe{File/Pipe}Handle.ReleaseHandle

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Win32.SafeHandles
         [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
-            // Close the handle. We do not want to throw here nor retry
-            // in the case of an EINTR error, so we simply check whether
-            // the call was successful or not.
+            // Close the handle. Although close is documented to potentially fail with EINTR, we never want
+            // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
+            // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
             int fd = (int)handle;
             Debug.Assert(fd >= 0);
             return Interop.libc.close(fd) == 0;

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
@@ -39,10 +39,12 @@ namespace Microsoft.Win32.SafeHandles
 
         protected override bool ReleaseHandle()
         {
-            // Close the handle. We do not want to throw here nor retry
-            // in the case of an EINTR error, so we simply check whether
-            // the call was successful or not.
-            return Interop.libc.close((int)handle) == 0;
+            // Close the handle. Although close is documented to potentially fail with EINTR, we never want
+            // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
+            // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
+            int fd = (int)handle;
+            Debug.Assert(fd >= 0);
+            return Interop.libc.close(fd) == 0;
         }
 
         public override bool IsInvalid


### PR DESCRIPTION
Add a better comment to indicate why we don't retry on an interrupted close syscall.

(And since I was changing this function anyway, I made SafePipeHandle's ReleaseHandle identical to that of SafeFileHandle, adding the same assert used by SafeFileHandle.ReleaseHandle.)

Fixes #1689