### PR TITLE
Add tests for CryptoStream et al

### DIFF
--- a/src/System.Security.Cryptography.Encryption/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Encryption/src/Resources/Strings.resx
@@ -144,9 +144,6 @@
   <data name="Cryptography_InvalidCipherMode" xml:space="preserve">
     <value>Specified cipher mode is not valid for this algorithm.</value>
   </data>
-  <data name="Cryptography_InvalidFeedbackSize" xml:space="preserve">
-    <value>Specified feedback size is invalid.</value>
-  </data>
   <data name="Cryptography_InvalidIVSize" xml:space="preserve">
     <value>Specified initialization vector (IV) does not match the block size for this algorithm.</value>
   </data>
@@ -164,8 +161,5 @@
   </data>
   <data name="NotSupported_UnwritableStream" xml:space="preserve">
     <value>Stream does not support writing.</value>
-  </data>
-  <data name="WorkInProgress" xml:space="preserve">
-    <value>This api is in the process of being ported. TESTCOP: If this shows up during a test run, bugdata.xml the test and link bug to #1017534</value>
   </data>
 </root>

--- a/src/System.Security.Cryptography.Encryption/src/System.Security.Cryptography.Encryption.csproj
+++ b/src/System.Security.Cryptography.Encryption/src/System.Security.Cryptography.Encryption.csproj
@@ -28,9 +28,6 @@
     <Compile Include="System\Security\Cryptography\SymmetricAlgorithm.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/CryptographicException.cs
+++ b/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/CryptographicException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
 using System.Globalization;
 
 namespace System.Security.Cryptography
@@ -17,20 +15,21 @@ namespace System.Security.Cryptography
         public CryptographicException(int hr)
             : base(SR.Arg_CryptographyException)
         {
+            HResult = hr;
         }
 
-        public CryptographicException(String message)
+        public CryptographicException(string message)
             : base(message)
         {
         }
 
-        public CryptographicException(String message, Exception inner)
+        public CryptographicException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
-        public CryptographicException(String format, String insert)
-            : base(String.Format(CultureInfo.CurrentCulture, format, insert))
+        public CryptographicException(string format, string insert)
+            : base(string.Format(CultureInfo.CurrentCulture, format, insert))
         {
         }
     }

--- a/src/System.Security.Cryptography.Encryption/tests/AsymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Encryption/tests/AsymmetricAlgorithm/Trivial.cs
@@ -35,6 +35,13 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             return;
         }
 
+        [Fact]
+        public static void TestInvalidAlgorithm()
+        {
+            var invalid = new Invalid();
+            Assert.Throws<NullReferenceException>(() => invalid.LegalKeySizes);
+        }
+
         private static byte[] GenerateRandom(int size)
         {
             byte[] data = new byte[size];
@@ -46,6 +53,10 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             return data;
         }
 
