### PR TITLE
Fix SymmetricAlgorithm.Key overflow bug

### DIFF
--- a/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Encryption/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -70,11 +70,12 @@ namespace System.Security.Cryptography
                 if (value == null)
                     throw new ArgumentNullException("value");
 
-                if (!ValidKeySize(value.Length * 8))
+                long bitLength = value.Length * 8L;
+                if (bitLength > int.MaxValue || !ValidKeySize((int)bitLength))
                     throw new CryptographicException(SR.Cryptography_InvalidKeySize);
 
                 // must convert bytes to bits
-                this.KeySize = value.Length * 8;
+                this.KeySize = (int)bitLength;
                 _key = value.CloneByteArray();
             }
         }

--- a/src/System.Security.Cryptography.Encryption/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Encryption/tests/SymmetricAlgorithm/Trivial.cs
@@ -59,6 +59,14 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                         }
                     }
                 }
+
+                // Test overflow
+                try
+                {
+                    byte[] hugeKey = new byte[536870917]; // value chosen so that when multiplied by 8 (bits) it overflows to the value 40
+                    Assert.Throws<CryptographicException>(() => s.Key = hugeKey);
+                }
+                catch (OutOfMemoryException) { } // in case there isn't enough memory at test-time to allocate the large array
             }
         }
 


### PR DESCRIPTION
Check that the key's size in bits doesn't overflow Int32.MaxValue, or else we could potentially be allowing in a gigantic key that happens to overflow to a valid key size.

Fixes #1755.