### PR TITLE
Implement generic interfaces on Regex collections

### DIFF
--- a/src/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -123,6 +123,9 @@
   <data name="AlternationCantHaveComment" xml:space="preserve">
     <value>Alternation conditions cannot be comments.</value>
   </data>
+  <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+  </data>
   <data name="BadClassInCharRange" xml:space="preserve">
     <value>Cannot include class \\{0} in character range.</value>
   </data>
@@ -185,6 +188,9 @@
   </data>
   <data name="NotEnoughParens" xml:space="preserve">
     <value>Not enough )'s.</value>
+  </data>
+  <data name="NotSupported_ReadOnlyCollection" xml:space="preserve">
+    <value>Collection is read-only.</value>
   </data>
   <data name="OnlyAllowedOnce" xml:space="preserve">
     <value>This operation is only allowed once per object.</value>

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -21,6 +21,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexCaptureCollection.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCode.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexCollectionDebuggerProxy.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexFCD.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexGroup.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexGroupCollection.cs" />

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaptureCollection.cs
@@ -5,6 +5,7 @@
 // contained in a compiled Regex.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Text.RegularExpressions
@@ -18,7 +19,9 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
-    public class CaptureCollection : ICollection
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<Capture>))]
+    public class CaptureCollection : IList<Capture>, IReadOnlyList<Capture>, IList
     {
         private readonly Group _group;
         private readonly int _capcount;
@@ -47,9 +50,33 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
+        /// Copies all the elements of the collection to the given array
+        /// beginning at the given index.
+        /// </summary>
+        public void CopyTo(Capture[] array, int arrayIndex)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+            if (arrayIndex < 0 || arrayIndex > array.Length)
+                throw new ArgumentOutOfRangeException("arrayIndex");
+            if (array.Length - arrayIndex < Count)
+                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+
+            for (int i = arrayIndex, j = 0; j < Count; i++, j++)
+            {
+                array[i] = this[j];
+            }
+        }
+
+        /// <summary>
         /// Provides an enumerator in the same order as Item[].
         /// </summary>
         public IEnumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator<Capture> IEnumerable<Capture>.GetEnumerator()
         {
             return new Enumerator(this);
         }
@@ -78,6 +105,109 @@ namespace System.Text.RegularExpressions
             return _captures[i];
         }
 
