### PR TITLE
Workaround for perf issue with the new jit pointer dereference in serialization

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -373,9 +373,13 @@ namespace System.Xml
 
                     while (true)
                     {
-                        while (chars < charsMax && *chars < 0x80)
+                        while (chars < charsMax)
                         {
-                            *bytes = (byte)*chars;
+                            char t = *chars;
+                            if (t >= 0x80)
+                                break;
+
+                            *bytes = (byte)t;
                             bytes++;
                             chars++;
                         }


### PR DESCRIPTION
With the new jit, the *chars deference is done twice which is more costly compared to legacy jit
