### PR TITLE
Remove null-padding from parsed section-header names.

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
@@ -85,10 +85,19 @@ namespace System.Reflection.PortableExecutable
             return _reader.ReadUInt64();
         }
 
-        public string ReadUTF8(int byteCount)
+        /// <summary>
+        /// Reads a fixed-length byte block at a null-padded UTF-8-encoded string.
+        /// The padding is not included in the returned string.
+        /// </summary>
+        public string ReadNullPaddedUTF8(int byteCount)
         {
             byte[] bytes = ReadBytes(byteCount);
-            return Encoding.UTF8.GetString(bytes, 0, byteCount);
+            int paddingStart = Array.IndexOf<byte>(bytes, 0);
+            if (paddingStart < 0)
+            {
+                paddingStart = bytes.Length;
+            }
+            return Encoding.UTF8.GetString(bytes, 0, paddingStart);
         }
 
         /// <summary>

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
@@ -88,16 +88,24 @@ namespace System.Reflection.PortableExecutable
         /// <summary>
         /// Reads a fixed-length byte block as a null-padded UTF8-encoded string.
         /// The padding is not included in the returned string.
+        /// 
+        /// Note that it is legal for UTF8 strings to contain NUL; if NUL occurs
+        /// between non-NUL codepoints, it is not considered to be padding and
+        /// is included in the result.
         /// </summary>
         public string ReadNullPaddedUTF8(int byteCount)
         {
             byte[] bytes = ReadBytes(byteCount);
-            int paddingStart = Array.IndexOf<byte>(bytes, 0);
-            if (paddingStart < 0)
+            int nonPaddedLength = 0;
+            for (int i = bytes.Length; i > 0; --i)
             {
-                paddingStart = bytes.Length;
+                if (bytes[i - 1] != 0)
+                {
+                    nonPaddedLength = i;
+                    break;
+                }
             }
-            return Encoding.UTF8.GetString(bytes, 0, paddingStart);
+            return Encoding.UTF8.GetString(bytes, 0, nonPaddedLength);
         }
 
         /// <summary>

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
@@ -86,7 +86,7 @@ namespace System.Reflection.PortableExecutable
         }
 
         /// <summary>