+        int IList<Capture>.IndexOf(Capture item)
+        {
+            var comparer = EqualityComparer<Capture>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        void IList<Capture>.Insert(int index, Capture item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList<Capture>.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        Capture IList<Capture>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
+        void ICollection<Capture>.Add(Capture item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void ICollection<Capture>.Clear()
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool ICollection<Capture>.Contains(Capture item)
+        {
+            return ((IList<Capture>)this).IndexOf(item) >= 0;
+        }
+
+        bool ICollection<Capture>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        bool ICollection<Capture>.Remove(Capture item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        int IList.Add(object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool IList.Contains(object value)
+        {
+            return value is Capture && ((ICollection<Capture>)this).Contains((Capture)value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return value is Capture ? ((IList<Capture>)this).IndexOf((Capture)value) : -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool IList.IsFixedSize
+        {
+            get { return true; }
+        }
+
+        bool IList.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        object IList.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
         bool ICollection.IsSynchronized
         {
             get { return false; }
@@ -99,7 +229,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        private class Enumerator : IEnumerator
+        private class Enumerator : IEnumerator<Capture>
         {
             private readonly CaptureCollection _collection;
             private int _index;
@@ -143,6 +273,10 @@ namespace System.Text.RegularExpressions
             void IEnumerator.Reset()
             {
                 _index = -1;
+            }
+
+            void IDisposable.Dispose()
+            {
             }
         }
     }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCollectionDebuggerProxy.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCollectionDebuggerProxy.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.RegularExpressions
+{
+    internal sealed class RegexCollectionDebuggerProxy<T>
+    {
+        private readonly ICollection<T> _collection;
+
+        public RegexCollectionDebuggerProxy(ICollection<T> collection)
+        {
+            if (collection == null)
+                throw new ArgumentNullException("collection");
+
+            _collection = collection;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get
+            {
+                T[] items = new T[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGroupCollection.cs
@@ -14,7 +14,9 @@ namespace System.Text.RegularExpressions
     /// Represents a sequence of capture substrings. The object is used
     /// to return the set of captures done by a single capturing group.
     /// </summary>
-    public class GroupCollection : ICollection
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<Group>))]
+    public class GroupCollection : IList<Group>, IReadOnlyList<Group>, IList
     {
         private readonly Match _match;
         private readonly Dictionary<int, int> _captureMap;
@@ -53,9 +55,33 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
+        /// Copies all the elements of the collection to the given array
+        /// beginning at the given index.
+        /// </summary>
+        public void CopyTo(Group[] array, int arrayIndex)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+            if (arrayIndex < 0 || arrayIndex > array.Length)
+                throw new ArgumentOutOfRangeException("arrayIndex");
+            if (array.Length - arrayIndex < Count)
+                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+
+            for (int i = arrayIndex, j = 0; j < Count; i++, j++)
+            {
+                array[i] = this[j];
+            }
+        }
+
+        /// <summary>
         /// Provides an enumerator in the same order as Item[].
         /// </summary>
         public IEnumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator<Group> IEnumerable<Group>.GetEnumerator()
         {
             return new Enumerator(this);
         }
@@ -101,6 +127,109 @@ namespace System.Text.RegularExpressions
             return _groups[groupnum - 1];
         }
 
+        int IList<Group>.IndexOf(Group item)
+        {
+            var comparer = EqualityComparer<Group>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        void IList<Group>.Insert(int index, Group item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList<Group>.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        Group IList<Group>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
+        void ICollection<Group>.Add(Group item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void ICollection<Group>.Clear()
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool ICollection<Group>.Contains(Group item)
+        {
+            return ((IList<Group>)this).IndexOf(item) >= 0;
+        }
+
+        bool ICollection<Group>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        bool ICollection<Group>.Remove(Group item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        int IList.Add(object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool IList.Contains(object value)
+        {
+            return value is Group && ((ICollection<Group>)this).Contains((Group)value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return value is Group ? ((IList<Group>)this).IndexOf((Group)value) : -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool IList.IsFixedSize
+        {
+            get { return true; }
+        }
+
+        bool IList.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        object IList.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
         bool ICollection.IsSynchronized
         {
             get { return false; }
@@ -122,7 +251,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        private class Enumerator : IEnumerator
+        private class Enumerator : IEnumerator<Group>
         {
             private readonly GroupCollection _collection;
             private int _index;
@@ -166,6 +295,10 @@ namespace System.Text.RegularExpressions
             void IEnumerator.Reset()
             {
                 _index = -1;
+            }
+
+            void IDisposable.Dispose()
+            {
             }
         }
     }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -19,7 +19,9 @@ namespace System.Text.RegularExpressions
     /// Represents the set of names appearing as capturing group
     /// names in a regular expression.
     /// </summary>
-    public class MatchCollection : ICollection
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(RegexCollectionDebuggerProxy<Match>))]
+    public class MatchCollection : IList<Match>, IReadOnlyList<Match>, IList
     {
         private readonly Regex _regex;
         private readonly List<Match> _matches;
@@ -77,9 +79,24 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
+        /// Copies all the elements of the collection to the given array
+        /// starting at the given index.
+        /// </summary>
+        public void CopyTo(Match[] array, int arrayIndex)
+        {
+            EnsureInitialized();
+            _matches.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>
         /// Provides an enumerator in the same order as Item[i].
         /// </summary>
         public IEnumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator<Match> IEnumerable<Match>.GetEnumerator()
         {
             return new Enumerator(this);
         }
@@ -123,6 +140,109 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        int IList<Match>.IndexOf(Match item)
+        {
+            var comparer = EqualityComparer<Match>.Default;
+            for (int i = 0; i < Count; i++)
+            {
+                if (comparer.Equals(this[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        void IList<Match>.Insert(int index, Match item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList<Match>.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        Match IList<Match>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
+        void ICollection<Match>.Add(Match item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void ICollection<Match>.Clear()
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool ICollection<Match>.Contains(Match item)
+        {
+            return ((IList<Match>)this).IndexOf(item) >= 0;
+        }
+
+        bool ICollection<Match>.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        bool ICollection<Match>.Remove(Match item)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        int IList.Add(object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool IList.Contains(object value)
+        {
+            return value is Match && ((ICollection<Match>)this).Contains((Match)value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return value is Match ? ((IList<Match>)this).IndexOf((Match)value) : -1;
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        bool IList.IsFixedSize
+        {
+            get { return true; }
+        }
+
+        bool IList.IsReadOnly
+        {
+            get { return true; }
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+        }
+
+        object IList.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection); }
+        }
+
         bool ICollection.IsSynchronized
         {
             get { return false; }
@@ -139,7 +259,7 @@ namespace System.Text.RegularExpressions
             ((ICollection)_matches).CopyTo(array, arrayIndex);
         }
 
-        private class Enumerator : IEnumerator
+        private class Enumerator : IEnumerator<Match>
         {
             private readonly MatchCollection _collection;
             private int _index;
@@ -188,6 +308,10 @@ namespace System.Text.RegularExpressions
             void IEnumerator.Reset()
             {
                 _index = -1;
+            }
+
+            void IDisposable.Dispose()
+            {
             }
         }
     }

--- a/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
@@ -1,73 +1,271 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using System;
-using System.Text.RegularExpressions;
 using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
 
 namespace Test
 {
-    /// <summary>
-    /// Tests the CaptureCollection class.
-    /// </summary>
     public class CaptureCollectionTests
     {
         [Fact]
         public static void CaptureCollection_GetEnumeratorTest_Negative()
         {
-            Regex rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
-            String strInput = "aaabbccccccccccaaaabc";
-            Match mtch1 = rgx1.Match(strInput);
-            CaptureCollection captrc1 = mtch1.Captures;
+            CaptureCollection collection = CreateCollection();
 
-            IEnumerator enmtr1 = captrc1.GetEnumerator();
+            IEnumerator enumerator = collection.GetEnumerator();
 
-            Capture currentCapture;
+            Capture current;
 
-            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
+            Assert.Throws<InvalidOperationException>(() => current = (Capture)enumerator.Current);
 
 
-            for (int i = 0; i < captrc1.Count; i++)
+            for (int i = 0; i < collection.Count; i++)
             {
-                enmtr1.MoveNext();
+                enumerator.MoveNext();
             }
 
-            enmtr1.MoveNext();
+            enumerator.MoveNext();
 
-            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
-            enmtr1.Reset();
+            Assert.Throws<InvalidOperationException>(() => current = (Capture)enumerator.Current);
+            enumerator.Reset();
 
-            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
+            Assert.Throws<InvalidOperationException>(() => current = (Capture)enumerator.Current);
         }
 
         [Fact]
         public static void CaptureCollection_GetEnumeratorTest()
         {
-            Regex rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
-            String strInput = "aaabbccccccccccaaaabc";
-            Match mtch1 = rgx1.Match(strInput);
-            CaptureCollection captrc1 = mtch1.Captures;
+            CaptureCollection collection = CreateCollection();
 
-            IEnumerator enmtr1 = captrc1.GetEnumerator();
+            IEnumerator enumerator = collection.GetEnumerator();
 
-            for (int i = 0; i < captrc1.Count; i++)
+            for (int i = 0; i < collection.Count; i++)
             {
-                enmtr1.MoveNext();
+                enumerator.MoveNext();
 
-                Assert.Equal(enmtr1.Current, captrc1[i]);
+                Assert.Equal(enumerator.Current, collection[i]);
             }
 
-            Assert.False(enmtr1.MoveNext(), "Err_5! enmtr1.MoveNext returned true");
+            Assert.False(enumerator.MoveNext());
 
-            enmtr1.Reset();
+            enumerator.Reset();
 
-            for (int i = 0; i < captrc1.Count; i++)
+            for (int i = 0; i < collection.Count; i++)
             {
-                enmtr1.MoveNext();
+                enumerator.MoveNext();
 
-                Assert.Equal(enmtr1.Current, captrc1[i]);
+                Assert.Equal(enumerator.Current, collection[i]);
             }
+        }
+
+        [Fact]
+        public static void Indexer()
+        {
+            CaptureCollection collection = CreateCollection();
+            Assert.Equal("This ", collection[0].ToString());
+            Assert.Equal("is ", collection[1].ToString());
+            Assert.Equal("a ", collection[2].ToString());
+            Assert.Equal("sentence", collection[3].ToString());
+        }
+
+        [Fact]
+        public static void IndexerIListOfT()
+        {
+            IList<Capture> collection = CreateCollection();
+            Assert.Equal("This ", collection[0].ToString());
+            Assert.Equal("is ", collection[1].ToString());
+            Assert.Equal("a ", collection[2].ToString());
+            Assert.Equal("sentence", collection[3].ToString());
+        }
+
+        [Fact]
+        public static void IndexerIListNonGeneric()
+        {
+            IList collection = CreateCollection();
+            Assert.Equal("This ", collection[0].ToString());
+            Assert.Equal("is ", collection[1].ToString());
+            Assert.Equal("a ", collection[2].ToString());
+            Assert.Equal("sentence", collection[3].ToString());
+        }
+
+        [Fact]
+        public static void Contains()
+        {
+            ICollection<Capture> collection = CreateCollection();
+            foreach (Capture item in collection)
+            {
+                Assert.True(collection.Contains(item));
+            }
+
+            foreach (Capture item in CreateCollection())
+            {
+                Assert.False(collection.Contains(item));
+            }
+        }
+
+        [Fact]
+        public static void ContainsNonGeneric()
+        {
+            IList collection = CreateCollection();
+            foreach (object item in collection)
+            {
+                Assert.True(collection.Contains(item));
+            }
+
+            foreach (object item in CreateCollection())
+            {
+                Assert.False(collection.Contains(item));
+            }
+
+            Assert.False(collection.Contains(new object()));
+        }
+
+        [Fact]
+        public static void IndexOf()
+        {
+            IList<Capture> collection = CreateCollection();
+
+            int i = 0;
+            foreach (Capture item in collection)
+            {
+                Assert.Equal(i, collection.IndexOf(item));
+                i++;
+            }
+
+            foreach (Capture item in CreateCollection())
+            {
+                Assert.Equal(-1, collection.IndexOf(item));
+            }
+        }
+
+        [Fact]
+        public static void IndexOfNonGeneric()
+        {
+            IList collection = CreateCollection();
+
+            int i = 0;
+            foreach (object item in collection)
+            {
+                Assert.Equal(i, collection.IndexOf(item));
+                i++;
+            }
+
+            foreach (object item in CreateCollection())
+            {
+                Assert.Equal(-1, collection.IndexOf(item));
+            }
+
+            Assert.Equal(-1, collection.IndexOf(new object()));
+        }
+
+        [Fact]
+        public static void CopyToExceptions()
+        {
+            CaptureCollection collection = CreateCollection();
+            Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Capture[1], -1));
+            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Capture[1], 0));
+            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Capture[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Capture[1], 2));
+        }
+
+        [Fact]
+        public static void CopyToNonGenericExceptions()
+        {
+            ICollection collection = CreateCollection();
+            Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
+            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Capture[10, 10], 0));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Capture[1], -1));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Capture[1], 0));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Capture[1], 1));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Capture[1], 2));
+            Assert.Throws<InvalidCastException>(() => collection.CopyTo(new int[collection.Count], 0));
+        }
+
+        [Fact]
+        public static void CopyTo()
+        {
+            string[] expected = new[] { "This ", "is ", "a ", "sentence" };
+            CaptureCollection collection = CreateCollection();
+
+            Capture[] array = new Capture[collection.Count];
+            collection.CopyTo(array, 0);
+
+            Assert.Equal(expected, array.Select(c => c.ToString()));
+        }
+
+        [Fact]
+        public static void CopyToNonGeneric()
+        {
+            string[] expected = new[] { "This ", "is ", "a ", "sentence" };
+            ICollection collection = CreateCollection();
+
+            Capture[] array = new Capture[collection.Count];
+            collection.CopyTo(array, 0);
+
+            Assert.Equal(expected, array.Select(c => c.ToString()));
+        }
+
+        [Fact]
+        public static void SyncRoot()
+        {
+            ICollection collection = CreateCollection();
+            Assert.NotNull(collection.SyncRoot);
+            Assert.Same(collection.SyncRoot, collection.SyncRoot);
+        }
+
+        [Fact]
+        public static void IsNotSynchronized()
+        {
+            ICollection collection = CreateCollection();
+            Assert.False(collection.IsSynchronized);
+        }
+
+        [Fact]
+        public void IsReadOnly()
+        {
+            IList<Capture> list = CreateCollection();
+            Assert.True(list.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => list.Add(default(Capture)));
+            Assert.Throws<NotSupportedException>(() => list.Clear());
+            Assert.Throws<NotSupportedException>(() => list.Insert(0, default(Capture)));
+            Assert.Throws<NotSupportedException>(() => list.Remove(default(Capture)));
+            Assert.Throws<NotSupportedException>(() => list.RemoveAt(0));
+            Assert.Throws<NotSupportedException>(() => list[0] = default(Capture));
+        }
+
+        [Fact]
+        public static void IsReadOnlyNonGeneric()
+        {
+            IList list = CreateCollection();
+            Assert.True(list.IsReadOnly);
+            Assert.True(list.IsFixedSize);
+            Assert.Throws<NotSupportedException>(() => list.Add(default(Capture)));
+            Assert.Throws<NotSupportedException>(() => list.Clear());
+            Assert.Throws<NotSupportedException>(() => list.Insert(0, default(Capture)));
+            Assert.Throws<NotSupportedException>(() => list.Remove(default(Capture)));
+            Assert.Throws<NotSupportedException>(() => list.RemoveAt(0));
+            Assert.Throws<NotSupportedException>(() => list[0] = default(Capture));
+        }
+
+        [Fact]
+        public static void DebuggerAttributeTests()
+        {
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(CreateCollection());
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(CreateCollection());
+        }
+
+        private static CaptureCollection CreateCollection()
+        {
+            Regex regex = new Regex(@"\b(\w+\s*)+\.");
+            Match match = regex.Match("This is a sentence.");
+            return match.Groups[1].Captures;
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/GroupCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/GroupCollectionTests.cs
@@ -11,37 +11,12 @@ using Xunit;
 
 namespace Test
 {
-    public class MatchCollectionTests
+    public class GroupCollectionTests
     {
         [Fact]
-        public static void EnumeratorTest1()
+        public static void EnumeratorTest()
         {
-            Regex regex = new Regex("e");
-            MatchCollection collection = regex.Matches("dotnet");
-            IEnumerator enumerator = collection.GetEnumerator();
-
-            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-            Assert.True(enumerator.MoveNext());
-            Assert.IsAssignableFrom<Match>(enumerator.Current);
-            Assert.Equal(4, ((Match)enumerator.Current).Index);
-            Assert.Equal("e", ((Match)enumerator.Current).Value);
-            Assert.False(enumerator.MoveNext());
-            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-
-            enumerator.Reset();
-            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-            Assert.True(enumerator.MoveNext());
-            Assert.IsAssignableFrom<Match>(enumerator.Current);
-            Assert.Equal(4, ((Match)enumerator.Current).Index);
-            Assert.Equal("e", ((Match)enumerator.Current).Value);
-            Assert.False(enumerator.MoveNext());
-            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-        }
-
-        [Fact]
-        public static void EnumeratorTest2()
-        {
-            MatchCollection collection = CreateCollection();
+            GroupCollection collection = CreateCollection();
             IEnumerator enumerator = collection.GetEnumerator();
 
             for (int i = 0; i < collection.Count; i++)
@@ -70,13 +45,13 @@ namespace Test
         [Fact]
         public static void Contains()
         {
-            ICollection<Match> collection = CreateCollection();
-            foreach (Match item in collection)
+            ICollection<Group> collection = CreateCollection();
+            foreach (Group item in collection)
             {
                 Assert.True(collection.Contains(item));
             }
 
-            foreach (Match item in CreateCollection())
+            foreach (Group item in CreateCollection())
             {
                 Assert.False(collection.Contains(item));
             }
@@ -102,16 +77,16 @@ namespace Test
         [Fact]
         public static void IndexOf()
         {
-            IList<Match> collection = CreateCollection();
+            IList<Group> collection = CreateCollection();
 
             int i = 0;
-            foreach (Match item in collection)
+            foreach (Group item in collection)
             {
                 Assert.Equal(i, collection.IndexOf(item));
                 i++;
             }
 
-            foreach (Match item in CreateCollection())
+            foreach (Group item in CreateCollection())
             {
                 Assert.Equal(-1, collection.IndexOf(item));
             }
@@ -140,36 +115,39 @@ namespace Test
         [Fact]
         public static void Indexer()
         {
-            MatchCollection collection = CreateCollection();
-            Assert.Equal("t", collection[0].ToString());
-            Assert.Equal("t", collection[1].ToString());
+            GroupCollection collection = CreateCollection();
+            Assert.Equal("212-555-6666", collection[0].ToString());
+            Assert.Equal("212", collection[1].ToString());
+            Assert.Equal("555-6666", collection[2].ToString());
         }
 
         [Fact]
         public static void IndexerIListOfT()
         {
-            IList<Match> collection = CreateCollection();
-            Assert.Equal("t", collection[0].ToString());
-            Assert.Equal("t", collection[1].ToString());
+            IList<Group> collection = CreateCollection();
+            Assert.Equal("212-555-6666", collection[0].ToString());
+            Assert.Equal("212", collection[1].ToString());
+            Assert.Equal("555-6666", collection[2].ToString());
         }
 
         [Fact]
         public static void IndexerIListNonGeneric()
         {
             IList collection = CreateCollection();
-            Assert.Equal("t", collection[0].ToString());
-            Assert.Equal("t", collection[1].ToString());
+            Assert.Equal("212-555-6666", collection[0].ToString());
+            Assert.Equal("212", collection[1].ToString());
+            Assert.Equal("555-6666", collection[2].ToString());
         }
 
         [Fact]
         public static void CopyToExceptions()
         {
-            MatchCollection collection = CreateCollection();
+            GroupCollection collection = CreateCollection();
             Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Match[1], -1));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[1], 0));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[1], 1));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[1], 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Group[1], -1));
+            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Group[1], 0));
+            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Group[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Group[1], 2));
         }
 
         [Fact]
@@ -177,21 +155,21 @@ namespace Test
         {
             ICollection collection = CreateCollection();
             Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[10, 10], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Match[1], -1));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[1], 0));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[1], 1));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Match[1], 2));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new int[collection.Count], 0));
