### PR TITLE
Remove xbuild dependency.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,12 @@
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __packageroot=$__scriptpath/packages
-__msbuildpath=$__packageroot/Microsoft.Build.Mono.Debug.14.1.0.0-prerelease/lib/MSBuild.exe
+__sourceroot=$__scriptpath/src
+__nugetpath=$__packageroot/NuGet.exe
+__nugetconfig=$__sourceroot/NuGet.Config
+__msbuildpackageid="Microsoft.Build.Mono.Debug"
+__msbuildpackageversion="14.1.0.0-prerelease"
+__msbuildpath=$__packageroot/$__msbuildpackageid.$__msbuildpackageversion/lib/MSBuild.exe
 __referenceassemblyroot=/usr/lib/mono/xbuild-frameworks
 __monoversion=$(mono --version | grep "version 4.[1-9]")
 
@@ -19,13 +24,39 @@ fi
 __buildproj=$__scriptpath/build.proj
 __buildlog=$__scriptpath/msbuild.log
 
-# Run the restore build tools under xbuild to get NuGet and MSBuild pulled down
-xbuild "$__buildproj" /t:_RestoreBuildTools /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=diag;LogFile=$__buildlog"
+# Pull NuGet.exe down if we don't have it already
+if [ ! -e "$__nugetpath" ]; then
+    which curl wget > /dev/null 2> /dev/null
+    if [ $? -ne 0 -a $? -ne 1 ]; then
+        echo "cURL or wget is required to build corefx. Please see https://github.com/dotnet/corefx/wiki/Building-On-Unix for more details."
+        exit 1
+    fi
+    echo "Restoring NuGet.exe..."
 
-if [ ! -e "$__msbuildpath" ]; then
-    echo "MSBuild.exe required at $__msbuildpath. Please see https://github.com/dotnet/corefx/wiki/Building-On-Unix for more details."
-    exit 1
+    which wget > /dev/null 2> /dev/null
+    if [ $? -ne 0 ]; then
+       curl -sSL --create-dirs -o $__nugetpath https://api.nuget.org/downloads/nuget.exe
+    else
+       mkdir -p $__packageroot
+       wget -q -O $__nugetpath https://api.nuget.org/downloads/nuget.exe
+    fi
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to restore NuGet.exe."
+        exit 1
+    fi
 fi
+
+# Grab the MSBuild package if we don't have it already
+if [ ! -e "$__msbuildpath" ]; then
+    echo "Restoring MSBuild..."
+    mono "$__nugetpath" install $__msbuildpackageid -Version $__msbuildpackageversion -ConfigFile "$__nugetconfig" -OutputDirectory "$__packageroot"
+    if [ $? -ne 0 ]; then
+        echo "Failed to restore MSBuild."
+        exit 1
+    fi
+fi
+
 
 if [ $(uname) == "Linux" ]; then
     __osgroup=Linux


### PR DESCRIPTION
Pull down nuget and msbuild in the build.sh script. Check for cURL and fail out if missing.

@weshaggard, @akoeplinger, @chcosta, @ellismg 