### PR TITLE
Add ConcurrentDictionary GetOrAdd/AddOrUpdate overloads with generic arg

### DIFF
--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
@@ -447,25 +447,33 @@ namespace System.Collections.Concurrent.Tests
                             {
                                 if (isAdd)
                                 {
-                                    //call either of the two overloads of GetOrAdd
-                                    if (j + ii % 2 == 0)
+                                    //call one of the overloads of GetOrAdd
+                                    switch (j % 3)
                                     {
-                                        dict.GetOrAdd(j, -j);
-                                    }
-                                    else
-                                    {
-                                        dict.GetOrAdd(j, x => -x);
+                                        case 0:
+                                            dict.GetOrAdd(j, -j);
+                                            break;
+                                        case 1:
+                                            dict.GetOrAdd(j, x => -x);
+                                            break;
+                                        case 2:
+                                            dict.GetOrAdd(j, (x,m) => x * m, -1);
+                                            break;
                                     }
                                 }
                                 else
                                 {
-                                    if (j + ii % 2 == 0)
+                                    switch (j % 3)
                                     {
-                                        dict.AddOrUpdate(j, -j, (k, v) => -j);
-                                    }
-                                    else
-                                    {
-                                        dict.AddOrUpdate(j, (k) => -k, (k, v) => -k);
+                                        case 0:
+                                            dict.AddOrUpdate(j, -j, (k, v) => -j);
+                                            break;
+                                        case 1:
+                                            dict.AddOrUpdate(j, (k) => -k, (k, v) => -k);
+                                            break;
+                                        case 2:
+                                            dict.AddOrUpdate(j, (k,m) => k*m, (k, v, m) => k * m, -1);
+                                            break;
                                     }
                                 }
                             }
@@ -622,6 +630,12 @@ namespace System.Collections.Concurrent.Tests
             // "TestExceptions:  FAILED.  this[] didn't throw ANE when null key is passed");
 
             Assert.Throws<ArgumentNullException>(
+               () => dictionary.GetOrAdd(null, (k,m) => 0, 0));
+            // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null key is passed");
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.GetOrAdd("1", null, 0));
+            // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null valueFactory is passed");
+            Assert.Throws<ArgumentNullException>(
                () => dictionary.GetOrAdd(null, (k) => 0));
             // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null key is passed");
             Assert.Throws<ArgumentNullException>(
@@ -631,6 +645,15 @@ namespace System.Collections.Concurrent.Tests
                () => dictionary.GetOrAdd(null, 0));
             // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null key is passed");
 
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.AddOrUpdate(null, (k, m) => 0, (k, v, m) => 0, 42));
+            // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null key is passed");
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.AddOrUpdate("1", (k, m) => 0, null, 42));
+            // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null updateFactory is passed");
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.AddOrUpdate("1", null, (k, v, m) => 0, 42));
+            // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null addFactory is passed");
             Assert.Throws<ArgumentNullException>(
                () => dictionary.AddOrUpdate(null, (k) => 0, (k, v) => 0));
             // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null key is passed");


### PR DESCRIPTION
Adds one overload to each of GetOrAdd and AddOrUpdate.  These overloads accept a generic argument that is passed through to any invocations of the supplied delegates, enabling developers to avoid delegate/closure allocations when more input is needed than just the key or existing value.  The implementations are exact copies of the existing overloads then augmented with the additional parameter and threading that through to the delegate invocations.

For AddOrUpdate, there are two existing overloads with delegates, and #394 proposes that a new overload be added for each. I went back and forth on that, and for now this PR only provide a new overload for the one that accepts two delegates, as the other just didn't seem worth it (to my recollection we also didn't discuss both of these overloads in the API review... I hadn't actually realized that a new overload was proposed for each of them).  If folks feel like it's really important to have the third one, though, I can add it.

Fixes https://github.com/dotnet/corefx/issues/394.