### PR TITLE
Multiple fixes to SecureString

### DIFF
--- a/src/System.Security.SecureString/src/Resources/Strings.resx
+++ b/src/System.Security.SecureString/src/Resources/Strings.resx
@@ -126,9 +126,6 @@
   <data name="ArgumentOutOfRange_IndexString" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the length of the string.</value>
   </data>
-  <data name="Arg_PlatformSecureString" xml:space="preserve">
-    <value>SecureString is only supported on Windows 2000 SP3 and higher platforms.</value>
-  </data>
   <data name="ArgumentOutOfRange_Capacity" xml:space="preserve">
     <value>Capacity exceeds maximum capacity.</value>
   </data>

--- a/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
+++ b/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
@@ -11,16 +11,24 @@ namespace System.Security
     {
         internal SafeBSTRHandle() : base(true) { }
 
-        internal static SafeBSTRHandle Allocate(string src, uint len)
+        internal static SafeBSTRHandle Allocate(string src, uint lenInChars)
         {
-            SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, len);
-            bstr.Initialize(len * sizeof(char));
+            SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, lenInChars);
+            if (bstr.IsInvalid) // SysAllocStringLen returns a NULL ptr when there's insufficient memory
+            {
+                throw new OutOfMemoryException();
+            }
+            bstr.Initialize(lenInChars * sizeof(char));
             return bstr;
         }
 
         internal static SafeBSTRHandle Allocate(IntPtr src, uint lenInBytes)
         {
             SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, lenInBytes / sizeof(char));
+            if (bstr.IsInvalid) // SysAllocStringLen returns a NULL ptr when there's insufficient memory
+            {
+                throw new OutOfMemoryException();
+            }
             bstr.Initialize(lenInBytes);
             return bstr;
         }

--- a/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
+++ b/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
@@ -24,6 +24,7 @@ namespace System.Security
 
         internal static SafeBSTRHandle Allocate(IntPtr src, uint lenInBytes)
         {
+            Debug.Assert(lenInBytes % sizeof(char) == 0);
             SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, lenInBytes / sizeof(char));
             if (bstr.IsInvalid) // SysAllocStringLen returns a NULL ptr when there's insufficient memory
             {

--- a/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
+++ b/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
@@ -64,16 +64,19 @@ namespace System.Security
             }
         }
 
-        internal unsafe static void Copy(SafeBSTRHandle source, SafeBSTRHandle target)
+        internal unsafe static void Copy(SafeBSTRHandle source, SafeBSTRHandle target, uint bytesToCopy)
         {
+            if (bytesToCopy == 0)
+                return;
+
             byte* sourcePtr = null, targetPtr = null;
             try
             {
                 source.AcquirePointer(ref sourcePtr);
                 target.AcquirePointer(ref targetPtr);
 
-                Debug.Assert(Interop.OleAut32.SysStringLen((IntPtr)targetPtr) >= Interop.OleAut32.SysStringLen((IntPtr)sourcePtr), "Target buffer is not large enough!");
-                Buffer.MemoryCopy(sourcePtr, targetPtr, (int)Interop.OleAut32.SysStringLen((IntPtr)targetPtr) * sizeof(char), (int)Interop.OleAut32.SysStringLen((IntPtr)sourcePtr) * sizeof(char));
+                Debug.Assert(Interop.OleAut32.SysStringLen((IntPtr)sourcePtr) * sizeof(char) >= bytesToCopy, "Source buffer is too small.");
+                Buffer.MemoryCopy(sourcePtr, targetPtr, Interop.OleAut32.SysStringLen((IntPtr)targetPtr) * sizeof(char), bytesToCopy);
             }
             finally
             {

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Unix.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Unix.cs
@@ -165,8 +165,7 @@ namespace System.Security
             try
             {
                 // Allocate space for the string to be returned, including space for a null terminator
-                if ((stringPtr = Marshal.AllocCoTaskMem((length + 1) * sizeof(char))) == IntPtr.Zero)
-                    throw new OutOfMemoryException();
+                stringPtr = Marshal.AllocCoTaskMem((length + 1) * sizeof(char));
 
                 _buffer.AcquirePointer(ref bufferPtr);
 

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
@@ -103,9 +103,9 @@ namespace System.Security
             }
             finally
             {
-                ProtectMemory(decryptedBuffer);
                 if (bufferPtr != null)
                     decryptedBuffer.ReleasePointer();
+                ProtectMemory(decryptedBuffer);
             }
         }
 
@@ -128,9 +128,9 @@ namespace System.Security
             }
             finally
             {
-                ProtectMemory(decryptedBuffer);
                 if (bufferPtr != null)
                     decryptedBuffer.ReleasePointer();
+                ProtectMemory(decryptedBuffer);
             }
         }
 
