### PR TITLE
Fixed bug in Process asynchronous output reading

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -255,7 +255,7 @@ namespace System.Diagnostics
                 }
                 currentIndex++;
             }
-            if (_sb[len - 1] == '\r')
+            if ((len > 0) && _sb[len - 1] == '\r')
             {
                 _bLastCarriageReturn = true;
             }

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/TestConsoleApp.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.TestConsoleApp/TestConsoleApp.cs
@@ -31,6 +31,18 @@ namespace System.Diagnostics.ProcessTests
                     Console.WriteLine(Name + " closed");
                     Sleep();
                 }
+                else if (args[0].Equals("byteAtATime"))
+                {
+                    var stdout = Console.OpenStandardOutput();
+                    var bytes = new byte[] { 97, 0 }; //Encoding.Unicode.GetBytes("a");
+
+                    for (int i = 0; i != bytes.Length; ++i)
+                    {
+                        stdout.WriteByte(bytes[i]);
+                        stdout.Flush();
+                        Sleep(100);
+                    }
+                }
                 else
                 {
                     Console.WriteLine(string.Join(" ", args));

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests/Process_StreamTests.cs
@@ -24,6 +24,11 @@ namespace System.Diagnostics.ProcessTests
             return CreateProcess("stream");
         }
 
+        Process CreateProcessByteAtATime()
+        {
+            return CreateProcess("byteAtATime");
+        }
+
         [Fact, ActiveIssue(1538, PlatformID.OSX)]
         public void Process_SyncErrorStream()
         {
@@ -106,6 +111,24 @@ namespace System.Diagnostics.ProcessTests
                 writer.WriteLine(str);
             }
             Assert.True(p.WaitForExit(WaitInMS));
+        }
+
+        [Fact]
+        public void Process_AsyncHalfCharacterAtATime()
+        {
+            var receivedOutput = false;
+            Process p = CreateProcessByteAtATime();
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.StandardOutputEncoding = Encoding.Unicode;
+            p.OutputDataReceived += (s, e) =>
+            {
+                Assert.Equal(e.Data, "a");
+                receivedOutput = true;
+            };
+            p.Start();
+            p.BeginOutputReadLine();
+            Assert.True(p.WaitForExit(WaitInMS));
+            Assert.True(receivedOutput);
         }
     }
 }


### PR DESCRIPTION
An `IndexOutOfRangeException` was being thrown when less than a character's worth of bytes was read at the beginning of a line in `System.Diagnostics.AsyncStreamReader`. Although it rarely happens (it seems to be a race condition), it causes an unhandled exception on a background thread which terminates the application.

Here is the stack trace from my application (.NET 4.5.1) when the exception was thrown:

	at System.Text.StringBuilder.get_Chars(Int32 index)
	at System.Diagnostics.AsyncStreamReader.GetLinesFromStringBuilder()
	at System.Diagnostics.AsyncStreamReader.ReadBuffer(IAsyncResult ar)
	at System.IO.Stream.ReadWriteTask.InvokeAsyncCallback(Object completedTask)
	at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
	at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
	at System.IO.Stream.ReadWriteTask.System.Threading.Tasks.ITaskCompletionAction.Invoke(Task completingTask)
	at System.Threading.Tasks.Task.FinishContinuations()
	at System.Threading.Tasks.Task.FinishStageThree()
	at System.Threading.Tasks.Task.FinishStageTwo()
	at System.Threading.Tasks.Task.Finish(Boolean bUserDelegateExecuted)
	at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
	at System.Threading.Tasks.Task.ExecuteEntry(Boolean bPreventDoubleExecution)
	at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
	at System.Threading.ThreadPoolWorkQueue.Dispatch()
	at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()

There was simply a missing check for length > 0 before checking the character at length - 1.

I added a unit test that was able to reproduce the unhandled exception but which now passes with this bug fix.