+            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Group[10, 10], 0));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Group[1], -1));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Group[1], 0));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Group[1], 1));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new Group[1], 2));
+            Assert.Throws<InvalidCastException>(() => collection.CopyTo(new int[collection.Count], 0));
         }
 
         [Fact]
         public static void CopyTo()
         {
-            string[] expected = new[] { "t", "t" };
-            MatchCollection collection = CreateCollection();
+            string[] expected = new[] { "212-555-6666", "212", "555-6666" };
+            GroupCollection collection = CreateCollection();
 
-            Match[] array = new Match[collection.Count];
+            Group[] array = new Group[collection.Count];
             collection.CopyTo(array, 0);
 
             Assert.Equal(expected, array.Select(c => c.ToString()));
@@ -200,10 +178,10 @@ namespace Test
         [Fact]
         public static void CopyToNonGeneric()
         {
-            string[] expected = new[] { "t", "t" };
+            string[] expected = new[] { "212-555-6666", "212", "555-6666" };
             ICollection collection = CreateCollection();
 
-            Capture[] array = new Capture[collection.Count];
+            Group[] array = new Group[collection.Count];
             collection.CopyTo(array, 0);
 
             Assert.Equal(expected, array.Select(c => c.ToString()));
@@ -227,14 +205,14 @@ namespace Test
         [Fact]
         public void IsReadOnly()
         {
-            IList<Match> list = CreateCollection();
+            IList<Group> list = CreateCollection();
             Assert.True(list.IsReadOnly);
-            Assert.Throws<NotSupportedException>(() => list.Add(default(Match)));
+            Assert.Throws<NotSupportedException>(() => list.Add(default(Group)));
             Assert.Throws<NotSupportedException>(() => list.Clear());
-            Assert.Throws<NotSupportedException>(() => list.Insert(0, default(Match)));
-            Assert.Throws<NotSupportedException>(() => list.Remove(default(Match)));
+            Assert.Throws<NotSupportedException>(() => list.Insert(0, default(Group)));
+            Assert.Throws<NotSupportedException>(() => list.Remove(default(Group)));
             Assert.Throws<NotSupportedException>(() => list.RemoveAt(0));
-            Assert.Throws<NotSupportedException>(() => list[0] = default(Match));
+            Assert.Throws<NotSupportedException>(() => list[0] = default(Group));
         }
 
         [Fact]
@@ -243,12 +221,12 @@ namespace Test
             IList list = CreateCollection();
             Assert.True(list.IsReadOnly);
             Assert.True(list.IsFixedSize);
-            Assert.Throws<NotSupportedException>(() => list.Add(default(Match)));
+            Assert.Throws<NotSupportedException>(() => list.Add(default(Group)));
             Assert.Throws<NotSupportedException>(() => list.Clear());
-            Assert.Throws<NotSupportedException>(() => list.Insert(0, default(Match)));
-            Assert.Throws<NotSupportedException>(() => list.Remove(default(Match)));
+            Assert.Throws<NotSupportedException>(() => list.Insert(0, default(Group)));
+            Assert.Throws<NotSupportedException>(() => list.Remove(default(Group)));
             Assert.Throws<NotSupportedException>(() => list.RemoveAt(0));
-            Assert.Throws<NotSupportedException>(() => list[0] = default(Match));
+            Assert.Throws<NotSupportedException>(() => list[0] = default(Group));
         }
 
         [Fact]
@@ -258,9 +236,11 @@ namespace Test
             DebuggerAttributes.ValidateDebuggerTypeProxyProperties(CreateCollection());
         }
 