+        private class Invalid : AsymmetricAlgorithm
+        {
+            // Valid algorithsm must override LegalKeySizes
+        }
 
         private class Trivial : AsymmetricAlgorithm
         {

--- a/src/System.Security.Cryptography.Encryption/tests/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Encryption/tests/CryptoStream.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
+{
+    public static class CryptoStreamTests
+    {
+        [Fact]
+        public static void Ctor()
+        {
+            var transform = new IdentityTransform(1, 1, true);
+            Assert.Throws<ArgumentException>(() => new CryptoStream(new MemoryStream(), transform, (CryptoStreamMode)12345));
+            Assert.Throws<ArgumentException>(() => new CryptoStream(new MemoryStream(new byte[0], writable: false), transform, CryptoStreamMode.Write));
+            Assert.Throws<ArgumentException>(() => new CryptoStream(new CryptoStream(new MemoryStream(new byte[0]), transform, CryptoStreamMode.Write), transform, CryptoStreamMode.Read));
+        }
+
+        [Theory]
+        [InlineData(64, 64, true)]
+        [InlineData(64, 128, true)]
+        [InlineData(128, 64, true)]
+        [InlineData(1, 1, true)]
+        [InlineData(37, 24, true)]
+        [InlineData(128, 3, true)]
+        [InlineData(8192, 64, true)]
+        [InlineData(64, 64, false)]
+        public static void Roundtrip(int inputBlockSize, int outputBlockSize, bool canTransformMultipleBlocks)
+        {
+            ICryptoTransform encryptor = new IdentityTransform(inputBlockSize, outputBlockSize, canTransformMultipleBlocks);
+            ICryptoTransform decryptor = new IdentityTransform(inputBlockSize, outputBlockSize, canTransformMultipleBlocks);
+
+            var stream = new MemoryStream();
+            using (CryptoStream encryptStream = new CryptoStream(stream, encryptor, CryptoStreamMode.Write))
+            {
+                Assert.True(encryptStream.CanWrite);
+                Assert.False(encryptStream.CanRead);
+                Assert.False(encryptStream.CanSeek);
+                Assert.False(encryptStream.HasFlushedFinalBlock);
+                Assert.Throws<NotSupportedException>(() => encryptStream.SetLength(1));
+                Assert.Throws<NotSupportedException>(() => encryptStream.Length);
+                Assert.Throws<NotSupportedException>(() => encryptStream.Position);
+                Assert.Throws<NotSupportedException>(() => encryptStream.Position = 0);
+                Assert.Throws<NotSupportedException>(() => encryptStream.Seek(0, SeekOrigin.Begin));
+                Assert.Throws<NotSupportedException>(() => encryptStream.Read(new byte[0], 0, 0));
+                Assert.Throws<NullReferenceException>(() => encryptStream.Write(null, 0, 0)); // No arg validation on buffer?
+                Assert.Throws<ArgumentOutOfRangeException>(() => encryptStream.Write(new byte[0], -1, 0));
+                Assert.Throws<ArgumentOutOfRangeException>(() => encryptStream.Write(new byte[0], 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => encryptStream.Write(new byte[0], 0, -1));
+                Assert.Throws<ArgumentException>(() => encryptStream.Write(new byte[3], 1, 4));
+
+                byte[] toWrite = Encoding.UTF8.GetBytes(LoremText);
+
+                // Write it all at once
+                encryptStream.Write(toWrite, 0, toWrite.Length);
+                Assert.False(encryptStream.HasFlushedFinalBlock);
+
+                // Write in chunks
+                encryptStream.Write(toWrite, 0, toWrite.Length / 2);
+                encryptStream.Write(toWrite, toWrite.Length / 2, toWrite.Length - (toWrite.Length / 2));
+                Assert.False(encryptStream.HasFlushedFinalBlock);
+
+                // Write one byte at a time
+                for (int i = 0; i < toWrite.Length; i++)
+                {
+                    encryptStream.WriteByte(toWrite[i]);
+                }
+                Assert.False(encryptStream.HasFlushedFinalBlock);
+
+                // Write async
+                encryptStream.WriteAsync(toWrite, 0, toWrite.Length).GetAwaiter().GetResult();
+                Assert.False(encryptStream.HasFlushedFinalBlock);
+
+                // Flush (nops)
+                encryptStream.Flush();
+                encryptStream.FlushAsync().GetAwaiter().GetResult();
+
+                encryptStream.FlushFinalBlock();
+                Assert.Throws<NotSupportedException>(() => encryptStream.FlushFinalBlock());
+                Assert.True(encryptStream.HasFlushedFinalBlock);
+
+                Assert.True(stream.Length > 0);
+            }
+
+            // Read/decrypt using Read
+            stream = new MemoryStream(stream.ToArray()); // CryptoStream.Dispose disposes the stream
+            using (CryptoStream decryptStream = new CryptoStream(stream, decryptor, CryptoStreamMode.Read))
+            {
+                Assert.False(decryptStream.CanWrite);
+                Assert.True(decryptStream.CanRead);
+                Assert.False(decryptStream.CanSeek);
+                Assert.False(decryptStream.HasFlushedFinalBlock);
+                Assert.Throws<NotSupportedException>(() => decryptStream.SetLength(1));
+                Assert.Throws<NotSupportedException>(() => decryptStream.Length);
+                Assert.Throws<NotSupportedException>(() => decryptStream.Position);
+                Assert.Throws<NotSupportedException>(() => decryptStream.Position = 0);
+                Assert.Throws<NotSupportedException>(() => decryptStream.Seek(0, SeekOrigin.Begin));
+                Assert.Throws<NotSupportedException>(() => decryptStream.Write(new byte[0], 0, 0));
+                Assert.Throws<NullReferenceException>(() => decryptStream.Read(null, 0, 0)); // No arg validation on buffer?
+                Assert.Throws<ArgumentOutOfRangeException>(() => decryptStream.Read(new byte[0], -1, 0));
+                Assert.Throws<ArgumentOutOfRangeException>(() => decryptStream.Read(new byte[0], 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => decryptStream.Read(new byte[0], 0, -1));
+                Assert.Throws<ArgumentException>(() => decryptStream.Read(new byte[3], 1, 4));
+
+                using (StreamReader reader = new StreamReader(decryptStream))
+                {
+                    Assert.Equal(
+                        LoremText + LoremText + LoremText + LoremText,
+                        reader.ReadToEnd());
+                }
+            }
+
+            // Read/decrypt using ReadToEnd
+            stream = new MemoryStream(stream.ToArray()); // CryptoStream.Dispose disposes the stream
+            using (CryptoStream decryptStream = new CryptoStream(stream, decryptor, CryptoStreamMode.Read))
+            using (StreamReader reader = new StreamReader(decryptStream))
+            {
+                Assert.Equal(
+                    LoremText + LoremText + LoremText + LoremText,
+                    reader.ReadToEndAsync().GetAwaiter().GetResult());
+            }
+
+            // Read/decrypt using a small buffer to force multiple calls to Read
+            stream = new MemoryStream(stream.ToArray()); // CryptoStream.Dispose disposes the stream
+            using (CryptoStream decryptStream = new CryptoStream(stream, decryptor, CryptoStreamMode.Read))
+            using (StreamReader reader = new StreamReader(decryptStream, Encoding.UTF8, true, bufferSize: 10))
+            {
+                Assert.Equal(
+                    LoremText + LoremText + LoremText + LoremText,
+                    reader.ReadToEndAsync().GetAwaiter().GetResult());
+            }
+        }
+
+        [Fact]
+        public static void NestedCryptoStreams()
+        {
+            ICryptoTransform encryptor = new IdentityTransform(1, 1, true);
+            using (MemoryStream output = new MemoryStream())
+            using (CryptoStream encryptStream1 = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
+            using (CryptoStream encryptStream2 = new CryptoStream(encryptStream1, encryptor, CryptoStreamMode.Write))
+            {
+                encryptStream2.Write(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+            }
+        }
+
+        [Fact]
+        public static void MultipleDispose()
+        {
+            ICryptoTransform encryptor = new IdentityTransform(1, 1, true);
+            using (MemoryStream output = new MemoryStream())
+            using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
+            {
+                encryptStream.Dispose();
+            }
+        }
+
+        private const string LoremText =
+            @"Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.
+              Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.
+              Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.
+              Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+              Proin pharetra nonummy pede. Mauris et orci.
+              Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.
+              Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend.
+              Ut nonummy.";
+
+        private sealed class IdentityTransform : ICryptoTransform
+        {
+            private readonly int _inputBlockSize, _outputBlockSize;
+            private readonly bool _canTransformMultipleBlocks;
+
+            private long _writePos, _readPos;
+            private MemoryStream _stream;
+
+            internal IdentityTransform(int inputBlockSize, int outputBlockSize, bool canTransformMultipleBlocks)
+            {
+                _inputBlockSize = inputBlockSize;
+                _outputBlockSize = outputBlockSize;
+                _canTransformMultipleBlocks = canTransformMultipleBlocks;
+                _stream = new MemoryStream();
+            }
+
+            public bool CanReuseTransform { get { return true; } }
+
+            public bool CanTransformMultipleBlocks { get { return _canTransformMultipleBlocks; } }
+
+            public int InputBlockSize { get { return _inputBlockSize; } }
+
+            public int OutputBlockSize { get { return _outputBlockSize; } }
+
+            public void Dispose() { }
+
+            public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+            {
+                _stream.Position = _writePos;
+                _stream.Write(inputBuffer, inputOffset, inputCount);
+                _writePos = _stream.Position;
+
+                _stream.Position = _readPos;
+                int copied = _stream.Read(outputBuffer, outputOffset, outputBuffer.Length - outputOffset);
+                _readPos = _stream.Position;
+
+                return copied;
+            }
+
+            public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+            {
+                _stream.Position = _writePos;
+                _stream.Write(inputBuffer, inputOffset, inputCount);
+
+                _stream.Position = _readPos;
+                long len = _stream.Length - _stream.Position;
+                byte[] outputBuffer = new byte[len];
+                _stream.Read(outputBuffer, 0, outputBuffer.Length);
+
+                _stream = new MemoryStream();
+                _writePos = 0;
+                _readPos = 0;
+                return outputBuffer;
+            }
+        }
+
+    }
+}

--- a/src/System.Security.Cryptography.Encryption/tests/CryptographicException.cs
+++ b/src/System.Security.Cryptography.Encryption/tests/CryptographicException.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
+{
+    public static class CryptographicExceptionTests
+    {
+        [Fact]
+        public static void Ctor()
+        {
+            string message = "Some Message";
+            var inner = new FormatException(message);
+
+            Assert.NotNull(new CryptographicException().Message);
+            Assert.Equal(message, new CryptographicException(message).Message);
+            Assert.Equal(message + " 12345", new CryptographicException(message + " {0}", "12345").Message);
+            Assert.Equal(5, new CryptographicException(5).HResult);
+            Assert.Same(inner, new CryptographicException(message, inner).InnerException);
+            Assert.Equal(message, new CryptographicException(message, inner).Message);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Encryption/tests/SymmetricAlgorithm/Minimal.cs
+++ b/src/System.Security.Cryptography.Encryption/tests/SymmetricAlgorithm/Minimal.cs
@@ -29,6 +29,23 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 Assert.Throws<NullReferenceException>(() => ignored = s.LegalKeySizes);
                 Assert.Throws<NullReferenceException>(() => ignored = s.KeySize = 5);
                 Assert.Throws<NullReferenceException>(() => s.Key = new byte[5]);
+
+                s.Mode = CipherMode.CBC;
+                Assert.Equal(CipherMode.CBC, s.Mode);
+                s.Mode = CipherMode.ECB;
+                Assert.Equal(CipherMode.ECB, s.Mode);
+                Assert.Throws<CryptographicException>(() => s.Mode = CipherMode.CTS);
+                Assert.Throws<CryptographicException>(() => s.Mode = (CipherMode)12345);
+                Assert.Equal(CipherMode.ECB, s.Mode);
+
+                s.Padding = PaddingMode.None;
+                Assert.Equal(PaddingMode.None, s.Padding);
+                s.Padding = PaddingMode.Zeros;
+                Assert.Equal(PaddingMode.Zeros, s.Padding);
+                s.Padding = PaddingMode.PKCS7;
+                Assert.Equal(PaddingMode.PKCS7, s.Padding);
+                Assert.Throws<CryptographicException>(() => s.Padding = (PaddingMode)12345);
+                Assert.Equal(PaddingMode.PKCS7, s.Padding);
             }
         }
 

--- a/src/System.Security.Cryptography.Encryption/tests/System.Security.Cryptography.Encryption.Tests.csproj
+++ b/src/System.Security.Cryptography.Encryption/tests/System.Security.Cryptography.Encryption.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$(CommonTestPath)\Tests.props" />
@@ -18,8 +18,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsymmetricAlgorithm\Trivial.cs" />
+    <Compile Include="CryptoStream.cs" />
     <Compile Include="SymmetricAlgorithm\Minimal.cs" />
     <Compile Include="SymmetricAlgorithm\Trivial.cs" />
+    <Compile Include="CryptographicException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.Hashing.Algorithms/tests/HashAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/tests/HashAlgorithmTest.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
             using (HashAlgorithm hash = Create())
             {
+                Assert.True(hash.HashSize > 0);
                 actual = hash.ComputeHash(input);
             }
 
@@ -35,6 +36,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
             using (HashAlgorithm hash = Create())
             {
+                Assert.True(hash.HashSize > 0);
                 actual = hash.ComputeHash(input, 0, input.Length);
             }
 

--- a/src/System.Security.Cryptography.Hashing.Algorithms/tests/HmacTests.cs
+++ b/src/System.Security.Cryptography.Hashing.Algorithms/tests/HmacTests.cs
@@ -31,7 +31,19 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
             using (HMAC hmac = Create())
             {
-                hmac.Key = _testKeys[testCaseId];
+                Assert.True(hmac.HashSize > 0);
+
+                byte[] key = (byte[])_testKeys[testCaseId].Clone();
+                hmac.Key = key;
+
+                // make sure the getter returns different objects each time
+                Assert.NotSame(key, hmac.Key); 
+                Assert.NotSame(hmac.Key, hmac.Key);
+
+                // make sure the setter didn't cache the exact object we passed in
+                key[0] = (byte)(key[0] + 1); 
+                Assert.NotEqual<byte>(key, hmac.Key);
+
                 computedDigest = hmac.ComputeHash(_testData[testCaseId]);
             }
 


### PR DESCRIPTION
This adds more tests for System.Security.Cryptography.Encryption and System.Security.Cryptography.Hashing.Algorithms, with the primary addition being for CryptoStream that wasn't previously exercised at all.

Code coverage:
- System.Security.Cryptography.Encryption: 31.7% => 91.7%
- System.Security.Cryptography.Hashing.Algorithms: 66.1% => 73.4%

There are two changes to the product code as part of this:
- Stored the int hr value passed to CryptographicException into its HResult property.
- Removed some unused resource strings.