-        /// Reads a fixed-length byte block at a null-padded UTF-8-encoded string.
+        /// Reads a fixed-length byte block as a null-padded UTF8-encoded string.
         /// The padding is not included in the returned string.
         /// </summary>
         public string ReadNullPaddedUTF8(int byteCount)

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionHeader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/SectionHeader.cs
@@ -85,7 +85,7 @@ namespace System.Reflection.PortableExecutable
 
         internal SectionHeader(ref PEBinaryReader reader)
         {
-            _name = reader.ReadUTF8(PEFileConstants.SizeofSectionName);
+            _name = reader.ReadNullPaddedUTF8(PEFileConstants.SizeofSectionName);
             _virtualSize = reader.ReadInt32();
             _virtualAddress = reader.ReadInt32();
             _sizeOfRawData = reader.ReadInt32();

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+using TestUtilities;
+
+using Xunit;
+
+namespace System.Reflection.Metadata.Tests.PortableExecutable
+{
+    public class PEBinaryReaderTests
+    {
+        [Fact]
+        public void ReadNullPaddedUTF8RemovesNullPadding()
+        {
+            var headerBytes = new byte[PEFileConstants.SizeofSectionName];
+            headerBytes[0] = 80;
+            headerBytes[1] = 80;
+            headerBytes[2] = 80;
+
+            var stream = new MemoryStream(headerBytes);
+            stream.Position = 0;
+
+            var reader = new PEBinaryReader(stream, headerBytes.Length);
+            var text = reader.ReadNullPaddedUTF8(PEFileConstants.SizeofSectionName);
+
+            AssertEx.AreEqual(3, text.Length, "PEBinaryReader.ReadNullPaddedUTF8 did not truncate null padding");
+            AssertEx.AreEqual("PPP", text, "PEBinaryReader.ReadNullPaddedUTF8 did not truncate null-byte padding");
+        }
+
+        [Fact]
+        public void ReadNullPaddedUTF8WorksWithNoNullPadding()
+        {
+            var headerBytes = Encoding.UTF8.GetBytes(".abcdefg");
+            var stream = new MemoryStream(headerBytes);
+            stream.Position = 0;
+
+            var reader = new PEBinaryReader(stream, headerBytes.Length);
+            var text = reader.ReadNullPaddedUTF8(PEFileConstants.SizeofSectionName);
+
+            AssertEx.AreEqual(".abcdefg", text, "PEBinaryReader.ReadNullPaddedUTF8 erroneously truncated a section name");
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEBinaryReaderTests.cs
@@ -28,7 +28,7 @@ namespace System.Reflection.Metadata.Tests.PortableExecutable
             var text = reader.ReadNullPaddedUTF8(PEFileConstants.SizeofSectionName);
 
             AssertEx.AreEqual(3, text.Length, "PEBinaryReader.ReadNullPaddedUTF8 did not truncate null padding");
-            AssertEx.AreEqual("PPP", text, "PEBinaryReader.ReadNullPaddedUTF8 did not truncate null-byte padding");
+            AssertEx.AreEqual("PPP", text);
         }
 
         [Fact]

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
@@ -19,6 +19,10 @@ namespace System.Reflection.Metadata.Tests.PortableExecutable
         [Theory]
         [InlineData(".debug", 0, 0, 0x5C, 0x152, 0, 0, 0, 0, SectionCharacteristics.LinkerInfo)]
         [InlineData(".drectve", 0, 0, 26, 0x12C, 0, 0, 0, 0, SectionCharacteristics.Align1Bytes)]
+        [InlineData("", 1, 1, 2, 3, 5, 8, 13, 21, SectionCharacteristics.Align16Bytes)]
+        [InlineData("x", 1, 1, 2, 3, 5, 8, 13, 21, SectionCharacteristics.MemSysheap)]
+        [InlineData(".बग", int.MaxValue, int.MinValue, int.MaxValue, int.MinValue, int.MaxValue, int.MaxValue, ushort.MaxValue, ushort.MaxValue, SectionCharacteristics.GPRel)]
+        [InlineData("nul\u0000nul", 1, 1, 1, 1, 1, 1, 1, 1, SectionCharacteristics.ContainsInitializedData)]
         public void Ctor(
             string name,
             int virtualSize,

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
@@ -14,8 +14,8 @@ namespace System.Reflection.Metadata.Tests.PortableExecutable
     public class SectionHeaderTests
     {
         [Theory]
-        [InlineData(".debug", 0, 0, 0x5C, 0x152, 0, 0, 0, 0, 0x42100048)] // no pad, initialized, discardable, 1-byte align, read-only
-        [InlineData(".drectve", 0, 0, 26, 0x12C, 0, 0, 0, 0, 0x00100A00)] // info, linker-remove, 1-byte align
+        [InlineData(".debug", 0, 0, 0x5C, 0x152, 0, 0, 0, 0, SectionCharacteristics.LinkerInfo)]
+        [InlineData(".drectve", 0, 0, 26, 0x12C, 0, 0, 0, 0, SectionCharacteristics.Align1Bytes)]
         public void Ctor(
             string name,
             int virtualSize,

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Metadata.Tests.PortableExecutable
         [InlineData(".drectve", 0, 0, 26, 0x12C, 0, 0, 0, 0, SectionCharacteristics.Align1Bytes)]
         [InlineData("", 1, 1, 2, 3, 5, 8, 13, 21, SectionCharacteristics.Align16Bytes)]
         [InlineData("x", 1, 1, 2, 3, 5, 8, 13, 21, SectionCharacteristics.MemSysheap)]
-        [InlineData(".बग", int.MaxValue, int.MinValue, int.MaxValue, int.MinValue, int.MaxValue, int.MaxValue, ushort.MaxValue, ushort.MaxValue, SectionCharacteristics.GPRel)]
+        [InlineData(".\u092c\u0917", int.MaxValue, int.MinValue, int.MaxValue, int.MinValue, int.MaxValue, int.MaxValue, ushort.MaxValue, ushort.MaxValue, SectionCharacteristics.GPRel)]
         [InlineData("nul\u0000nul", 1, 1, 1, 1, 1, 1, 1, 1, SectionCharacteristics.ContainsInitializedData)]
         public void Ctor(
             string name,

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/SectionHeaderTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+using TestUtilities;
+
+using Xunit;
+
+namespace System.Reflection.Metadata.Tests.PortableExecutable
+{
+    public class SectionHeaderTests
+    {
+        [Theory]
+        [InlineData(".debug", 0, 0, 0x5C, 0x152, 0, 0, 0, 0, 0x42100048)] // no pad, initialized, discardable, 1-byte align, read-only
+        [InlineData(".drectve", 0, 0, 26, 0x12C, 0, 0, 0, 0, 0x00100A00)] // info, linker-remove, 1-byte align
+        public void Ctor(
+            string name,
+            int virtualSize,
+            int virtualAddress,
+            int sizeOfRawData,
+            int ptrToRawData,
+            int ptrToRelocations,
+            int ptrToLineNumbers,
+            ushort numRelocations,
+            ushort numLineNumbers,
+            SectionCharacteristics characteristics)
+        {
+            var stream = new MemoryStream();
+            var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+            writer.Write(PadSectionName(name));
+            writer.Write(virtualSize);
+            writer.Write(virtualAddress);
+            writer.Write(sizeOfRawData);
+            writer.Write(ptrToRawData);
+            writer.Write(ptrToRelocations);
+            writer.Write(ptrToLineNumbers);
+            writer.Write(numRelocations);
+            writer.Write(numLineNumbers);
+            writer.Write((uint) characteristics);
+            writer.Dispose();
+
+            stream.Position = 0;
+            var reader = new PEBinaryReader(stream, (int) stream.Length);
+
+            var header = new SectionHeader(ref reader);
+
+            AssertEx.AreEqual(name, header.Name);
+            AssertEx.AreEqual(virtualSize, header.VirtualSize);
+            AssertEx.AreEqual(virtualAddress, header.VirtualAddress);
+            AssertEx.AreEqual(sizeOfRawData, header.SizeOfRawData);
+            AssertEx.AreEqual(ptrToRawData, header.PointerToRawData);
+            AssertEx.AreEqual(ptrToLineNumbers, header.PointerToLineNumbers);
+            AssertEx.AreEqual(numRelocations, header.NumberOfRelocations);
+            AssertEx.AreEqual(numLineNumbers, header.NumberOfLineNumbers);
+            AssertEx.AreEqual(characteristics, header.SectionCharacteristics);
+        }
+
+        private static byte[] PadSectionName(string name)
+        {
+            var nameBytes = Encoding.UTF8.GetBytes(name);
+            Assert.True(name.Length <= PEFileConstants.SizeofSectionName);
+
+            var bytes = new byte[PEFileConstants.SizeofSectionName];
+            Buffer.BlockCopy(nameBytes, 0, bytes, 0, nameBytes.Length);
+            return bytes;
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -49,7 +49,9 @@
     <Compile Include="Metadata\TagToTokenTests.cs" />
     <Compile Include="PortableExecutable\AbstractMemoryBlockTests.cs" />
     <Compile Include="PortableExecutable\BadImageFormat.cs" />
+    <Compile Include="PortableExecutable\PEBinaryReaderTests.cs" />
     <Compile Include="PortableExecutable\PEReaderTests.cs" />
+    <Compile Include="PortableExecutable\SectionHeaderTests.cs" />
     <Compile Include="PortableExecutable\StreamExtensionsTests.cs" />
     <Compile Include="Resources\TestResources.cs" />
     <Compile Include="TestUtilities\AssertEx.cs" />


### PR DESCRIPTION
Fixes issue #1805.

As I understand the issue, the ECMA spec is outdated, and section-header names are 8-byte null-padded UTF-8 strings.  While UTF-8 strings can legally hold null bytes (the NUL codepoint), the nulls here are padding and not properly part of the header name.

This diff truncates the null padding and adds some test coverage for PEBinaryReader and SectionHeader.

As this is my first contribution, I'm new to the codebase and have probably missed something important (besides CLA); thanks in advance for letting me know what those important things are!