-        private static MatchCollection CreateCollection()
+        private static GroupCollection CreateCollection()
         {
-            return new Regex("t").Matches("dotnet");
+            Regex regex = new Regex(@"(\d{3})-(\d{3}-\d{4})");
+            Match match = regex.Match("212-555-6666");
+            return match.Groups;
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="CaptureCollectionTests.cs" />
     <Compile Include="CaptureTests.cs" />
     <Compile Include="EscapeUnescapeTests.cs" />
+    <Compile Include="GroupCollectionTests.cs" />
     <Compile Include="GroupNamesAndNumbers.cs" />
     <Compile Include="IsMatchMatchSplitTests.cs" />
     <Compile Include="MatchCollectionTests.cs" />
@@ -53,6 +54,9 @@
     <Compile Include="RegexLangElementsCoverageTests.cs" />
     <Compile Include="CharacterClassSubtractionSimple.cs" />
     <Compile Include="Support.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Text.RegularExpressions.csproj">

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -2,8 +2,11 @@
   "dependencies": {
     "System.Collections": "4.0.10-beta-*",
     "System.Console": "4.0.0-beta-*",
+    "System.Diagnostics.Debug": "4.0.0-beta-*",
     "System.Globalization": "4.0.10-beta-*",
     "System.IO": "4.0.10-beta-*",
+    "System.Linq": "4.0.0-beta-*",
+    "System.Reflection": "4.0.0-beta-*",
     "System.Runtime": "4.0.20-beta-*",
     "System.Runtime.Extensions": "4.0.10-beta-*",
     "System.Text.Encoding": "4.0.10-beta-*",

--- a/src/System.Text.RegularExpressions/tests/project.lock.json
+++ b/src/System.Text.RegularExpressions/tests/project.lock.json
@@ -33,15 +33,12 @@
           "lib/DNXCore50/System.Console.dll"
         ]
       },
