### PR TITLE
Fix race condition in mutex test

### DIFF
--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -62,11 +62,11 @@ public class MutexTests
             using (Mutex m2 = Mutex.OpenExisting(Name))
             {
                 Assert.True(m1.WaitOne());
-                Assert.False(Task.Run(() => m2.WaitOne(0)).Result);
+                Assert.False(Task.Factory.StartNew(() => m2.WaitOne(0), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Result);
                 m1.ReleaseMutex();
 
                 Assert.True(m2.WaitOne());
-                Assert.False(Task.Run(() => m1.WaitOne(0)).Result);
+                Assert.False(Task.Factory.StartNew(() => m1.WaitOne(0), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Result);
                 m2.ReleaseMutex();
             }
 


### PR DESCRIPTION
One of the tests I added earlier today has a race condition that causes the test to fail.  The test relies on a task running on another thread, in order for the wait on the mutex to time out, but it's possible as written for the task to get inlined into the current thread when we wait on it, which will inadvertently cause the wait on the mutex to succeed.  A simple fix is just to use LongRunning, which will give the task a dedicated thread and ensure it's not inlined in a wait.