### PR TITLE
Make {Process/ProcessThread].PriorityBoostEnabled consistent on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Unix.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics
         private bool PriorityBoostEnabledCore
         {
             get { return false; }
-            set { throw new PlatformNotSupportedException(); }
+            set { } // Nop
         }
 
         /// <summary>


### PR DESCRIPTION
This property isn't supported on Unix, but how we don't support it currently differs between Process and ProcessThread: the former makes it a nop, whereas the latter makes it throw an exception.  This commit just makes the behavior consistent, having both be a nop, since ignoring this has limited impact on the consuming application.

Fixes #1726.