-      "System.Diagnostics.Debug/4.0.10-beta-22816": {
+      "System.Diagnostics.Debug/4.0.0-beta-22927": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-22816"
+          "System.Runtime": "4.0.0-beta-22927"
         },
         "compile": [
-          "lib/contract/System.Diagnostics.Debug.dll"
-        ],
-        "runtime": [
-          "lib/aspnetcore50/System.Diagnostics.Debug.dll"
+          "ref/any/System.Diagnostics.Debug.dll"
         ]
       },
       "System.Globalization/4.0.10-beta-22927": {
@@ -79,16 +76,19 @@
           "lib/any/System.IO.FileSystem.Primitives.dll"
         ]
       },
-      "System.Linq/4.0.0-beta-22816": {
+      "System.Linq/4.0.0-beta-22927": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-22816",
-          "System.Runtime": "4.0.20-beta-22816"
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927"
         },
         "compile": [
-          "lib/contract/System.Linq.dll"
+          "ref/any/System.Linq.dll"
         ],
         "runtime": [
-          "lib/aspnetcore50/System.Linq.dll"
+          "lib/any/System.Linq.dll"
         ]
       },
       "System.Private.Uri/4.0.0-beta-22927": {
@@ -96,17 +96,14 @@
           "lib/DNXCore50/System.Private.Uri.dll"
         ]
       },
