### PR TITLE
Implement Debug.ShowAssertDialog on Unix

### DIFF
--- a/src/Common/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Unix.cs
@@ -28,8 +28,21 @@ namespace System.Diagnostics
 
             public void ShowAssertDialog(string stackTrace, string message, string detailMessage)
             {
-                // TODO: Implement this
-                throw new NotImplementedException();
+                // TODO: Determine whether there's anything better we can do here once
+                //       Debugger.* is available on Unix.
+
+                // When an assert fails, it calls WriteCore with the assert message, followed
+                // by calling ShowAssertDialog.  If s_shouldWriteToStdError is true,
+                // then the assert will have already been written to the console.  But if it's
+                // false (the default), then it's easy for the important failure information
+                // to be missed.  As such, if if it's false, we still output the error information to
+                // stderr for lack of any better place to display it to the user; this will also
+                // help ensure it shows up in continuous integration logs.
+                string assertMessage = FormatAssert(stackTrace, message, detailMessage) + Environment.NewLine;
+                if (!s_shouldWriteToStdErr)
+                {
+                    WriteToFile(Interop.Devices.stderr, assertMessage);
+                }
             }
 
             public void WriteCore(string message)

--- a/src/Common/src/System/Diagnostics/Debug.cs
+++ b/src/Common/src/System/Diagnostics/Debug.cs
@@ -41,7 +41,7 @@ namespace System.Diagnostics
                     stackTrace = "";
                 }
 
-                WriteAssert(stackTrace, message, detailMessage);
+                WriteLine(FormatAssert(stackTrace, message, detailMessage));
                 s_logger.ShowAssertDialog(stackTrace, message, detailMessage);
             }
         }
@@ -58,16 +58,14 @@ namespace System.Diagnostics
             Assert(false, message, detailMessage);
         }
 
-        private static void WriteAssert(string stackTrace, string message, string detailMessage)
+        private static string FormatAssert(string stackTrace, string message, string detailMessage)
         {
-            string assertMessage = SR.DebugAssertBanner + Environment.NewLine
-                                   + SR.DebugAssertShortMessage + Environment.NewLine
-                                   + message + Environment.NewLine
-                                   + SR.DebugAssertLongMessage + Environment.NewLine
-                                   + detailMessage + Environment.NewLine
-                                   + stackTrace;
-
-            WriteLine(assertMessage);
+            return SR.DebugAssertBanner + Environment.NewLine
+                   + SR.DebugAssertShortMessage + Environment.NewLine
+                   + message + Environment.NewLine
+                   + SR.DebugAssertLongMessage + Environment.NewLine
+                   + detailMessage + Environment.NewLine
+                   + stackTrace;
         }
 
         [System.Diagnostics.Conditional("DEBUG")]


### PR DESCRIPTION
Provides a slightly better ShowAssertDialog implementation.  While we will probably want to do something better once we have better debugger integration, for now this avoids throwing an exception and instead ensures that the assert information is written out to stderr, making assertion failures visible at the console and in CI logs.

Fixes #1724.