### PR TITLE
Fix System.Collections.Immutable.Tests on machines with VS 2015

### DIFF
--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -74,6 +74,7 @@
     <ProjectReference Include="..\src\System.Collections.Immutable.csproj">
       <Project>{1dd0ff15-6234-4bd6-850a-317f05479554}</Project>
       <Name>System.Collections.Immutable</Name>
+      <Private>true</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The tests were failing because ResolveAssemblyReferences was not copying
System.Collections.Immutable from the project reference.  RAR was finding
the assembly in the GAC and skipping it.  That is never really safe to do for
CoreCLR so we should look into whether or not we can disable this globally.
For now I am using the same fix as https://github.com/nguerrera/corefx/commit/2bc73d7450fd7f301df28c18f975babf27ef3164.  Fixes #1685