### PR TITLE
Make tools packages.config host platform specific.

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -64,7 +64,7 @@
   <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
 
   <Target Name="_RestoreBuildTools"
-          Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget\packages.config"
+          Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget/packages.$(OsEnvironment).config"
           Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath);$(DnuToolPath)">
     <Message Importance="High" Text="Restoring build tools..." />
 
@@ -79,7 +79,7 @@
           Condition="!Exists('$(NuGetToolPath)') and '$(OsEnvironment)'=='Unix'" />
 
     <PropertyGroup>
-      <_RestoreBuildToolsCommand>$(NugetRestoreCommand) "$(SourceDir).nuget/packages.config"</_RestoreBuildToolsCommand>
+      <_RestoreBuildToolsCommand>$(NugetRestoreCommand) "$(SourceDir).nuget/packages.$(OsEnvironment).config"</_RestoreBuildToolsCommand>
     </PropertyGroup>
 
     <!-- Restore build tools -->

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00048" />
-  <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11682" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-11760" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00048" />
+  <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-11682" />
+  <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
+</packages>

--- a/src/Microsoft.CSharp/Microsoft.CSharp.sln
+++ b/src/Microsoft.CSharp/Microsoft.CSharp.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.CSharp", "src\Mic
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A595FB46-5F47-4E70-BDCD-53350879188C}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/Microsoft.Win32.Primitives/Microsoft.Win32.Primitives.sln
+++ b/src/Microsoft.Win32.Primitives/Microsoft.Win32.Primitives.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Primitives"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6DF80DBD-B979-4B4D-89F1-5C35273809A6}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/Microsoft.Win32.Registry/Microsoft.Win32.Registry.sln
+++ b/src/Microsoft.Win32.Registry/Microsoft.Win32.Registry.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FBCF7C99-4809-411D-BE8A-8E3E0DD17B7E}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry.Tests", "tests\Microsoft.Win32.Registry.Tests.csproj", "{20A2BA2C-5517-483F-8FFE-643441A59852}"

--- a/src/System.Collections.Concurrent/System.Collections.Concurrent.sln
+++ b/src/System.Collections.Concurrent/System.Collections.Concurrent.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Concurre
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Collections.Immutable/System.Collections.Immutable.sln
+++ b/src/System.Collections.Immutable/System.Collections.Immutable.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Immutabl
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1CA59CB2-FE88-4510-92AC-3561026C3B13}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Collections.Specialized/System.Collections.Specialized.sln
+++ b/src/System.Collections.Specialized/System.Collections.Specialized.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Speciali
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Specialized.Tests", "tests\System.Collections.Specialized.Tests.csproj", "{7F5F5134-00FE-4DE8-B20C-3DA8BA2EBA68}"

--- a/src/System.ComponentModel.Annotations/System.ComponentModel.Annotations.sln
+++ b/src/System.ComponentModel.Annotations/System.ComponentModel.Annotations.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ComponentModel.Annot
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{3A3E1C22-FF83-4D70-A94A-6C130805E6BF}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.ComponentModel.EventBasedAsync/System.ComponentModel.EventBasedAsync.sln
+++ b/src/System.ComponentModel.EventBasedAsync/System.ComponentModel.EventBasedAsync.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ComponentModel.Event
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.ComponentModel.Primitives/System.ComponentModel.Primitives.sln
+++ b/src/System.ComponentModel.Primitives/System.ComponentModel.Primitives.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ComponentModel.Primitives", "src\System.ComponentModel.Primitives.csproj", "{F620F382-30D1-451E-B125-2A612F92068B}"

--- a/src/System.ComponentModel/System.ComponentModel.sln
+++ b/src/System.ComponentModel/System.ComponentModel.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ComponentModel", "sr
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ComponentModel.Tests", "tests\System.ComponentModel.Tests.csproj", "{40C01084-DAB1-4F24-8729-85523BC9F04E}"

--- a/src/System.Console/System.Console.sln
+++ b/src/System.Console/System.Console.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Console", "src\Syste
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Console.Tests", "tests\System.Console.Tests.csproj", "{99E5069D-241F-48A6-8F29-404B4AED72BF}"

--- a/src/System.Diagnostics.Debug/System.Diagnostics.Debug.sln
+++ b/src/System.Diagnostics.Debug/System.Diagnostics.Debug.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Debug.Te
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Diagnostics.FileVersionInfo/System.Diagnostics.FileVersionInfo.sln
+++ b/src/System.Diagnostics.FileVersionInfo/System.Diagnostics.FileVersionInfo.sln
@@ -15,7 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.FileVers
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{2D0715BD-01EA-4E9D-AC88-DA5410C15183}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
+++ b/src/System.Diagnostics.Process/System.Diagnostics.Process.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{EFFF9E5B-58A0-4D0E-891D-40EF450FE7DA}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Process.Tests", "tests\System.Diagnostics.Process.Tests\System.Diagnostics.Process.Tests.csproj", "{E1114510-844C-4BB2-BBAD-8595BD16E24B}"

