### PR TITLE
Fix ImmutableArray<T>.Equals handling of variant types

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1006,9 +1006,10 @@ namespace System.Collections.Immutable
         [Pure]
         public override bool Equals(object obj)
         {
-            if (obj is ImmutableArray<T>)
+            IImmutableArray other = obj as IImmutableArray;
+            if (other != null)
             {
-                return this.Equals((ImmutableArray<T>)obj);
+                return this.array == other.Array;
             }
 
             return false;

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -251,7 +251,8 @@ namespace System.Collections.Immutable.Test
             ImmutableArray<string> derivedImmutable = ImmutableArray.Create("a", "b", "c");
             ImmutableArray<object> baseImmutable = derivedImmutable.As<object>();
             Assert.False(baseImmutable.IsDefault);
-            Assert.Equal(derivedImmutable, baseImmutable);
+            // Must cast to object or the IEnumerable<object> overload of Equals would be used
+            Assert.Equal((object)derivedImmutable, baseImmutable, EqualityComparer<object>.Default);
 
             // Make sure we can reverse that, as a means to verify the underlying array is the same instance.
             ImmutableArray<string> derivedImmutable2 = baseImmutable.As<string>();
@@ -285,7 +286,8 @@ namespace System.Collections.Immutable.Test
         {
             ImmutableArray<string> derivedImmutable = ImmutableArray.Create("a", "b", "c");
             ImmutableArray<object> baseImmutable = ImmutableArray.CreateRange<object>(derivedImmutable);
-            Assert.Equal(derivedImmutable, baseImmutable);
+            // Must cast to object or the IEnumerable<object> overload of Equals would be used
+            Assert.Equal((object)derivedImmutable, baseImmutable, EqualityComparer<object>.Default);
 
             // Make sure we can reverse that, as a means to verify the underlying array is the same instance.
             ImmutableArray<string> derivedImmutable2 = baseImmutable.As<string>();
@@ -297,7 +299,8 @@ namespace System.Collections.Immutable.Test
         {
             ImmutableArray<string> derivedImmutable = ImmutableArray.Create("a", "b", "c");
             ImmutableArray<object> baseImmutable = ImmutableArray<object>.CastUp(derivedImmutable);
-            Assert.Equal(derivedImmutable, baseImmutable);
+            // Must cast to object or the IEnumerable<object> overload of Equals would be used
+            Assert.Equal((object)derivedImmutable, baseImmutable, EqualityComparer<object>.Default);
 
             // Make sure we can reverse that, as a means to verify the underlying array is the same instance.
             Assert.Equal(derivedImmutable, baseImmutable.As<string>());


### PR DESCRIPTION
This commit updates the implementation of `ImmutableArray<T>.Equals(object)` to use `IImmutableArray` instead of `ImmutableArray<T>`. This allows the underlying arrays to be compared by reference as instances of `System.Array`, even if the `ImmutableArray<T>` instances wrapping them use a different type arguments `T`.

Fixes #1731
Fixes #1733