### PR TITLE
Small API cleanup

### DIFF
--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptStringEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptStringEncoder.cs
@@ -96,7 +96,7 @@ namespace System.Text.Encodings.Web
         // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
         // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
         [CLSCompliant(false)]
-        public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {
             if (buffer == null)
             {
@@ -109,15 +109,15 @@ namespace System.Text.Encodings.Web
             // be written out as numeric entities for defense-in-depth.
             // See UnicodeEncoderBase ctor comments for more info.
 
-            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\b') { return b.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\t') { return t.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\n') { return n.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\f') { return f.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\r') { return r.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '/') { return forward.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\\') { return back.TryCopyCharacters(buffer, length, out numberOfCharactersWritten); }
-            else { return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, length, out numberOfCharactersWritten); }
+            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\b') { return b.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\t') { return t.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\n') { return n.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\f') { return f.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\r') { return r.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '/') { return forward.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\\') { return back.TryCopyCharacters(buffer, bufferLength, out numberOfCharactersWritten); }
+            else { return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
         }
 
         private unsafe static bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoderExtensions.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoderExtensions.cs
@@ -113,12 +113,12 @@ namespace System.Text.Encodings.Web
             }
         }
 
-        public static void Encode(this TextEncoder encoder, string value, TextWriter output)
+        public static void Encode(this TextEncoder encoder, TextWriter output, string value)
         {
-            Encode(encoder, value, 0, value.Length, output);
+            Encode(encoder, output, value, 0, value.Length);
         }
 
-        public static void Encode(this TextEncoder encoder, string value, int startIndex, int characterCount, TextWriter output)
+        public static void Encode(this TextEncoder encoder, TextWriter output, string value, int startIndex, int characterCount)
         {
             if (encoder == null)
             {
@@ -163,12 +163,12 @@ namespace System.Text.Encodings.Web
                         substring++;
                     }
 
-                    EncodeCore(encoder, substring, characterCount - firstIndexToEncode, output);
+                    EncodeCore(encoder, output, substring, characterCount - firstIndexToEncode);
                 }
             }
         }
 
-        public static void Encode(this TextEncoder encoder, char[] value, int startIndex, int characterCount, TextWriter output)
+        public static void Encode(this TextEncoder encoder, TextWriter output, char[] value, int startIndex, int characterCount)
         {
             if(encoder == null)
             {
@@ -213,12 +213,12 @@ namespace System.Text.Encodings.Web
                         substring++;
                     }
 
-                    EncodeCore(encoder, substring, characterCount - firstIndexToEncode, output);
+                    EncodeCore(encoder, output, substring, characterCount - firstIndexToEncode);
                 }
             }
         }
 
-        private static unsafe void EncodeCore(this TextEncoder encoder, char* value, int valueLength, TextWriter output)
+        private static unsafe void EncodeCore(this TextEncoder encoder, TextWriter output, char* value, int valueLength)
         {
             Debug.Assert(encoder != null && value != null & output != null);
             Debug.Assert(valueLength >= 0);

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
@@ -138,14 +138,14 @@ namespace System.Text.Encodings.Web
         }
 
         [CLSCompliant(false)]
-        public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {
             if (buffer == null)
             {
                 throw new ArgumentNullException("buffer");
             }
 
-            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, length, out numberOfCharactersWritten); }
+            if (!Encodes(unicodeScalar)) { return unicodeScalar.TryWriteScalarAsChar(buffer, bufferLength, out numberOfCharactersWritten); }
 
             numberOfCharactersWritten = 0;
             uint asUtf8 = (uint)UnicodeHelpers.GetUtf8RepresentationForScalarValue((uint)unicodeScalar);
@@ -153,7 +153,7 @@ namespace System.Text.Encodings.Web
             {
                 char highNibble, lowNibble;
                 HexUtil.ByteToHexDigits((byte)asUtf8, out highNibble, out lowNibble);
-                if (length < 3)
+                if (bufferLength < 3)
                 {
                     numberOfCharactersWritten = 0;
                     return false;

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace System.Text.Encodings.Web
             StringWriter writer = new StringWriter();
 
             // Act
-            encoder.Encode("Hello+there!", writer);
+            encoder.Encode(writer, "Hello+there!");
 
             // Assert
             Assert.Equal("Hello&#x2B;there!", writer.ToString());
@@ -65,7 +65,7 @@ namespace System.Text.Encodings.Web
             StringWriter writer = new StringWriter();
 
             // Act
-            encoder.Encode("Hello+there!", writer);
+            encoder.Encode(writer, "Hello+there!");
 
             // Assert
             Assert.Equal("Hello%2Bthere!", writer.ToString());

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public void HtmlEncode(char[] value, int startIndex, int characterCount, TextWriter output)
         {
-            _encoder.Encode(value, startIndex, characterCount, output);
+            _encoder.Encode(output, value, startIndex, characterCount);
         }
 
         public string HtmlEncode(string value)
@@ -68,7 +68,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public void HtmlEncode(string value, int startIndex, int characterCount, TextWriter output)
         {
-            _encoder.Encode(value, startIndex, characterCount, output);
+            _encoder.Encode(output, value, startIndex, characterCount);
         }
     }
 
@@ -121,7 +121,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public void JavaScriptStringEncode(char[] value, int startIndex, int characterCount, TextWriter output)
         {
-            _encoder.Encode(value, startIndex, characterCount, output);
+            _encoder.Encode(output, value, startIndex, characterCount);
         }
 
         public string JavaScriptStringEncode(string value)
@@ -131,7 +131,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public void JavaScriptStringEncode(string value, int startIndex, int characterCount, TextWriter output)
         {
-            _encoder.Encode(value, startIndex, characterCount, output);
+            _encoder.Encode(output, value, startIndex, characterCount);
         }
     }
 
@@ -184,7 +184,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public void UrlEncode(char[] value, int startIndex, int characterCount, TextWriter output)
         {
-            _encoder.Encode(value, startIndex, characterCount, output);
+            _encoder.Encode(output, value, startIndex, characterCount);
         }
 
         public string UrlEncode(string value)
@@ -194,7 +194,7 @@ namespace Microsoft.Framework.WebEncoders
 
         public void UrlEncode(string value, int startIndex, int characterCount, TextWriter output)
         {
-            _encoder.Encode(value, startIndex, characterCount, output);
+            _encoder.Encode(output, value, startIndex, characterCount);
         }
     }
 }


### PR DESCRIPTION
This is last set of small changes before I will submit the API for an API review.

I changed the order of parameters to Encode to make the APIs work better with intellisense, i.e.
I made the parameter order as consistent as possible.

It would be even better if Encode that takes TextWriter, and Encode that returns string were not simply overloads,
but we can discuss this at the API review.