--- a/src/System.Diagnostics.TextWriterTraceListener/System.Diagnostics.TextWriterTraceListener.sln
+++ b/src/System.Diagnostics.TextWriterTraceListener/System.Diagnostics.TextWriterTraceListener.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.TextWriterTraceListener", "src\System.Diagnostics.TextWriterTraceListener.csproj", "{315929D9-D76E-47E9-BE82-C787FB3A7876}"

--- a/src/System.Diagnostics.TraceSource/System.Diagnostics.TraceSource.sln
+++ b/src/System.Diagnostics.TraceSource/System.Diagnostics.TraceSource.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.TraceSource", "src\System.Diagnostics.TraceSource.csproj", "{5380420C-EB1D-4C53-9CFC-916578C18334}"

--- a/src/System.Globalization.Extensions/System.Globalization.Extensions.sln
+++ b/src/System.Globalization.Extensions/System.Globalization.Extensions.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Globalization.Extens
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Globalization.Extensions.Tests", "tests\System.Globalization.Extensions.Tests.csproj", "{BC439554-4AB4-4C94-8E28-C00EDE4FD1C7}"

--- a/src/System.IO.FileSystem.DriveInfo/System.IO.FileSystem.DriveInfo.sln
+++ b/src/System.IO.FileSystem.DriveInfo/System.IO.FileSystem.DriveInfo.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.DriveI
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FBCF7C99-4809-411D-BE8A-8E3E0DD17B7E}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.DriveInfo.Tests", "tests\System.IO.FileSystem.DriveInfo.Tests.csproj", "{7D9E5F2F-5677-40FC-AD04-FA7D603E4806}"

--- a/src/System.IO.Pipes/System.IO.Pipes.sln
+++ b/src/System.IO.Pipes/System.IO.Pipes.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Pipes", "src\Syst
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1F3D7076-05EC-4EA4-820A-EA00BFE99057}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Pipes.Tests", "tests\System.IO.Pipes.Tests.csproj", "{142469EC-D665-4FE2-845A-FDA69F9CC557}"

--- a/src/System.Linq.Parallel/System.Linq.Parallel.sln
+++ b/src/System.Linq.Parallel/System.Linq.Parallel.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Linq.Parallel.Tests"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Numerics.Vectors/System.Numerics.Vectors.sln
+++ b/src/System.Numerics.Vectors/System.Numerics.Vectors.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Numerics.Vectors.Tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{D65B336B-658A-499D-9613-1731050D994F}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Private.DataContractSerialization/System.Private.DataContractSerialization.sln
+++ b/src/System.Private.DataContractSerialization/System.Private.DataContractSerialization.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.DataContract
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Reflection.Metadata/System.Reflection.Metadata.sln
+++ b/src/System.Reflection.Metadata/System.Reflection.Metadata.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Metadata.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5C5F1FFD-CC57-4DFF-9CAF-0A2852323AD6}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Resources.ReaderWriter/System.Resources.ReaderWriter.sln
+++ b/src/System.Resources.ReaderWriter/System.Resources.ReaderWriter.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Resources.ReaderWrit
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{F1123D80-2297-4958-B2D6-8261DBCBC223}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Resources.ReaderWriter.Tests", "tests\System.Resources.ReaderWriter.Tests.csproj", "{8D7202E8-084A-4C20-AB93-3BF70D2E0651}"

--- a/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
+++ b/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
@@ -6,7 +6,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions.T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1CA59CB2-FE88-4510-92AC-3561026C3B13}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions.CoreCLR", "src\System.Runtime.Extensions.CoreCLR.csproj", "{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}"

--- a/src/System.Runtime.Serialization.Primitives/System.Runtime.Serialization.Primitives.sln
+++ b/src/System.Runtime.Serialization.Primitives/System.Runtime.Serialization.Primitives.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serializatio
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Runtime.Serialization.Xml/System.Runtime.Serialization.Xml.sln
+++ b/src/System.Runtime.Serialization.Xml/System.Runtime.Serialization.Xml.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serializatio
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Runtime/System.Runtime.sln
+++ b/src/System.Runtime/System.Runtime.sln
@@ -6,7 +6,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Tests", "tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1CA59CB2-FE88-4510-92AC-3561026C3B13}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.CoreCLR", "src\System.Runtime.CoreCLR.csproj", "{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}"