-      "System.Reflection/4.0.10-beta-22816": {
+      "System.Reflection/4.0.0-beta-22927": {
         "dependencies": {
-          "System.IO": "4.0.10-beta-22816",
-          "System.Reflection.Primitives": "4.0.0-beta-22816",
-          "System.Runtime": "4.0.20-beta-22816"
+          "System.IO": "4.0.0-beta-22927",
+          "System.Reflection.Primitives": "4.0.0-beta-22927",
+          "System.Runtime": "4.0.0-beta-22927"
         },
         "compile": [
-          "lib/contract/System.Reflection.dll"
-        ],
-        "runtime": [
-          "lib/aspnetcore50/System.Reflection.dll"
+          "ref/any/System.Reflection.dll"
         ]
       },
       "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -278,7 +275,7 @@
           "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.core.dll"
         ]
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00050": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00051": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10-beta-22703",
           "System.IO": "4.0.10-beta-22703",
@@ -332,17 +329,18 @@
         "runtimes/win8-aot/lib/netcore50/System.Console.dll"
       ]
     },
-    "System.Diagnostics.Debug/4.0.10-beta-22816": {
-      "sha512": "sFAWo06FoJmZLT0oH/HzbpWUdaEPK6ao58ttrdqnQ6QXRtTH85NXHRrhxpU/tDSODX1fPuwIEf+i5vSVJvoCOQ==",
+    "System.Diagnostics.Debug/4.0.0-beta-22927": {
+      "sha512": "MJfDEvl1LY5/JXbfiD/fei8kLX7xq7E60vBLzuOuDDd16KPJE4wTd3PhxoXyQtf7iesq+lLS5uVPJylgYcJMZw==",
       "files": [
         "License.rtf",
-        "System.Diagnostics.Debug.4.0.10-beta-22816.nupkg",
-        "System.Diagnostics.Debug.4.0.10-beta-22816.nupkg.sha512",
+        "System.Diagnostics.Debug.4.0.0-beta-22927.nupkg",
+        "System.Diagnostics.Debug.4.0.0-beta-22927.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec",
-        "lib/aspnetcore50/System.Diagnostics.Debug.dll",
-        "lib/contract/System.Diagnostics.Debug.dll",
-        "lib/net45/System.Diagnostics.Debug.dll",
-        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Diagnostics.Debug.dll"
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "ref/any/System.Diagnostics.Debug.dll",
+        "ref/net45/_._",
+        "ref/win8/_._"
       ]
     },
     "System.Globalization/4.0.10-beta-22927": {
@@ -385,17 +383,16 @@
         "ref/net46/System.IO.FileSystem.Primitives.dll"
       ]
     },
