### PR TITLE
Inner loop tests for Auto/ManualResetEvent, EventWaitHande, and Mutex

### DIFF
--- a/src/System.Threading/tests/AutoResetEventTests.cs
+++ b/src/System.Threading/tests/AutoResetEventTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class AutoResetEventTests
+{
+    [Fact]
+    public void Ctor()
+    {
+        using (AutoResetEvent are = new AutoResetEvent(false))
+            Assert.False(are.WaitOne(0));
+
+        using (AutoResetEvent are = new AutoResetEvent(true))
+            Assert.True(are.WaitOne(0));
+    }
+
+    [Fact]
+    public void SetReset()
+    {
+        using (AutoResetEvent are = new AutoResetEvent(false))
+        {
+            Assert.False(are.WaitOne(0));
+            are.Set();
+            Assert.True(are.WaitOne(0));
+            Assert.False(are.WaitOne(0));
+            are.Set();
+            are.Reset();
+            Assert.False(are.WaitOne(0));
+        }
+    }
+
+    [Fact]
+    public void WaitHandleWaitAll()
+    {
+        AutoResetEvent[] handles = new AutoResetEvent[10];
+        for (int i = 0; i < handles.Length; i++)
+            handles[i] = new AutoResetEvent(false);
+
+        Task<bool> t = Task.Run(() => WaitHandle.WaitAll(handles));
+        for (int i = 0; i < handles.Length; i++)
+        {
+            Assert.False(t.IsCompleted);
+            handles[i].Set();
+        }
+        Assert.True(t.Result);
+
+        Assert.False(WaitHandle.WaitAll(handles, 0));
+    }
+
+    [Fact]
+    public void WaitHandleWaitAny()
+    {
+        AutoResetEvent[] handles = new AutoResetEvent[10];
+        for (int i = 0; i < handles.Length; i++)
+            handles[i] = new AutoResetEvent(false);
+
+        Task<int> t = Task.Run(() => WaitHandle.WaitAny(handles));
+        handles[5].Set();
+        Assert.Equal(5, t.Result);
+
+        Assert.Equal(WaitHandle.WaitTimeout, WaitHandle.WaitAny(handles, 0));
+    }
+
+    [Fact]
+    public void PingPong()
+    {
+        using (AutoResetEvent are1 = new AutoResetEvent(true), are2 = new AutoResetEvent(false))
+        {
+            const int Iters = 10;
+            Task.WaitAll(
+                Task.Factory.StartNew(() =>
+                {
+                    for (int i = 0; i < Iters; i++)
+                    {
+                        Assert.True(are1.WaitOne());
+                        are2.Set();
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
+                Task.Factory.StartNew(() =>
+                {
+                    for (int i = 0; i < Iters; i++)
+                    {
+                        Assert.True(are2.WaitOne());
+                        are1.Set();
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
+        }
+    }
+
+}

--- a/src/System.Threading/tests/EventWaitHandleTests.cs
+++ b/src/System.Threading/tests/EventWaitHandleTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class EventWaitHandleTests
+{
+    [Fact]
+    public void Ctor()
+    {
+        using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset))
+            Assert.False(are.WaitOne(0));
+        using (EventWaitHandle are = new EventWaitHandle(true, EventResetMode.AutoReset))
+            Assert.True(are.WaitOne(0));
+        using (EventWaitHandle mre = new EventWaitHandle(false, EventResetMode.ManualReset))
+            Assert.False(mre.WaitOne(0));
+        using (EventWaitHandle mre = new EventWaitHandle(true, EventResetMode.ManualReset))
+            Assert.True(mre.WaitOne(0));
+
+        Assert.Throws<ArgumentException>(() => new EventWaitHandle(true, (EventResetMode)12345));
+        Assert.Throws<ArgumentException>(() => new EventWaitHandle(true, EventResetMode.AutoReset, new string('a', 1000)));
+
+        const string Name = "EventWaitHandleTestCtor";
+
+        using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset, Name))
+            Assert.False(are.WaitOne(0));
+        using (EventWaitHandle are = new EventWaitHandle(true, EventResetMode.AutoReset, Name))
+            Assert.True(are.WaitOne(0));
+        using (EventWaitHandle mre = new EventWaitHandle(false, EventResetMode.ManualReset, Name))
+            Assert.False(mre.WaitOne(0));
+        using (EventWaitHandle mre = new EventWaitHandle(true, EventResetMode.ManualReset, Name))
+            Assert.True(mre.WaitOne(0));
+        
+        bool createdNew;
+        using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset, Name, out createdNew))
+        {
+            Assert.True(createdNew);
+            using (EventWaitHandle are2 = new EventWaitHandle(false, EventResetMode.AutoReset, Name, out createdNew))
+            {
+                Assert.False(createdNew);
+            }
+        }
+        using (EventWaitHandle mre = new EventWaitHandle(false, EventResetMode.ManualReset, Name, out createdNew))
+        {
+            Assert.True(createdNew);
+            using (EventWaitHandle mre2 = new EventWaitHandle(false, EventResetMode.ManualReset, Name, out createdNew))
+            {
+                Assert.False(createdNew);
+            }
+        }
+
+        using (Mutex m = new Mutex(false, Name))
+        {
+            Assert.Throws<WaitHandleCannotBeOpenedException>(() => new EventWaitHandle(false, EventResetMode.AutoReset, Name));
+            Assert.Throws<WaitHandleCannotBeOpenedException>(() => new EventWaitHandle(false, EventResetMode.ManualReset, Name));
+        }
+    }
+
+    [Fact]
+    public void SetReset()
+    {
+        using (EventWaitHandle are = new EventWaitHandle(false, EventResetMode.AutoReset))
+        {
+            Assert.False(are.WaitOne(0));
+            are.Set();
+            Assert.True(are.WaitOne(0));
+            Assert.False(are.WaitOne(0));
+            are.Set();
+            are.Reset();
+            Assert.False(are.WaitOne(0));
+        }
+
+        using (EventWaitHandle mre = new EventWaitHandle(false, EventResetMode.ManualReset))
+        {
+            Assert.False(mre.WaitOne(0));
+            mre.Set();
+            Assert.True(mre.WaitOne(0));
+            Assert.True(mre.WaitOne(0));
+            mre.Set();
+            Assert.True(mre.WaitOne(0));
+            mre.Reset();
+            Assert.False(mre.WaitOne(0));
+        }
+    }
+
+    [Fact]
+    public void OpenExisting()
+    {
+        const string Name = "EventWaitHandleTestOpenExisting";
+
+        EventWaitHandle resultHandle;
+        Assert.False(EventWaitHandle.TryOpenExisting(Name, out resultHandle));
+        Assert.Null(resultHandle);
+
+        using (EventWaitHandle are1 = new EventWaitHandle(false, EventResetMode.AutoReset, Name))
+        {
+            using (EventWaitHandle are2 = EventWaitHandle.OpenExisting(Name))
+            {
+                are1.Set();
+                Assert.True(are2.WaitOne(0));
+                Assert.False(are1.WaitOne(0));
+                Assert.False(are2.WaitOne(0));
+
+                are2.Set();
+                Assert.True(are1.WaitOne(0));
+                Assert.False(are2.WaitOne(0));
+                Assert.False(are1.WaitOne(0));
+            }
+
+            Assert.True(EventWaitHandle.TryOpenExisting(Name, out resultHandle));
+            Assert.NotNull(resultHandle);
+            resultHandle.Dispose();
+        }
+    }
+
+}

--- a/src/System.Threading/tests/ManualResetEventTests.cs
+++ b/src/System.Threading/tests/ManualResetEventTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class ManualResetEventTests
+{
+    [Fact]
+    public void Ctor()
+    {
+        using (ManualResetEvent mre = new ManualResetEvent(false))
+            Assert.False(mre.WaitOne(0));
+
+        using (ManualResetEvent mre = new ManualResetEvent(true))
+            Assert.True(mre.WaitOne(0));
+    }
+
+    [Fact]
+    public void SetReset()
+    {
+        using (ManualResetEvent mre = new ManualResetEvent(false))
+        {
+            Assert.False(mre.WaitOne(0));
+            mre.Set();
+            Assert.True(mre.WaitOne(0));
+            Assert.True(mre.WaitOne(0));
+            mre.Set();
+            Assert.True(mre.WaitOne(0));
+            mre.Reset();
+            Assert.False(mre.WaitOne(0));
+        }
+    }
+
+    [Fact]
+    public void WaitHandleWaitAll()
+    {
+        ManualResetEvent[] handles = new ManualResetEvent[10];
+        for (int i = 0; i < handles.Length; i++)
+            handles[i] = new ManualResetEvent(false);
+
+        Task<bool> t = Task.Run(() => WaitHandle.WaitAll(handles));
+        for (int i = 0; i < handles.Length; i++)
+        {
+            Assert.False(t.IsCompleted);
+            handles[i].Set();
+        }
+        Assert.True(t.Result);
+
+        Assert.True(WaitHandle.WaitAll(handles, 0));
+    }
+
+    [Fact]
+    public void WaitHandleWaitAny()
+    {
+        ManualResetEvent[] handles = new ManualResetEvent[10];
+        for (int i = 0; i < handles.Length; i++)
+            handles[i] = new ManualResetEvent(false);
+
+        Task<int> t = Task.Run(() => WaitHandle.WaitAny(handles));
+        handles[5].Set();
+        Assert.Equal(5, t.Result);
+
+        Assert.Equal(5, WaitHandle.WaitAny(handles, 0));
+    }
+
+    [Fact]
+    public void PingPong()
+    {
+        using (ManualResetEvent mre1 = new ManualResetEvent(true), mre2 = new ManualResetEvent(false))
+        {
+            const int Iters = 10;
+            Task.WaitAll(
+                Task.Factory.StartNew(() =>
+                {
+                    for (int i = 0; i < Iters; i++)
+                    {
+                        Assert.True(mre1.WaitOne());
+                        mre1.Reset();
+                        mre2.Set();
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
+                Task.Factory.StartNew(() =>
+                {
+                    for (int i = 0; i < Iters; i++)
+                    {
+                        Assert.True(mre2.WaitOne());
+                        mre2.Reset();
+                        mre1.Set();
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
+        }
+    }
+
+}

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class MutexTests
+{
+    [Fact]
+    public void Ctor()
+    {
+        using (Mutex m = new Mutex())
+        {
+            Assert.True(m.WaitOne());
+            m.ReleaseMutex();
+        }
+
+        using (Mutex m = new Mutex(false))
+        {
+            Assert.True(m.WaitOne());
+            m.ReleaseMutex();
+        }
+
+        using (Mutex m = new Mutex(true))
+        {
+            Assert.True(m.WaitOne());
+            m.ReleaseMutex();
+            m.ReleaseMutex();
+        }
+
+        Assert.Throws<ArgumentException>(() => new Mutex(false, new string('a', 1000)));
+
+        const string Name = "MutexTestsCtor";
+        bool createdNew;
+        using (Mutex m1 = new Mutex(false, Name, out createdNew))
+        {
+            Assert.True(createdNew);
+            using (Mutex m2 = new Mutex(false, Name, out createdNew))
+            {
+                Assert.False(createdNew);
+            }
+        }
+
+        using (Semaphore s = new Semaphore(1, 1, Name))
+        {
+            Assert.Throws<WaitHandleCannotBeOpenedException>(() => new Mutex(false, Name));
+        }
+    }
+
+    [Fact]
+    public void OpenExisting()
+    {
+        const string Name = "MutexTestsOpenExisting";
+
+        Mutex resultHandle;
+        Assert.False(Mutex.TryOpenExisting(Name, out resultHandle));
+
+        using (Mutex m1 = new Mutex(false, Name))
+        {
+            using (Mutex m2 = Mutex.OpenExisting(Name))
+            {
+                Assert.True(m1.WaitOne());
+                Assert.False(Task.Run(() => m2.WaitOne(0)).Result);
+                m1.ReleaseMutex();
+
+                Assert.True(m2.WaitOne());
+                Assert.False(Task.Run(() => m1.WaitOne(0)).Result);
+                m2.ReleaseMutex();
+            }
+
+            Assert.True(Mutex.TryOpenExisting(Name, out resultHandle));
+            Assert.NotNull(resultHandle);
+            resultHandle.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AbandonExisting()
+    {
+        using (Mutex m = new Mutex())
+        {
+            Task.Factory.StartNew(() => m.WaitOne(), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Wait();
+            Assert.Throws<AbandonedMutexException>(() => m.WaitOne());
+        }
+
+        using (Mutex m = new Mutex())
+        {
+            Task.Factory.StartNew(() => m.WaitOne(), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Wait();
+            AbandonedMutexException ame = Assert.Throws<AbandonedMutexException>(() => WaitHandle.WaitAny(new[] { m }));
+            Assert.Equal(0, ame.MutexIndex);
+        }
+    }
+
+}

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -13,13 +13,17 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="AsyncLocalTests.cs" />
+    <Compile Include="AutoResetEventTests.cs" />
     <Compile Include="BarrierCancellationTests.cs" />
     <Compile Include="BarrierTests.cs" />
     <Compile Include="CountdownEventCancellationTests.cs" />
     <Compile Include="CountdownEventTests.cs" />
     <Compile Include="EtwTests.cs" />
+    <Compile Include="EventWaitHandleTests.cs" />
+    <Compile Include="ManualResetEventTests.cs" />
     <Compile Include="ManualResetEventSlimCancellationTests.cs" />
     <Compile Include="ManualResetEventSlimTests.cs" />
+    <Compile Include="MutexTests.cs" />
     <Compile Include="SemaphoreSlimCancellationTests.cs" />
     <Compile Include="SemaphoreSlimTests.cs" />
     <Compile Include="SpinLockTests.cs" />


### PR DESCRIPTION
As with the Semaphore tests in #1680, these cover basic functionality of the sync primitives, and are not intended to be stress/concurrency tests.