### PR TITLE
Move DNU/Roslyn forward

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -12,10 +12,10 @@
   <PropertyGroup>
     <BuildToolsVersion>1.0.25-prerelease-00047</BuildToolsVersion>
     <DnxVersion Condition="'$(OsEnvironment)'!='Unix'">1.0.0-beta5-11682</DnxVersion>
-    <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta5-11624</DnxVersion>
+    <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta5-11760</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
-    <RoslynVersion>1.0.0-rc2-20150421-01</RoslynVersion>
+    <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
   </PropertyGroup>
 

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00047" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11682" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
-  <package id="dnx-mono" version="1.0.0-beta5-11624" />
-  <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc2-20150421-01" />
+  <package id="dnx-mono" version="1.0.0-beta5-11760" />
+  <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />
 </packages>


### PR DESCRIPTION
Move to newer Mono build of DNU and RC3 of Roslyn.

Note that while DNU seems to work fairly well on CI builds on Mono I cannot get reliable compiles for many projects. Some always have random segfaults (CSharp library), some sometimes do, some sometimes hang. Running on 14.04LTE with latest MSBuild xplat branch.

```
[mono-20150515162943]jeremy@jeremy-ublte:~/repos/corefx$ mono -V
Mono JIT compiler version 4.1.0 (tarball Fri May 15 17:10:34 UTC 2015)
```

@akoeplinger, @weshaggard, @ericstj 