-    "System.Linq/4.0.0-beta-22816": {
-      "sha512": "QlwRD8FTiYAZ7BxEjB5u9vjKaAHZ6KvuZYm+4tjYduTIWpFI3o34UjowJXCaPlLwc8USRshAXLgnsQ3iaOjv8Q==",
+    "System.Linq/4.0.0-beta-22927": {
+      "sha512": "eVlTn053TNQ7pipRD4fpKlQ8XagjnYEVfHY6asnJOnmo3kXDK84xRZIfTESQHUtlplcL5EYGyF/n5uIraIeKgw==",
       "files": [
-        "License.rtf",
-        "System.Linq.4.0.0-beta-22816.nupkg",
-        "System.Linq.4.0.0-beta-22816.nupkg.sha512",
+        "System.Linq.4.0.0-beta-22927.nupkg",
+        "System.Linq.4.0.0-beta-22927.nupkg.sha512",
         "System.Linq.nuspec",
-        "lib/aspnetcore50/System.Linq.dll",
-        "lib/contract/System.Linq.dll",
-        "lib/net45/System.Linq.dll",
-        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Linq.dll"
+        "lib/any/System.Linq.dll",
+        "lib/net46/System.Linq.dll",
+        "ref/any/System.Linq.dll",
+        "ref/net46/System.Linq.dll"
       ]
     },
     "System.Private.Uri/4.0.0-beta-22927": {
@@ -411,17 +408,18 @@
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
-    "System.Reflection/4.0.10-beta-22816": {
-      "sha512": "YzEbWoLTsPOUL4mPRbeRkhfJ12VgIJVy7fwoKnp0RgxXwuQQ2CPFt2E3qjl2TWzMpnhyRBtM2L/qkt4Dlg8Okw==",
+    "System.Reflection/4.0.0-beta-22927": {
+      "sha512": "L7aRhzNCaasOUPMWH1kmvofKHFvmZfvb4sS0FGK2SkEZi1ZfYBGaWd1N9GYoIGOQwNgmMrmO/fLEY9VeIRYbDw==",
       "files": [
         "License.rtf",
-        "System.Reflection.4.0.10-beta-22816.nupkg",
-        "System.Reflection.4.0.10-beta-22816.nupkg.sha512",
+        "System.Reflection.4.0.0-beta-22927.nupkg",
+        "System.Reflection.4.0.0-beta-22927.nupkg.sha512",
         "System.Reflection.nuspec",
-        "lib/aspnetcore50/System.Reflection.dll",
-        "lib/contract/System.Reflection.dll",
-        "lib/net45/System.Reflection.dll",
-        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Reflection.dll"
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "ref/any/System.Reflection.dll",
+        "ref/net45/_._",
+        "ref/win8/_._"
       ]
     },
     "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -654,11 +652,11 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80/xunit.runner.utility.xml"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00050": {
-      "sha512": "PoQB+RKMYPWEhclcQ/n09ZbYKwRKGadgQCMkCmhQIewOiev8AcaO03yoTbO5oEEcOxHKnl3DsGffB+IZD/Z45g==",
+    "xunit.netcore.extensions/1.0.0-prerelease-00051": {
+      "sha512": "8exRcZk2lrXIH3/DQFQ2pZ3eeYggXgCVGJmFOUetvsO2UROnjBAqGgtCPWB/jQE//ZVOYlOzKDzwvQlbEj4ktw==",
       "files": [
-        "xunit.netcore.extensions.1.0.0-prerelease-00050.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00050.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00051.nupkg.sha512",
         "xunit.netcore.extensions.nuspec",
         "lib/portable-wpa80+win80+net45+aspnetcore50/Xunit.NetCore.Extensions.dll"
       ]
@@ -668,8 +666,11 @@
     "": [
       "System.Collections >= 4.0.10-beta-*",
       "System.Console >= 4.0.0-beta-*",
+      "System.Diagnostics.Debug >= 4.0.0-beta-*",
       "System.Globalization >= 4.0.10-beta-*",
       "System.IO >= 4.0.10-beta-*",
+      "System.Linq >= 4.0.0-beta-*",
+      "System.Reflection >= 4.0.0-beta-*",
       "System.Runtime >= 4.0.20-beta-*",
       "System.Runtime.Extensions >= 4.0.10-beta-*",
       "System.Text.Encoding >= 4.0.10-beta-*",


### PR DESCRIPTION
Implement `IList<T>`, `IReadOnlyList<T>`, and `IList` on the Regex collections.

Fixes #271