### PR TITLE
Improve UnmanagedMemoryStream code coverage

### DIFF
--- a/src/System.IO.UnmanagedMemoryStream/src/Resources/Strings.resx
+++ b/src/System.IO.UnmanagedMemoryStream/src/Resources/Strings.resx
@@ -150,9 +150,6 @@
   <data name="ArgumentOutOfRange_LengthGreaterThanCapacity" xml:space="preserve">
     <value>The length cannot be greater than the capacity.</value>
   </data>
-  <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
-    <value>Specified file length was too large for the file system.</value>
-  </data>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non negative number is required.</value>
   </data>
@@ -161,9 +158,6 @@
   </data>
   <data name="ArgumentOutOfRange_StreamLength" xml:space="preserve">
     <value>Stream length must be non-negative and less than 2^31 - 1 - origin.</value>
-  </data>
-  <data name="ArgumentOutOfRange_UnmanagedMemStreamLength" xml:space="preserve">
-    <value>UnmanagedMemoryStream length must be non-negative and less than 2^63 - 1 - baseAddress.</value>
   </data>
   <data name="ArgumentOutOfRange_UnmanagedMemStreamWrapAround" xml:space="preserve">
     <value>The UnmanagedMemoryStream capacity would wrap around the high end of the address space.</value>
@@ -203,8 +197,5 @@
   </data>
   <data name="IO_StreamTooLong" xml:space="preserve">
     <value>Stream was too long.</value>
-  </data>
-  <data name="PlatformNotSupported_NamedMaps" xml:space="preserve">
-    <value>Named maps are not supported.</value>
   </data>
 </root>

--- a/src/System.IO.UnmanagedMemoryStream/tests/HGlobalSafeBuffer.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/HGlobalSafeBuffer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    internal sealed class HGlobalSafeBuffer : SafeBuffer
+    {
+        internal HGlobalSafeBuffer(int capacity) : base(true)
+        {
+            SetHandle(Marshal.AllocHGlobal(capacity));
+            Initialize((ulong)capacity);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Marshal.FreeHGlobal(handle);
+            return true;
+        }
+    }
+}

--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -25,9 +25,11 @@
     <Compile Include="ArrayHelpers.cs" />
     <Compile Include="UmaTests.cs" />
     <Compile Include="UmsCtorTests.cs" />
+    <Compile Include="HGlobalSafeBuffer.cs" />
     <Compile Include="UmsRead.cs" />
     <Compile Include="UmsSafeBuffer.cs" />
     <Compile Include="UmaCtorTests.cs" />
+    <Compile Include="UmsFlush.cs" />
     <Compile Include="UmsWrite.cs" />
     <Compile Include="UmsReadWrite.cs" />
     <Compile Include="UmsTests.cs" />

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsCtorTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsCtorTests.cs
@@ -34,18 +34,115 @@ namespace System.IO.Tests
             int someInt32 = 42;
             int* pInt32 = &someInt32;
             byte* pByte = (byte*)pInt32;
+
             using (var stream = new UnmanagedMemoryStream(pByte, 0))
             {
                 Assert.True(stream.CanRead);
                 Assert.True(stream.CanSeek);
                 Assert.False(stream.CanWrite);
+                Assert.False(stream.CanTimeout);
 
                 Assert.Equal(0, stream.Length);
                 Assert.Equal(0, stream.Capacity);
                 Assert.Equal(0, stream.Position);
 
-                Assert.False(stream.PositionPointer != pByte);
+                Assert.Throws<InvalidOperationException>(() => stream.ReadTimeout);
+                Assert.Throws<InvalidOperationException>(() => stream.ReadTimeout = 42);
+                Assert.Throws<InvalidOperationException>(() => stream.WriteTimeout);
+                Assert.Throws<InvalidOperationException>(() => stream.WriteTimeout = 42);
+
+                Assert.True(stream.PositionPointer == pByte);
             }
