### PR TITLE
Add "frameworks" node to project.json files that missed them

### DIFF
--- a/src/Microsoft.VisualBasic/src/project.json
+++ b/src/Microsoft.VisualBasic/src/project.json
@@ -20,5 +20,8 @@
     "System.Text.Encoding": "4.0.10-beta-22809",
     "System.Threading": "4.0.10-beta-22809",
     "System.Threading.Tasks": "4.0.10-beta-22809"
+  },
+  "frameworks": {
+    "dnxcore50": {}
   }
 }

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "Microsoft.DotNet.CoreCLR": "1.0.0-prerelease"
+  },
+  "frameworks": {
+    "dnxcore50": {}
   }
 }

--- a/src/System.Security.Principal.Windows/src/project.json
+++ b/src/System.Security.Principal.Windows/src/project.json
@@ -14,5 +14,8 @@
     "System.Security.Claims": "4.0.0-beta-22809",
     "System.Security.Principal": "4.0.0-beta-22809",
     "System.Threading": "4.0.10-beta-22809"
+  },
+  "frameworks": {
+    "dnxcore50": {}
   }
 }

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -4,5 +4,8 @@
     "System.Runtime.Handles": "4.0.0-beta-22809",
     "System.Collections": "4.0.10-beta-22809",
     "System.Security.Claims": "4.0.0-beta-22809"
+  },
+  "frameworks": {
+    "dnxcore50": {}
   }
 }

--- a/src/System.Security.Principal/src/project.json
+++ b/src/System.Security.Principal/src/project.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
        "System.Runtime": "4.0.20-beta-22809"
-  } 
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
 }

--- a/src/System.Security.Principal/tests/project.json
+++ b/src/System.Security.Principal/tests/project.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "System.Runtime": "4.0.20-beta-22809"
+  },
+  "frameworks": {
+    "dnxcore50": {}
   }
 }

--- a/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/4.0.10.0/Encoding/project.json
@@ -12,5 +12,8 @@
     "xunit.assert": "2.0.0-beta5-build2785",
     "xunit.core.netcore": "1.0.1-prerelease",
     "xunit.runner.visualstudio": "0.99.9-build1021"
+  },
+  "frameworks": {
+    "dnxcore50": {}
   }
 }


### PR DESCRIPTION
This caused an issue when building on Linux as the projects would build against DNX,4.5.1 instead of DNXCore,5.0