@@ -263,6 +263,7 @@ namespace System.Security
             finally
             {
                 decryptedBuffer.ClearBuffer();
+                decryptedBuffer.Dispose();
             }
         }
 

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
@@ -13,7 +13,7 @@ namespace System.Security
         internal SecureString(SecureString str)
         {
             AllocateBuffer(str.EncryptedBufferLength);
-            SafeBSTRHandle.Copy(str._encryptedBuffer, _encryptedBuffer);
+            SafeBSTRHandle.Copy(str._encryptedBuffer, _encryptedBuffer, str.EncryptedBufferLength * sizeof(char));
             _decryptedLength = str._decryptedLength;
         }
 
@@ -232,7 +232,7 @@ namespace System.Security
             }
 
             SafeBSTRHandle newBuffer = SafeBSTRHandle.Allocate(null, (uint)capacity);
-            SafeBSTRHandle.Copy(decryptedBuffer, newBuffer);
+            SafeBSTRHandle.Copy(decryptedBuffer, newBuffer, (uint)_decryptedLength * sizeof(char));
             decryptedBuffer.Dispose();
             decryptedBuffer = newBuffer;
         }

--- a/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
+++ b/src/System.Security.SecureString/src/System/Security/SecureString.Windows.cs
@@ -161,12 +161,6 @@ namespace System.Security
             try
             {
                 ptr = Marshal.AllocCoTaskMem((length + 1) * 2);
-
-                if (ptr == IntPtr.Zero)
-                {
-                    throw new OutOfMemoryException();
-                }
-
                 decryptedBuffer = UnProtectMemory();
                 decryptedBuffer.AcquirePointer(ref bufferPtr);
                 Buffer.MemoryCopy(bufferPtr, (byte*)ptr.ToPointer(), ((length + 1) * 2), length * 2);
@@ -222,10 +216,6 @@ namespace System.Security
         private void AllocateBuffer(uint size)
         {
             _encryptedBuffer = SafeBSTRHandle.Allocate(null, size);
-            if (_encryptedBuffer.IsInvalid)
-            {
-                throw new OutOfMemoryException();
-            }
         }
 
         [System.Security.SecurityCritical]  // auto-generated
@@ -242,12 +232,6 @@ namespace System.Security
             }
 
             SafeBSTRHandle newBuffer = SafeBSTRHandle.Allocate(null, (uint)capacity);
-
-            if (newBuffer.IsInvalid)
-            {
-                throw new OutOfMemoryException();
-            }
-
             SafeBSTRHandle.Copy(decryptedBuffer, newBuffer);
             decryptedBuffer.Dispose();
             decryptedBuffer = newBuffer;

--- a/src/System.Security.SecureString/tests/SecureStringTests.cs
+++ b/src/System.Security.SecureString/tests/SecureStringTests.cs
@@ -254,6 +254,21 @@ public static class SecureStringTest
 
             testString.RemoveAt(0);
             VerifyString(testString, "bc");
+
+            testString.RemoveAt(1);
+            VerifyString(testString, "b");
+
+            testString.RemoveAt(0);
+            VerifyString(testString, "");
+
+            testString.AppendChar('f');
+            VerifyString(testString, "f");
+
+            testString.AppendChar('g');
+            VerifyString(testString, "fg");
+
+            testString.RemoveAt(0);
+            VerifyString(testString, "g");
         }
 
         if (s_isWindowsOrPrivilegedUnix)


### PR DESCRIPTION
Fixes for a variety of issues (more details in the commit descriptions):
1. There's a bug that results in an assert + argument exception when the SecureString shrinks and then re-grows.
2. SecureString's handling of OOM conditions is inconsistent.
3. Lots of SafeBuffers are being left to finalization to clean up. 
4. The assembly has an unused resource string.