+
+            using (var stream = new DerivedUnmanagedMemoryStream())
+            {
+                Assert.False(stream.CanRead);
+                Assert.False(stream.CanSeek);
+                Assert.False(stream.CanWrite);
+                Assert.False(stream.CanTimeout);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Initialize(pByte, -1, 4, FileAccess.Read));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Initialize(pByte, 1, -4, FileAccess.Read));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Initialize(pByte, 5, 4, FileAccess.Read));
+                Assert.Throws<ArgumentOutOfRangeException>(() => stream.Initialize(pByte, 1, 4, (FileAccess)12345));
+                stream.Initialize(pByte, 1, 4, FileAccess.ReadWrite);
+                Assert.Throws<InvalidOperationException>(() => stream.Initialize(pByte, 1, 4, FileAccess.ReadWrite));
+
+                Assert.True(stream.CanRead);
+                Assert.True(stream.CanSeek);
+                Assert.True(stream.CanWrite);
+
+                Assert.Equal(1, stream.Length);
+                Assert.Equal(4, stream.Capacity);
+                Assert.Equal(0, stream.Position);
+
+                Assert.Throws<InvalidOperationException>(() => stream.ReadTimeout);
+                Assert.Throws<InvalidOperationException>(() => stream.ReadTimeout = 42);
+                Assert.Throws<InvalidOperationException>(() => stream.WriteTimeout);
+                Assert.Throws<InvalidOperationException>(() => stream.WriteTimeout = 42);
+
+                Assert.True(stream.PositionPointer == pByte);
+            }
+        }
+
+        [Fact]
+        public static unsafe void BufferCtor()
+        {
+            const int length = 99;
+            using (FakeSafeBuffer buffer = new FakeSafeBuffer(length))
+            using (var stream = new DerivedUnmanagedMemoryStream(buffer, length, FileAccess.Read))
+            {
+                Assert.True(stream.CanRead);
+                Assert.True(stream.CanSeek);
+                Assert.False(stream.CanWrite);
+
+                Assert.Equal(length, stream.Length);
+                Assert.Equal(length, stream.Capacity);
+                Assert.Equal(0, stream.Position);
+            }
+
+            using (FakeSafeBuffer buffer = new FakeSafeBuffer(length))
+            using (var stream = new DerivedUnmanagedMemoryStream())
+            {
+                Assert.False(stream.CanRead);
+                Assert.False(stream.CanSeek);
+                Assert.False(stream.CanWrite);
+
+                stream.Initialize(buffer, 0, length, FileAccess.Write);
+                Assert.Throws<InvalidOperationException>(() => stream.Initialize(buffer, 0, length, FileAccess.Write));
+
+                Assert.False(stream.CanRead);
+                Assert.True(stream.CanSeek);
+                Assert.True(stream.CanWrite);
+
+                Assert.Equal(length, stream.Length);
+                Assert.Equal(length, stream.Capacity);
+                Assert.Equal(0, stream.Position);
+
+                Assert.Throws<NotSupportedException>(() => stream.SetLength(1));
+            }
+        }
+    }
+
+    // Derived class used to exercise protected members and to test behaviors before and after initialization
+    internal sealed unsafe class DerivedUnmanagedMemoryStream : UnmanagedMemoryStream
+    {
+        internal DerivedUnmanagedMemoryStream()
+        {
+        }
+
+        internal DerivedUnmanagedMemoryStream(FakeSafeBuffer buffer, long length, FileAccess access) : base(buffer, 0, length, access)
+        {
+        }
+
+        internal new void Initialize(byte* pointer, long length, long capacity, FileAccess access)
+        {
+            base.Initialize(pointer, length, capacity, access);
+        }
+
+        internal void Initialize(FakeSafeBuffer buffer, long offset, long capacity, FileAccess access)
+        {
+            base.Initialize(buffer, offset, capacity, access);
         }
     }
 }

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsFlush.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsFlush.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FlushTests
+    {
+        [Fact]
+        public static void Flush()
+        {
+            const int length = 1000;
+            using (var manager = new UmsManager(FileAccess.Write, length))
+            {
+                UnmanagedMemoryStream stream = manager.Stream;
+
+                stream.Flush();
+                Assert.True(stream.FlushAsync(new CancellationToken(true)).IsCanceled);
+                Assert.True(stream.FlushAsync().Status == TaskStatus.RanToCompletion);
+            }
+
+            using (var stream = new DerivedUnmanagedMemoryStream())
+            {
+                Assert.Throws<ObjectDisposedException>(() => stream.Flush());
+
+                Task t = stream.FlushAsync();
+                Assert.True(t.IsFaulted);
+                Assert.IsType<ObjectDisposedException>(t.Exception.InnerException);
+            }
+        }
+
+    }
+}

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsTests.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsTests.cs
@@ -4,7 +4,7 @@
 using Xunit;
 using System.Threading;
 