--- a/src/System.Security.SecureString/System.Security.SecureString.sln
+++ b/src/System.Security.SecureString/System.Security.SecureString.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.SecureStrin
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FBCF7C99-4809-411D-BE8A-8E3E0DD17B7E}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.SecureString.Tests", "tests\System.Security.SecureString.Tests.csproj", "{69609238-62C7-479D-A8CE-709F41101D3C}"

--- a/src/System.Text.Encodings.Web/System.Text.Encodings.Web.sln
+++ b/src/System.Text.Encodings.Web/System.Text.Encodings.Web.sln
@@ -6,7 +6,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Text.Encodings.Web",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1CA59CB2-FE88-4510-92AC-3561026C3B13}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Text.Encodings.Web.Tests", "tests\System.Text.Encodings.Web.Tests.csproj", "{95DFC527-4DC1-495E-97D7-E94EE1F7140D}"

--- a/src/System.Text.RegularExpressions/System.Text.RegularExpressions.sln
+++ b/src/System.Text.RegularExpressions/System.Text.RegularExpressions.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Text.RegularExpressi
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C5A39CF5-01CB-4CD8-96A6-7D6E95EA5CCC}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow.sln
+++ b/src/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow.sln
@@ -14,7 +14,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Tasks.Data
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{3A3E1C22-FF83-4D70-A94A-6C130805E6BF}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Threading.Tasks.Parallel/System.Threading.Tasks.Parallel.sln
+++ b/src/System.Threading.Tasks.Parallel/System.Threading.Tasks.Parallel.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Tasks.Para
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{47919FF5-DA40-4D99-AF2D-F560282AA913}"
 	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.config = ..\.nuget\packages.config
+		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Xml.ReaderWriter/System.Xml.ReaderWriter.sln
+++ b/src/System.Xml.ReaderWriter/System.Xml.ReaderWriter.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.ReaderWriter", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DABDD-5158-4CAF-88B0-B823EE173E53}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.RW.CharCheckingReader.Tests", "tests\Readers\CharCheckingReader\System.Xml.RW.CharCheckingReader.Tests.csproj", "{6DC15D23-8213-4700-9815-AD8DEED1CE5F}"

--- a/src/System.Xml.XDocument/System.Xml.XDocument.sln
+++ b/src/System.Xml.XDocument/System.Xml.XDocument.sln
@@ -32,7 +32,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModuleCore", "..\Common\tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DABDD-5158-4CAF-88B0-B823EE173E53}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XDocument.xNodeBuilder.Tests", "tests\xNodeBuilder\System.Xml.XDocument.xNodeBuilder.Tests.csproj", "{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}"

--- a/src/System.Xml.XPath.XDocument/System.Xml.XPath.XDocument.sln
+++ b/src/System.Xml.XPath.XDocument/System.Xml.XPath.XDocument.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XDocument.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DABDD-5158-4CAF-88B0-B823EE173E53}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XmlDocument", "..\System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj", "{17CB2E3C-2904-4241-94DB-3894D24F35DA}"

--- a/src/System.Xml.XPath.XmlDocument/System.Xml.XPath.XmlDocument.sln
+++ b/src/System.Xml.XPath.XmlDocument/System.Xml.XPath.XmlDocument.sln
@@ -12,7 +12,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.XmlDocumen
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DABDD-5158-4CAF-88B0-B823EE173E53}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Xml.XPath/System.Xml.XPath.sln
+++ b/src/System.Xml.XPath/System.Xml.XPath.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XPath.Tests", "t
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DABDD-5158-4CAF-88B0-B823EE173E53}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Xml.XmlDocument/System.Xml.XmlDocument.sln
+++ b/src/System.Xml.XmlDocument/System.Xml.XmlDocument.sln
@@ -8,7 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XmlDocument.Test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CF6DABDD-5158-4CAF-88B0-B823EE173E53}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Global

--- a/src/System.Xml.XmlSerializer/System.Xml.XmlSerializer.sln
+++ b/src/System.Xml.XmlSerializer/System.Xml.XmlSerializer.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XmlSerializer", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9618597D-FDAE-42CB-B368-80DB80EA1E37}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
+		.nuget\packages.Windows_NT.config = .nuget\packages.Windows_NT.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xml.XmlSerializer.Tests", "tests\System.Xml.XmlSerializer.Tests.csproj", "{4050F1D1-1DD2-4B48-A17B-E3F90DD18C4B}"


### PR DESCRIPTION
Avoids downloading packages that don't apply to the current build environment.

@weshaggard, @ericstj, @chcosta 