### PR TITLE
Add ReaderWriterLockSlim inner loop tests and fix Dispose bug

### DIFF
--- a/src/System.Threading/src/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/System.Threading/src/System/Threading/ReaderWriterLockSlim.cs
@@ -1105,11 +1105,8 @@ namespace System.Threading
 
         private void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && !_fDisposed)
             {
-                if (_fDisposed)
-                    throw new ObjectDisposedException(null);
-
                 if (WaitingReadCount > 0 || WaitingUpgradeCount > 0 || WaitingWriteCount > 0)
                     throw new SynchronizationLockException(SR.SynchronizationLockException_IncorrectDispose);
 

--- a/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -1,0 +1,385 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Test
+{
+    public static class ReaderWriterLockSlimTests
+    {
+        [Fact]
+        public static void Ctor()
+        {
+            ReaderWriterLockSlim rwls;
+
+            using (rwls = new ReaderWriterLockSlim())
+            {
+                Assert.Equal(LockRecursionPolicy.NoRecursion, rwls.RecursionPolicy);
+            }
+
+            using (rwls = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion))
+            {
+                Assert.Equal(LockRecursionPolicy.NoRecursion, rwls.RecursionPolicy);
+            }
+
+            using (rwls = new ReaderWriterLockSlim((LockRecursionPolicy)12345))
+            {
+                Assert.Equal(LockRecursionPolicy.NoRecursion, rwls.RecursionPolicy);
+            }
+
+            using (rwls = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion))
+            {
+                Assert.Equal(LockRecursionPolicy.SupportsRecursion, rwls.RecursionPolicy);
+            }
+        }
+
+        [Fact]
+        public static void Dispose()
+        {
+            ReaderWriterLockSlim rwls;
+
+            rwls = new ReaderWriterLockSlim();
+            rwls.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => rwls.TryEnterReadLock(0));
+            Assert.Throws<ObjectDisposedException>(() => rwls.TryEnterUpgradeableReadLock(0));
+            Assert.Throws<ObjectDisposedException>(() => rwls.TryEnterWriteLock(0));
+            rwls.Dispose();
+
+            for (int i = 0; i < 3; i++)
+            {
+                rwls = new ReaderWriterLockSlim();
+                switch (i)
+                {
+                    case 0: rwls.EnterReadLock(); break;
+                    case 1: rwls.EnterUpgradeableReadLock(); break;
+                    case 2: rwls.EnterWriteLock(); break;
+                }
+                Assert.Throws<SynchronizationLockException>(() => rwls.Dispose());
+            }
+        }
+
+        [Fact]
+        public static void EnterExit()
+        {
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                Assert.False(rwls.IsReadLockHeld);
+                rwls.EnterReadLock();
+                Assert.True(rwls.IsReadLockHeld);
+                rwls.ExitReadLock();
+                Assert.False(rwls.IsReadLockHeld);
+
+                Assert.False(rwls.IsUpgradeableReadLockHeld);
+                rwls.EnterUpgradeableReadLock();
+                Assert.True(rwls.IsUpgradeableReadLockHeld);
+                rwls.ExitUpgradeableReadLock();
+                Assert.False(rwls.IsUpgradeableReadLockHeld);
+
+                Assert.False(rwls.IsWriteLockHeld);
+                rwls.EnterWriteLock();
+                Assert.True(rwls.IsWriteLockHeld);
+                rwls.ExitWriteLock();
+                Assert.False(rwls.IsWriteLockHeld);
+
+                Assert.False(rwls.IsUpgradeableReadLockHeld);
+                rwls.EnterUpgradeableReadLock();
+                Assert.False(rwls.IsWriteLockHeld);
+                Assert.True(rwls.IsUpgradeableReadLockHeld);
+                rwls.EnterWriteLock();
+                Assert.True(rwls.IsWriteLockHeld);
+                rwls.ExitWriteLock();
+                Assert.False(rwls.IsWriteLockHeld);
+                Assert.True(rwls.IsUpgradeableReadLockHeld);
+                rwls.ExitUpgradeableReadLock();
+                Assert.False(rwls.IsUpgradeableReadLockHeld);
+
+                Assert.True(rwls.TryEnterReadLock(0));
+                rwls.ExitReadLock();
+
+                Assert.True(rwls.TryEnterReadLock(Timeout.InfiniteTimeSpan));
+                rwls.ExitReadLock();
+
+                Assert.True(rwls.TryEnterUpgradeableReadLock(0));
+                rwls.ExitUpgradeableReadLock();
+
+                Assert.True(rwls.TryEnterUpgradeableReadLock(Timeout.InfiniteTimeSpan));
+                rwls.ExitUpgradeableReadLock();
+
+                Assert.True(rwls.TryEnterWriteLock(0));
+                rwls.ExitWriteLock();
+
+                Assert.True(rwls.TryEnterWriteLock(Timeout.InfiniteTimeSpan));
+                rwls.ExitWriteLock();
+            }
+        }
+
+        [Fact]
+        public static void DeadlockAvoidance()
+        {
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                rwls.EnterReadLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterReadLock());
+                Assert.Throws<LockRecursionException>(() => rwls.EnterUpgradeableReadLock());
+                Assert.Throws<LockRecursionException>(() => rwls.EnterWriteLock());
+                rwls.ExitReadLock();
+
+                rwls.EnterUpgradeableReadLock();
+                rwls.EnterReadLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterReadLock());
+                rwls.ExitReadLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterUpgradeableReadLock());
+                rwls.EnterWriteLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterWriteLock());
+                rwls.ExitWriteLock();
+                rwls.ExitUpgradeableReadLock();
+
+                rwls.EnterWriteLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterReadLock());
+                Assert.Throws<LockRecursionException>(() => rwls.EnterUpgradeableReadLock());
+                Assert.Throws<LockRecursionException>(() => rwls.EnterWriteLock());
+                rwls.ExitWriteLock();
+            }
+
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion))
+            {
+                rwls.EnterReadLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterWriteLock());
+                rwls.EnterReadLock();
+                Assert.Throws<LockRecursionException>(() => rwls.EnterUpgradeableReadLock());
+                rwls.ExitReadLock();
+                rwls.ExitReadLock();
+
+                rwls.EnterUpgradeableReadLock();
+                rwls.EnterReadLock();
+                rwls.EnterUpgradeableReadLock();
+                rwls.ExitUpgradeableReadLock();
+                rwls.EnterReadLock();
+                rwls.ExitReadLock();
+                rwls.ExitReadLock();
+                rwls.EnterWriteLock();
+                rwls.EnterWriteLock();
+                rwls.ExitWriteLock();
+                rwls.ExitWriteLock();
+                rwls.ExitUpgradeableReadLock();
+
+                rwls.EnterWriteLock();
+                rwls.EnterReadLock();
+                rwls.ExitReadLock();
+                rwls.EnterUpgradeableReadLock();
+                rwls.ExitUpgradeableReadLock();
+                rwls.EnterWriteLock();
+                rwls.ExitWriteLock();
+                rwls.ExitWriteLock();
+            }
+        }
+
+        [Theory]
+        [InlineData(LockRecursionPolicy.NoRecursion)]
+        [InlineData(LockRecursionPolicy.SupportsRecursion)]
+        public static void InvalidExits(LockRecursionPolicy policy)
+        {
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim(policy))
+            {
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitReadLock());
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitUpgradeableReadLock());
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitWriteLock());
+
+                rwls.EnterReadLock();
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitUpgradeableReadLock());
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitWriteLock());
+                rwls.ExitReadLock();
+
+                rwls.EnterUpgradeableReadLock();
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitReadLock());
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitWriteLock());
+                rwls.ExitUpgradeableReadLock();
+
+                rwls.EnterWriteLock();
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitReadLock());
+                Assert.Throws<SynchronizationLockException>(() => rwls.ExitUpgradeableReadLock());
+                rwls.ExitWriteLock();
+
+                using (Barrier barrier = new Barrier(2))
+                {
+                    Task t = Task.Factory.StartNew(() =>
+                    {
+                        rwls.EnterWriteLock();
+                        barrier.SignalAndWait();
+                        barrier.SignalAndWait();
+                        rwls.ExitWriteLock();
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+                    barrier.SignalAndWait();
+                    Assert.Throws<SynchronizationLockException>(() => rwls.ExitWriteLock());
+                    barrier.SignalAndWait();
+
+                    t.GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        [Fact]
+        public static void InvalidTimeouts()
+        {
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => rwls.TryEnterReadLock(-2));
+                Assert.Throws<ArgumentOutOfRangeException>(() => rwls.TryEnterUpgradeableReadLock(-3));
+                Assert.Throws<ArgumentOutOfRangeException>(() => rwls.TryEnterWriteLock(-4));
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => rwls.TryEnterReadLock(TimeSpan.MaxValue));
+                Assert.Throws<ArgumentOutOfRangeException>(() => rwls.TryEnterUpgradeableReadLock(TimeSpan.MinValue));
+                Assert.Throws<ArgumentOutOfRangeException>(() => rwls.TryEnterWriteLock(TimeSpan.FromMilliseconds(-2)));
+            }
+        }
+
+        [Fact]
+        public static void WritersAreMutuallyExclusiveFromReaders()
+        {
+            using (Barrier barrier = new Barrier(2))
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                Task.WaitAll(
+                    Task.Run(() =>
+                    {
+                        rwls.EnterWriteLock();
+                        barrier.SignalAndWait();
+                        Assert.True(rwls.IsWriteLockHeld);
+                        barrier.SignalAndWait();
+                        rwls.ExitWriteLock();
+                    }),
+                    Task.Run(() =>
+                    {
+                        barrier.SignalAndWait();
+                        Assert.False(rwls.TryEnterReadLock(0));
+                        Assert.False(rwls.IsReadLockHeld);
+                        barrier.SignalAndWait();
+                    }));
+            }
+        }
+
+        [Fact]
+        public static void WritersAreMutuallyExclusiveFromWriters()
+        {
+            using (Barrier barrier = new Barrier(2))
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                Task.WaitAll(
+                    Task.Run(() =>
+                    {
+                        rwls.EnterWriteLock();
+                        barrier.SignalAndWait();
+                        Assert.True(rwls.IsWriteLockHeld);
+                        barrier.SignalAndWait();
+                        rwls.ExitWriteLock();
+                    }),
+                    Task.Run(() =>
+                    {
+                        barrier.SignalAndWait();
+                        Assert.False(rwls.TryEnterWriteLock(0));
+                        Assert.False(rwls.IsReadLockHeld);
+                        barrier.SignalAndWait();
+                    }));
+            }
+        }
+
+        [Fact]
+        public static void ReadersMayBeConcurrent()
+        {
+            using (Barrier barrier = new Barrier(2))
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                Assert.Equal(0, rwls.CurrentReadCount);
+                Task.WaitAll(
+                    Task.Run(() =>
+                    {
+                        rwls.EnterReadLock();
+                        barrier.SignalAndWait(); // 1
+                        Assert.True(rwls.IsReadLockHeld);
+                        barrier.SignalAndWait(); // 2
+                        Assert.Equal(2, rwls.CurrentReadCount);
+                        barrier.SignalAndWait(); // 3
+                        barrier.SignalAndWait(); // 4
+                        rwls.ExitReadLock();
+                    }),
+                    Task.Run(() =>
+                    {
+                        barrier.SignalAndWait(); // 1
+                        rwls.EnterReadLock();
+                        barrier.SignalAndWait(); // 2
+                        Assert.True(rwls.IsReadLockHeld);
+                        Assert.Equal(0, rwls.WaitingReadCount);
+                        barrier.SignalAndWait(); // 3
+                        rwls.ExitReadLock();
+                        barrier.SignalAndWait(); // 4
+                    }));
+                Assert.Equal(0, rwls.CurrentReadCount);
+            }
+        }
+
+        [Fact]
+        public static void WriterToWriterChain()
+        {
+            using (AutoResetEvent are = new AutoResetEvent(false))
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                rwls.EnterWriteLock();
+                Task t = Task.Factory.StartNew(() =>
+                {
+                    Assert.False(rwls.TryEnterWriteLock(10));
+                    Task.Run(() => are.Set()); // ideally this won't fire until we've called EnterWriteLock, but it's a benign race in that the test will succeed either way
+                    rwls.EnterWriteLock();
+                    rwls.ExitWriteLock();
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                are.WaitOne();
+                rwls.ExitWriteLock();
+                t.GetAwaiter().GetResult();
+            }
+        }
+
+        [Fact]
+        public static void WriterToReaderChain()
+        {
+            using (AutoResetEvent are = new AutoResetEvent(false))
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                rwls.EnterWriteLock();
+                Task t = Task.Factory.StartNew(() =>
+                {
+                    Assert.False(rwls.TryEnterReadLock(TimeSpan.FromMilliseconds(10)));
+                    Task.Run(() => are.Set()); // ideally this won't fire until we've called EnterReadLock, but it's a benign race in that the test will succeed either way
+                    rwls.EnterReadLock();
+                    rwls.ExitReadLock();
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                are.WaitOne();
+                rwls.ExitWriteLock();
+                t.GetAwaiter().GetResult();
+            }
+        }
+
+        [Fact]
+        public static void WriterToUpgradeableReaderChain()
+        {
+            using (AutoResetEvent are = new AutoResetEvent(false))
+            using (ReaderWriterLockSlim rwls = new ReaderWriterLockSlim())
+            {
+                rwls.EnterWriteLock();
+                Task t = Task.Factory.StartNew(() =>
+                {
+                    Assert.False(rwls.TryEnterUpgradeableReadLock(TimeSpan.FromMilliseconds(10)));
+                    Task.Run(() => are.Set()); // ideally this won't fire until we've called EnterReadLock, but it's a benign race in that the test will succeed either way
+                    rwls.EnterUpgradeableReadLock();
+                    rwls.ExitUpgradeableReadLock();
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                are.WaitOne();
+                rwls.ExitWriteLock();
+                t.GetAwaiter().GetResult();
+            }
+        }
+
+    }
+}

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -23,6 +23,7 @@
     <Compile Include="SemaphoreSlimCancellationTests.cs" />
     <Compile Include="SemaphoreSlimTests.cs" />
     <Compile Include="SpinLockTests.cs" />
+    <Compile Include="ReaderWriterLockSlimTests.cs" />
     <Compile Include="ThreadLocalTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">


### PR DESCRIPTION
Basic functionality tests for RWLS.  Does not attempt to do any kind of outer-loop stress or concurrency testing beyond very basic behavior.

The tests highlighted a bug where calling Dispose multiple times resulted in an ObjectDisposedException.  I've fixed it as part of this, too.