-// TODO: add WriteAsync, Timeout, Flush, CopyTo tests
+// TODO: add CopyTo tests
 
 namespace System.IO.Tests
 {

--- a/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
+++ b/src/System.IO.UnmanagedMemoryStream/tests/UmsWrite.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
 {
     public class UmsWriteTests
     {
-        // TODO: add tests for different offsets and lengths
         [Fact]
         public static void Write()
         {
@@ -20,12 +21,37 @@ namespace System.IO.Tests
 
                 var bytes = ArrayHelpers.CreateByteArray(length);
                 stream.Write(bytes.Copy(), 0, length);
-
                 var memory = manager.ToArray();
-
                 Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
 
                 stream.Write(new byte[0], 0, 0);
+
+                stream.SetLength(1);
+                Assert.Equal(1, stream.Length);
+                stream.SetLength(4);
+                Assert.Equal(4, stream.Length);
+                stream.SetLength(0);
+                Assert.Equal(0, stream.Length);
+
+                stream.Position = 1;
+                bytes = ArrayHelpers.CreateByteArray(length - 1);
+                stream.Write(bytes, 0, length - 1);
+                memory = manager.ToArray();
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    Assert.Equal(bytes[i], memory[i + 1]);
+                }
+                
+                Assert.True(stream.WriteAsync(bytes, 0, bytes.Length, new CancellationToken(true)).IsCanceled);
+
+                stream.Position = 0;
+                bytes = ArrayHelpers.CreateByteArray(length);
+                for (int i = 0; i < 4; i++)
+                {
+                    Task t = stream.WriteAsync(bytes, i * (bytes.Length / 4), bytes.Length / 4);
+                    Assert.True(t.Status == TaskStatus.RanToCompletion);
+                }
+                Assert.Equal(bytes, manager.ToArray(), ArrayHelpers.Comparer<byte>());
             }
         }
 
@@ -39,14 +65,23 @@ namespace System.IO.Tests
                 UmsTests.WriteUmsInvariants(stream);
 
                 var bytes = ArrayHelpers.CreateByteArray(length);
-
                 for (int index = 0; index < bytes.Length; index++)
                 {
                     stream.WriteByte(bytes[index]);
                 }
-
                 var memory = manager.ToArray();
+                Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
 
+                stream.SetLength(0);
+                stream.Position = 1;
+                bytes = ArrayHelpers.CreateByteArray(length);
+                for (int index = 1; index < bytes.Length; index++)
+                {
+                    stream.WriteByte(bytes[index]);
+                }
+                stream.Position = 0;
+                stream.WriteByte(bytes[0]);
+                memory = manager.ToArray();
                 Assert.Equal(bytes, memory, ArrayHelpers.Comparer<byte>());
             }
         }
@@ -72,7 +107,7 @@ namespace System.IO.Tests
             {
                 UnmanagedMemoryStream stream = manager.Stream;
                 UmsTests.WriteUmsInvariants(stream);
-                
+
                 if (IntPtr.Size == 4)
                 {
                     Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = long.MaxValue);
@@ -87,5 +122,6 @@ namespace System.IO.Tests
                 }
             }
         }
+
     }
 }


### PR DESCRIPTION
Before:
- UnmanagedMemoryAccessor: 98.8%
- UnmanagedMemoryStream: 81.3%
- Overall (including SR): 89.4%

After:
- UnmanagedMemoryAccessor: 99.7%
- UnmanagdMemoryStream: 98.1%
- Overall (including SR): 96.1%

All that remains are some hard-to-reach error paths, e.g. pointer overflow.

Fixes #1711.  #1721 is also adding tests for CopyTo, which will remove the last TODO in the tests.