### PR TITLE
Removes some tests that are now bogus

### DIFF
--- a/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
@@ -71,17 +71,6 @@ namespace Microsoft.Framework.WebEncoders
             }
         }
 
-        [Fact]
-        public void Default_ReturnsSingletonInstance()
-        {
-            // Act
-            HtmlEncoder encoder1 = HtmlEncoder.Default;
-            HtmlEncoder encoder2 = HtmlEncoder.Default;
-
-            // Assert
-            Assert.Same(encoder1, encoder2);
-        }
-
         [Theory]
         [InlineData("<", "&lt;")]
         [InlineData(">", "&gt;")]

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -72,17 +72,6 @@ namespace Microsoft.Framework.WebEncoders
         }
 
         [Fact]
-        public void Default_ReturnsSingletonInstance()
-        {
-            // Act
-            JavaScriptStringEncoder encoder1 = JavaScriptStringEncoder.Default;
-            JavaScriptStringEncoder encoder2 = JavaScriptStringEncoder.Default;
-
-            // Assert
-            Assert.Same(encoder1, encoder2);
-        }
-
-        [Fact]
         public void JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple_Escaping() {
             // The following two calls could be simply InlineData to the Theory below
             // Unfortunatelly, the xUnit logger fails to escape the inputs when logging the test results,

--- a/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
@@ -76,17 +76,6 @@ namespace Microsoft.Framework.WebEncoders
         }
 
         [Fact]
-        public void Default_ReturnsSingletonInstance()
-        {
-            // Act
-            UrlEncoder encoder1 = UrlEncoder.Default;
-            UrlEncoder encoder2 = UrlEncoder.Default;
-
-            // Assert
-            Assert.Same(encoder1, encoder2);
-        }
-
-        [Fact]
         public void UrlEncode_AllRangesAllowed_StillEncodesForbiddenChars()
         {
             // Arrange


### PR DESCRIPTION
Last week I changed the implementation of encoders such that they now don't guarantee that their Default property always returns the same instance of the default encoder. Access to the property’s backing field used to be synchronized using memory berries; I now removed these synchronizations. This change was made to simplify code and improve performance of the common scenario: retrieving the default encoder, at the cost of having to create (and collect) more than one instance of the encoder in rare cases (once in a blue moon).
This change just remove tests that test behavior that we don’t guarantee anymore.