### PR TITLE
Add System.Numerics.Matrices Namespace

### DIFF
--- a/src/System.Numerics.Matrices/System.Numerics.Matrices.sln
+++ b/src/System.Numerics.Matrices/System.Numerics.Matrices.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22920.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Numerics.Matrices", "src\System.Numerics.Matrices.csproj", "{A7402731-F3B8-4DFE-8507-88623CA1B2BA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Numerics.Matrices/src/System.Numerics.Matrices.csproj
+++ b/src/System.Numerics.Matrices/src/System.Numerics.Matrices.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A7402731-F3B8-4DFE-8507-88623CA1B2BA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.Numerics.Matrices</RootNamespace>
+    <AssemblyName>System.Numerics.Matrices</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Numerics\IMatrix.cs" />
+    <Compile Include="System\Numerics\Matrix1x2.cs" />
+    <Compile Include="System\Numerics\Matrix1x3.cs" />
+    <Compile Include="System\Numerics\Matrix1x4.cs" />
+    <Compile Include="System\Numerics\Matrix1x5.cs" />
+    <Compile Include="System\Numerics\Matrix1x6.cs" />
+    <Compile Include="System\Numerics\Matrix1x7.cs" />
+    <Compile Include="System\Numerics\Matrix1x8.cs" />
+    <Compile Include="System\Numerics\Matrix2x1.cs" />
+    <Compile Include="System\Numerics\Matrix2x2.cs" />
+    <Compile Include="System\Numerics\Matrix2x3.cs" />
+    <Compile Include="System\Numerics\Matrix2x4.cs" />
+    <Compile Include="System\Numerics\Matrix2x5.cs" />
+    <Compile Include="System\Numerics\Matrix2x6.cs" />
+    <Compile Include="System\Numerics\Matrix2x7.cs" />
+    <Compile Include="System\Numerics\Matrix2x8.cs" />
+    <Compile Include="System\Numerics\Matrix3x1.cs" />
+    <Compile Include="System\Numerics\Matrix3x2.cs" />
+    <Compile Include="System\Numerics\Matrix3x3.cs" />
+    <Compile Include="System\Numerics\Matrix3x4.cs" />
+    <Compile Include="System\Numerics\Matrix3x5.cs" />
+    <Compile Include="System\Numerics\Matrix3x6.cs" />
+    <Compile Include="System\Numerics\Matrix3x7.cs" />
+    <Compile Include="System\Numerics\Matrix3x8.cs" />
+    <Compile Include="System\Numerics\Matrix4x1.cs" />
+    <Compile Include="System\Numerics\Matrix4x2.cs" />
+    <Compile Include="System\Numerics\Matrix4x3.cs" />
+    <Compile Include="System\Numerics\Matrix4x4.cs" />
+    <Compile Include="System\Numerics\Matrix4x5.cs" />
+    <Compile Include="System\Numerics\Matrix4x6.cs" />
+    <Compile Include="System\Numerics\Matrix4x7.cs" />
+    <Compile Include="System\Numerics\Matrix4x8.cs" />
+    <Compile Include="System\Numerics\Matrix5x1.cs" />
+    <Compile Include="System\Numerics\Matrix5x2.cs" />
+    <Compile Include="System\Numerics\Matrix5x3.cs" />
+    <Compile Include="System\Numerics\Matrix5x4.cs" />
+    <Compile Include="System\Numerics\Matrix5x5.cs" />
+    <Compile Include="System\Numerics\Matrix5x6.cs" />
+    <Compile Include="System\Numerics\Matrix5x7.cs" />
+    <Compile Include="System\Numerics\Matrix5x8.cs" />
+    <Compile Include="System\Numerics\Matrix6x1.cs" />
+    <Compile Include="System\Numerics\Matrix6x2.cs" />
+    <Compile Include="System\Numerics\Matrix6x3.cs" />
+    <Compile Include="System\Numerics\Matrix6x4.cs" />
+    <Compile Include="System\Numerics\Matrix6x5.cs" />
+    <Compile Include="System\Numerics\Matrix6x6.cs" />
+    <Compile Include="System\Numerics\Matrix6x7.cs" />
+    <Compile Include="System\Numerics\Matrix6x8.cs" />
+    <Compile Include="System\Numerics\Matrix7x1.cs" />
+    <Compile Include="System\Numerics\Matrix7x2.cs" />
+    <Compile Include="System\Numerics\Matrix7x3.cs" />
+    <Compile Include="System\Numerics\Matrix7x4.cs" />
+    <Compile Include="System\Numerics\Matrix7x5.cs" />
+    <Compile Include="System\Numerics\Matrix7x6.cs" />
+    <Compile Include="System\Numerics\Matrix7x7.cs" />
+    <Compile Include="System\Numerics\Matrix7x8.cs" />
+    <Compile Include="System\Numerics\Matrix8x1.cs" />
+    <Compile Include="System\Numerics\Matrix8x2.cs" />
+    <Compile Include="System\Numerics\Matrix8x3.cs" />
+    <Compile Include="System\Numerics\Matrix8x4.cs" />
+    <Compile Include="System\Numerics\Matrix8x5.cs" />
+    <Compile Include="System\Numerics\Matrix8x6.cs" />
+    <Compile Include="System\Numerics\Matrix8x7.cs" />
+    <Compile Include="System\Numerics\Matrix8x8.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="System\Numerics\MatrixTemplate.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MatrixTemplate.txt</LastGenOutput>
+    </Content>
+    <Content Include="System\Numerics\MatrixTemplate.txt">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>MatrixTemplate.tt</DependentUpon>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/System.Numerics.Matrices/src/System/Numerics/IMatrix.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/IMatrix.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Numerics.Matrices
+{
+    interface IMatrix
+    {
+        double this[int col, int row] { get; set; }
+        int Columns { get; }
+        int Rows { get; }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x2.cs
@@ -1,0 +1,294 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x2: IEquatable<Matrix1x2>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 2;
+
+        static Matrix1x2()
+        {
+            Zero = new Matrix1x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        public Matrix1x2(double m11, 
+                         double m12)
+        {
+			M11 = m11; 
+			M12 = m12; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x2(double value)
+        {
+			M11 = 
+			M12 = value;
+        }
+
+		public double M11;
+		public double M12;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x2.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x2)
+                return this == (Matrix1x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x2: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               , M11
+                               , M12); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x1 Transpose()
+        {
+            return new Matrix2x1(M11, M12);
+        }
+
+        public static bool operator ==(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon;
+        }
+
+        public static Matrix1x2 operator +(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix1x2 operator -(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix1x2 operator *(Matrix1x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix1x2 operator *(double scalar, Matrix1x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix2x2 operator *(Matrix1x2 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix1x2 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix1x2 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix1x2 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix1x2 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix1x2 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix1x2 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x3.cs
@@ -1,0 +1,354 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x3: IEquatable<Matrix1x3>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 3;
+
+        static Matrix1x3()
+        {
+            Zero = new Matrix1x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        public Matrix1x3(double m11, 
+                         double m12, 
+                         double m13)
+        {
+			M11 = m11; 
+			M12 = m12; 
+			M13 = m13; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x3(double value)
+        {
+			M11 = 
+			M12 = 
+			M13 = value;
+        }
+
+		public double M11;
+		public double M12;
+		public double M13;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x3.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x3)
+                return this == (Matrix1x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02])
+                         + (x[02] ^ x[03]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x3: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               + "{{|{02}|}}"
+                               , M11
+                               , M12
+                               , M13); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x1 Transpose()
+        {
+            return new Matrix3x1(M11, M12, M13);
+        }
+
+        public static bool operator ==(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon;
+        }
+
+        public static Matrix1x3 operator +(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix1x3 operator -(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix1x3 operator *(Matrix1x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix1x3 operator *(double scalar, Matrix1x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix2x3 operator *(Matrix1x3 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix1x3 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix1x3 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix1x3 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix1x3 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix1x3 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix1x3 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m83 = matrix1.M13 * matrix2.M81;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x4.cs
@@ -1,0 +1,414 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x4: IEquatable<Matrix1x4>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 4;
+
+        static Matrix1x4()
+        {
+            Zero = new Matrix1x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        public Matrix1x4(double m11, 
+                         double m12, 
+                         double m13, 
+                         double m14)
+        {
+			M11 = m11; 
+			M12 = m12; 
+			M13 = m13; 
+			M14 = m14; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x4(double value)
+        {
+			M11 = 
+			M12 = 
+			M13 = 
+			M14 = value;
+        }
+
+		public double M11;
+		public double M12;
+		public double M13;
+		public double M14;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x4.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x4)
+                return this == (Matrix1x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02])
+                         + (x[02] ^ x[03])
+                         + (x[03] ^ x[04]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x4: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               + "{{|{02}|}}"
+                               + "{{|{03}|}}"
+                               , M11
+                               , M12
+                               , M13
+                               , M14); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x1 Transpose()
+        {
+            return new Matrix4x1(M11, M12, M13, M14);
+        }
+
+        public static bool operator ==(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon;
+        }
+
+        public static Matrix1x4 operator +(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m14 = matrix1.M14 + matrix2.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix1x4 operator -(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m14 = matrix1.M14 - matrix2.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix1x4 operator *(Matrix1x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m14 = matrix.M14 * scalar;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix1x4 operator *(double scalar, Matrix1x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+            double m14 = scalar * matrix.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix2x4 operator *(Matrix1x4 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix1x4 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix1x4 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix1x4 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix1x4 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix1x4 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix1x4 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m83 = matrix1.M13 * matrix2.M81;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m84 = matrix1.M14 * matrix2.M81;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x5.cs
@@ -1,0 +1,474 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x5: IEquatable<Matrix1x5>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 5;
+
+        static Matrix1x5()
+        {
+            Zero = new Matrix1x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        public Matrix1x5(double m11, 
+                         double m12, 
+                         double m13, 
+                         double m14, 
+                         double m15)
+        {
+			M11 = m11; 
+			M12 = m12; 
+			M13 = m13; 
+			M14 = m14; 
+			M15 = m15; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x5(double value)
+        {
+			M11 = 
+			M12 = 
+			M13 = 
+			M14 = 
+			M15 = value;
+        }
+
+		public double M11;
+		public double M12;
+		public double M13;
+		public double M14;
+		public double M15;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x5.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x5)
+                return this == (Matrix1x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02])
+                         + (x[02] ^ x[03])
+                         + (x[03] ^ x[04])
+                         + (x[04] ^ x[05]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x5: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               + "{{|{02}|}}"
+                               + "{{|{03}|}}"
+                               + "{{|{04}|}}"
+                               , M11
+                               , M12
+                               , M13
+                               , M14
+                               , M15); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x1 Transpose()
+        {
+            return new Matrix5x1(M11, M12, M13, M14, M15);
+        }
+
+        public static bool operator ==(Matrix1x5 matrix1, Matrix1x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x5 matrix1, Matrix1x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon;
+        }
+
+        public static Matrix1x5 operator +(Matrix1x5 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m15 = matrix1.M15 + matrix2.M15;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+
+        public static Matrix1x5 operator -(Matrix1x5 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m15 = matrix1.M15 - matrix2.M15;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+
+        public static Matrix1x5 operator *(Matrix1x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m15 = matrix.M15 * scalar;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+
+        public static Matrix1x5 operator *(double scalar, Matrix1x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+            double m14 = scalar * matrix.M14;
+            double m15 = scalar * matrix.M15;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+
+        public static Matrix2x5 operator *(Matrix1x5 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix1x5 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix1x5 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix1x5 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix1x5 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix1x5 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix1x5 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m83 = matrix1.M13 * matrix2.M81;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m84 = matrix1.M14 * matrix2.M81;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m85 = matrix1.M15 * matrix2.M81;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x6.cs
@@ -1,0 +1,534 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x6: IEquatable<Matrix1x6>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 6;
+
+        static Matrix1x6()
+        {
+            Zero = new Matrix1x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        public Matrix1x6(double m11, 
+                         double m12, 
+                         double m13, 
+                         double m14, 
+                         double m15, 
+                         double m16)
+        {
+			M11 = m11; 
+			M12 = m12; 
+			M13 = m13; 
+			M14 = m14; 
+			M15 = m15; 
+			M16 = m16; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x6(double value)
+        {
+			M11 = 
+			M12 = 
+			M13 = 
+			M14 = 
+			M15 = 
+			M16 = value;
+        }
+
+		public double M11;
+		public double M12;
+		public double M13;
+		public double M14;
+		public double M15;
+		public double M16;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x6.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x6)
+                return this == (Matrix1x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02])
+                         + (x[02] ^ x[03])
+                         + (x[03] ^ x[04])
+                         + (x[04] ^ x[05])
+                         + (x[05] ^ x[06]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x6: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               + "{{|{02}|}}"
+                               + "{{|{03}|}}"
+                               + "{{|{04}|}}"
+                               + "{{|{05}|}}"
+                               , M11
+                               , M12
+                               , M13
+                               , M14
+                               , M15
+                               , M16); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x1 Transpose()
+        {
+            return new Matrix6x1(M11, M12, M13, M14, M15, M16);
+        }
+
+        public static bool operator ==(Matrix1x6 matrix1, Matrix1x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x6 matrix1, Matrix1x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon;
+        }
+
+        public static Matrix1x6 operator +(Matrix1x6 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m16 = matrix1.M16 + matrix2.M16;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+
+        public static Matrix1x6 operator -(Matrix1x6 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m16 = matrix1.M16 - matrix2.M16;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+
+        public static Matrix1x6 operator *(Matrix1x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m16 = matrix.M16 * scalar;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+
+        public static Matrix1x6 operator *(double scalar, Matrix1x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+            double m14 = scalar * matrix.M14;
+            double m15 = scalar * matrix.M15;
+            double m16 = scalar * matrix.M16;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+
+        public static Matrix2x6 operator *(Matrix1x6 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix1x6 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix1x6 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix1x6 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix1x6 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix1x6 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m76 = matrix1.M16 * matrix2.M71;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix1x6 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m83 = matrix1.M13 * matrix2.M81;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m84 = matrix1.M14 * matrix2.M81;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m85 = matrix1.M15 * matrix2.M81;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m76 = matrix1.M16 * matrix2.M71;
+            double m86 = matrix1.M16 * matrix2.M81;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x7.cs
@@ -1,0 +1,594 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x7: IEquatable<Matrix1x7>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 7;
+
+        static Matrix1x7()
+        {
+            Zero = new Matrix1x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        public Matrix1x7(double m11, 
+                         double m12, 
+                         double m13, 
+                         double m14, 
+                         double m15, 
+                         double m16, 
+                         double m17)
+        {
+			M11 = m11; 
+			M12 = m12; 
+			M13 = m13; 
+			M14 = m14; 
+			M15 = m15; 
+			M16 = m16; 
+			M17 = m17; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x7(double value)
+        {
+			M11 = 
+			M12 = 
+			M13 = 
+			M14 = 
+			M15 = 
+			M16 = 
+			M17 = value;
+        }
+
+		public double M11;
+		public double M12;
+		public double M13;
+		public double M14;
+		public double M15;
+		public double M16;
+		public double M17;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x7.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x7)
+                return this == (Matrix1x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02])
+                         + (x[02] ^ x[03])
+                         + (x[03] ^ x[04])
+                         + (x[04] ^ x[05])
+                         + (x[05] ^ x[06])
+                         + (x[06] ^ x[07]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x7: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               + "{{|{02}|}}"
+                               + "{{|{03}|}}"
+                               + "{{|{04}|}}"
+                               + "{{|{05}|}}"
+                               + "{{|{06}|}}"
+                               , M11
+                               , M12
+                               , M13
+                               , M14
+                               , M15
+                               , M16
+                               , M17); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x1 Transpose()
+        {
+            return new Matrix7x1(M11, M12, M13, M14, M15, M16, M17);
+        }
+
+        public static bool operator ==(Matrix1x7 matrix1, Matrix1x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x7 matrix1, Matrix1x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon;
+        }
+
+        public static Matrix1x7 operator +(Matrix1x7 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m17 = matrix1.M17 + matrix2.M17;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+
+        public static Matrix1x7 operator -(Matrix1x7 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m17 = matrix1.M17 - matrix2.M17;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+
+        public static Matrix1x7 operator *(Matrix1x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m17 = matrix.M17 * scalar;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+
+        public static Matrix1x7 operator *(double scalar, Matrix1x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+            double m14 = scalar * matrix.M14;
+            double m15 = scalar * matrix.M15;
+            double m16 = scalar * matrix.M16;
+            double m17 = scalar * matrix.M17;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+
+        public static Matrix2x7 operator *(Matrix1x7 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix1x7 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix1x7 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix1x7 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix1x7 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m67 = matrix1.M17 * matrix2.M61;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix1x7 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m76 = matrix1.M16 * matrix2.M71;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m67 = matrix1.M17 * matrix2.M61;
+            double m77 = matrix1.M17 * matrix2.M71;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix1x7 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m83 = matrix1.M13 * matrix2.M81;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m84 = matrix1.M14 * matrix2.M81;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m85 = matrix1.M15 * matrix2.M81;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m76 = matrix1.M16 * matrix2.M71;
+            double m86 = matrix1.M16 * matrix2.M81;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m67 = matrix1.M17 * matrix2.M61;
+            double m77 = matrix1.M17 * matrix2.M71;
+            double m87 = matrix1.M17 * matrix2.M81;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x8.cs
@@ -1,0 +1,654 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x8: IEquatable<Matrix1x8>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 8;
+
+        static Matrix1x8()
+        {
+            Zero = new Matrix1x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix1x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        public Matrix1x8(double m11, 
+                         double m12, 
+                         double m13, 
+                         double m14, 
+                         double m15, 
+                         double m16, 
+                         double m17, 
+                         double m18)
+        {
+			M11 = m11; 
+			M12 = m12; 
+			M13 = m13; 
+			M14 = m14; 
+			M15 = m15; 
+			M16 = m16; 
+			M17 = m17; 
+			M18 = m18; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x8(double value)
+        {
+			M11 = 
+			M12 = 
+			M13 = 
+			M14 = 
+			M15 = 
+			M16 = 
+			M17 = 
+			M18 = value;
+        }
+
+		public double M11;
+		public double M12;
+		public double M13;
+		public double M14;
+		public double M15;
+		public double M16;
+		public double M17;
+		public double M18;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix1x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix1x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix1x8.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x8)
+                return this == (Matrix1x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01])
+                         + (x[01] ^ x[02])
+                         + (x[02] ^ x[03])
+                         + (x[03] ^ x[04])
+                         + (x[04] ^ x[05])
+                         + (x[05] ^ x[06])
+                         + (x[06] ^ x[07])
+                         + (x[07] ^ x[08]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix1x8: "
+                               + "{{|{00}|}}"
+                               + "{{|{01}|}}"
+                               + "{{|{02}|}}"
+                               + "{{|{03}|}}"
+                               + "{{|{04}|}}"
+                               + "{{|{05}|}}"
+                               + "{{|{06}|}}"
+                               + "{{|{07}|}}"
+                               , M11
+                               , M12
+                               , M13
+                               , M14
+                               , M15
+                               , M16
+                               , M17
+                               , M18); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x1 Transpose()
+        {
+            return new Matrix8x1(M11, M12, M13, M14, M15, M16, M17, M18);
+        }
+
+        public static bool operator ==(Matrix1x8 matrix1, Matrix1x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix1x8 matrix1, Matrix1x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon;
+        }
+
+        public static Matrix1x8 operator +(Matrix1x8 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m18 = matrix1.M18 + matrix2.M18;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+
+        public static Matrix1x8 operator -(Matrix1x8 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m18 = matrix1.M18 - matrix2.M18;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+
+        public static Matrix1x8 operator *(Matrix1x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m18 = matrix.M18 * scalar;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+
+        public static Matrix1x8 operator *(double scalar, Matrix1x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+            double m14 = scalar * matrix.M14;
+            double m15 = scalar * matrix.M15;
+            double m16 = scalar * matrix.M16;
+            double m17 = scalar * matrix.M17;
+            double m18 = scalar * matrix.M18;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+
+        public static Matrix2x8 operator *(Matrix1x8 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix1x8 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+            double m38 = matrix1.M18 * matrix2.M31;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix1x8 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+            double m38 = matrix1.M18 * matrix2.M31;
+            double m48 = matrix1.M18 * matrix2.M41;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix1x8 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+            double m38 = matrix1.M18 * matrix2.M31;
+            double m48 = matrix1.M18 * matrix2.M41;
+            double m58 = matrix1.M18 * matrix2.M51;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix1x8 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m67 = matrix1.M17 * matrix2.M61;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+            double m38 = matrix1.M18 * matrix2.M31;
+            double m48 = matrix1.M18 * matrix2.M41;
+            double m58 = matrix1.M18 * matrix2.M51;
+            double m68 = matrix1.M18 * matrix2.M61;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix1x8 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m76 = matrix1.M16 * matrix2.M71;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m67 = matrix1.M17 * matrix2.M61;
+            double m77 = matrix1.M17 * matrix2.M71;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+            double m38 = matrix1.M18 * matrix2.M31;
+            double m48 = matrix1.M18 * matrix2.M41;
+            double m58 = matrix1.M18 * matrix2.M51;
+            double m68 = matrix1.M18 * matrix2.M61;
+            double m78 = matrix1.M18 * matrix2.M71;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix1x8 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m51 = matrix1.M11 * matrix2.M51;
+            double m61 = matrix1.M11 * matrix2.M61;
+            double m71 = matrix1.M11 * matrix2.M71;
+            double m81 = matrix1.M11 * matrix2.M81;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m52 = matrix1.M12 * matrix2.M51;
+            double m62 = matrix1.M12 * matrix2.M61;
+            double m72 = matrix1.M12 * matrix2.M71;
+            double m82 = matrix1.M12 * matrix2.M81;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m53 = matrix1.M13 * matrix2.M51;
+            double m63 = matrix1.M13 * matrix2.M61;
+            double m73 = matrix1.M13 * matrix2.M71;
+            double m83 = matrix1.M13 * matrix2.M81;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+            double m54 = matrix1.M14 * matrix2.M51;
+            double m64 = matrix1.M14 * matrix2.M61;
+            double m74 = matrix1.M14 * matrix2.M71;
+            double m84 = matrix1.M14 * matrix2.M81;
+            double m15 = matrix1.M15 * matrix2.M11;
+            double m25 = matrix1.M15 * matrix2.M21;
+            double m35 = matrix1.M15 * matrix2.M31;
+            double m45 = matrix1.M15 * matrix2.M41;
+            double m55 = matrix1.M15 * matrix2.M51;
+            double m65 = matrix1.M15 * matrix2.M61;
+            double m75 = matrix1.M15 * matrix2.M71;
+            double m85 = matrix1.M15 * matrix2.M81;
+            double m16 = matrix1.M16 * matrix2.M11;
+            double m26 = matrix1.M16 * matrix2.M21;
+            double m36 = matrix1.M16 * matrix2.M31;
+            double m46 = matrix1.M16 * matrix2.M41;
+            double m56 = matrix1.M16 * matrix2.M51;
+            double m66 = matrix1.M16 * matrix2.M61;
+            double m76 = matrix1.M16 * matrix2.M71;
+            double m86 = matrix1.M16 * matrix2.M81;
+            double m17 = matrix1.M17 * matrix2.M11;
+            double m27 = matrix1.M17 * matrix2.M21;
+            double m37 = matrix1.M17 * matrix2.M31;
+            double m47 = matrix1.M17 * matrix2.M41;
+            double m57 = matrix1.M17 * matrix2.M51;
+            double m67 = matrix1.M17 * matrix2.M61;
+            double m77 = matrix1.M17 * matrix2.M71;
+            double m87 = matrix1.M17 * matrix2.M81;
+            double m18 = matrix1.M18 * matrix2.M11;
+            double m28 = matrix1.M18 * matrix2.M21;
+            double m38 = matrix1.M18 * matrix2.M31;
+            double m48 = matrix1.M18 * matrix2.M41;
+            double m58 = matrix1.M18 * matrix2.M51;
+            double m68 = matrix1.M18 * matrix2.M61;
+            double m78 = matrix1.M18 * matrix2.M71;
+            double m88 = matrix1.M18 * matrix2.M81;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x1.cs
@@ -1,0 +1,243 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x1: IEquatable<Matrix2x1>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 1;
+
+        static Matrix2x1()
+        {
+            Zero = new Matrix2x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        public Matrix2x1(double m11, double m21)
+        {
+			M11 = m11; M21 = m21; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x1(double value)
+        {
+			M11 = M21 = value;
+        }
+
+		public double M11;
+		public double M21;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x1)
+                return this == (Matrix2x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x1: "
+                               + "{{|{00}|{01}|}}"
+                               , M11, M21); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x2 Transpose()
+        {
+            return new Matrix1x2(M11, 
+                                 M21);
+        }
+
+        public static bool operator ==(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon;
+        }
+
+        public static Matrix2x1 operator +(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator -(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator *(Matrix2x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator *(double scalar, Matrix2x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator *(Matrix2x1 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix2x1 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix2x1 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix2x1 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix2x1 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix2x1 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix2x1 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x2.cs
@@ -1,0 +1,342 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x2: IEquatable<Matrix2x2>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 2;
+
+        static Matrix2x2()
+        {
+            Zero = new Matrix2x2(0);
+			Identitiy = new Matrix2x2(1, 0, 
+                                      0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x2 Zero;
+        
+        /// <summary>
+        /// Constant Matrix2x2 with value intialized to the identity of a 2 x 2 matrix
+        /// </summary>
+        public static readonly Matrix2x2 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix2x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        public Matrix2x2(double m11, double m21, 
+                         double m12, double m22)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x2(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x2)
+                return this == (Matrix2x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x2: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               , M11, M21
+                               , M12, M22); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x2 Transpose()
+        {
+            return new Matrix2x2(M11, M12, 
+                                 M21, M22);
+        }
+
+        public static bool operator ==(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon;
+        }
+
+        public static Matrix2x2 operator +(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix2x2 operator -(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix2x2 operator *(Matrix2x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix2x2 operator *(double scalar, Matrix2x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix1x2 operator *(Matrix2x2 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix2x2 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix2x2 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix2x2 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix2x2 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix2x2 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix2x2 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x3.cs
@@ -1,0 +1,409 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x3: IEquatable<Matrix2x3>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 3;
+
+        static Matrix2x3()
+        {
+            Zero = new Matrix2x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        public Matrix2x3(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+			M13 = m13; M23 = m23; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x3(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = 
+			M13 = M23 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+		public double M13;
+		public double M23;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x3)
+                return this == (Matrix2x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x3: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               + "{{|{04}|{05}|}}"
+                               , M11, M21
+                               , M12, M22
+                               , M13, M23); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x2 Transpose()
+        {
+            return new Matrix3x2(M11, M12, M13, 
+                                 M21, M22, M23);
+        }
+
+        public static bool operator ==(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon;
+        }
+
+        public static Matrix2x3 operator +(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix2x3 operator -(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix2x3 operator *(Matrix2x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix2x3 operator *(double scalar, Matrix2x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix1x3 operator *(Matrix2x3 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix2x3 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix2x3 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix2x3 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix2x3 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix2x3 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix2x3 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix2x3 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x4.cs
@@ -1,0 +1,483 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x4: IEquatable<Matrix2x4>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 4;
+
+        static Matrix2x4()
+        {
+            Zero = new Matrix2x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        public Matrix2x4(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23, 
+                         double m14, double m24)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+			M13 = m13; M23 = m23; 
+			M14 = m14; M24 = m24; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x4(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = 
+			M13 = M23 = 
+			M14 = M24 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+		public double M13;
+		public double M23;
+		public double M14;
+		public double M24;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 4
+        /// </summary>
+        public Matrix2x1 Row4 { get { return new Matrix2x1(M14, M24); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x4)
+                return this == (Matrix2x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x4: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               + "{{|{04}|{05}|}}"
+                               + "{{|{06}|{07}|}}"
+                               , M11, M21
+                               , M12, M22
+                               , M13, M23
+                               , M14, M24); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x2 Transpose()
+        {
+            return new Matrix4x2(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24);
+        }
+
+        public static bool operator ==(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon;
+        }
+
+        public static Matrix2x4 operator +(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix2x4 operator -(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix2x4 operator *(Matrix2x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix2x4 operator *(double scalar, Matrix2x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix1x4 operator *(Matrix2x4 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix2x4 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix2x4 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix2x4 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix2x4 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix2x4 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix2x4 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix2x4 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x5.cs
@@ -1,0 +1,557 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x5: IEquatable<Matrix2x5>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 5;
+
+        static Matrix2x5()
+        {
+            Zero = new Matrix2x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        public Matrix2x5(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23, 
+                         double m14, double m24, 
+                         double m15, double m25)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+			M13 = m13; M23 = m23; 
+			M14 = m14; M24 = m24; 
+			M15 = m15; M25 = m25; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x5(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = 
+			M13 = M23 = 
+			M14 = M24 = 
+			M15 = M25 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+		public double M13;
+		public double M23;
+		public double M14;
+		public double M24;
+		public double M15;
+		public double M25;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 4
+        /// </summary>
+        public Matrix2x1 Row4 { get { return new Matrix2x1(M14, M24); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 5
+        /// </summary>
+        public Matrix2x1 Row5 { get { return new Matrix2x1(M15, M25); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x5)
+                return this == (Matrix2x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x5: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               + "{{|{04}|{05}|}}"
+                               + "{{|{06}|{07}|}}"
+                               + "{{|{08}|{09}|}}"
+                               , M11, M21
+                               , M12, M22
+                               , M13, M23
+                               , M14, M24
+                               , M15, M25); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x2 Transpose()
+        {
+            return new Matrix5x2(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25);
+        }
+
+        public static bool operator ==(Matrix2x5 matrix1, Matrix2x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x5 matrix1, Matrix2x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon;
+        }
+
+        public static Matrix2x5 operator +(Matrix2x5 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+
+        public static Matrix2x5 operator -(Matrix2x5 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+
+        public static Matrix2x5 operator *(Matrix2x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+
+        public static Matrix2x5 operator *(double scalar, Matrix2x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+
+        public static Matrix1x5 operator *(Matrix2x5 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix2x5 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix2x5 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix2x5 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix2x5 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix2x5 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix2x5 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix2x5 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x6.cs
@@ -1,0 +1,631 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x6: IEquatable<Matrix2x6>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 6;
+
+        static Matrix2x6()
+        {
+            Zero = new Matrix2x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        public Matrix2x6(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23, 
+                         double m14, double m24, 
+                         double m15, double m25, 
+                         double m16, double m26)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+			M13 = m13; M23 = m23; 
+			M14 = m14; M24 = m24; 
+			M15 = m15; M25 = m25; 
+			M16 = m16; M26 = m26; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x6(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = 
+			M13 = M23 = 
+			M14 = M24 = 
+			M15 = M25 = 
+			M16 = M26 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+		public double M13;
+		public double M23;
+		public double M14;
+		public double M24;
+		public double M15;
+		public double M25;
+		public double M16;
+		public double M26;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 4
+        /// </summary>
+        public Matrix2x1 Row4 { get { return new Matrix2x1(M14, M24); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 5
+        /// </summary>
+        public Matrix2x1 Row5 { get { return new Matrix2x1(M15, M25); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 6
+        /// </summary>
+        public Matrix2x1 Row6 { get { return new Matrix2x1(M16, M26); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x6)
+                return this == (Matrix2x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x6: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               + "{{|{04}|{05}|}}"
+                               + "{{|{06}|{07}|}}"
+                               + "{{|{08}|{09}|}}"
+                               + "{{|{10}|{11}|}}"
+                               , M11, M21
+                               , M12, M22
+                               , M13, M23
+                               , M14, M24
+                               , M15, M25
+                               , M16, M26); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x2 Transpose()
+        {
+            return new Matrix6x2(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26);
+        }
+
+        public static bool operator ==(Matrix2x6 matrix1, Matrix2x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x6 matrix1, Matrix2x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon;
+        }
+
+        public static Matrix2x6 operator +(Matrix2x6 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+
+        public static Matrix2x6 operator -(Matrix2x6 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+
+        public static Matrix2x6 operator *(Matrix2x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+
+        public static Matrix2x6 operator *(double scalar, Matrix2x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+
+        public static Matrix1x6 operator *(Matrix2x6 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix2x6 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix2x6 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix2x6 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix2x6 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix2x6 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix2x6 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix2x6 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x7.cs
@@ -1,0 +1,705 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x7: IEquatable<Matrix2x7>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 7;
+
+        static Matrix2x7()
+        {
+            Zero = new Matrix2x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        public Matrix2x7(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23, 
+                         double m14, double m24, 
+                         double m15, double m25, 
+                         double m16, double m26, 
+                         double m17, double m27)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+			M13 = m13; M23 = m23; 
+			M14 = m14; M24 = m24; 
+			M15 = m15; M25 = m25; 
+			M16 = m16; M26 = m26; 
+			M17 = m17; M27 = m27; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x7(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = 
+			M13 = M23 = 
+			M14 = M24 = 
+			M15 = M25 = 
+			M16 = M26 = 
+			M17 = M27 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+		public double M13;
+		public double M23;
+		public double M14;
+		public double M24;
+		public double M15;
+		public double M25;
+		public double M16;
+		public double M26;
+		public double M17;
+		public double M27;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 4
+        /// </summary>
+        public Matrix2x1 Row4 { get { return new Matrix2x1(M14, M24); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 5
+        /// </summary>
+        public Matrix2x1 Row5 { get { return new Matrix2x1(M15, M25); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 6
+        /// </summary>
+        public Matrix2x1 Row6 { get { return new Matrix2x1(M16, M26); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 7
+        /// </summary>
+        public Matrix2x1 Row7 { get { return new Matrix2x1(M17, M27); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x7)
+                return this == (Matrix2x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x7: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               + "{{|{04}|{05}|}}"
+                               + "{{|{06}|{07}|}}"
+                               + "{{|{08}|{09}|}}"
+                               + "{{|{10}|{11}|}}"
+                               + "{{|{12}|{13}|}}"
+                               , M11, M21
+                               , M12, M22
+                               , M13, M23
+                               , M14, M24
+                               , M15, M25
+                               , M16, M26
+                               , M17, M27); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x2 Transpose()
+        {
+            return new Matrix7x2(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27);
+        }
+
+        public static bool operator ==(Matrix2x7 matrix1, Matrix2x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x7 matrix1, Matrix2x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon;
+        }
+
+        public static Matrix2x7 operator +(Matrix2x7 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+
+        public static Matrix2x7 operator -(Matrix2x7 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+
+        public static Matrix2x7 operator *(Matrix2x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+
+        public static Matrix2x7 operator *(double scalar, Matrix2x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+
+        public static Matrix1x7 operator *(Matrix2x7 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix2x7 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix2x7 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix2x7 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix2x7 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix2x7 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix2x7 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix2x7 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x8.cs
@@ -1,0 +1,779 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x8: IEquatable<Matrix2x8>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 8;
+
+        static Matrix2x8()
+        {
+            Zero = new Matrix2x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix2x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        public Matrix2x8(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23, 
+                         double m14, double m24, 
+                         double m15, double m25, 
+                         double m16, double m26, 
+                         double m17, double m27, 
+                         double m18, double m28)
+        {
+			M11 = m11; M21 = m21; 
+			M12 = m12; M22 = m22; 
+			M13 = m13; M23 = m23; 
+			M14 = m14; M24 = m24; 
+			M15 = m15; M25 = m25; 
+			M16 = m16; M26 = m26; 
+			M17 = m17; M27 = m27; 
+			M18 = m18; M28 = m28; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x8(double value)
+        {
+			M11 = M21 = 
+			M12 = M22 = 
+			M13 = M23 = 
+			M14 = M24 = 
+			M15 = M25 = 
+			M16 = M26 = 
+			M17 = M27 = 
+			M18 = M28 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M12;
+		public double M22;
+		public double M13;
+		public double M23;
+		public double M14;
+		public double M24;
+		public double M15;
+		public double M25;
+		public double M16;
+		public double M26;
+		public double M17;
+		public double M27;
+		public double M18;
+		public double M28;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix2x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix2x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix2x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 4
+        /// </summary>
+        public Matrix2x1 Row4 { get { return new Matrix2x1(M14, M24); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 5
+        /// </summary>
+        public Matrix2x1 Row5 { get { return new Matrix2x1(M15, M25); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 6
+        /// </summary>
+        public Matrix2x1 Row6 { get { return new Matrix2x1(M16, M26); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 7
+        /// </summary>
+        public Matrix2x1 Row7 { get { return new Matrix2x1(M17, M27); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 8
+        /// </summary>
+        public Matrix2x1 Row8 { get { return new Matrix2x1(M18, M28); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x8)
+                return this == (Matrix2x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03])
+                         + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix2x8: "
+                               + "{{|{00}|{01}|}}"
+                               + "{{|{02}|{03}|}}"
+                               + "{{|{04}|{05}|}}"
+                               + "{{|{06}|{07}|}}"
+                               + "{{|{08}|{09}|}}"
+                               + "{{|{10}|{11}|}}"
+                               + "{{|{12}|{13}|}}"
+                               + "{{|{14}|{15}|}}"
+                               , M11, M21
+                               , M12, M22
+                               , M13, M23
+                               , M14, M24
+                               , M15, M25
+                               , M16, M26
+                               , M17, M27
+                               , M18, M28); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x2 Transpose()
+        {
+            return new Matrix8x2(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28);
+        }
+
+        public static bool operator ==(Matrix2x8 matrix1, Matrix2x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix2x8 matrix1, Matrix2x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon;
+        }
+
+        public static Matrix2x8 operator +(Matrix2x8 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+
+        public static Matrix2x8 operator -(Matrix2x8 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+
+        public static Matrix2x8 operator *(Matrix2x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+
+        public static Matrix2x8 operator *(double scalar, Matrix2x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+
+        public static Matrix1x8 operator *(Matrix2x8 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix2x8 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix2x8 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix2x8 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix2x8 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix2x8 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix2x8 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix2x8 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x1.cs
@@ -1,0 +1,252 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x1: IEquatable<Matrix3x1>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 1;
+
+        static Matrix3x1()
+        {
+            Zero = new Matrix3x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        public Matrix3x1(double m11, double m21, double m31)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x1(double value)
+        {
+			M11 = M21 = M31 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x1)
+                return this == (Matrix3x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x1: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               , M11, M21, M31); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x3 Transpose()
+        {
+            return new Matrix1x3(M11, 
+                                 M21, 
+                                 M31);
+        }
+
+        public static bool operator ==(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon;
+        }
+
+        public static Matrix3x1 operator +(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix3x1 operator -(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix3x1 operator *(Matrix3x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix3x1 operator *(double scalar, Matrix3x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix2x1 operator *(Matrix3x1 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix3x1 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix3x1 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix3x1 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix3x1 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix3x1 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix3x1 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x2.cs
@@ -1,0 +1,356 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x2: IEquatable<Matrix3x2>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 2;
+
+        static Matrix3x2()
+        {
+            Zero = new Matrix3x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        public Matrix3x2(double m11, double m21, double m31, 
+                         double m12, double m22, double m32)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x2(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x2)
+                return this == (Matrix3x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x2: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x3 Transpose()
+        {
+            return new Matrix2x3(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32);
+        }
+
+        public static bool operator ==(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon;
+        }
+
+        public static Matrix3x2 operator +(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix3x2 operator -(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix3x2 operator *(Matrix3x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix3x2 operator *(double scalar, Matrix3x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix1x2 operator *(Matrix3x2 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix3x2 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix3x2 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix3x2 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix3x2 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix3x2 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix3x2 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix3x2 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x3.cs
@@ -1,0 +1,446 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x3: IEquatable<Matrix3x3>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 3;
+
+        static Matrix3x3()
+        {
+            Zero = new Matrix3x3(0);
+			Identitiy = new Matrix3x3(1, 0, 0, 
+                                      0, 1, 0, 
+                                      0, 0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x3 Zero;
+        
+        /// <summary>
+        /// Constant Matrix3x3 with value intialized to the identity of a 3 x 3 matrix
+        /// </summary>
+        public static readonly Matrix3x3 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix3x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        public Matrix3x3(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+			M13 = m13; M23 = m23; M33 = m33; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x3(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = 
+			M13 = M23 = M33 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M13;
+		public double M23;
+		public double M33;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x3)
+                return this == (Matrix3x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x3: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32
+                               , M13, M23, M33); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x3 Transpose()
+        {
+            return new Matrix3x3(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33);
+        }
+
+        public static bool operator ==(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon;
+        }
+
+        public static Matrix3x3 operator +(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix3x3 operator -(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix3x3 operator *(Matrix3x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix3x3 operator *(double scalar, Matrix3x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix1x3 operator *(Matrix3x3 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix3x3 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix3x3 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix3x3 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix3x3 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix3x3 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix3x3 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x4.cs
@@ -1,0 +1,520 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x4: IEquatable<Matrix3x4>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 4;
+
+        static Matrix3x4()
+        {
+            Zero = new Matrix3x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        public Matrix3x4(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33, 
+                         double m14, double m24, double m34)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+			M13 = m13; M23 = m23; M33 = m33; 
+			M14 = m14; M24 = m24; M34 = m34; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x4(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = 
+			M13 = M23 = M33 = 
+			M14 = M24 = M34 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M14;
+		public double M24;
+		public double M34;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 4
+        /// </summary>
+        public Matrix3x1 Row4 { get { return new Matrix3x1(M14, M24, M34); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x4)
+                return this == (Matrix3x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x4: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|}}"
+                               + "{{|{09}|{10}|{11}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32
+                               , M13, M23, M33
+                               , M14, M24, M34); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x3 Transpose()
+        {
+            return new Matrix4x3(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34);
+        }
+
+        public static bool operator ==(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon;
+        }
+
+        public static Matrix3x4 operator +(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix3x4 operator -(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix3x4 operator *(Matrix3x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix3x4 operator *(double scalar, Matrix3x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix1x4 operator *(Matrix3x4 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix3x4 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix3x4 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix3x4 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix3x4 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix3x4 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix3x4 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix3x4 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x5.cs
@@ -1,0 +1,602 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x5: IEquatable<Matrix3x5>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 5;
+
+        static Matrix3x5()
+        {
+            Zero = new Matrix3x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        public Matrix3x5(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33, 
+                         double m14, double m24, double m34, 
+                         double m15, double m25, double m35)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+			M13 = m13; M23 = m23; M33 = m33; 
+			M14 = m14; M24 = m24; M34 = m34; 
+			M15 = m15; M25 = m25; M35 = m35; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x5(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = 
+			M13 = M23 = M33 = 
+			M14 = M24 = M34 = 
+			M15 = M25 = M35 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M15;
+		public double M25;
+		public double M35;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 3
+        /// </summary>
+        public Matrix1x5 Column3 { get { return new Matrix1x5(M31, M32, M33, M34, M35); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 4
+        /// </summary>
+        public Matrix3x1 Row4 { get { return new Matrix3x1(M14, M24, M34); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 5
+        /// </summary>
+        public Matrix3x1 Row5 { get { return new Matrix3x1(M15, M25, M35); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x5)
+                return this == (Matrix3x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x5: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|}}"
+                               + "{{|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32
+                               , M13, M23, M33
+                               , M14, M24, M34
+                               , M15, M25, M35); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x3 Transpose()
+        {
+            return new Matrix5x3(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25, 
+                                 M31, M32, M33, M34, M35);
+        }
+
+        public static bool operator ==(Matrix3x5 matrix1, Matrix3x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x5 matrix1, Matrix3x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon;
+        }
+
+        public static Matrix3x5 operator +(Matrix3x5 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+
+        public static Matrix3x5 operator -(Matrix3x5 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+
+        public static Matrix3x5 operator *(Matrix3x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+
+        public static Matrix3x5 operator *(double scalar, Matrix3x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+
+        public static Matrix1x5 operator *(Matrix3x5 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix3x5 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix3x5 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix3x5 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix3x5 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix3x5 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix3x5 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix3x5 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x6.cs
@@ -1,0 +1,684 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x6: IEquatable<Matrix3x6>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 6;
+
+        static Matrix3x6()
+        {
+            Zero = new Matrix3x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        public Matrix3x6(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33, 
+                         double m14, double m24, double m34, 
+                         double m15, double m25, double m35, 
+                         double m16, double m26, double m36)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+			M13 = m13; M23 = m23; M33 = m33; 
+			M14 = m14; M24 = m24; M34 = m34; 
+			M15 = m15; M25 = m25; M35 = m35; 
+			M16 = m16; M26 = m26; M36 = m36; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x6(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = 
+			M13 = M23 = M33 = 
+			M14 = M24 = M34 = 
+			M15 = M25 = M35 = 
+			M16 = M26 = M36 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M16;
+		public double M26;
+		public double M36;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 3
+        /// </summary>
+        public Matrix1x6 Column3 { get { return new Matrix1x6(M31, M32, M33, M34, M35, M36); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 4
+        /// </summary>
+        public Matrix3x1 Row4 { get { return new Matrix3x1(M14, M24, M34); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 5
+        /// </summary>
+        public Matrix3x1 Row5 { get { return new Matrix3x1(M15, M25, M35); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 6
+        /// </summary>
+        public Matrix3x1 Row6 { get { return new Matrix3x1(M16, M26, M36); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x6)
+                return this == (Matrix3x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x6: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|}}"
+                               + "{{|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32
+                               , M13, M23, M33
+                               , M14, M24, M34
+                               , M15, M25, M35
+                               , M16, M26, M36); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x3 Transpose()
+        {
+            return new Matrix6x3(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26, 
+                                 M31, M32, M33, M34, M35, M36);
+        }
+
+        public static bool operator ==(Matrix3x6 matrix1, Matrix3x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x6 matrix1, Matrix3x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon;
+        }
+
+        public static Matrix3x6 operator +(Matrix3x6 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+
+        public static Matrix3x6 operator -(Matrix3x6 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+
+        public static Matrix3x6 operator *(Matrix3x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+
+        public static Matrix3x6 operator *(double scalar, Matrix3x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+
+        public static Matrix1x6 operator *(Matrix3x6 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix3x6 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix3x6 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix3x6 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix3x6 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix3x6 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix3x6 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix3x6 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x7.cs
@@ -1,0 +1,766 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x7: IEquatable<Matrix3x7>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 7;
+
+        static Matrix3x7()
+        {
+            Zero = new Matrix3x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        public Matrix3x7(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33, 
+                         double m14, double m24, double m34, 
+                         double m15, double m25, double m35, 
+                         double m16, double m26, double m36, 
+                         double m17, double m27, double m37)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+			M13 = m13; M23 = m23; M33 = m33; 
+			M14 = m14; M24 = m24; M34 = m34; 
+			M15 = m15; M25 = m25; M35 = m35; 
+			M16 = m16; M26 = m26; M36 = m36; 
+			M17 = m17; M27 = m27; M37 = m37; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x7(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = 
+			M13 = M23 = M33 = 
+			M14 = M24 = M34 = 
+			M15 = M25 = M35 = 
+			M16 = M26 = M36 = 
+			M17 = M27 = M37 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M17;
+		public double M27;
+		public double M37;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 3
+        /// </summary>
+        public Matrix1x7 Column3 { get { return new Matrix1x7(M31, M32, M33, M34, M35, M36, M37); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 4
+        /// </summary>
+        public Matrix3x1 Row4 { get { return new Matrix3x1(M14, M24, M34); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 5
+        /// </summary>
+        public Matrix3x1 Row5 { get { return new Matrix3x1(M15, M25, M35); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 6
+        /// </summary>
+        public Matrix3x1 Row6 { get { return new Matrix3x1(M16, M26, M36); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 7
+        /// </summary>
+        public Matrix3x1 Row7 { get { return new Matrix3x1(M17, M27, M37); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x7)
+                return this == (Matrix3x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x7: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|}}"
+                               + "{{|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32
+                               , M13, M23, M33
+                               , M14, M24, M34
+                               , M15, M25, M35
+                               , M16, M26, M36
+                               , M17, M27, M37); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x3 Transpose()
+        {
+            return new Matrix7x3(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27, 
+                                 M31, M32, M33, M34, M35, M36, M37);
+        }
+
+        public static bool operator ==(Matrix3x7 matrix1, Matrix3x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x7 matrix1, Matrix3x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon;
+        }
+
+        public static Matrix3x7 operator +(Matrix3x7 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+
+        public static Matrix3x7 operator -(Matrix3x7 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+
+        public static Matrix3x7 operator *(Matrix3x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+
+        public static Matrix3x7 operator *(double scalar, Matrix3x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+
+        public static Matrix1x7 operator *(Matrix3x7 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix3x7 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix3x7 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix3x7 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix3x7 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix3x7 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix3x7 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix3x7 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x8.cs
@@ -1,0 +1,848 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x8: IEquatable<Matrix3x8>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 8;
+
+        static Matrix3x8()
+        {
+            Zero = new Matrix3x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix3x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        /// <param name="m38">The column 3, row 8 value</param>
+        public Matrix3x8(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33, 
+                         double m14, double m24, double m34, 
+                         double m15, double m25, double m35, 
+                         double m16, double m26, double m36, 
+                         double m17, double m27, double m37, 
+                         double m18, double m28, double m38)
+        {
+			M11 = m11; M21 = m21; M31 = m31; 
+			M12 = m12; M22 = m22; M32 = m32; 
+			M13 = m13; M23 = m23; M33 = m33; 
+			M14 = m14; M24 = m24; M34 = m34; 
+			M15 = m15; M25 = m25; M35 = m35; 
+			M16 = m16; M26 = m26; M36 = m36; 
+			M17 = m17; M27 = m27; M37 = m37; 
+			M18 = m18; M28 = m28; M38 = m38; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x8(double value)
+        {
+			M11 = M21 = M31 = 
+			M12 = M22 = M32 = 
+			M13 = M23 = M33 = 
+			M14 = M24 = M34 = 
+			M15 = M25 = M35 = 
+			M16 = M26 = M36 = 
+			M17 = M27 = M37 = 
+			M18 = M28 = M38 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M18;
+		public double M28;
+		public double M38;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix3x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix3x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix3x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 3
+        /// </summary>
+        public Matrix1x8 Column3 { get { return new Matrix1x8(M31, M32, M33, M34, M35, M36, M37, M38); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 4
+        /// </summary>
+        public Matrix3x1 Row4 { get { return new Matrix3x1(M14, M24, M34); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 5
+        /// </summary>
+        public Matrix3x1 Row5 { get { return new Matrix3x1(M15, M25, M35); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 6
+        /// </summary>
+        public Matrix3x1 Row6 { get { return new Matrix3x1(M16, M26, M36); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 7
+        /// </summary>
+        public Matrix3x1 Row7 { get { return new Matrix3x1(M17, M27, M37); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 8
+        /// </summary>
+        public Matrix3x1 Row8 { get { return new Matrix3x1(M18, M28, M38); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x8)
+                return this == (Matrix3x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05])
+                         + (x[03] ^ x[04]) + (x[05] ^ x[06]) + (x[07] ^ x[08])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[21] ^ x[22]) + (x[23] ^ x[24]) + (x[25] ^ x[26]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix3x8: "
+                               + "{{|{00}|{01}|{02}|}}"
+                               + "{{|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|}}"
+                               + "{{|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|}}"
+                               + "{{|{21}|{22}|{23}|}}"
+                               , M11, M21, M31
+                               , M12, M22, M32
+                               , M13, M23, M33
+                               , M14, M24, M34
+                               , M15, M25, M35
+                               , M16, M26, M36
+                               , M17, M27, M37
+                               , M18, M28, M38); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x3 Transpose()
+        {
+            return new Matrix8x3(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28, 
+                                 M31, M32, M33, M34, M35, M36, M37, M38);
+        }
+
+        public static bool operator ==(Matrix3x8 matrix1, Matrix3x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M38 - matrix2.M38) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix3x8 matrix1, Matrix3x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon
+                || Math.Abs(matrix1.M38 - matrix2.M38) > Double.Epsilon;
+        }
+
+        public static Matrix3x8 operator +(Matrix3x8 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+            double m38 = matrix1.M38 + matrix2.M38;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+
+        public static Matrix3x8 operator -(Matrix3x8 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+            double m38 = matrix1.M38 - matrix2.M38;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+
+        public static Matrix3x8 operator *(Matrix3x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+            double m38 = matrix.M38 * scalar;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+
+        public static Matrix3x8 operator *(double scalar, Matrix3x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+            double m38 = scalar * matrix.M38;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+
+        public static Matrix1x8 operator *(Matrix3x8 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix3x8 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix3x8 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix3x8 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix3x8 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix3x8 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix3x8 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix3x8 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82 + matrix1.M38 * matrix2.M83;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x1.cs
@@ -1,0 +1,261 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x1: IEquatable<Matrix4x1>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 1;
+
+        static Matrix4x1()
+        {
+            Zero = new Matrix4x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        public Matrix4x1(double m11, double m21, double m31, double m41)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x1(double value)
+        {
+			M11 = M21 = M31 = M41 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x1)
+                return this == (Matrix4x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x1: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               , M11, M21, M31, M41); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x4 Transpose()
+        {
+            return new Matrix1x4(M11, 
+                                 M21, 
+                                 M31, 
+                                 M41);
+        }
+
+        public static bool operator ==(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon;
+        }
+
+        public static Matrix4x1 operator +(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix4x1 operator -(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix4x1 operator *(Matrix4x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix4x1 operator *(double scalar, Matrix4x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix2x1 operator *(Matrix4x1 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix4x1 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix4x1 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix4x1 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix4x1 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix4x1 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix4x1 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x2.cs
@@ -1,0 +1,377 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x2: IEquatable<Matrix4x2>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 2;
+
+        static Matrix4x2()
+        {
+            Zero = new Matrix4x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        public Matrix4x2(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x2(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 4
+        /// </summary>
+        public Matrix1x2 Column4 { get { return new Matrix1x2(M41, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x2)
+                return this == (Matrix4x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x2: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x4 Transpose()
+        {
+            return new Matrix2x4(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32, 
+                                 M41, M42);
+        }
+
+        public static bool operator ==(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon;
+        }
+
+        public static Matrix4x2 operator +(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix4x2 operator -(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix4x2 operator *(Matrix4x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix4x2 operator *(double scalar, Matrix4x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix1x2 operator *(Matrix4x2 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix4x2 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix4x2 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix4x2 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix4x2 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix4x2 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix4x2 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix4x2 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x3.cs
@@ -1,0 +1,467 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x3: IEquatable<Matrix4x3>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 3;
+
+        static Matrix4x3()
+        {
+            Zero = new Matrix4x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        public Matrix4x3(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x3(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = 
+			M13 = M23 = M33 = M43 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 4
+        /// </summary>
+        public Matrix1x3 Column4 { get { return new Matrix1x3(M41, M42, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x3)
+                return this == (Matrix4x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x3: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42
+                               , M13, M23, M33, M43); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x4 Transpose()
+        {
+            return new Matrix3x4(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33, 
+                                 M41, M42, M43);
+        }
+
+        public static bool operator ==(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon;
+        }
+
+        public static Matrix4x3 operator +(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix4x3 operator -(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix4x3 operator *(Matrix4x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix4x3 operator *(double scalar, Matrix4x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix1x3 operator *(Matrix4x3 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix4x3 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix4x3 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix4x3 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix4x3 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix4x3 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix4x3 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix4x3 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x4.cs
@@ -1,0 +1,566 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x4: IEquatable<Matrix4x4>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 4;
+
+        static Matrix4x4()
+        {
+            Zero = new Matrix4x4(0);
+			Identitiy = new Matrix4x4(1, 0, 0, 0, 
+                                      0, 1, 0, 0, 
+                                      0, 0, 1, 0, 
+                                      0, 0, 0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x4 Zero;
+        
+        /// <summary>
+        /// Constant Matrix4x4 with value intialized to the identity of a 4 x 4 matrix
+        /// </summary>
+        public static readonly Matrix4x4 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix4x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        public Matrix4x4(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43, 
+                         double m14, double m24, double m34, double m44)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x4(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = 
+			M13 = M23 = M33 = M43 = 
+			M14 = M24 = M34 = M44 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 4
+        /// </summary>
+        public Matrix1x4 Column4 { get { return new Matrix1x4(M41, M42, M43, M44); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 4
+        /// </summary>
+        public Matrix4x1 Row4 { get { return new Matrix4x1(M14, M24, M34, M44); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x4)
+                return this == (Matrix4x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x4: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42
+                               , M13, M23, M33, M43
+                               , M14, M24, M34, M44); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x4 Transpose()
+        {
+            return new Matrix4x4(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34, 
+                                 M41, M42, M43, M44);
+        }
+
+        public static bool operator ==(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon;
+        }
+
+        public static Matrix4x4 operator +(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix4x4 operator -(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix4x4 operator *(Matrix4x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix4x4 operator *(double scalar, Matrix4x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix1x4 operator *(Matrix4x4 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix4x4 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix4x4 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix4x4 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix4x4 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix4x4 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix4x4 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x5.cs
@@ -1,0 +1,647 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x5: IEquatable<Matrix4x5>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 5;
+
+        static Matrix4x5()
+        {
+            Zero = new Matrix4x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        public Matrix4x5(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43, 
+                         double m14, double m24, double m34, double m44, 
+                         double m15, double m25, double m35, double m45)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x5(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = 
+			M13 = M23 = M33 = M43 = 
+			M14 = M24 = M34 = M44 = 
+			M15 = M25 = M35 = M45 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 3
+        /// </summary>
+        public Matrix1x5 Column3 { get { return new Matrix1x5(M31, M32, M33, M34, M35); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 4
+        /// </summary>
+        public Matrix1x5 Column4 { get { return new Matrix1x5(M41, M42, M43, M44, M45); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 4
+        /// </summary>
+        public Matrix4x1 Row4 { get { return new Matrix4x1(M14, M24, M34, M44); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 5
+        /// </summary>
+        public Matrix4x1 Row5 { get { return new Matrix4x1(M15, M25, M35, M45); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x5)
+                return this == (Matrix4x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x5: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42
+                               , M13, M23, M33, M43
+                               , M14, M24, M34, M44
+                               , M15, M25, M35, M45); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x4 Transpose()
+        {
+            return new Matrix5x4(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25, 
+                                 M31, M32, M33, M34, M35, 
+                                 M41, M42, M43, M44, M45);
+        }
+
+        public static bool operator ==(Matrix4x5 matrix1, Matrix4x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x5 matrix1, Matrix4x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon;
+        }
+
+        public static Matrix4x5 operator +(Matrix4x5 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+
+        public static Matrix4x5 operator -(Matrix4x5 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+
+        public static Matrix4x5 operator *(Matrix4x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+
+        public static Matrix4x5 operator *(double scalar, Matrix4x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+
+        public static Matrix1x5 operator *(Matrix4x5 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix4x5 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix4x5 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix4x5 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix4x5 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix4x5 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix4x5 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix4x5 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x6.cs
@@ -1,0 +1,737 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x6: IEquatable<Matrix4x6>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 6;
+
+        static Matrix4x6()
+        {
+            Zero = new Matrix4x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        public Matrix4x6(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43, 
+                         double m14, double m24, double m34, double m44, 
+                         double m15, double m25, double m35, double m45, 
+                         double m16, double m26, double m36, double m46)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x6(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = 
+			M13 = M23 = M33 = M43 = 
+			M14 = M24 = M34 = M44 = 
+			M15 = M25 = M35 = M45 = 
+			M16 = M26 = M36 = M46 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 3
+        /// </summary>
+        public Matrix1x6 Column3 { get { return new Matrix1x6(M31, M32, M33, M34, M35, M36); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 4
+        /// </summary>
+        public Matrix1x6 Column4 { get { return new Matrix1x6(M41, M42, M43, M44, M45, M46); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 4
+        /// </summary>
+        public Matrix4x1 Row4 { get { return new Matrix4x1(M14, M24, M34, M44); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 5
+        /// </summary>
+        public Matrix4x1 Row5 { get { return new Matrix4x1(M15, M25, M35, M45); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 6
+        /// </summary>
+        public Matrix4x1 Row6 { get { return new Matrix4x1(M16, M26, M36, M46); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x6)
+                return this == (Matrix4x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x6: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42
+                               , M13, M23, M33, M43
+                               , M14, M24, M34, M44
+                               , M15, M25, M35, M45
+                               , M16, M26, M36, M46); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x4 Transpose()
+        {
+            return new Matrix6x4(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26, 
+                                 M31, M32, M33, M34, M35, M36, 
+                                 M41, M42, M43, M44, M45, M46);
+        }
+
+        public static bool operator ==(Matrix4x6 matrix1, Matrix4x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x6 matrix1, Matrix4x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon;
+        }
+
+        public static Matrix4x6 operator +(Matrix4x6 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+
+        public static Matrix4x6 operator -(Matrix4x6 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+
+        public static Matrix4x6 operator *(Matrix4x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+
+        public static Matrix4x6 operator *(double scalar, Matrix4x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+
+        public static Matrix1x6 operator *(Matrix4x6 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix4x6 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix4x6 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix4x6 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix4x6 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix4x6 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix4x6 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix4x6 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x7.cs
@@ -1,0 +1,827 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x7: IEquatable<Matrix4x7>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 7;
+
+        static Matrix4x7()
+        {
+            Zero = new Matrix4x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        public Matrix4x7(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43, 
+                         double m14, double m24, double m34, double m44, 
+                         double m15, double m25, double m35, double m45, 
+                         double m16, double m26, double m36, double m46, 
+                         double m17, double m27, double m37, double m47)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x7(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = 
+			M13 = M23 = M33 = M43 = 
+			M14 = M24 = M34 = M44 = 
+			M15 = M25 = M35 = M45 = 
+			M16 = M26 = M36 = M46 = 
+			M17 = M27 = M37 = M47 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 3
+        /// </summary>
+        public Matrix1x7 Column3 { get { return new Matrix1x7(M31, M32, M33, M34, M35, M36, M37); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 4
+        /// </summary>
+        public Matrix1x7 Column4 { get { return new Matrix1x7(M41, M42, M43, M44, M45, M46, M47); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 4
+        /// </summary>
+        public Matrix4x1 Row4 { get { return new Matrix4x1(M14, M24, M34, M44); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 5
+        /// </summary>
+        public Matrix4x1 Row5 { get { return new Matrix4x1(M15, M25, M35, M45); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 6
+        /// </summary>
+        public Matrix4x1 Row6 { get { return new Matrix4x1(M16, M26, M36, M46); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 7
+        /// </summary>
+        public Matrix4x1 Row7 { get { return new Matrix4x1(M17, M27, M37, M47); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x7)
+                return this == (Matrix4x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x7: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42
+                               , M13, M23, M33, M43
+                               , M14, M24, M34, M44
+                               , M15, M25, M35, M45
+                               , M16, M26, M36, M46
+                               , M17, M27, M37, M47); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x4 Transpose()
+        {
+            return new Matrix7x4(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27, 
+                                 M31, M32, M33, M34, M35, M36, M37, 
+                                 M41, M42, M43, M44, M45, M46, M47);
+        }
+
+        public static bool operator ==(Matrix4x7 matrix1, Matrix4x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x7 matrix1, Matrix4x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon;
+        }
+
+        public static Matrix4x7 operator +(Matrix4x7 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+
+        public static Matrix4x7 operator -(Matrix4x7 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+
+        public static Matrix4x7 operator *(Matrix4x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+
+        public static Matrix4x7 operator *(double scalar, Matrix4x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+
+        public static Matrix1x7 operator *(Matrix4x7 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix4x7 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix4x7 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix4x7 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix4x7 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix4x7 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix4x7 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix4x7 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x8.cs
@@ -1,0 +1,917 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x8: IEquatable<Matrix4x8>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 8;
+
+        static Matrix4x8()
+        {
+            Zero = new Matrix4x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix4x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        /// <param name="m38">The column 3, row 8 value</param>
+        /// <param name="m48">The column 4, row 8 value</param>
+        public Matrix4x8(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43, 
+                         double m14, double m24, double m34, double m44, 
+                         double m15, double m25, double m35, double m45, 
+                         double m16, double m26, double m36, double m46, 
+                         double m17, double m27, double m37, double m47, 
+                         double m18, double m28, double m38, double m48)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; 
+			M18 = m18; M28 = m28; M38 = m38; M48 = m48; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x8(double value)
+        {
+			M11 = M21 = M31 = M41 = 
+			M12 = M22 = M32 = M42 = 
+			M13 = M23 = M33 = M43 = 
+			M14 = M24 = M34 = M44 = 
+			M15 = M25 = M35 = M45 = 
+			M16 = M26 = M36 = M46 = 
+			M17 = M27 = M37 = M47 = 
+			M18 = M28 = M38 = M48 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M18;
+		public double M28;
+		public double M38;
+		public double M48;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix4x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix4x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix4x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 3
+        /// </summary>
+        public Matrix1x8 Column3 { get { return new Matrix1x8(M31, M32, M33, M34, M35, M36, M37, M38); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 4
+        /// </summary>
+        public Matrix1x8 Column4 { get { return new Matrix1x8(M41, M42, M43, M44, M45, M46, M47, M48); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 4
+        /// </summary>
+        public Matrix4x1 Row4 { get { return new Matrix4x1(M14, M24, M34, M44); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 5
+        /// </summary>
+        public Matrix4x1 Row5 { get { return new Matrix4x1(M15, M25, M35, M45); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 6
+        /// </summary>
+        public Matrix4x1 Row6 { get { return new Matrix4x1(M16, M26, M36, M46); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 7
+        /// </summary>
+        public Matrix4x1 Row7 { get { return new Matrix4x1(M17, M27, M37, M47); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 8
+        /// </summary>
+        public Matrix4x1 Row8 { get { return new Matrix4x1(M18, M28, M38, M48); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x8)
+                return this == (Matrix4x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07])
+                         + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31])
+                         + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix4x8: "
+                               + "{{|{00}|{01}|{02}|{03}|}}"
+                               + "{{|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|}}"
+                               + "{{|{28}|{29}|{30}|{31}|}}"
+                               , M11, M21, M31, M41
+                               , M12, M22, M32, M42
+                               , M13, M23, M33, M43
+                               , M14, M24, M34, M44
+                               , M15, M25, M35, M45
+                               , M16, M26, M36, M46
+                               , M17, M27, M37, M47
+                               , M18, M28, M38, M48); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x4 Transpose()
+        {
+            return new Matrix8x4(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28, 
+                                 M31, M32, M33, M34, M35, M36, M37, M38, 
+                                 M41, M42, M43, M44, M45, M46, M47, M48);
+        }
+
+        public static bool operator ==(Matrix4x8 matrix1, Matrix4x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M38 - matrix2.M38) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M48 - matrix2.M48) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix4x8 matrix1, Matrix4x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon
+                || Math.Abs(matrix1.M38 - matrix2.M38) > Double.Epsilon
+                || Math.Abs(matrix1.M48 - matrix2.M48) > Double.Epsilon;
+        }
+
+        public static Matrix4x8 operator +(Matrix4x8 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+            double m38 = matrix1.M38 + matrix2.M38;
+            double m48 = matrix1.M48 + matrix2.M48;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+
+        public static Matrix4x8 operator -(Matrix4x8 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+            double m38 = matrix1.M38 - matrix2.M38;
+            double m48 = matrix1.M48 - matrix2.M48;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+
+        public static Matrix4x8 operator *(Matrix4x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+            double m38 = matrix.M38 * scalar;
+            double m48 = matrix.M48 * scalar;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+
+        public static Matrix4x8 operator *(double scalar, Matrix4x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+            double m38 = scalar * matrix.M38;
+            double m48 = scalar * matrix.M48;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+
+        public static Matrix1x8 operator *(Matrix4x8 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix4x8 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix4x8 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix4x8 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix4x8 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix4x8 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix4x8 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix4x8 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82 + matrix1.M38 * matrix2.M83 + matrix1.M48 * matrix2.M84;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x1.cs
@@ -1,0 +1,270 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x1: IEquatable<Matrix5x1>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 1;
+
+        static Matrix5x1()
+        {
+            Zero = new Matrix5x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        public Matrix5x1(double m11, double m21, double m31, double m41, double m51)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x1(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x1)
+                return this == (Matrix5x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x1: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               , M11, M21, M31, M41, M51); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x5 Transpose()
+        {
+            return new Matrix1x5(M11, 
+                                 M21, 
+                                 M31, 
+                                 M41, 
+                                 M51);
+        }
+
+        public static bool operator ==(Matrix5x1 matrix1, Matrix5x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x1 matrix1, Matrix5x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon;
+        }
+
+        public static Matrix5x1 operator +(Matrix5x1 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+
+        public static Matrix5x1 operator -(Matrix5x1 matrix1, Matrix5x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+
+        public static Matrix5x1 operator *(Matrix5x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+
+        public static Matrix5x1 operator *(double scalar, Matrix5x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+
+        public static Matrix2x1 operator *(Matrix5x1 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix5x1 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix5x1 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix5x1 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix5x1 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix5x1 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix5x1 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x2.cs
@@ -1,0 +1,398 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x2: IEquatable<Matrix5x2>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 2;
+
+        static Matrix5x2()
+        {
+            Zero = new Matrix5x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        public Matrix5x2(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x2(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 4
+        /// </summary>
+        public Matrix1x2 Column4 { get { return new Matrix1x2(M41, M42); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 5
+        /// </summary>
+        public Matrix1x2 Column5 { get { return new Matrix1x2(M51, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x2)
+                return this == (Matrix5x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x2: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x5 Transpose()
+        {
+            return new Matrix2x5(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32, 
+                                 M41, M42, 
+                                 M51, M52);
+        }
+
+        public static bool operator ==(Matrix5x2 matrix1, Matrix5x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x2 matrix1, Matrix5x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon;
+        }
+
+        public static Matrix5x2 operator +(Matrix5x2 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+
+        public static Matrix5x2 operator -(Matrix5x2 matrix1, Matrix5x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+
+        public static Matrix5x2 operator *(Matrix5x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+
+        public static Matrix5x2 operator *(double scalar, Matrix5x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+
+        public static Matrix1x2 operator *(Matrix5x2 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix5x2 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix5x2 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix5x2 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix5x2 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix5x2 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix5x2 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix5x2 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x3.cs
@@ -1,0 +1,496 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x3: IEquatable<Matrix5x3>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 3;
+
+        static Matrix5x3()
+        {
+            Zero = new Matrix5x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        public Matrix5x3(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52, 
+                         double m13, double m23, double m33, double m43, double m53)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x3(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = 
+			M13 = M23 = M33 = M43 = M53 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 4
+        /// </summary>
+        public Matrix1x3 Column4 { get { return new Matrix1x3(M41, M42, M43); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 5
+        /// </summary>
+        public Matrix1x3 Column5 { get { return new Matrix1x3(M51, M52, M53); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 3
+        /// </summary>
+        public Matrix5x1 Row3 { get { return new Matrix5x1(M13, M23, M33, M43, M53); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x3)
+                return this == (Matrix5x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x3: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               + "{{|{10}|{11}|{12}|{13}|{14}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52
+                               , M13, M23, M33, M43, M53); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x5 Transpose()
+        {
+            return new Matrix3x5(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33, 
+                                 M41, M42, M43, 
+                                 M51, M52, M53);
+        }
+
+        public static bool operator ==(Matrix5x3 matrix1, Matrix5x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x3 matrix1, Matrix5x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon;
+        }
+
+        public static Matrix5x3 operator +(Matrix5x3 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+
+        public static Matrix5x3 operator -(Matrix5x3 matrix1, Matrix5x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+
+        public static Matrix5x3 operator *(Matrix5x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+
+        public static Matrix5x3 operator *(double scalar, Matrix5x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+
+        public static Matrix1x3 operator *(Matrix5x3 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix5x3 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix5x3 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix5x3 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix5x3 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix5x3 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix5x3 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix5x3 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x4.cs
@@ -1,0 +1,594 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x4: IEquatable<Matrix5x4>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 4;
+
+        static Matrix5x4()
+        {
+            Zero = new Matrix5x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        public Matrix5x4(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52, 
+                         double m13, double m23, double m33, double m43, double m53, 
+                         double m14, double m24, double m34, double m44, double m54)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x4(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = 
+			M13 = M23 = M33 = M43 = M53 = 
+			M14 = M24 = M34 = M44 = M54 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 4
+        /// </summary>
+        public Matrix1x4 Column4 { get { return new Matrix1x4(M41, M42, M43, M44); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 5
+        /// </summary>
+        public Matrix1x4 Column5 { get { return new Matrix1x4(M51, M52, M53, M54); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 3
+        /// </summary>
+        public Matrix5x1 Row3 { get { return new Matrix5x1(M13, M23, M33, M43, M53); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 4
+        /// </summary>
+        public Matrix5x1 Row4 { get { return new Matrix5x1(M14, M24, M34, M44, M54); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x4)
+                return this == (Matrix5x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]) + (x[21] ^ x[22]) + (x[23] ^ x[24]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x4: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               + "{{|{10}|{11}|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|{18}|{19}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52
+                               , M13, M23, M33, M43, M53
+                               , M14, M24, M34, M44, M54); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x5 Transpose()
+        {
+            return new Matrix4x5(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34, 
+                                 M41, M42, M43, M44, 
+                                 M51, M52, M53, M54);
+        }
+
+        public static bool operator ==(Matrix5x4 matrix1, Matrix5x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x4 matrix1, Matrix5x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon;
+        }
+
+        public static Matrix5x4 operator +(Matrix5x4 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+
+        public static Matrix5x4 operator -(Matrix5x4 matrix1, Matrix5x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+
+        public static Matrix5x4 operator *(Matrix5x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+
+        public static Matrix5x4 operator *(double scalar, Matrix5x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+
+        public static Matrix1x4 operator *(Matrix5x4 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix5x4 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix5x4 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix5x4 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix5x4 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix5x4 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix5x4 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix5x4 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x5.cs
@@ -1,0 +1,702 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x5: IEquatable<Matrix5x5>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 5;
+
+        static Matrix5x5()
+        {
+            Zero = new Matrix5x5(0);
+			Identitiy = new Matrix5x5(1, 0, 0, 0, 0, 
+                                      0, 1, 0, 0, 0, 
+                                      0, 0, 1, 0, 0, 
+                                      0, 0, 0, 1, 0, 
+                                      0, 0, 0, 0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x5 Zero;
+        
+        /// <summary>
+        /// Constant Matrix5x5 with value intialized to the identity of a 5 x 5 matrix
+        /// </summary>
+        public static readonly Matrix5x5 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix5x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        public Matrix5x5(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52, 
+                         double m13, double m23, double m33, double m43, double m53, 
+                         double m14, double m24, double m34, double m44, double m54, 
+                         double m15, double m25, double m35, double m45, double m55)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x5(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = 
+			M13 = M23 = M33 = M43 = M53 = 
+			M14 = M24 = M34 = M44 = M54 = 
+			M15 = M25 = M35 = M45 = M55 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 3
+        /// </summary>
+        public Matrix1x5 Column3 { get { return new Matrix1x5(M31, M32, M33, M34, M35); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 4
+        /// </summary>
+        public Matrix1x5 Column4 { get { return new Matrix1x5(M41, M42, M43, M44, M45); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 5
+        /// </summary>
+        public Matrix1x5 Column5 { get { return new Matrix1x5(M51, M52, M53, M54, M55); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 3
+        /// </summary>
+        public Matrix5x1 Row3 { get { return new Matrix5x1(M13, M23, M33, M43, M53); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 4
+        /// </summary>
+        public Matrix5x1 Row4 { get { return new Matrix5x1(M14, M24, M34, M44, M54); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 5
+        /// </summary>
+        public Matrix5x1 Row5 { get { return new Matrix5x1(M15, M25, M35, M45, M55); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x5)
+                return this == (Matrix5x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]) + (x[21] ^ x[22]) + (x[23] ^ x[24])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x5: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               + "{{|{10}|{11}|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|{24}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52
+                               , M13, M23, M33, M43, M53
+                               , M14, M24, M34, M44, M54
+                               , M15, M25, M35, M45, M55); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x5 Transpose()
+        {
+            return new Matrix5x5(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25, 
+                                 M31, M32, M33, M34, M35, 
+                                 M41, M42, M43, M44, M45, 
+                                 M51, M52, M53, M54, M55);
+        }
+
+        public static bool operator ==(Matrix5x5 matrix1, Matrix5x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x5 matrix1, Matrix5x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon;
+        }
+
+        public static Matrix5x5 operator +(Matrix5x5 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+
+        public static Matrix5x5 operator -(Matrix5x5 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+
+        public static Matrix5x5 operator *(Matrix5x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+
+        public static Matrix5x5 operator *(double scalar, Matrix5x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+
+        public static Matrix1x5 operator *(Matrix5x5 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix5x5 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix5x5 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix5x5 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix5x5 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix5x5 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix5x5 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix5x5 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x6.cs
@@ -1,0 +1,790 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x6: IEquatable<Matrix5x6>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 6;
+
+        static Matrix5x6()
+        {
+            Zero = new Matrix5x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        public Matrix5x6(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52, 
+                         double m13, double m23, double m33, double m43, double m53, 
+                         double m14, double m24, double m34, double m44, double m54, 
+                         double m15, double m25, double m35, double m45, double m55, 
+                         double m16, double m26, double m36, double m46, double m56)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x6(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = 
+			M13 = M23 = M33 = M43 = M53 = 
+			M14 = M24 = M34 = M44 = M54 = 
+			M15 = M25 = M35 = M45 = M55 = 
+			M16 = M26 = M36 = M46 = M56 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 3
+        /// </summary>
+        public Matrix1x6 Column3 { get { return new Matrix1x6(M31, M32, M33, M34, M35, M36); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 4
+        /// </summary>
+        public Matrix1x6 Column4 { get { return new Matrix1x6(M41, M42, M43, M44, M45, M46); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 5
+        /// </summary>
+        public Matrix1x6 Column5 { get { return new Matrix1x6(M51, M52, M53, M54, M55, M56); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 3
+        /// </summary>
+        public Matrix5x1 Row3 { get { return new Matrix5x1(M13, M23, M33, M43, M53); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 4
+        /// </summary>
+        public Matrix5x1 Row4 { get { return new Matrix5x1(M14, M24, M34, M44, M54); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 5
+        /// </summary>
+        public Matrix5x1 Row5 { get { return new Matrix5x1(M15, M25, M35, M45, M55); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 6
+        /// </summary>
+        public Matrix5x1 Row6 { get { return new Matrix5x1(M16, M26, M36, M46, M56); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x6)
+                return this == (Matrix5x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]) + (x[21] ^ x[22]) + (x[23] ^ x[24])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x6: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               + "{{|{10}|{11}|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|{24}|}}"
+                               + "{{|{25}|{26}|{27}|{28}|{29}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52
+                               , M13, M23, M33, M43, M53
+                               , M14, M24, M34, M44, M54
+                               , M15, M25, M35, M45, M55
+                               , M16, M26, M36, M46, M56); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x5 Transpose()
+        {
+            return new Matrix6x5(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26, 
+                                 M31, M32, M33, M34, M35, M36, 
+                                 M41, M42, M43, M44, M45, M46, 
+                                 M51, M52, M53, M54, M55, M56);
+        }
+
+        public static bool operator ==(Matrix5x6 matrix1, Matrix5x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x6 matrix1, Matrix5x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon;
+        }
+
+        public static Matrix5x6 operator +(Matrix5x6 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+
+        public static Matrix5x6 operator -(Matrix5x6 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+
+        public static Matrix5x6 operator *(Matrix5x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+
+        public static Matrix5x6 operator *(double scalar, Matrix5x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+
+        public static Matrix1x6 operator *(Matrix5x6 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix5x6 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix5x6 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix5x6 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix5x6 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix5x6 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix5x6 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix5x6 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x7.cs
@@ -1,0 +1,888 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x7: IEquatable<Matrix5x7>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 7;
+
+        static Matrix5x7()
+        {
+            Zero = new Matrix5x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        public Matrix5x7(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52, 
+                         double m13, double m23, double m33, double m43, double m53, 
+                         double m14, double m24, double m34, double m44, double m54, 
+                         double m15, double m25, double m35, double m45, double m55, 
+                         double m16, double m26, double m36, double m46, double m56, 
+                         double m17, double m27, double m37, double m47, double m57)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x7(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = 
+			M13 = M23 = M33 = M43 = M53 = 
+			M14 = M24 = M34 = M44 = M54 = 
+			M15 = M25 = M35 = M45 = M55 = 
+			M16 = M26 = M36 = M46 = M56 = 
+			M17 = M27 = M37 = M47 = M57 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 3
+        /// </summary>
+        public Matrix1x7 Column3 { get { return new Matrix1x7(M31, M32, M33, M34, M35, M36, M37); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 4
+        /// </summary>
+        public Matrix1x7 Column4 { get { return new Matrix1x7(M41, M42, M43, M44, M45, M46, M47); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 5
+        /// </summary>
+        public Matrix1x7 Column5 { get { return new Matrix1x7(M51, M52, M53, M54, M55, M56, M57); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 3
+        /// </summary>
+        public Matrix5x1 Row3 { get { return new Matrix5x1(M13, M23, M33, M43, M53); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 4
+        /// </summary>
+        public Matrix5x1 Row4 { get { return new Matrix5x1(M14, M24, M34, M44, M54); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 5
+        /// </summary>
+        public Matrix5x1 Row5 { get { return new Matrix5x1(M15, M25, M35, M45, M55); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 6
+        /// </summary>
+        public Matrix5x1 Row6 { get { return new Matrix5x1(M16, M26, M36, M46, M56); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 7
+        /// </summary>
+        public Matrix5x1 Row7 { get { return new Matrix5x1(M17, M27, M37, M47, M57); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x7)
+                return this == (Matrix5x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]) + (x[21] ^ x[22]) + (x[23] ^ x[24])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34])
+                         + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x7: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               + "{{|{10}|{11}|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|{24}|}}"
+                               + "{{|{25}|{26}|{27}|{28}|{29}|}}"
+                               + "{{|{30}|{31}|{32}|{33}|{34}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52
+                               , M13, M23, M33, M43, M53
+                               , M14, M24, M34, M44, M54
+                               , M15, M25, M35, M45, M55
+                               , M16, M26, M36, M46, M56
+                               , M17, M27, M37, M47, M57); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x5 Transpose()
+        {
+            return new Matrix7x5(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27, 
+                                 M31, M32, M33, M34, M35, M36, M37, 
+                                 M41, M42, M43, M44, M45, M46, M47, 
+                                 M51, M52, M53, M54, M55, M56, M57);
+        }
+
+        public static bool operator ==(Matrix5x7 matrix1, Matrix5x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x7 matrix1, Matrix5x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon;
+        }
+
+        public static Matrix5x7 operator +(Matrix5x7 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+
+        public static Matrix5x7 operator -(Matrix5x7 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+
+        public static Matrix5x7 operator *(Matrix5x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+
+        public static Matrix5x7 operator *(double scalar, Matrix5x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+
+        public static Matrix1x7 operator *(Matrix5x7 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix5x7 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix5x7 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix5x7 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix5x7 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix5x7 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix5x7 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix5x7 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix5x8.cs
@@ -1,0 +1,986 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix5x8: IEquatable<Matrix5x8>, IMatrix
+    {
+        public const int ColumnCount = 5;
+        public const int RowCount = 8;
+
+        static Matrix5x8()
+        {
+            Zero = new Matrix5x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix5x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix5x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix5x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        /// <param name="m38">The column 3, row 8 value</param>
+        /// <param name="m48">The column 4, row 8 value</param>
+        /// <param name="m58">The column 5, row 8 value</param>
+        public Matrix5x8(double m11, double m21, double m31, double m41, double m51, 
+                         double m12, double m22, double m32, double m42, double m52, 
+                         double m13, double m23, double m33, double m43, double m53, 
+                         double m14, double m24, double m34, double m44, double m54, 
+                         double m15, double m25, double m35, double m45, double m55, 
+                         double m16, double m26, double m36, double m46, double m56, 
+                         double m17, double m27, double m37, double m47, double m57, 
+                         double m18, double m28, double m38, double m48, double m58)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; 
+			M18 = m18; M28 = m28; M38 = m38; M48 = m48; M58 = m58; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix5x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix5x8(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = 
+			M12 = M22 = M32 = M42 = M52 = 
+			M13 = M23 = M33 = M43 = M53 = 
+			M14 = M24 = M34 = M44 = M54 = 
+			M15 = M25 = M35 = M45 = M55 = 
+			M16 = M26 = M36 = M46 = M56 = 
+			M17 = M27 = M37 = M47 = M57 = 
+			M18 = M28 = M38 = M48 = M58 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M18;
+		public double M28;
+		public double M38;
+		public double M48;
+		public double M58;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix5x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix5x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix5x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 3
+        /// </summary>
+        public Matrix1x8 Column3 { get { return new Matrix1x8(M31, M32, M33, M34, M35, M36, M37, M38); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 4
+        /// </summary>
+        public Matrix1x8 Column4 { get { return new Matrix1x8(M41, M42, M43, M44, M45, M46, M47, M48); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 5
+        /// </summary>
+        public Matrix1x8 Column5 { get { return new Matrix1x8(M51, M52, M53, M54, M55, M56, M57, M58); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 1
+        /// </summary>
+        public Matrix5x1 Row1 { get { return new Matrix5x1(M11, M21, M31, M41, M51); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 2
+        /// </summary>
+        public Matrix5x1 Row2 { get { return new Matrix5x1(M12, M22, M32, M42, M52); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 3
+        /// </summary>
+        public Matrix5x1 Row3 { get { return new Matrix5x1(M13, M23, M33, M43, M53); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 4
+        /// </summary>
+        public Matrix5x1 Row4 { get { return new Matrix5x1(M14, M24, M34, M44, M54); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 5
+        /// </summary>
+        public Matrix5x1 Row5 { get { return new Matrix5x1(M15, M25, M35, M45, M55); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 6
+        /// </summary>
+        public Matrix5x1 Row6 { get { return new Matrix5x1(M16, M26, M36, M46, M56); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 7
+        /// </summary>
+        public Matrix5x1 Row7 { get { return new Matrix5x1(M17, M27, M37, M47, M57); } }
+        /// <summary>
+        /// Gets a new Matrix5x1 containing the values of column 8
+        /// </summary>
+        public Matrix5x1 Row8 { get { return new Matrix5x1(M18, M28, M38, M48, M58); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix5x8)
+                return this == (Matrix5x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix5x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix5x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09])
+                         + (x[05] ^ x[06]) + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14])
+                         + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19])
+                         + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]) + (x[21] ^ x[22]) + (x[23] ^ x[24])
+                         + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34])
+                         + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39])
+                         + (x[35] ^ x[36]) + (x[37] ^ x[38]) + (x[39] ^ x[40]) + (x[41] ^ x[42]) + (x[43] ^ x[44]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix5x8: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|}}"
+                               + "{{|{05}|{06}|{07}|{08}|{09}|}}"
+                               + "{{|{10}|{11}|{12}|{13}|{14}|}}"
+                               + "{{|{15}|{16}|{17}|{18}|{19}|}}"
+                               + "{{|{20}|{21}|{22}|{23}|{24}|}}"
+                               + "{{|{25}|{26}|{27}|{28}|{29}|}}"
+                               + "{{|{30}|{31}|{32}|{33}|{34}|}}"
+                               + "{{|{35}|{36}|{37}|{38}|{39}|}}"
+                               , M11, M21, M31, M41, M51
+                               , M12, M22, M32, M42, M52
+                               , M13, M23, M33, M43, M53
+                               , M14, M24, M34, M44, M54
+                               , M15, M25, M35, M45, M55
+                               , M16, M26, M36, M46, M56
+                               , M17, M27, M37, M47, M57
+                               , M18, M28, M38, M48, M58); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x5 Transpose()
+        {
+            return new Matrix8x5(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28, 
+                                 M31, M32, M33, M34, M35, M36, M37, M38, 
+                                 M41, M42, M43, M44, M45, M46, M47, M48, 
+                                 M51, M52, M53, M54, M55, M56, M57, M58);
+        }
+
+        public static bool operator ==(Matrix5x8 matrix1, Matrix5x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M38 - matrix2.M38) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M48 - matrix2.M48) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M58 - matrix2.M58) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix5x8 matrix1, Matrix5x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon
+                || Math.Abs(matrix1.M38 - matrix2.M38) > Double.Epsilon
+                || Math.Abs(matrix1.M48 - matrix2.M48) > Double.Epsilon
+                || Math.Abs(matrix1.M58 - matrix2.M58) > Double.Epsilon;
+        }
+
+        public static Matrix5x8 operator +(Matrix5x8 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+            double m38 = matrix1.M38 + matrix2.M38;
+            double m48 = matrix1.M48 + matrix2.M48;
+            double m58 = matrix1.M58 + matrix2.M58;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+
+        public static Matrix5x8 operator -(Matrix5x8 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+            double m38 = matrix1.M38 - matrix2.M38;
+            double m48 = matrix1.M48 - matrix2.M48;
+            double m58 = matrix1.M58 - matrix2.M58;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+
+        public static Matrix5x8 operator *(Matrix5x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+            double m38 = matrix.M38 * scalar;
+            double m48 = matrix.M48 * scalar;
+            double m58 = matrix.M58 * scalar;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+
+        public static Matrix5x8 operator *(double scalar, Matrix5x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+            double m38 = scalar * matrix.M38;
+            double m48 = scalar * matrix.M48;
+            double m58 = scalar * matrix.M58;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+
+        public static Matrix1x8 operator *(Matrix5x8 matrix1, Matrix1x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix5x8 matrix1, Matrix2x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix5x8 matrix1, Matrix3x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix5x8 matrix1, Matrix4x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix5x8 matrix1, Matrix5x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix5x8 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix5x8 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix5x8 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82 + matrix1.M38 * matrix2.M83 + matrix1.M48 * matrix2.M84 + matrix1.M58 * matrix2.M85;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x1.cs
@@ -1,0 +1,279 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x1: IEquatable<Matrix6x1>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 1;
+
+        static Matrix6x1()
+        {
+            Zero = new Matrix6x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        public Matrix6x1(double m11, double m21, double m31, double m41, double m51, double m61)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x1(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x1)
+                return this == (Matrix6x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x1: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               , M11, M21, M31, M41, M51, M61); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x6 Transpose()
+        {
+            return new Matrix1x6(M11, 
+                                 M21, 
+                                 M31, 
+                                 M41, 
+                                 M51, 
+                                 M61);
+        }
+
+        public static bool operator ==(Matrix6x1 matrix1, Matrix6x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x1 matrix1, Matrix6x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon;
+        }
+
+        public static Matrix6x1 operator +(Matrix6x1 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+
+        public static Matrix6x1 operator -(Matrix6x1 matrix1, Matrix6x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+
+        public static Matrix6x1 operator *(Matrix6x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+
+        public static Matrix6x1 operator *(double scalar, Matrix6x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+
+        public static Matrix2x1 operator *(Matrix6x1 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix6x1 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix6x1 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix6x1 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix6x1 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix6x1 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix6x1 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x2.cs
@@ -1,0 +1,419 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x2: IEquatable<Matrix6x2>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 2;
+
+        static Matrix6x2()
+        {
+            Zero = new Matrix6x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        public Matrix6x2(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x2(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 4
+        /// </summary>
+        public Matrix1x2 Column4 { get { return new Matrix1x2(M41, M42); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 5
+        /// </summary>
+        public Matrix1x2 Column5 { get { return new Matrix1x2(M51, M52); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 6
+        /// </summary>
+        public Matrix1x2 Column6 { get { return new Matrix1x2(M61, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x2)
+                return this == (Matrix6x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x2: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x6 Transpose()
+        {
+            return new Matrix2x6(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32, 
+                                 M41, M42, 
+                                 M51, M52, 
+                                 M61, M62);
+        }
+
+        public static bool operator ==(Matrix6x2 matrix1, Matrix6x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x2 matrix1, Matrix6x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon;
+        }
+
+        public static Matrix6x2 operator +(Matrix6x2 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+
+        public static Matrix6x2 operator -(Matrix6x2 matrix1, Matrix6x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+
+        public static Matrix6x2 operator *(Matrix6x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+
+        public static Matrix6x2 operator *(double scalar, Matrix6x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+
+        public static Matrix1x2 operator *(Matrix6x2 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix6x2 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix6x2 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix6x2 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix6x2 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix6x2 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix6x2 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix6x2 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x3.cs
@@ -1,0 +1,525 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x3: IEquatable<Matrix6x3>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 3;
+
+        static Matrix6x3()
+        {
+            Zero = new Matrix6x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        public Matrix6x3(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, 
+                         double m13, double m23, double m33, double m43, double m53, double m63)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x3(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 4
+        /// </summary>
+        public Matrix1x3 Column4 { get { return new Matrix1x3(M41, M42, M43); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 5
+        /// </summary>
+        public Matrix1x3 Column5 { get { return new Matrix1x3(M51, M52, M53); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 6
+        /// </summary>
+        public Matrix1x3 Column6 { get { return new Matrix1x3(M61, M62, M63); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 3
+        /// </summary>
+        public Matrix6x1 Row3 { get { return new Matrix6x1(M13, M23, M33, M43, M53, M63); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x3)
+                return this == (Matrix6x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x3: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|{16}|{17}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62
+                               , M13, M23, M33, M43, M53, M63); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x6 Transpose()
+        {
+            return new Matrix3x6(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33, 
+                                 M41, M42, M43, 
+                                 M51, M52, M53, 
+                                 M61, M62, M63);
+        }
+
+        public static bool operator ==(Matrix6x3 matrix1, Matrix6x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x3 matrix1, Matrix6x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon;
+        }
+
+        public static Matrix6x3 operator +(Matrix6x3 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+
+        public static Matrix6x3 operator -(Matrix6x3 matrix1, Matrix6x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+
+        public static Matrix6x3 operator *(Matrix6x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+
+        public static Matrix6x3 operator *(double scalar, Matrix6x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+
+        public static Matrix1x3 operator *(Matrix6x3 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix6x3 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix6x3 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix6x3 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix6x3 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix6x3 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix6x3 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix6x3 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x4.cs
@@ -1,0 +1,631 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x4: IEquatable<Matrix6x4>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 4;
+
+        static Matrix6x4()
+        {
+            Zero = new Matrix6x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        public Matrix6x4(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, 
+                         double m14, double m24, double m34, double m44, double m54, double m64)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x4(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 4
+        /// </summary>
+        public Matrix1x4 Column4 { get { return new Matrix1x4(M41, M42, M43, M44); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 5
+        /// </summary>
+        public Matrix1x4 Column5 { get { return new Matrix1x4(M51, M52, M53, M54); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 6
+        /// </summary>
+        public Matrix1x4 Column6 { get { return new Matrix1x4(M61, M62, M63, M64); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 3
+        /// </summary>
+        public Matrix6x1 Row3 { get { return new Matrix6x1(M13, M23, M33, M43, M53, M63); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 4
+        /// </summary>
+        public Matrix6x1 Row4 { get { return new Matrix6x1(M14, M24, M34, M44, M54, M64); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x4)
+                return this == (Matrix6x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x4: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62
+                               , M13, M23, M33, M43, M53, M63
+                               , M14, M24, M34, M44, M54, M64); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x6 Transpose()
+        {
+            return new Matrix4x6(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34, 
+                                 M41, M42, M43, M44, 
+                                 M51, M52, M53, M54, 
+                                 M61, M62, M63, M64);
+        }
+
+        public static bool operator ==(Matrix6x4 matrix1, Matrix6x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x4 matrix1, Matrix6x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon;
+        }
+
+        public static Matrix6x4 operator +(Matrix6x4 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+
+        public static Matrix6x4 operator -(Matrix6x4 matrix1, Matrix6x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+
+        public static Matrix6x4 operator *(Matrix6x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+
+        public static Matrix6x4 operator *(double scalar, Matrix6x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+
+        public static Matrix1x4 operator *(Matrix6x4 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix6x4 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix6x4 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix6x4 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix6x4 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix6x4 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix6x4 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix6x4 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x5.cs
@@ -1,0 +1,737 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x5: IEquatable<Matrix6x5>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 5;
+
+        static Matrix6x5()
+        {
+            Zero = new Matrix6x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        public Matrix6x5(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, 
+                         double m15, double m25, double m35, double m45, double m55, double m65)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x5(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 3
+        /// </summary>
+        public Matrix1x5 Column3 { get { return new Matrix1x5(M31, M32, M33, M34, M35); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 4
+        /// </summary>
+        public Matrix1x5 Column4 { get { return new Matrix1x5(M41, M42, M43, M44, M45); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 5
+        /// </summary>
+        public Matrix1x5 Column5 { get { return new Matrix1x5(M51, M52, M53, M54, M55); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 6
+        /// </summary>
+        public Matrix1x5 Column6 { get { return new Matrix1x5(M61, M62, M63, M64, M65); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 3
+        /// </summary>
+        public Matrix6x1 Row3 { get { return new Matrix6x1(M13, M23, M33, M43, M53, M63); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 4
+        /// </summary>
+        public Matrix6x1 Row4 { get { return new Matrix6x1(M14, M24, M34, M44, M54, M64); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 5
+        /// </summary>
+        public Matrix6x1 Row5 { get { return new Matrix6x1(M15, M25, M35, M45, M55, M65); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x5)
+                return this == (Matrix6x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x5: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62
+                               , M13, M23, M33, M43, M53, M63
+                               , M14, M24, M34, M44, M54, M64
+                               , M15, M25, M35, M45, M55, M65); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x6 Transpose()
+        {
+            return new Matrix5x6(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25, 
+                                 M31, M32, M33, M34, M35, 
+                                 M41, M42, M43, M44, M45, 
+                                 M51, M52, M53, M54, M55, 
+                                 M61, M62, M63, M64, M65);
+        }
+
+        public static bool operator ==(Matrix6x5 matrix1, Matrix6x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x5 matrix1, Matrix6x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon;
+        }
+
+        public static Matrix6x5 operator +(Matrix6x5 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+
+        public static Matrix6x5 operator -(Matrix6x5 matrix1, Matrix6x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+
+        public static Matrix6x5 operator *(Matrix6x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+
+        public static Matrix6x5 operator *(double scalar, Matrix6x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+
+        public static Matrix1x5 operator *(Matrix6x5 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix6x5 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix6x5 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix6x5 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix6x5 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix6x5 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix6x5 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix6x5 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x6.cs
@@ -1,0 +1,854 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x6: IEquatable<Matrix6x6>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 6;
+
+        static Matrix6x6()
+        {
+            Zero = new Matrix6x6(0);
+			Identitiy = new Matrix6x6(1, 0, 0, 0, 0, 0, 
+                                      0, 1, 0, 0, 0, 0, 
+                                      0, 0, 1, 0, 0, 0, 
+                                      0, 0, 0, 1, 0, 0, 
+                                      0, 0, 0, 0, 1, 0, 
+                                      0, 0, 0, 0, 0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x6 Zero;
+        
+        /// <summary>
+        /// Constant Matrix6x6 with value intialized to the identity of a 6 x 6 matrix
+        /// </summary>
+        public static readonly Matrix6x6 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix6x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        public Matrix6x6(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, 
+                         double m16, double m26, double m36, double m46, double m56, double m66)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x6(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 3
+        /// </summary>
+        public Matrix1x6 Column3 { get { return new Matrix1x6(M31, M32, M33, M34, M35, M36); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 4
+        /// </summary>
+        public Matrix1x6 Column4 { get { return new Matrix1x6(M41, M42, M43, M44, M45, M46); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 5
+        /// </summary>
+        public Matrix1x6 Column5 { get { return new Matrix1x6(M51, M52, M53, M54, M55, M56); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 6
+        /// </summary>
+        public Matrix1x6 Column6 { get { return new Matrix1x6(M61, M62, M63, M64, M65, M66); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 3
+        /// </summary>
+        public Matrix6x1 Row3 { get { return new Matrix6x1(M13, M23, M33, M43, M53, M63); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 4
+        /// </summary>
+        public Matrix6x1 Row4 { get { return new Matrix6x1(M14, M24, M34, M44, M54, M64); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 5
+        /// </summary>
+        public Matrix6x1 Row5 { get { return new Matrix6x1(M15, M25, M35, M45, M55, M65); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 6
+        /// </summary>
+        public Matrix6x1 Row6 { get { return new Matrix6x1(M16, M26, M36, M46, M56, M66); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x6)
+                return this == (Matrix6x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35])
+                         + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x6: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|}}"
+                               + "{{|{30}|{31}|{32}|{33}|{34}|{35}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62
+                               , M13, M23, M33, M43, M53, M63
+                               , M14, M24, M34, M44, M54, M64
+                               , M15, M25, M35, M45, M55, M65
+                               , M16, M26, M36, M46, M56, M66); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x6 Transpose()
+        {
+            return new Matrix6x6(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26, 
+                                 M31, M32, M33, M34, M35, M36, 
+                                 M41, M42, M43, M44, M45, M46, 
+                                 M51, M52, M53, M54, M55, M56, 
+                                 M61, M62, M63, M64, M65, M66);
+        }
+
+        public static bool operator ==(Matrix6x6 matrix1, Matrix6x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x6 matrix1, Matrix6x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon;
+        }
+
+        public static Matrix6x6 operator +(Matrix6x6 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+
+        public static Matrix6x6 operator -(Matrix6x6 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+
+        public static Matrix6x6 operator *(Matrix6x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+
+        public static Matrix6x6 operator *(double scalar, Matrix6x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+
+        public static Matrix1x6 operator *(Matrix6x6 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix6x6 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix6x6 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix6x6 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix6x6 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix6x6 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix6x6 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix6x6 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x7.cs
@@ -1,0 +1,949 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x7: IEquatable<Matrix6x7>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 7;
+
+        static Matrix6x7()
+        {
+            Zero = new Matrix6x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m67">The column 6, row 7 value</param>
+        public Matrix6x7(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, 
+                         double m17, double m27, double m37, double m47, double m57, double m67)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; M67 = m67; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x7(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = 
+			M17 = M27 = M37 = M47 = M57 = M67 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M67;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 3
+        /// </summary>
+        public Matrix1x7 Column3 { get { return new Matrix1x7(M31, M32, M33, M34, M35, M36, M37); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 4
+        /// </summary>
+        public Matrix1x7 Column4 { get { return new Matrix1x7(M41, M42, M43, M44, M45, M46, M47); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 5
+        /// </summary>
+        public Matrix1x7 Column5 { get { return new Matrix1x7(M51, M52, M53, M54, M55, M56, M57); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 6
+        /// </summary>
+        public Matrix1x7 Column6 { get { return new Matrix1x7(M61, M62, M63, M64, M65, M66, M67); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 3
+        /// </summary>
+        public Matrix6x1 Row3 { get { return new Matrix6x1(M13, M23, M33, M43, M53, M63); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 4
+        /// </summary>
+        public Matrix6x1 Row4 { get { return new Matrix6x1(M14, M24, M34, M44, M54, M64); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 5
+        /// </summary>
+        public Matrix6x1 Row5 { get { return new Matrix6x1(M15, M25, M35, M45, M55, M65); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 6
+        /// </summary>
+        public Matrix6x1 Row6 { get { return new Matrix6x1(M16, M26, M36, M46, M56, M66); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 7
+        /// </summary>
+        public Matrix6x1 Row7 { get { return new Matrix6x1(M17, M27, M37, M47, M57, M67); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x7)
+                return this == (Matrix6x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35])
+                         + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41])
+                         + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x7: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|}}"
+                               + "{{|{30}|{31}|{32}|{33}|{34}|{35}|}}"
+                               + "{{|{36}|{37}|{38}|{39}|{40}|{41}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62
+                               , M13, M23, M33, M43, M53, M63
+                               , M14, M24, M34, M44, M54, M64
+                               , M15, M25, M35, M45, M55, M65
+                               , M16, M26, M36, M46, M56, M66
+                               , M17, M27, M37, M47, M57, M67); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x6 Transpose()
+        {
+            return new Matrix7x6(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27, 
+                                 M31, M32, M33, M34, M35, M36, M37, 
+                                 M41, M42, M43, M44, M45, M46, M47, 
+                                 M51, M52, M53, M54, M55, M56, M57, 
+                                 M61, M62, M63, M64, M65, M66, M67);
+        }
+
+        public static bool operator ==(Matrix6x7 matrix1, Matrix6x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M67 - matrix2.M67) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x7 matrix1, Matrix6x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M67 - matrix2.M67) > Double.Epsilon;
+        }
+
+        public static Matrix6x7 operator +(Matrix6x7 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m67 = matrix1.M67 + matrix2.M67;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+
+        public static Matrix6x7 operator -(Matrix6x7 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m67 = matrix1.M67 - matrix2.M67;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+
+        public static Matrix6x7 operator *(Matrix6x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m67 = matrix.M67 * scalar;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+
+        public static Matrix6x7 operator *(double scalar, Matrix6x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m67 = scalar * matrix.M67;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+
+        public static Matrix1x7 operator *(Matrix6x7 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix6x7 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix6x7 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix6x7 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix6x7 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix6x7 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix6x7 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix6x7 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85 + matrix1.M67 * matrix2.M86;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix6x8.cs
@@ -1,0 +1,1055 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix6x8: IEquatable<Matrix6x8>, IMatrix
+    {
+        public const int ColumnCount = 6;
+        public const int RowCount = 8;
+
+        static Matrix6x8()
+        {
+            Zero = new Matrix6x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix6x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix6x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix6x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m67">The column 6, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        /// <param name="m38">The column 3, row 8 value</param>
+        /// <param name="m48">The column 4, row 8 value</param>
+        /// <param name="m58">The column 5, row 8 value</param>
+        /// <param name="m68">The column 6, row 8 value</param>
+        public Matrix6x8(double m11, double m21, double m31, double m41, double m51, double m61, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, 
+                         double m17, double m27, double m37, double m47, double m57, double m67, 
+                         double m18, double m28, double m38, double m48, double m58, double m68)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; M67 = m67; 
+			M18 = m18; M28 = m28; M38 = m38; M48 = m48; M58 = m58; M68 = m68; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix6x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix6x8(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = 
+			M17 = M27 = M37 = M47 = M57 = M67 = 
+			M18 = M28 = M38 = M48 = M58 = M68 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M67;
+		public double M18;
+		public double M28;
+		public double M38;
+		public double M48;
+		public double M58;
+		public double M68;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix6x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix6x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix6x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 3
+        /// </summary>
+        public Matrix1x8 Column3 { get { return new Matrix1x8(M31, M32, M33, M34, M35, M36, M37, M38); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 4
+        /// </summary>
+        public Matrix1x8 Column4 { get { return new Matrix1x8(M41, M42, M43, M44, M45, M46, M47, M48); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 5
+        /// </summary>
+        public Matrix1x8 Column5 { get { return new Matrix1x8(M51, M52, M53, M54, M55, M56, M57, M58); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 6
+        /// </summary>
+        public Matrix1x8 Column6 { get { return new Matrix1x8(M61, M62, M63, M64, M65, M66, M67, M68); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 1
+        /// </summary>
+        public Matrix6x1 Row1 { get { return new Matrix6x1(M11, M21, M31, M41, M51, M61); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 2
+        /// </summary>
+        public Matrix6x1 Row2 { get { return new Matrix6x1(M12, M22, M32, M42, M52, M62); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 3
+        /// </summary>
+        public Matrix6x1 Row3 { get { return new Matrix6x1(M13, M23, M33, M43, M53, M63); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 4
+        /// </summary>
+        public Matrix6x1 Row4 { get { return new Matrix6x1(M14, M24, M34, M44, M54, M64); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 5
+        /// </summary>
+        public Matrix6x1 Row5 { get { return new Matrix6x1(M15, M25, M35, M45, M55, M65); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 6
+        /// </summary>
+        public Matrix6x1 Row6 { get { return new Matrix6x1(M16, M26, M36, M46, M56, M66); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 7
+        /// </summary>
+        public Matrix6x1 Row7 { get { return new Matrix6x1(M17, M27, M37, M47, M57, M67); } }
+        /// <summary>
+        /// Gets a new Matrix6x1 containing the values of column 8
+        /// </summary>
+        public Matrix6x1 Row8 { get { return new Matrix6x1(M18, M28, M38, M48, M58, M68); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix6x8)
+                return this == (Matrix6x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix6x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix6x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11])
+                         + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17])
+                         + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35])
+                         + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41])
+                         + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47])
+                         + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]) + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix6x8: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|}}"
+                               + "{{|{06}|{07}|{08}|{09}|{10}|{11}|}}"
+                               + "{{|{12}|{13}|{14}|{15}|{16}|{17}|}}"
+                               + "{{|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|}}"
+                               + "{{|{30}|{31}|{32}|{33}|{34}|{35}|}}"
+                               + "{{|{36}|{37}|{38}|{39}|{40}|{41}|}}"
+                               + "{{|{42}|{43}|{44}|{45}|{46}|{47}|}}"
+                               , M11, M21, M31, M41, M51, M61
+                               , M12, M22, M32, M42, M52, M62
+                               , M13, M23, M33, M43, M53, M63
+                               , M14, M24, M34, M44, M54, M64
+                               , M15, M25, M35, M45, M55, M65
+                               , M16, M26, M36, M46, M56, M66
+                               , M17, M27, M37, M47, M57, M67
+                               , M18, M28, M38, M48, M58, M68); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x6 Transpose()
+        {
+            return new Matrix8x6(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28, 
+                                 M31, M32, M33, M34, M35, M36, M37, M38, 
+                                 M41, M42, M43, M44, M45, M46, M47, M48, 
+                                 M51, M52, M53, M54, M55, M56, M57, M58, 
+                                 M61, M62, M63, M64, M65, M66, M67, M68);
+        }
+
+        public static bool operator ==(Matrix6x8 matrix1, Matrix6x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M67 - matrix2.M67) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M38 - matrix2.M38) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M48 - matrix2.M48) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M58 - matrix2.M58) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M68 - matrix2.M68) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix6x8 matrix1, Matrix6x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M67 - matrix2.M67) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon
+                || Math.Abs(matrix1.M38 - matrix2.M38) > Double.Epsilon
+                || Math.Abs(matrix1.M48 - matrix2.M48) > Double.Epsilon
+                || Math.Abs(matrix1.M58 - matrix2.M58) > Double.Epsilon
+                || Math.Abs(matrix1.M68 - matrix2.M68) > Double.Epsilon;
+        }
+
+        public static Matrix6x8 operator +(Matrix6x8 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m67 = matrix1.M67 + matrix2.M67;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+            double m38 = matrix1.M38 + matrix2.M38;
+            double m48 = matrix1.M48 + matrix2.M48;
+            double m58 = matrix1.M58 + matrix2.M58;
+            double m68 = matrix1.M68 + matrix2.M68;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+
+        public static Matrix6x8 operator -(Matrix6x8 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m67 = matrix1.M67 - matrix2.M67;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+            double m38 = matrix1.M38 - matrix2.M38;
+            double m48 = matrix1.M48 - matrix2.M48;
+            double m58 = matrix1.M58 - matrix2.M58;
+            double m68 = matrix1.M68 - matrix2.M68;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+
+        public static Matrix6x8 operator *(Matrix6x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m67 = matrix.M67 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+            double m38 = matrix.M38 * scalar;
+            double m48 = matrix.M48 * scalar;
+            double m58 = matrix.M58 * scalar;
+            double m68 = matrix.M68 * scalar;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+
+        public static Matrix6x8 operator *(double scalar, Matrix6x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m67 = scalar * matrix.M67;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+            double m38 = scalar * matrix.M38;
+            double m48 = scalar * matrix.M48;
+            double m58 = scalar * matrix.M58;
+            double m68 = scalar * matrix.M68;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+
+        public static Matrix1x8 operator *(Matrix6x8 matrix1, Matrix1x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix6x8 matrix1, Matrix2x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix6x8 matrix1, Matrix3x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix6x8 matrix1, Matrix4x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix6x8 matrix1, Matrix5x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix6x8 matrix1, Matrix6x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix6x8 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75 + matrix1.M68 * matrix2.M76;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix6x8 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85 + matrix1.M67 * matrix2.M86;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75 + matrix1.M68 * matrix2.M76;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82 + matrix1.M38 * matrix2.M83 + matrix1.M48 * matrix2.M84 + matrix1.M58 * matrix2.M85 + matrix1.M68 * matrix2.M86;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x1.cs
@@ -1,0 +1,288 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x1: IEquatable<Matrix7x1>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 1;
+
+        static Matrix7x1()
+        {
+            Zero = new Matrix7x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        public Matrix7x1(double m11, double m21, double m31, double m41, double m51, double m61, double m71)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x1(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x1)
+                return this == (Matrix7x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x1: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x7 Transpose()
+        {
+            return new Matrix1x7(M11, 
+                                 M21, 
+                                 M31, 
+                                 M41, 
+                                 M51, 
+                                 M61, 
+                                 M71);
+        }
+
+        public static bool operator ==(Matrix7x1 matrix1, Matrix7x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x1 matrix1, Matrix7x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon;
+        }
+
+        public static Matrix7x1 operator +(Matrix7x1 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+
+        public static Matrix7x1 operator -(Matrix7x1 matrix1, Matrix7x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+
+        public static Matrix7x1 operator *(Matrix7x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+
+        public static Matrix7x1 operator *(double scalar, Matrix7x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+
+        public static Matrix2x1 operator *(Matrix7x1 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix7x1 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix7x1 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix7x1 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix7x1 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix7x1 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix7x1 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x2.cs
@@ -1,0 +1,440 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x2: IEquatable<Matrix7x2>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 2;
+
+        static Matrix7x2()
+        {
+            Zero = new Matrix7x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        public Matrix7x2(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x2(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 4
+        /// </summary>
+        public Matrix1x2 Column4 { get { return new Matrix1x2(M41, M42); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 5
+        /// </summary>
+        public Matrix1x2 Column5 { get { return new Matrix1x2(M51, M52); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 6
+        /// </summary>
+        public Matrix1x2 Column6 { get { return new Matrix1x2(M61, M62); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 7
+        /// </summary>
+        public Matrix1x2 Column7 { get { return new Matrix1x2(M71, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x2)
+                return this == (Matrix7x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x2: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x7 Transpose()
+        {
+            return new Matrix2x7(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32, 
+                                 M41, M42, 
+                                 M51, M52, 
+                                 M61, M62, 
+                                 M71, M72);
+        }
+
+        public static bool operator ==(Matrix7x2 matrix1, Matrix7x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x2 matrix1, Matrix7x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon;
+        }
+
+        public static Matrix7x2 operator +(Matrix7x2 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+
+        public static Matrix7x2 operator -(Matrix7x2 matrix1, Matrix7x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+
+        public static Matrix7x2 operator *(Matrix7x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+
+        public static Matrix7x2 operator *(double scalar, Matrix7x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+
+        public static Matrix1x2 operator *(Matrix7x2 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix7x2 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix7x2 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix7x2 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix7x2 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix7x2 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix7x2 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix7x2 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x3.cs
@@ -1,0 +1,554 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x3: IEquatable<Matrix7x3>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 3;
+
+        static Matrix7x3()
+        {
+            Zero = new Matrix7x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        public Matrix7x3(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x3(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 4
+        /// </summary>
+        public Matrix1x3 Column4 { get { return new Matrix1x3(M41, M42, M43); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 5
+        /// </summary>
+        public Matrix1x3 Column5 { get { return new Matrix1x3(M51, M52, M53); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 6
+        /// </summary>
+        public Matrix1x3 Column6 { get { return new Matrix1x3(M61, M62, M63); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 7
+        /// </summary>
+        public Matrix1x3 Column7 { get { return new Matrix1x3(M71, M72, M73); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 3
+        /// </summary>
+        public Matrix7x1 Row3 { get { return new Matrix7x1(M13, M23, M33, M43, M53, M63, M73); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x3)
+                return this == (Matrix7x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x3: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               + "{{|{14}|{15}|{16}|{17}|{18}|{19}|{20}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72
+                               , M13, M23, M33, M43, M53, M63, M73); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x7 Transpose()
+        {
+            return new Matrix3x7(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33, 
+                                 M41, M42, M43, 
+                                 M51, M52, M53, 
+                                 M61, M62, M63, 
+                                 M71, M72, M73);
+        }
+
+        public static bool operator ==(Matrix7x3 matrix1, Matrix7x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x3 matrix1, Matrix7x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon;
+        }
+
+        public static Matrix7x3 operator +(Matrix7x3 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+
+        public static Matrix7x3 operator -(Matrix7x3 matrix1, Matrix7x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+
+        public static Matrix7x3 operator *(Matrix7x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+
+        public static Matrix7x3 operator *(double scalar, Matrix7x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+
+        public static Matrix1x3 operator *(Matrix7x3 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix7x3 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix7x3 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix7x3 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix7x3 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix7x3 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix7x3 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix7x3 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x4.cs
@@ -1,0 +1,668 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x4: IEquatable<Matrix7x4>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 4;
+
+        static Matrix7x4()
+        {
+            Zero = new Matrix7x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        public Matrix7x4(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x4(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 4
+        /// </summary>
+        public Matrix1x4 Column4 { get { return new Matrix1x4(M41, M42, M43, M44); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 5
+        /// </summary>
+        public Matrix1x4 Column5 { get { return new Matrix1x4(M51, M52, M53, M54); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 6
+        /// </summary>
+        public Matrix1x4 Column6 { get { return new Matrix1x4(M61, M62, M63, M64); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 7
+        /// </summary>
+        public Matrix1x4 Column7 { get { return new Matrix1x4(M71, M72, M73, M74); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 3
+        /// </summary>
+        public Matrix7x1 Row3 { get { return new Matrix7x1(M13, M23, M33, M43, M53, M63, M73); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 4
+        /// </summary>
+        public Matrix7x1 Row4 { get { return new Matrix7x1(M14, M24, M34, M44, M54, M64, M74); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x4)
+                return this == (Matrix7x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[21] ^ x[22]) + (x[23] ^ x[24]) + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x4: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               + "{{|{14}|{15}|{16}|{17}|{18}|{19}|{20}|}}"
+                               + "{{|{21}|{22}|{23}|{24}|{25}|{26}|{27}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72
+                               , M13, M23, M33, M43, M53, M63, M73
+                               , M14, M24, M34, M44, M54, M64, M74); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x7 Transpose()
+        {
+            return new Matrix4x7(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34, 
+                                 M41, M42, M43, M44, 
+                                 M51, M52, M53, M54, 
+                                 M61, M62, M63, M64, 
+                                 M71, M72, M73, M74);
+        }
+
+        public static bool operator ==(Matrix7x4 matrix1, Matrix7x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x4 matrix1, Matrix7x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon;
+        }
+
+        public static Matrix7x4 operator +(Matrix7x4 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+
+        public static Matrix7x4 operator -(Matrix7x4 matrix1, Matrix7x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+
+        public static Matrix7x4 operator *(Matrix7x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+
+        public static Matrix7x4 operator *(double scalar, Matrix7x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+
+        public static Matrix1x4 operator *(Matrix7x4 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix7x4 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix7x4 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix7x4 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix7x4 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix7x4 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix7x4 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix7x4 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x5.cs
@@ -1,0 +1,782 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x5: IEquatable<Matrix7x5>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 5;
+
+        static Matrix7x5()
+        {
+            Zero = new Matrix7x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        public Matrix7x5(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x5(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 3
+        /// </summary>
+        public Matrix1x5 Column3 { get { return new Matrix1x5(M31, M32, M33, M34, M35); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 4
+        /// </summary>
+        public Matrix1x5 Column4 { get { return new Matrix1x5(M41, M42, M43, M44, M45); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 5
+        /// </summary>
+        public Matrix1x5 Column5 { get { return new Matrix1x5(M51, M52, M53, M54, M55); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 6
+        /// </summary>
+        public Matrix1x5 Column6 { get { return new Matrix1x5(M61, M62, M63, M64, M65); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 7
+        /// </summary>
+        public Matrix1x5 Column7 { get { return new Matrix1x5(M71, M72, M73, M74, M75); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 3
+        /// </summary>
+        public Matrix7x1 Row3 { get { return new Matrix7x1(M13, M23, M33, M43, M53, M63, M73); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 4
+        /// </summary>
+        public Matrix7x1 Row4 { get { return new Matrix7x1(M14, M24, M34, M44, M54, M64, M74); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 5
+        /// </summary>
+        public Matrix7x1 Row5 { get { return new Matrix7x1(M15, M25, M35, M45, M55, M65, M75); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x5)
+                return this == (Matrix7x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[21] ^ x[22]) + (x[23] ^ x[24]) + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34])
+                         + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x5: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               + "{{|{14}|{15}|{16}|{17}|{18}|{19}|{20}|}}"
+                               + "{{|{21}|{22}|{23}|{24}|{25}|{26}|{27}|}}"
+                               + "{{|{28}|{29}|{30}|{31}|{32}|{33}|{34}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72
+                               , M13, M23, M33, M43, M53, M63, M73
+                               , M14, M24, M34, M44, M54, M64, M74
+                               , M15, M25, M35, M45, M55, M65, M75); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x7 Transpose()
+        {
+            return new Matrix5x7(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25, 
+                                 M31, M32, M33, M34, M35, 
+                                 M41, M42, M43, M44, M45, 
+                                 M51, M52, M53, M54, M55, 
+                                 M61, M62, M63, M64, M65, 
+                                 M71, M72, M73, M74, M75);
+        }
+
+        public static bool operator ==(Matrix7x5 matrix1, Matrix7x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x5 matrix1, Matrix7x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon;
+        }
+
+        public static Matrix7x5 operator +(Matrix7x5 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+
+        public static Matrix7x5 operator -(Matrix7x5 matrix1, Matrix7x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+
+        public static Matrix7x5 operator *(Matrix7x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+
+        public static Matrix7x5 operator *(double scalar, Matrix7x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+
+        public static Matrix1x5 operator *(Matrix7x5 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix7x5 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix7x5 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix7x5 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix7x5 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix7x5 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix7x5 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix7x5 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x6.cs
@@ -1,0 +1,896 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x6: IEquatable<Matrix7x6>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 6;
+
+        static Matrix7x6()
+        {
+            Zero = new Matrix7x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m76">The column 7, row 6 value</param>
+        public Matrix7x6(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, double m76)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; M76 = m76; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x6(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = M76 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M76;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 3
+        /// </summary>
+        public Matrix1x6 Column3 { get { return new Matrix1x6(M31, M32, M33, M34, M35, M36); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 4
+        /// </summary>
+        public Matrix1x6 Column4 { get { return new Matrix1x6(M41, M42, M43, M44, M45, M46); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 5
+        /// </summary>
+        public Matrix1x6 Column5 { get { return new Matrix1x6(M51, M52, M53, M54, M55, M56); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 6
+        /// </summary>
+        public Matrix1x6 Column6 { get { return new Matrix1x6(M61, M62, M63, M64, M65, M66); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 7
+        /// </summary>
+        public Matrix1x6 Column7 { get { return new Matrix1x6(M71, M72, M73, M74, M75, M76); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 3
+        /// </summary>
+        public Matrix7x1 Row3 { get { return new Matrix7x1(M13, M23, M33, M43, M53, M63, M73); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 4
+        /// </summary>
+        public Matrix7x1 Row4 { get { return new Matrix7x1(M14, M24, M34, M44, M54, M64, M74); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 5
+        /// </summary>
+        public Matrix7x1 Row5 { get { return new Matrix7x1(M15, M25, M35, M45, M55, M65, M75); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 6
+        /// </summary>
+        public Matrix7x1 Row6 { get { return new Matrix7x1(M16, M26, M36, M46, M56, M66, M76); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x6)
+                return this == (Matrix7x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[21] ^ x[22]) + (x[23] ^ x[24]) + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34])
+                         + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41])
+                         + (x[35] ^ x[36]) + (x[37] ^ x[38]) + (x[39] ^ x[40]) + (x[41] ^ x[42]) + (x[43] ^ x[44]) + (x[45] ^ x[46]) + (x[47] ^ x[48]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x6: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               + "{{|{14}|{15}|{16}|{17}|{18}|{19}|{20}|}}"
+                               + "{{|{21}|{22}|{23}|{24}|{25}|{26}|{27}|}}"
+                               + "{{|{28}|{29}|{30}|{31}|{32}|{33}|{34}|}}"
+                               + "{{|{35}|{36}|{37}|{38}|{39}|{40}|{41}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72
+                               , M13, M23, M33, M43, M53, M63, M73
+                               , M14, M24, M34, M44, M54, M64, M74
+                               , M15, M25, M35, M45, M55, M65, M75
+                               , M16, M26, M36, M46, M56, M66, M76); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x7 Transpose()
+        {
+            return new Matrix6x7(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26, 
+                                 M31, M32, M33, M34, M35, M36, 
+                                 M41, M42, M43, M44, M45, M46, 
+                                 M51, M52, M53, M54, M55, M56, 
+                                 M61, M62, M63, M64, M65, M66, 
+                                 M71, M72, M73, M74, M75, M76);
+        }
+
+        public static bool operator ==(Matrix7x6 matrix1, Matrix7x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M76 - matrix2.M76) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x6 matrix1, Matrix7x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M76 - matrix2.M76) > Double.Epsilon;
+        }
+
+        public static Matrix7x6 operator +(Matrix7x6 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m76 = matrix1.M76 + matrix2.M76;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+
+        public static Matrix7x6 operator -(Matrix7x6 matrix1, Matrix7x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m76 = matrix1.M76 - matrix2.M76;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+
+        public static Matrix7x6 operator *(Matrix7x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m76 = matrix.M76 * scalar;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+
+        public static Matrix7x6 operator *(double scalar, Matrix7x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m76 = scalar * matrix.M76;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+
+        public static Matrix1x6 operator *(Matrix7x6 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix7x6 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix7x6 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix7x6 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix7x6 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix7x6 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix7x6 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix7x6 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86 + matrix1.M76 * matrix2.M87;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x7.cs
@@ -1,0 +1,1022 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x7: IEquatable<Matrix7x7>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 7;
+
+        static Matrix7x7()
+        {
+            Zero = new Matrix7x7(0);
+			Identitiy = new Matrix7x7(1, 0, 0, 0, 0, 0, 0, 
+                                      0, 1, 0, 0, 0, 0, 0, 
+                                      0, 0, 1, 0, 0, 0, 0, 
+                                      0, 0, 0, 1, 0, 0, 0, 
+                                      0, 0, 0, 0, 1, 0, 0, 
+                                      0, 0, 0, 0, 0, 1, 0, 
+                                      0, 0, 0, 0, 0, 0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x7 Zero;
+        
+        /// <summary>
+        /// Constant Matrix7x7 with value intialized to the identity of a 7 x 7 matrix
+        /// </summary>
+        public static readonly Matrix7x7 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix7x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m76">The column 7, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m67">The column 6, row 7 value</param>
+        /// <param name="m77">The column 7, row 7 value</param>
+        public Matrix7x7(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, double m76, 
+                         double m17, double m27, double m37, double m47, double m57, double m67, double m77)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; M76 = m76; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; M67 = m67; M77 = m77; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x7(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = M76 = 
+			M17 = M27 = M37 = M47 = M57 = M67 = M77 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M76;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M67;
+		public double M77;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 3
+        /// </summary>
+        public Matrix1x7 Column3 { get { return new Matrix1x7(M31, M32, M33, M34, M35, M36, M37); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 4
+        /// </summary>
+        public Matrix1x7 Column4 { get { return new Matrix1x7(M41, M42, M43, M44, M45, M46, M47); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 5
+        /// </summary>
+        public Matrix1x7 Column5 { get { return new Matrix1x7(M51, M52, M53, M54, M55, M56, M57); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 6
+        /// </summary>
+        public Matrix1x7 Column6 { get { return new Matrix1x7(M61, M62, M63, M64, M65, M66, M67); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 7
+        /// </summary>
+        public Matrix1x7 Column7 { get { return new Matrix1x7(M71, M72, M73, M74, M75, M76, M77); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 3
+        /// </summary>
+        public Matrix7x1 Row3 { get { return new Matrix7x1(M13, M23, M33, M43, M53, M63, M73); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 4
+        /// </summary>
+        public Matrix7x1 Row4 { get { return new Matrix7x1(M14, M24, M34, M44, M54, M64, M74); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 5
+        /// </summary>
+        public Matrix7x1 Row5 { get { return new Matrix7x1(M15, M25, M35, M45, M55, M65, M75); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 6
+        /// </summary>
+        public Matrix7x1 Row6 { get { return new Matrix7x1(M16, M26, M36, M46, M56, M66, M76); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 7
+        /// </summary>
+        public Matrix7x1 Row7 { get { return new Matrix7x1(M17, M27, M37, M47, M57, M67, M77); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x7)
+                return this == (Matrix7x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[21] ^ x[22]) + (x[23] ^ x[24]) + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34])
+                         + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41])
+                         + (x[35] ^ x[36]) + (x[37] ^ x[38]) + (x[39] ^ x[40]) + (x[41] ^ x[42]) + (x[43] ^ x[44]) + (x[45] ^ x[46]) + (x[47] ^ x[48])
+                         + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]) + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x7: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               + "{{|{14}|{15}|{16}|{17}|{18}|{19}|{20}|}}"
+                               + "{{|{21}|{22}|{23}|{24}|{25}|{26}|{27}|}}"
+                               + "{{|{28}|{29}|{30}|{31}|{32}|{33}|{34}|}}"
+                               + "{{|{35}|{36}|{37}|{38}|{39}|{40}|{41}|}}"
+                               + "{{|{42}|{43}|{44}|{45}|{46}|{47}|{48}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72
+                               , M13, M23, M33, M43, M53, M63, M73
+                               , M14, M24, M34, M44, M54, M64, M74
+                               , M15, M25, M35, M45, M55, M65, M75
+                               , M16, M26, M36, M46, M56, M66, M76
+                               , M17, M27, M37, M47, M57, M67, M77); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x7 Transpose()
+        {
+            return new Matrix7x7(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27, 
+                                 M31, M32, M33, M34, M35, M36, M37, 
+                                 M41, M42, M43, M44, M45, M46, M47, 
+                                 M51, M52, M53, M54, M55, M56, M57, 
+                                 M61, M62, M63, M64, M65, M66, M67, 
+                                 M71, M72, M73, M74, M75, M76, M77);
+        }
+
+        public static bool operator ==(Matrix7x7 matrix1, Matrix7x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M76 - matrix2.M76) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M67 - matrix2.M67) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M77 - matrix2.M77) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x7 matrix1, Matrix7x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M76 - matrix2.M76) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M67 - matrix2.M67) > Double.Epsilon
+                || Math.Abs(matrix1.M77 - matrix2.M77) > Double.Epsilon;
+        }
+
+        public static Matrix7x7 operator +(Matrix7x7 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m76 = matrix1.M76 + matrix2.M76;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m67 = matrix1.M67 + matrix2.M67;
+            double m77 = matrix1.M77 + matrix2.M77;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+
+        public static Matrix7x7 operator -(Matrix7x7 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m76 = matrix1.M76 - matrix2.M76;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m67 = matrix1.M67 - matrix2.M67;
+            double m77 = matrix1.M77 - matrix2.M77;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+
+        public static Matrix7x7 operator *(Matrix7x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m76 = matrix.M76 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m67 = matrix.M67 * scalar;
+            double m77 = matrix.M77 * scalar;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+
+        public static Matrix7x7 operator *(double scalar, Matrix7x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m76 = scalar * matrix.M76;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m67 = scalar * matrix.M67;
+            double m77 = scalar * matrix.M77;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+
+        public static Matrix1x7 operator *(Matrix7x7 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix7x7 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix7x7 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix7x7 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix7x7 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix7x7 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix7x7 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix7x7 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86 + matrix1.M76 * matrix2.M87;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85 + matrix1.M67 * matrix2.M86 + matrix1.M77 * matrix2.M87;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix7x8.cs
@@ -1,0 +1,1124 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix7x8: IEquatable<Matrix7x8>, IMatrix
+    {
+        public const int ColumnCount = 7;
+        public const int RowCount = 8;
+
+        static Matrix7x8()
+        {
+            Zero = new Matrix7x8(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix7x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix7x8 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix7x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m76">The column 7, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m67">The column 6, row 7 value</param>
+        /// <param name="m77">The column 7, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        /// <param name="m38">The column 3, row 8 value</param>
+        /// <param name="m48">The column 4, row 8 value</param>
+        /// <param name="m58">The column 5, row 8 value</param>
+        /// <param name="m68">The column 6, row 8 value</param>
+        /// <param name="m78">The column 7, row 8 value</param>
+        public Matrix7x8(double m11, double m21, double m31, double m41, double m51, double m61, double m71, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, double m76, 
+                         double m17, double m27, double m37, double m47, double m57, double m67, double m77, 
+                         double m18, double m28, double m38, double m48, double m58, double m68, double m78)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; M76 = m76; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; M67 = m67; M77 = m77; 
+			M18 = m18; M28 = m28; M38 = m38; M48 = m48; M58 = m58; M68 = m68; M78 = m78; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix7x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix7x8(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = M76 = 
+			M17 = M27 = M37 = M47 = M57 = M67 = M77 = 
+			M18 = M28 = M38 = M48 = M58 = M68 = M78 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M76;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M67;
+		public double M77;
+		public double M18;
+		public double M28;
+		public double M38;
+		public double M48;
+		public double M58;
+		public double M68;
+		public double M78;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix7x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix7x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix7x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 3
+        /// </summary>
+        public Matrix1x8 Column3 { get { return new Matrix1x8(M31, M32, M33, M34, M35, M36, M37, M38); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 4
+        /// </summary>
+        public Matrix1x8 Column4 { get { return new Matrix1x8(M41, M42, M43, M44, M45, M46, M47, M48); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 5
+        /// </summary>
+        public Matrix1x8 Column5 { get { return new Matrix1x8(M51, M52, M53, M54, M55, M56, M57, M58); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 6
+        /// </summary>
+        public Matrix1x8 Column6 { get { return new Matrix1x8(M61, M62, M63, M64, M65, M66, M67, M68); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 7
+        /// </summary>
+        public Matrix1x8 Column7 { get { return new Matrix1x8(M71, M72, M73, M74, M75, M76, M77, M78); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 1
+        /// </summary>
+        public Matrix7x1 Row1 { get { return new Matrix7x1(M11, M21, M31, M41, M51, M61, M71); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 2
+        /// </summary>
+        public Matrix7x1 Row2 { get { return new Matrix7x1(M12, M22, M32, M42, M52, M62, M72); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 3
+        /// </summary>
+        public Matrix7x1 Row3 { get { return new Matrix7x1(M13, M23, M33, M43, M53, M63, M73); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 4
+        /// </summary>
+        public Matrix7x1 Row4 { get { return new Matrix7x1(M14, M24, M34, M44, M54, M64, M74); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 5
+        /// </summary>
+        public Matrix7x1 Row5 { get { return new Matrix7x1(M15, M25, M35, M45, M55, M65, M75); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 6
+        /// </summary>
+        public Matrix7x1 Row6 { get { return new Matrix7x1(M16, M26, M36, M46, M56, M66, M76); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 7
+        /// </summary>
+        public Matrix7x1 Row7 { get { return new Matrix7x1(M17, M27, M37, M47, M57, M67, M77); } }
+        /// <summary>
+        /// Gets a new Matrix7x1 containing the values of column 8
+        /// </summary>
+        public Matrix7x1 Row8 { get { return new Matrix7x1(M18, M28, M38, M48, M58, M68, M78); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix7x8)
+                return this == (Matrix7x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix7x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix7x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13])
+                         + (x[07] ^ x[08]) + (x[09] ^ x[10]) + (x[11] ^ x[12]) + (x[13] ^ x[14]) + (x[15] ^ x[16]) + (x[17] ^ x[18]) + (x[19] ^ x[20])
+                         + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27])
+                         + (x[21] ^ x[22]) + (x[23] ^ x[24]) + (x[25] ^ x[26]) + (x[27] ^ x[28]) + (x[29] ^ x[30]) + (x[31] ^ x[32]) + (x[33] ^ x[34])
+                         + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41])
+                         + (x[35] ^ x[36]) + (x[37] ^ x[38]) + (x[39] ^ x[40]) + (x[41] ^ x[42]) + (x[43] ^ x[44]) + (x[45] ^ x[46]) + (x[47] ^ x[48])
+                         + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]) + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55])
+                         + (x[49] ^ x[50]) + (x[51] ^ x[52]) + (x[53] ^ x[54]) + (x[55] ^ x[56]) + (x[57] ^ x[58]) + (x[59] ^ x[60]) + (x[61] ^ x[62]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix7x8: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|}}"
+                               + "{{|{07}|{08}|{09}|{10}|{11}|{12}|{13}|}}"
+                               + "{{|{14}|{15}|{16}|{17}|{18}|{19}|{20}|}}"
+                               + "{{|{21}|{22}|{23}|{24}|{25}|{26}|{27}|}}"
+                               + "{{|{28}|{29}|{30}|{31}|{32}|{33}|{34}|}}"
+                               + "{{|{35}|{36}|{37}|{38}|{39}|{40}|{41}|}}"
+                               + "{{|{42}|{43}|{44}|{45}|{46}|{47}|{48}|}}"
+                               + "{{|{49}|{50}|{51}|{52}|{53}|{54}|{55}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71
+                               , M12, M22, M32, M42, M52, M62, M72
+                               , M13, M23, M33, M43, M53, M63, M73
+                               , M14, M24, M34, M44, M54, M64, M74
+                               , M15, M25, M35, M45, M55, M65, M75
+                               , M16, M26, M36, M46, M56, M66, M76
+                               , M17, M27, M37, M47, M57, M67, M77
+                               , M18, M28, M38, M48, M58, M68, M78); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x7 Transpose()
+        {
+            return new Matrix8x7(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28, 
+                                 M31, M32, M33, M34, M35, M36, M37, M38, 
+                                 M41, M42, M43, M44, M45, M46, M47, M48, 
+                                 M51, M52, M53, M54, M55, M56, M57, M58, 
+                                 M61, M62, M63, M64, M65, M66, M67, M68, 
+                                 M71, M72, M73, M74, M75, M76, M77, M78);
+        }
+
+        public static bool operator ==(Matrix7x8 matrix1, Matrix7x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M76 - matrix2.M76) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M67 - matrix2.M67) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M77 - matrix2.M77) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M38 - matrix2.M38) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M48 - matrix2.M48) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M58 - matrix2.M58) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M68 - matrix2.M68) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M78 - matrix2.M78) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix7x8 matrix1, Matrix7x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M76 - matrix2.M76) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M67 - matrix2.M67) > Double.Epsilon
+                || Math.Abs(matrix1.M77 - matrix2.M77) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon
+                || Math.Abs(matrix1.M38 - matrix2.M38) > Double.Epsilon
+                || Math.Abs(matrix1.M48 - matrix2.M48) > Double.Epsilon
+                || Math.Abs(matrix1.M58 - matrix2.M58) > Double.Epsilon
+                || Math.Abs(matrix1.M68 - matrix2.M68) > Double.Epsilon
+                || Math.Abs(matrix1.M78 - matrix2.M78) > Double.Epsilon;
+        }
+
+        public static Matrix7x8 operator +(Matrix7x8 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m76 = matrix1.M76 + matrix2.M76;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m67 = matrix1.M67 + matrix2.M67;
+            double m77 = matrix1.M77 + matrix2.M77;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+            double m38 = matrix1.M38 + matrix2.M38;
+            double m48 = matrix1.M48 + matrix2.M48;
+            double m58 = matrix1.M58 + matrix2.M58;
+            double m68 = matrix1.M68 + matrix2.M68;
+            double m78 = matrix1.M78 + matrix2.M78;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+
+        public static Matrix7x8 operator -(Matrix7x8 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m76 = matrix1.M76 - matrix2.M76;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m67 = matrix1.M67 - matrix2.M67;
+            double m77 = matrix1.M77 - matrix2.M77;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+            double m38 = matrix1.M38 - matrix2.M38;
+            double m48 = matrix1.M48 - matrix2.M48;
+            double m58 = matrix1.M58 - matrix2.M58;
+            double m68 = matrix1.M68 - matrix2.M68;
+            double m78 = matrix1.M78 - matrix2.M78;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+
+        public static Matrix7x8 operator *(Matrix7x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m76 = matrix.M76 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m67 = matrix.M67 * scalar;
+            double m77 = matrix.M77 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+            double m38 = matrix.M38 * scalar;
+            double m48 = matrix.M48 * scalar;
+            double m58 = matrix.M58 * scalar;
+            double m68 = matrix.M68 * scalar;
+            double m78 = matrix.M78 * scalar;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+
+        public static Matrix7x8 operator *(double scalar, Matrix7x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m76 = scalar * matrix.M76;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m67 = scalar * matrix.M67;
+            double m77 = scalar * matrix.M77;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+            double m38 = scalar * matrix.M38;
+            double m48 = scalar * matrix.M48;
+            double m58 = scalar * matrix.M58;
+            double m68 = scalar * matrix.M68;
+            double m78 = scalar * matrix.M78;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+
+        public static Matrix1x8 operator *(Matrix7x8 matrix1, Matrix1x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix7x8 matrix1, Matrix2x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix7x8 matrix1, Matrix3x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix7x8 matrix1, Matrix4x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix7x8 matrix1, Matrix5x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix7x8 matrix1, Matrix6x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66 + matrix1.M78 * matrix2.M67;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix7x8 matrix1, Matrix7x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66 + matrix1.M78 * matrix2.M67;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75 + matrix1.M68 * matrix2.M76 + matrix1.M78 * matrix2.M77;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix7x8 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86 + matrix1.M76 * matrix2.M87;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85 + matrix1.M67 * matrix2.M86 + matrix1.M77 * matrix2.M87;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66 + matrix1.M78 * matrix2.M67;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75 + matrix1.M68 * matrix2.M76 + matrix1.M78 * matrix2.M77;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82 + matrix1.M38 * matrix2.M83 + matrix1.M48 * matrix2.M84 + matrix1.M58 * matrix2.M85 + matrix1.M68 * matrix2.M86 + matrix1.M78 * matrix2.M87;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x1.cs
@@ -1,0 +1,297 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x1: IEquatable<Matrix8x1>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 1;
+
+        static Matrix8x1()
+        {
+            Zero = new Matrix8x1(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        public Matrix8x1(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x1(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x1.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x1.RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x1)
+                return this == (Matrix8x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x1: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x8 Transpose()
+        {
+            return new Matrix1x8(M11, 
+                                 M21, 
+                                 M31, 
+                                 M41, 
+                                 M51, 
+                                 M61, 
+                                 M71, 
+                                 M81);
+        }
+
+        public static bool operator ==(Matrix8x1 matrix1, Matrix8x1 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x1 matrix1, Matrix8x1 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon;
+        }
+
+        public static Matrix8x1 operator +(Matrix8x1 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+
+        public static Matrix8x1 operator -(Matrix8x1 matrix1, Matrix8x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+
+        public static Matrix8x1 operator *(Matrix8x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+
+        public static Matrix8x1 operator *(double scalar, Matrix8x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+
+        public static Matrix2x1 operator *(Matrix8x1 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix8x1 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix8x1 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+        public static Matrix5x1 operator *(Matrix8x1 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+
+            return new Matrix5x1(m11, m21, m31, m41, m51);
+        }
+        public static Matrix6x1 operator *(Matrix8x1 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+
+            return new Matrix6x1(m11, m21, m31, m41, m51, m61);
+        }
+        public static Matrix7x1 operator *(Matrix8x1 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+
+            return new Matrix7x1(m11, m21, m31, m41, m51, m61, m71);
+        }
+        public static Matrix8x1 operator *(Matrix8x1 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+
+            return new Matrix8x1(m11, m21, m31, m41, m51, m61, m71, m81);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x2.cs
@@ -1,0 +1,461 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x2: IEquatable<Matrix8x2>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 2;
+
+        static Matrix8x2()
+        {
+            Zero = new Matrix8x2(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        public Matrix8x2(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x2(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x2.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x2.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 4
+        /// </summary>
+        public Matrix1x2 Column4 { get { return new Matrix1x2(M41, M42); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 5
+        /// </summary>
+        public Matrix1x2 Column5 { get { return new Matrix1x2(M51, M52); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 6
+        /// </summary>
+        public Matrix1x2 Column6 { get { return new Matrix1x2(M61, M62); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 7
+        /// </summary>
+        public Matrix1x2 Column7 { get { return new Matrix1x2(M71, M72); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 8
+        /// </summary>
+        public Matrix1x2 Column8 { get { return new Matrix1x2(M81, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x2)
+                return this == (Matrix8x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x2: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x8 Transpose()
+        {
+            return new Matrix2x8(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32, 
+                                 M41, M42, 
+                                 M51, M52, 
+                                 M61, M62, 
+                                 M71, M72, 
+                                 M81, M82);
+        }
+
+        public static bool operator ==(Matrix8x2 matrix1, Matrix8x2 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x2 matrix1, Matrix8x2 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon;
+        }
+
+        public static Matrix8x2 operator +(Matrix8x2 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+
+        public static Matrix8x2 operator -(Matrix8x2 matrix1, Matrix8x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+
+        public static Matrix8x2 operator *(Matrix8x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+
+        public static Matrix8x2 operator *(double scalar, Matrix8x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+
+        public static Matrix1x2 operator *(Matrix8x2 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix8x2 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix8x2 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix8x2 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+        public static Matrix5x2 operator *(Matrix8x2 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+
+            return new Matrix5x2(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52);
+        }
+        public static Matrix6x2 operator *(Matrix8x2 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+
+            return new Matrix6x2(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62);
+        }
+        public static Matrix7x2 operator *(Matrix8x2 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+
+            return new Matrix7x2(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72);
+        }
+        public static Matrix8x2 operator *(Matrix8x2 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+
+            return new Matrix8x2(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x3.cs
@@ -1,0 +1,583 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x3: IEquatable<Matrix8x3>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 3;
+
+        static Matrix8x3()
+        {
+            Zero = new Matrix8x3(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m83">The column 8, row 3 value</param>
+        public Matrix8x3(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, double m83)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; M83 = m83; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x3(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = M83 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M83;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x3.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x3.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 4
+        /// </summary>
+        public Matrix1x3 Column4 { get { return new Matrix1x3(M41, M42, M43); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 5
+        /// </summary>
+        public Matrix1x3 Column5 { get { return new Matrix1x3(M51, M52, M53); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 6
+        /// </summary>
+        public Matrix1x3 Column6 { get { return new Matrix1x3(M61, M62, M63); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 7
+        /// </summary>
+        public Matrix1x3 Column7 { get { return new Matrix1x3(M71, M72, M73); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 8
+        /// </summary>
+        public Matrix1x3 Column8 { get { return new Matrix1x3(M81, M82, M83); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 3
+        /// </summary>
+        public Matrix8x1 Row3 { get { return new Matrix8x1(M13, M23, M33, M43, M53, M63, M73, M83); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x3)
+                return this == (Matrix8x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x3: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82
+                               , M13, M23, M33, M43, M53, M63, M73, M83); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x8 Transpose()
+        {
+            return new Matrix3x8(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33, 
+                                 M41, M42, M43, 
+                                 M51, M52, M53, 
+                                 M61, M62, M63, 
+                                 M71, M72, M73, 
+                                 M81, M82, M83);
+        }
+
+        public static bool operator ==(Matrix8x3 matrix1, Matrix8x3 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M83 - matrix2.M83) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x3 matrix1, Matrix8x3 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M83 - matrix2.M83) > Double.Epsilon;
+        }
+
+        public static Matrix8x3 operator +(Matrix8x3 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m83 = matrix1.M83 + matrix2.M83;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+
+        public static Matrix8x3 operator -(Matrix8x3 matrix1, Matrix8x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m83 = matrix1.M83 - matrix2.M83;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+
+        public static Matrix8x3 operator *(Matrix8x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m83 = matrix.M83 * scalar;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+
+        public static Matrix8x3 operator *(double scalar, Matrix8x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m83 = scalar * matrix.M83;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+
+        public static Matrix1x3 operator *(Matrix8x3 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix8x3 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix8x3 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix8x3 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+        public static Matrix5x3 operator *(Matrix8x3 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+
+            return new Matrix5x3(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53);
+        }
+        public static Matrix6x3 operator *(Matrix8x3 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+
+            return new Matrix6x3(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63);
+        }
+        public static Matrix7x3 operator *(Matrix8x3 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+
+            return new Matrix7x3(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73);
+        }
+        public static Matrix8x3 operator *(Matrix8x3 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87 + matrix1.M83 * matrix2.M88;
+
+            return new Matrix8x3(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x4.cs
@@ -1,0 +1,705 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x4: IEquatable<Matrix8x4>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 4;
+
+        static Matrix8x4()
+        {
+            Zero = new Matrix8x4(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m83">The column 8, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m84">The column 8, row 4 value</param>
+        public Matrix8x4(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, double m83, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, double m84)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; M83 = m83; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; M84 = m84; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x4(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = M83 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = M84 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M83;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M84;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x4.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x4.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 4
+        /// </summary>
+        public Matrix1x4 Column4 { get { return new Matrix1x4(M41, M42, M43, M44); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 5
+        /// </summary>
+        public Matrix1x4 Column5 { get { return new Matrix1x4(M51, M52, M53, M54); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 6
+        /// </summary>
+        public Matrix1x4 Column6 { get { return new Matrix1x4(M61, M62, M63, M64); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 7
+        /// </summary>
+        public Matrix1x4 Column7 { get { return new Matrix1x4(M71, M72, M73, M74); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 8
+        /// </summary>
+        public Matrix1x4 Column8 { get { return new Matrix1x4(M81, M82, M83, M84); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 3
+        /// </summary>
+        public Matrix8x1 Row3 { get { return new Matrix8x1(M13, M23, M33, M43, M53, M63, M73, M83); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 4
+        /// </summary>
+        public Matrix8x1 Row4 { get { return new Matrix8x1(M14, M24, M34, M44, M54, M64, M74, M84); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x4)
+                return this == (Matrix8x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x4: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|{30}|{31}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82
+                               , M13, M23, M33, M43, M53, M63, M73, M83
+                               , M14, M24, M34, M44, M54, M64, M74, M84); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x8 Transpose()
+        {
+            return new Matrix4x8(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34, 
+                                 M41, M42, M43, M44, 
+                                 M51, M52, M53, M54, 
+                                 M61, M62, M63, M64, 
+                                 M71, M72, M73, M74, 
+                                 M81, M82, M83, M84);
+        }
+
+        public static bool operator ==(Matrix8x4 matrix1, Matrix8x4 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M83 - matrix2.M83) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M84 - matrix2.M84) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x4 matrix1, Matrix8x4 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M83 - matrix2.M83) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M84 - matrix2.M84) > Double.Epsilon;
+        }
+
+        public static Matrix8x4 operator +(Matrix8x4 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m83 = matrix1.M83 + matrix2.M83;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m84 = matrix1.M84 + matrix2.M84;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+
+        public static Matrix8x4 operator -(Matrix8x4 matrix1, Matrix8x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m83 = matrix1.M83 - matrix2.M83;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m84 = matrix1.M84 - matrix2.M84;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+
+        public static Matrix8x4 operator *(Matrix8x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m83 = matrix.M83 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m84 = matrix.M84 * scalar;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+
+        public static Matrix8x4 operator *(double scalar, Matrix8x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m83 = scalar * matrix.M83;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m84 = scalar * matrix.M84;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+
+        public static Matrix1x4 operator *(Matrix8x4 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix8x4 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix8x4 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix8x4 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+        public static Matrix5x4 operator *(Matrix8x4 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+
+            return new Matrix5x4(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54);
+        }
+        public static Matrix6x4 operator *(Matrix8x4 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+
+            return new Matrix6x4(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64);
+        }
+        public static Matrix7x4 operator *(Matrix8x4 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+
+            return new Matrix7x4(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74);
+        }
+        public static Matrix8x4 operator *(Matrix8x4 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87 + matrix1.M83 * matrix2.M88;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87 + matrix1.M84 * matrix2.M88;
+
+            return new Matrix8x4(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x5.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x5.cs
@@ -1,0 +1,827 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x5: IEquatable<Matrix8x5>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 5;
+
+        static Matrix8x5()
+        {
+            Zero = new Matrix8x5(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x5 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x5 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x5 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m83">The column 8, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m84">The column 8, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m85">The column 8, row 5 value</param>
+        public Matrix8x5(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, double m83, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, double m84, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, double m85)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; M83 = m83; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; M84 = m84; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; M85 = m85; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x5 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x5(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = M83 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = M84 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = M85 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M83;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M84;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M85;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x5* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x5.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x5.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 1
+        /// </summary>
+        public Matrix1x5 Column1 { get { return new Matrix1x5(M11, M12, M13, M14, M15); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 2
+        /// </summary>
+        public Matrix1x5 Column2 { get { return new Matrix1x5(M21, M22, M23, M24, M25); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 3
+        /// </summary>
+        public Matrix1x5 Column3 { get { return new Matrix1x5(M31, M32, M33, M34, M35); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 4
+        /// </summary>
+        public Matrix1x5 Column4 { get { return new Matrix1x5(M41, M42, M43, M44, M45); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 5
+        /// </summary>
+        public Matrix1x5 Column5 { get { return new Matrix1x5(M51, M52, M53, M54, M55); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 6
+        /// </summary>
+        public Matrix1x5 Column6 { get { return new Matrix1x5(M61, M62, M63, M64, M65); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 7
+        /// </summary>
+        public Matrix1x5 Column7 { get { return new Matrix1x5(M71, M72, M73, M74, M75); } }
+        /// <summary>
+        /// Gets a new Matrix1x5 containing the values of column 8
+        /// </summary>
+        public Matrix1x5 Column8 { get { return new Matrix1x5(M81, M82, M83, M84, M85); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 3
+        /// </summary>
+        public Matrix8x1 Row3 { get { return new Matrix8x1(M13, M23, M33, M43, M53, M63, M73, M83); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 4
+        /// </summary>
+        public Matrix8x1 Row4 { get { return new Matrix8x1(M14, M24, M34, M44, M54, M64, M74, M84); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 5
+        /// </summary>
+        public Matrix8x1 Row5 { get { return new Matrix8x1(M15, M25, M35, M45, M55, M65, M75, M85); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x5)
+                return this == (Matrix8x5)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x5 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x5* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39])
+                         + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x5: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|{30}|{31}|}}"
+                               + "{{|{32}|{33}|{34}|{35}|{36}|{37}|{38}|{39}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82
+                               , M13, M23, M33, M43, M53, M63, M73, M83
+                               , M14, M24, M34, M44, M54, M64, M74, M84
+                               , M15, M25, M35, M45, M55, M65, M75, M85); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix5x8 Transpose()
+        {
+            return new Matrix5x8(M11, M12, M13, M14, M15, 
+                                 M21, M22, M23, M24, M25, 
+                                 M31, M32, M33, M34, M35, 
+                                 M41, M42, M43, M44, M45, 
+                                 M51, M52, M53, M54, M55, 
+                                 M61, M62, M63, M64, M65, 
+                                 M71, M72, M73, M74, M75, 
+                                 M81, M82, M83, M84, M85);
+        }
+
+        public static bool operator ==(Matrix8x5 matrix1, Matrix8x5 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M83 - matrix2.M83) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M84 - matrix2.M84) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M85 - matrix2.M85) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x5 matrix1, Matrix8x5 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M83 - matrix2.M83) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M84 - matrix2.M84) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M85 - matrix2.M85) > Double.Epsilon;
+        }
+
+        public static Matrix8x5 operator +(Matrix8x5 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m83 = matrix1.M83 + matrix2.M83;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m84 = matrix1.M84 + matrix2.M84;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m85 = matrix1.M85 + matrix2.M85;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+
+        public static Matrix8x5 operator -(Matrix8x5 matrix1, Matrix8x5 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m83 = matrix1.M83 - matrix2.M83;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m84 = matrix1.M84 - matrix2.M84;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m85 = matrix1.M85 - matrix2.M85;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+
+        public static Matrix8x5 operator *(Matrix8x5 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m83 = matrix.M83 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m84 = matrix.M84 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m85 = matrix.M85 * scalar;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+
+        public static Matrix8x5 operator *(double scalar, Matrix8x5 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m83 = scalar * matrix.M83;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m84 = scalar * matrix.M84;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m85 = scalar * matrix.M85;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+
+        public static Matrix1x5 operator *(Matrix8x5 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+
+            return new Matrix1x5(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15);
+        }
+        public static Matrix2x5 operator *(Matrix8x5 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+
+            return new Matrix2x5(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25);
+        }
+        public static Matrix3x5 operator *(Matrix8x5 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+
+            return new Matrix3x5(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35);
+        }
+        public static Matrix4x5 operator *(Matrix8x5 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+
+            return new Matrix4x5(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45);
+        }
+        public static Matrix5x5 operator *(Matrix8x5 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+
+            return new Matrix5x5(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55);
+        }
+        public static Matrix6x5 operator *(Matrix8x5 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+
+            return new Matrix6x5(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65);
+        }
+        public static Matrix7x5 operator *(Matrix8x5 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+
+            return new Matrix7x5(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75);
+        }
+        public static Matrix8x5 operator *(Matrix8x5 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87 + matrix1.M83 * matrix2.M88;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87 + matrix1.M84 * matrix2.M88;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87 + matrix1.M85 * matrix2.M88;
+
+            return new Matrix8x5(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x6.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x6.cs
@@ -1,0 +1,949 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x6: IEquatable<Matrix8x6>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 6;
+
+        static Matrix8x6()
+        {
+            Zero = new Matrix8x6(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x6 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x6 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x6 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m83">The column 8, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m84">The column 8, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m85">The column 8, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m76">The column 7, row 6 value</param>
+        /// <param name="m86">The column 8, row 6 value</param>
+        public Matrix8x6(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, double m83, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, double m84, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, double m85, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, double m76, double m86)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; M83 = m83; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; M84 = m84; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; M85 = m85; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; M76 = m76; M86 = m86; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x6 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x6(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = M83 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = M84 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = M85 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = M76 = M86 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M83;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M84;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M85;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M76;
+		public double M86;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x6* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x6.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x6.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 1
+        /// </summary>
+        public Matrix1x6 Column1 { get { return new Matrix1x6(M11, M12, M13, M14, M15, M16); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 2
+        /// </summary>
+        public Matrix1x6 Column2 { get { return new Matrix1x6(M21, M22, M23, M24, M25, M26); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 3
+        /// </summary>
+        public Matrix1x6 Column3 { get { return new Matrix1x6(M31, M32, M33, M34, M35, M36); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 4
+        /// </summary>
+        public Matrix1x6 Column4 { get { return new Matrix1x6(M41, M42, M43, M44, M45, M46); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 5
+        /// </summary>
+        public Matrix1x6 Column5 { get { return new Matrix1x6(M51, M52, M53, M54, M55, M56); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 6
+        /// </summary>
+        public Matrix1x6 Column6 { get { return new Matrix1x6(M61, M62, M63, M64, M65, M66); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 7
+        /// </summary>
+        public Matrix1x6 Column7 { get { return new Matrix1x6(M71, M72, M73, M74, M75, M76); } }
+        /// <summary>
+        /// Gets a new Matrix1x6 containing the values of column 8
+        /// </summary>
+        public Matrix1x6 Column8 { get { return new Matrix1x6(M81, M82, M83, M84, M85, M86); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 3
+        /// </summary>
+        public Matrix8x1 Row3 { get { return new Matrix8x1(M13, M23, M33, M43, M53, M63, M73, M83); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 4
+        /// </summary>
+        public Matrix8x1 Row4 { get { return new Matrix8x1(M14, M24, M34, M44, M54, M64, M74, M84); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 5
+        /// </summary>
+        public Matrix8x1 Row5 { get { return new Matrix8x1(M15, M25, M35, M45, M55, M65, M75, M85); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 6
+        /// </summary>
+        public Matrix8x1 Row6 { get { return new Matrix8x1(M16, M26, M36, M46, M56, M66, M76, M86); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x6)
+                return this == (Matrix8x6)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x6 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x6* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39])
+                         + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47])
+                         + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]) + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x6: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|{30}|{31}|}}"
+                               + "{{|{32}|{33}|{34}|{35}|{36}|{37}|{38}|{39}|}}"
+                               + "{{|{40}|{41}|{42}|{43}|{44}|{45}|{46}|{47}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82
+                               , M13, M23, M33, M43, M53, M63, M73, M83
+                               , M14, M24, M34, M44, M54, M64, M74, M84
+                               , M15, M25, M35, M45, M55, M65, M75, M85
+                               , M16, M26, M36, M46, M56, M66, M76, M86); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix6x8 Transpose()
+        {
+            return new Matrix6x8(M11, M12, M13, M14, M15, M16, 
+                                 M21, M22, M23, M24, M25, M26, 
+                                 M31, M32, M33, M34, M35, M36, 
+                                 M41, M42, M43, M44, M45, M46, 
+                                 M51, M52, M53, M54, M55, M56, 
+                                 M61, M62, M63, M64, M65, M66, 
+                                 M71, M72, M73, M74, M75, M76, 
+                                 M81, M82, M83, M84, M85, M86);
+        }
+
+        public static bool operator ==(Matrix8x6 matrix1, Matrix8x6 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M83 - matrix2.M83) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M84 - matrix2.M84) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M85 - matrix2.M85) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M76 - matrix2.M76) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M86 - matrix2.M86) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x6 matrix1, Matrix8x6 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M83 - matrix2.M83) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M84 - matrix2.M84) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M85 - matrix2.M85) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M76 - matrix2.M76) > Double.Epsilon
+                || Math.Abs(matrix1.M86 - matrix2.M86) > Double.Epsilon;
+        }
+
+        public static Matrix8x6 operator +(Matrix8x6 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m83 = matrix1.M83 + matrix2.M83;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m84 = matrix1.M84 + matrix2.M84;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m85 = matrix1.M85 + matrix2.M85;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m76 = matrix1.M76 + matrix2.M76;
+            double m86 = matrix1.M86 + matrix2.M86;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+
+        public static Matrix8x6 operator -(Matrix8x6 matrix1, Matrix8x6 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m83 = matrix1.M83 - matrix2.M83;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m84 = matrix1.M84 - matrix2.M84;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m85 = matrix1.M85 - matrix2.M85;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m76 = matrix1.M76 - matrix2.M76;
+            double m86 = matrix1.M86 - matrix2.M86;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+
+        public static Matrix8x6 operator *(Matrix8x6 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m83 = matrix.M83 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m84 = matrix.M84 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m85 = matrix.M85 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m76 = matrix.M76 * scalar;
+            double m86 = matrix.M86 * scalar;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+
+        public static Matrix8x6 operator *(double scalar, Matrix8x6 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m83 = scalar * matrix.M83;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m84 = scalar * matrix.M84;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m85 = scalar * matrix.M85;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m76 = scalar * matrix.M76;
+            double m86 = scalar * matrix.M86;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+
+        public static Matrix1x6 operator *(Matrix8x6 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+
+            return new Matrix1x6(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16);
+        }
+        public static Matrix2x6 operator *(Matrix8x6 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+
+            return new Matrix2x6(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26);
+        }
+        public static Matrix3x6 operator *(Matrix8x6 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+
+            return new Matrix3x6(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36);
+        }
+        public static Matrix4x6 operator *(Matrix8x6 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+
+            return new Matrix4x6(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46);
+        }
+        public static Matrix5x6 operator *(Matrix8x6 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+
+            return new Matrix5x6(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56);
+        }
+        public static Matrix6x6 operator *(Matrix8x6 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+
+            return new Matrix6x6(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66);
+        }
+        public static Matrix7x6 operator *(Matrix8x6 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77 + matrix1.M86 * matrix2.M78;
+
+            return new Matrix7x6(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76);
+        }
+        public static Matrix8x6 operator *(Matrix8x6 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87 + matrix1.M83 * matrix2.M88;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87 + matrix1.M84 * matrix2.M88;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87 + matrix1.M85 * matrix2.M88;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77 + matrix1.M86 * matrix2.M78;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86 + matrix1.M76 * matrix2.M87 + matrix1.M86 * matrix2.M88;
+
+            return new Matrix8x6(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x7.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x7.cs
@@ -1,0 +1,1071 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x7: IEquatable<Matrix8x7>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 7;
+
+        static Matrix8x7()
+        {
+            Zero = new Matrix8x7(0);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x7 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x7 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix8x7 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m83">The column 8, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m84">The column 8, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m85">The column 8, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m76">The column 7, row 6 value</param>
+        /// <param name="m86">The column 8, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m67">The column 6, row 7 value</param>
+        /// <param name="m77">The column 7, row 7 value</param>
+        /// <param name="m87">The column 8, row 7 value</param>
+        public Matrix8x7(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, double m83, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, double m84, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, double m85, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, double m76, double m86, 
+                         double m17, double m27, double m37, double m47, double m57, double m67, double m77, double m87)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; M83 = m83; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; M84 = m84; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; M85 = m85; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; M76 = m76; M86 = m86; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; M67 = m67; M77 = m77; M87 = m87; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x7 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x7(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = M83 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = M84 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = M85 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = M76 = M86 = 
+			M17 = M27 = M37 = M47 = M57 = M67 = M77 = M87 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M83;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M84;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M85;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M76;
+		public double M86;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M67;
+		public double M77;
+		public double M87;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x7* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x7.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x7.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 1
+        /// </summary>
+        public Matrix1x7 Column1 { get { return new Matrix1x7(M11, M12, M13, M14, M15, M16, M17); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 2
+        /// </summary>
+        public Matrix1x7 Column2 { get { return new Matrix1x7(M21, M22, M23, M24, M25, M26, M27); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 3
+        /// </summary>
+        public Matrix1x7 Column3 { get { return new Matrix1x7(M31, M32, M33, M34, M35, M36, M37); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 4
+        /// </summary>
+        public Matrix1x7 Column4 { get { return new Matrix1x7(M41, M42, M43, M44, M45, M46, M47); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 5
+        /// </summary>
+        public Matrix1x7 Column5 { get { return new Matrix1x7(M51, M52, M53, M54, M55, M56, M57); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 6
+        /// </summary>
+        public Matrix1x7 Column6 { get { return new Matrix1x7(M61, M62, M63, M64, M65, M66, M67); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 7
+        /// </summary>
+        public Matrix1x7 Column7 { get { return new Matrix1x7(M71, M72, M73, M74, M75, M76, M77); } }
+        /// <summary>
+        /// Gets a new Matrix1x7 containing the values of column 8
+        /// </summary>
+        public Matrix1x7 Column8 { get { return new Matrix1x7(M81, M82, M83, M84, M85, M86, M87); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 3
+        /// </summary>
+        public Matrix8x1 Row3 { get { return new Matrix8x1(M13, M23, M33, M43, M53, M63, M73, M83); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 4
+        /// </summary>
+        public Matrix8x1 Row4 { get { return new Matrix8x1(M14, M24, M34, M44, M54, M64, M74, M84); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 5
+        /// </summary>
+        public Matrix8x1 Row5 { get { return new Matrix8x1(M15, M25, M35, M45, M55, M65, M75, M85); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 6
+        /// </summary>
+        public Matrix8x1 Row6 { get { return new Matrix8x1(M16, M26, M36, M46, M56, M66, M76, M86); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 7
+        /// </summary>
+        public Matrix8x1 Row7 { get { return new Matrix8x1(M17, M27, M37, M47, M57, M67, M77, M87); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x7)
+                return this == (Matrix8x7)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x7 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x7* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39])
+                         + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47])
+                         + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]) + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55])
+                         + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55]) + (x[56] ^ x[57]) + (x[58] ^ x[59]) + (x[60] ^ x[61]) + (x[62] ^ x[63]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x7: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|{30}|{31}|}}"
+                               + "{{|{32}|{33}|{34}|{35}|{36}|{37}|{38}|{39}|}}"
+                               + "{{|{40}|{41}|{42}|{43}|{44}|{45}|{46}|{47}|}}"
+                               + "{{|{48}|{49}|{50}|{51}|{52}|{53}|{54}|{55}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82
+                               , M13, M23, M33, M43, M53, M63, M73, M83
+                               , M14, M24, M34, M44, M54, M64, M74, M84
+                               , M15, M25, M35, M45, M55, M65, M75, M85
+                               , M16, M26, M36, M46, M56, M66, M76, M86
+                               , M17, M27, M37, M47, M57, M67, M77, M87); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix7x8 Transpose()
+        {
+            return new Matrix7x8(M11, M12, M13, M14, M15, M16, M17, 
+                                 M21, M22, M23, M24, M25, M26, M27, 
+                                 M31, M32, M33, M34, M35, M36, M37, 
+                                 M41, M42, M43, M44, M45, M46, M47, 
+                                 M51, M52, M53, M54, M55, M56, M57, 
+                                 M61, M62, M63, M64, M65, M66, M67, 
+                                 M71, M72, M73, M74, M75, M76, M77, 
+                                 M81, M82, M83, M84, M85, M86, M87);
+        }
+
+        public static bool operator ==(Matrix8x7 matrix1, Matrix8x7 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M83 - matrix2.M83) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M84 - matrix2.M84) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M85 - matrix2.M85) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M76 - matrix2.M76) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M86 - matrix2.M86) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M67 - matrix2.M67) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M77 - matrix2.M77) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M87 - matrix2.M87) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x7 matrix1, Matrix8x7 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M83 - matrix2.M83) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M84 - matrix2.M84) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M85 - matrix2.M85) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M76 - matrix2.M76) > Double.Epsilon
+                || Math.Abs(matrix1.M86 - matrix2.M86) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M67 - matrix2.M67) > Double.Epsilon
+                || Math.Abs(matrix1.M77 - matrix2.M77) > Double.Epsilon
+                || Math.Abs(matrix1.M87 - matrix2.M87) > Double.Epsilon;
+        }
+
+        public static Matrix8x7 operator +(Matrix8x7 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m83 = matrix1.M83 + matrix2.M83;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m84 = matrix1.M84 + matrix2.M84;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m85 = matrix1.M85 + matrix2.M85;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m76 = matrix1.M76 + matrix2.M76;
+            double m86 = matrix1.M86 + matrix2.M86;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m67 = matrix1.M67 + matrix2.M67;
+            double m77 = matrix1.M77 + matrix2.M77;
+            double m87 = matrix1.M87 + matrix2.M87;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+
+        public static Matrix8x7 operator -(Matrix8x7 matrix1, Matrix8x7 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m83 = matrix1.M83 - matrix2.M83;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m84 = matrix1.M84 - matrix2.M84;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m85 = matrix1.M85 - matrix2.M85;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m76 = matrix1.M76 - matrix2.M76;
+            double m86 = matrix1.M86 - matrix2.M86;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m67 = matrix1.M67 - matrix2.M67;
+            double m77 = matrix1.M77 - matrix2.M77;
+            double m87 = matrix1.M87 - matrix2.M87;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+
+        public static Matrix8x7 operator *(Matrix8x7 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m83 = matrix.M83 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m84 = matrix.M84 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m85 = matrix.M85 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m76 = matrix.M76 * scalar;
+            double m86 = matrix.M86 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m67 = matrix.M67 * scalar;
+            double m77 = matrix.M77 * scalar;
+            double m87 = matrix.M87 * scalar;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+
+        public static Matrix8x7 operator *(double scalar, Matrix8x7 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m83 = scalar * matrix.M83;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m84 = scalar * matrix.M84;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m85 = scalar * matrix.M85;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m76 = scalar * matrix.M76;
+            double m86 = scalar * matrix.M86;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m67 = scalar * matrix.M67;
+            double m77 = scalar * matrix.M77;
+            double m87 = scalar * matrix.M87;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+
+        public static Matrix1x7 operator *(Matrix8x7 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+
+            return new Matrix1x7(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17);
+        }
+        public static Matrix2x7 operator *(Matrix8x7 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+
+            return new Matrix2x7(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27);
+        }
+        public static Matrix3x7 operator *(Matrix8x7 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+
+            return new Matrix3x7(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37);
+        }
+        public static Matrix4x7 operator *(Matrix8x7 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+
+            return new Matrix4x7(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47);
+        }
+        public static Matrix5x7 operator *(Matrix8x7 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+
+            return new Matrix5x7(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57);
+        }
+        public static Matrix6x7 operator *(Matrix8x7 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67 + matrix1.M87 * matrix2.M68;
+
+            return new Matrix6x7(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67);
+        }
+        public static Matrix7x7 operator *(Matrix8x7 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77 + matrix1.M86 * matrix2.M78;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67 + matrix1.M87 * matrix2.M68;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77 + matrix1.M87 * matrix2.M78;
+
+            return new Matrix7x7(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77);
+        }
+        public static Matrix8x7 operator *(Matrix8x7 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87 + matrix1.M83 * matrix2.M88;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87 + matrix1.M84 * matrix2.M88;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87 + matrix1.M85 * matrix2.M88;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77 + matrix1.M86 * matrix2.M78;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86 + matrix1.M76 * matrix2.M87 + matrix1.M86 * matrix2.M88;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67 + matrix1.M87 * matrix2.M68;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77 + matrix1.M87 * matrix2.M78;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85 + matrix1.M67 * matrix2.M86 + matrix1.M77 * matrix2.M87 + matrix1.M87 * matrix2.M88;
+
+            return new Matrix8x7(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x8.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix8x8.cs
@@ -1,0 +1,1206 @@
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix8x8: IEquatable<Matrix8x8>, IMatrix
+    {
+        public const int ColumnCount = 8;
+        public const int RowCount = 8;
+
+        static Matrix8x8()
+        {
+            Zero = new Matrix8x8(0);
+			Identitiy = new Matrix8x8(1, 0, 0, 0, 0, 0, 0, 0, 
+                                      0, 1, 0, 0, 0, 0, 0, 0, 
+                                      0, 0, 1, 0, 0, 0, 0, 0, 
+                                      0, 0, 0, 1, 0, 0, 0, 0, 
+                                      0, 0, 0, 0, 1, 0, 0, 0, 
+                                      0, 0, 0, 0, 0, 1, 0, 0, 
+                                      0, 0, 0, 0, 0, 0, 1, 0, 
+                                      0, 0, 0, 0, 0, 0, 0, 1);
+        }
+
+        /// <summary>
+        /// Constant Matrix8x8 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix8x8 Zero;
+        
+        /// <summary>
+        /// Constant Matrix8x8 with value intialized to the identity of a 8 x 8 matrix
+        /// </summary>
+        public static readonly Matrix8x8 Identitiy;
+
+        /// <summary>
+        /// Initializes a Matrix8x8 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m51">The column 5, row 1 value</param>
+        /// <param name="m61">The column 6, row 1 value</param>
+        /// <param name="m71">The column 7, row 1 value</param>
+        /// <param name="m81">The column 8, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m52">The column 5, row 2 value</param>
+        /// <param name="m62">The column 6, row 2 value</param>
+        /// <param name="m72">The column 7, row 2 value</param>
+        /// <param name="m82">The column 8, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m53">The column 5, row 3 value</param>
+        /// <param name="m63">The column 6, row 3 value</param>
+        /// <param name="m73">The column 7, row 3 value</param>
+        /// <param name="m83">The column 8, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        /// <param name="m54">The column 5, row 4 value</param>
+        /// <param name="m64">The column 6, row 4 value</param>
+        /// <param name="m74">The column 7, row 4 value</param>
+        /// <param name="m84">The column 8, row 4 value</param>
+        /// <param name="m15">The column 1, row 5 value</param>
+        /// <param name="m25">The column 2, row 5 value</param>
+        /// <param name="m35">The column 3, row 5 value</param>
+        /// <param name="m45">The column 4, row 5 value</param>
+        /// <param name="m55">The column 5, row 5 value</param>
+        /// <param name="m65">The column 6, row 5 value</param>
+        /// <param name="m75">The column 7, row 5 value</param>
+        /// <param name="m85">The column 8, row 5 value</param>
+        /// <param name="m16">The column 1, row 6 value</param>
+        /// <param name="m26">The column 2, row 6 value</param>
+        /// <param name="m36">The column 3, row 6 value</param>
+        /// <param name="m46">The column 4, row 6 value</param>
+        /// <param name="m56">The column 5, row 6 value</param>
+        /// <param name="m66">The column 6, row 6 value</param>
+        /// <param name="m76">The column 7, row 6 value</param>
+        /// <param name="m86">The column 8, row 6 value</param>
+        /// <param name="m17">The column 1, row 7 value</param>
+        /// <param name="m27">The column 2, row 7 value</param>
+        /// <param name="m37">The column 3, row 7 value</param>
+        /// <param name="m47">The column 4, row 7 value</param>
+        /// <param name="m57">The column 5, row 7 value</param>
+        /// <param name="m67">The column 6, row 7 value</param>
+        /// <param name="m77">The column 7, row 7 value</param>
+        /// <param name="m87">The column 8, row 7 value</param>
+        /// <param name="m18">The column 1, row 8 value</param>
+        /// <param name="m28">The column 2, row 8 value</param>
+        /// <param name="m38">The column 3, row 8 value</param>
+        /// <param name="m48">The column 4, row 8 value</param>
+        /// <param name="m58">The column 5, row 8 value</param>
+        /// <param name="m68">The column 6, row 8 value</param>
+        /// <param name="m78">The column 7, row 8 value</param>
+        /// <param name="m88">The column 8, row 8 value</param>
+        public Matrix8x8(double m11, double m21, double m31, double m41, double m51, double m61, double m71, double m81, 
+                         double m12, double m22, double m32, double m42, double m52, double m62, double m72, double m82, 
+                         double m13, double m23, double m33, double m43, double m53, double m63, double m73, double m83, 
+                         double m14, double m24, double m34, double m44, double m54, double m64, double m74, double m84, 
+                         double m15, double m25, double m35, double m45, double m55, double m65, double m75, double m85, 
+                         double m16, double m26, double m36, double m46, double m56, double m66, double m76, double m86, 
+                         double m17, double m27, double m37, double m47, double m57, double m67, double m77, double m87, 
+                         double m18, double m28, double m38, double m48, double m58, double m68, double m78, double m88)
+        {
+			M11 = m11; M21 = m21; M31 = m31; M41 = m41; M51 = m51; M61 = m61; M71 = m71; M81 = m81; 
+			M12 = m12; M22 = m22; M32 = m32; M42 = m42; M52 = m52; M62 = m62; M72 = m72; M82 = m82; 
+			M13 = m13; M23 = m23; M33 = m33; M43 = m43; M53 = m53; M63 = m63; M73 = m73; M83 = m83; 
+			M14 = m14; M24 = m24; M34 = m34; M44 = m44; M54 = m54; M64 = m64; M74 = m74; M84 = m84; 
+			M15 = m15; M25 = m25; M35 = m35; M45 = m45; M55 = m55; M65 = m65; M75 = m75; M85 = m85; 
+			M16 = m16; M26 = m26; M36 = m36; M46 = m46; M56 = m56; M66 = m66; M76 = m76; M86 = m86; 
+			M17 = m17; M27 = m27; M37 = m37; M47 = m47; M57 = m57; M67 = m67; M77 = m77; M87 = m87; 
+			M18 = m18; M28 = m28; M38 = m38; M48 = m48; M58 = m58; M68 = m68; M78 = m78; M88 = m88; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix8x8 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix8x8(double value)
+        {
+			M11 = M21 = M31 = M41 = M51 = M61 = M71 = M81 = 
+			M12 = M22 = M32 = M42 = M52 = M62 = M72 = M82 = 
+			M13 = M23 = M33 = M43 = M53 = M63 = M73 = M83 = 
+			M14 = M24 = M34 = M44 = M54 = M64 = M74 = M84 = 
+			M15 = M25 = M35 = M45 = M55 = M65 = M75 = M85 = 
+			M16 = M26 = M36 = M46 = M56 = M66 = M76 = M86 = 
+			M17 = M27 = M37 = M47 = M57 = M67 = M77 = M87 = 
+			M18 = M28 = M38 = M48 = M58 = M68 = M78 = M88 = value;
+        }
+
+		public double M11;
+		public double M21;
+		public double M31;
+		public double M41;
+		public double M51;
+		public double M61;
+		public double M71;
+		public double M81;
+		public double M12;
+		public double M22;
+		public double M32;
+		public double M42;
+		public double M52;
+		public double M62;
+		public double M72;
+		public double M82;
+		public double M13;
+		public double M23;
+		public double M33;
+		public double M43;
+		public double M53;
+		public double M63;
+		public double M73;
+		public double M83;
+		public double M14;
+		public double M24;
+		public double M34;
+		public double M44;
+		public double M54;
+		public double M64;
+		public double M74;
+		public double M84;
+		public double M15;
+		public double M25;
+		public double M35;
+		public double M45;
+		public double M55;
+		public double M65;
+		public double M75;
+		public double M85;
+		public double M16;
+		public double M26;
+		public double M36;
+		public double M46;
+		public double M56;
+		public double M66;
+		public double M76;
+		public double M86;
+		public double M17;
+		public double M27;
+		public double M37;
+		public double M47;
+		public double M57;
+		public double M67;
+		public double M77;
+		public double M87;
+		public double M18;
+		public double M28;
+		public double M38;
+		public double M48;
+		public double M58;
+		public double M68;
+		public double M78;
+		public double M88;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (Matrix8x8* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return Matrix8x8.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return Matrix8x8.RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 1
+        /// </summary>
+        public Matrix1x8 Column1 { get { return new Matrix1x8(M11, M12, M13, M14, M15, M16, M17, M18); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 2
+        /// </summary>
+        public Matrix1x8 Column2 { get { return new Matrix1x8(M21, M22, M23, M24, M25, M26, M27, M28); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 3
+        /// </summary>
+        public Matrix1x8 Column3 { get { return new Matrix1x8(M31, M32, M33, M34, M35, M36, M37, M38); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 4
+        /// </summary>
+        public Matrix1x8 Column4 { get { return new Matrix1x8(M41, M42, M43, M44, M45, M46, M47, M48); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 5
+        /// </summary>
+        public Matrix1x8 Column5 { get { return new Matrix1x8(M51, M52, M53, M54, M55, M56, M57, M58); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 6
+        /// </summary>
+        public Matrix1x8 Column6 { get { return new Matrix1x8(M61, M62, M63, M64, M65, M66, M67, M68); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 7
+        /// </summary>
+        public Matrix1x8 Column7 { get { return new Matrix1x8(M71, M72, M73, M74, M75, M76, M77, M78); } }
+        /// <summary>
+        /// Gets a new Matrix1x8 containing the values of column 8
+        /// </summary>
+        public Matrix1x8 Column8 { get { return new Matrix1x8(M81, M82, M83, M84, M85, M86, M87, M88); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 1
+        /// </summary>
+        public Matrix8x1 Row1 { get { return new Matrix8x1(M11, M21, M31, M41, M51, M61, M71, M81); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 2
+        /// </summary>
+        public Matrix8x1 Row2 { get { return new Matrix8x1(M12, M22, M32, M42, M52, M62, M72, M82); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 3
+        /// </summary>
+        public Matrix8x1 Row3 { get { return new Matrix8x1(M13, M23, M33, M43, M53, M63, M73, M83); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 4
+        /// </summary>
+        public Matrix8x1 Row4 { get { return new Matrix8x1(M14, M24, M34, M44, M54, M64, M74, M84); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 5
+        /// </summary>
+        public Matrix8x1 Row5 { get { return new Matrix8x1(M15, M25, M35, M45, M55, M65, M75, M85); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 6
+        /// </summary>
+        public Matrix8x1 Row6 { get { return new Matrix8x1(M16, M26, M36, M46, M56, M66, M76, M86); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 7
+        /// </summary>
+        public Matrix8x1 Row7 { get { return new Matrix8x1(M17, M27, M37, M47, M57, M67, M77, M87); } }
+        /// <summary>
+        /// Gets a new Matrix8x1 containing the values of column 8
+        /// </summary>
+        public Matrix8x1 Row8 { get { return new Matrix8x1(M18, M28, M38, M48, M58, M68, M78, M88); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix8x8)
+                return this == (Matrix8x8)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix8x8 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix8x8* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return (x[00] ^ x[01]) + (x[02] ^ x[03]) + (x[04] ^ x[05]) + (x[06] ^ x[07]) + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15])
+                         + (x[08] ^ x[09]) + (x[10] ^ x[11]) + (x[12] ^ x[13]) + (x[14] ^ x[15]) + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23])
+                         + (x[16] ^ x[17]) + (x[18] ^ x[19]) + (x[20] ^ x[21]) + (x[22] ^ x[23]) + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31])
+                         + (x[24] ^ x[25]) + (x[26] ^ x[27]) + (x[28] ^ x[29]) + (x[30] ^ x[31]) + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39])
+                         + (x[32] ^ x[33]) + (x[34] ^ x[35]) + (x[36] ^ x[37]) + (x[38] ^ x[39]) + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47])
+                         + (x[40] ^ x[41]) + (x[42] ^ x[43]) + (x[44] ^ x[45]) + (x[46] ^ x[47]) + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55])
+                         + (x[48] ^ x[49]) + (x[50] ^ x[51]) + (x[52] ^ x[53]) + (x[54] ^ x[55]) + (x[56] ^ x[57]) + (x[58] ^ x[59]) + (x[60] ^ x[61]) + (x[62] ^ x[63])
+                         + (x[56] ^ x[57]) + (x[58] ^ x[59]) + (x[60] ^ x[61]) + (x[62] ^ x[63]) + (x[64] ^ x[65]) + (x[66] ^ x[67]) + (x[68] ^ x[69]) + (x[70] ^ x[71]);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("Matrix8x8: "
+                               + "{{|{00}|{01}|{02}|{03}|{04}|{05}|{06}|{07}|}}"
+                               + "{{|{08}|{09}|{10}|{11}|{12}|{13}|{14}|{15}|}}"
+                               + "{{|{16}|{17}|{18}|{19}|{20}|{21}|{22}|{23}|}}"
+                               + "{{|{24}|{25}|{26}|{27}|{28}|{29}|{30}|{31}|}}"
+                               + "{{|{32}|{33}|{34}|{35}|{36}|{37}|{38}|{39}|}}"
+                               + "{{|{40}|{41}|{42}|{43}|{44}|{45}|{46}|{47}|}}"
+                               + "{{|{48}|{49}|{50}|{51}|{52}|{53}|{54}|{55}|}}"
+                               + "{{|{56}|{57}|{58}|{59}|{60}|{61}|{62}|{63}|}}"
+                               , M11, M21, M31, M41, M51, M61, M71, M81
+                               , M12, M22, M32, M42, M52, M62, M72, M82
+                               , M13, M23, M33, M43, M53, M63, M73, M83
+                               , M14, M24, M34, M44, M54, M64, M74, M84
+                               , M15, M25, M35, M45, M55, M65, M75, M85
+                               , M16, M26, M36, M46, M56, M66, M76, M86
+                               , M17, M27, M37, M47, M57, M67, M77, M87
+                               , M18, M28, M38, M48, M58, M68, M78, M88); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix8x8 Transpose()
+        {
+            return new Matrix8x8(M11, M12, M13, M14, M15, M16, M17, M18, 
+                                 M21, M22, M23, M24, M25, M26, M27, M28, 
+                                 M31, M32, M33, M34, M35, M36, M37, M38, 
+                                 M41, M42, M43, M44, M45, M46, M47, M48, 
+                                 M51, M52, M53, M54, M55, M56, M57, M58, 
+                                 M61, M62, M63, M64, M65, M66, M67, M68, 
+                                 M71, M72, M73, M74, M75, M76, M77, M78, 
+                                 M81, M82, M83, M84, M85, M86, M87, M88);
+        }
+
+        public static bool operator ==(Matrix8x8 matrix1, Matrix8x8 matrix2)
+        {
+            return (matrix1 == matrix2 || Math.Abs(matrix1.M11 - matrix2.M11) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M21 - matrix2.M21) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M31 - matrix2.M31) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M41 - matrix2.M41) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M51 - matrix2.M51) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M61 - matrix2.M61) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M71 - matrix2.M71) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M81 - matrix2.M81) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M12 - matrix2.M12) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M22 - matrix2.M22) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M32 - matrix2.M32) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M42 - matrix2.M42) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M52 - matrix2.M52) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M62 - matrix2.M62) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M72 - matrix2.M72) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M82 - matrix2.M82) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M13 - matrix2.M13) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M23 - matrix2.M23) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M33 - matrix2.M33) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M43 - matrix2.M43) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M53 - matrix2.M53) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M63 - matrix2.M63) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M73 - matrix2.M73) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M83 - matrix2.M83) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M14 - matrix2.M14) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M24 - matrix2.M24) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M34 - matrix2.M34) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M44 - matrix2.M44) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M54 - matrix2.M54) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M64 - matrix2.M64) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M74 - matrix2.M74) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M84 - matrix2.M84) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M15 - matrix2.M15) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M25 - matrix2.M25) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M35 - matrix2.M35) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M45 - matrix2.M45) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M55 - matrix2.M55) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M65 - matrix2.M65) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M75 - matrix2.M75) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M85 - matrix2.M85) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M16 - matrix2.M16) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M26 - matrix2.M26) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M36 - matrix2.M36) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M46 - matrix2.M46) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M56 - matrix2.M56) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M66 - matrix2.M66) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M76 - matrix2.M76) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M86 - matrix2.M86) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M17 - matrix2.M17) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M27 - matrix2.M27) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M37 - matrix2.M37) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M47 - matrix2.M47) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M57 - matrix2.M57) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M67 - matrix2.M67) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M77 - matrix2.M77) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M87 - matrix2.M87) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M18 - matrix2.M18) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M28 - matrix2.M28) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M38 - matrix2.M38) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M48 - matrix2.M48) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M58 - matrix2.M58) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M68 - matrix2.M68) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M78 - matrix2.M78) <= Double.Epsilon)
+                && (matrix1 == matrix2 || Math.Abs(matrix1.M88 - matrix2.M88) <= Double.Epsilon);
+        }
+
+        public static bool operator !=(Matrix8x8 matrix1, Matrix8x8 matrix2)
+        {
+            return Math.Abs(matrix1.M11 - matrix2.M11) > Double.Epsilon
+                || Math.Abs(matrix1.M21 - matrix2.M21) > Double.Epsilon
+                || Math.Abs(matrix1.M31 - matrix2.M31) > Double.Epsilon
+                || Math.Abs(matrix1.M41 - matrix2.M41) > Double.Epsilon
+                || Math.Abs(matrix1.M51 - matrix2.M51) > Double.Epsilon
+                || Math.Abs(matrix1.M61 - matrix2.M61) > Double.Epsilon
+                || Math.Abs(matrix1.M71 - matrix2.M71) > Double.Epsilon
+                || Math.Abs(matrix1.M81 - matrix2.M81) > Double.Epsilon
+                || Math.Abs(matrix1.M12 - matrix2.M12) > Double.Epsilon
+                || Math.Abs(matrix1.M22 - matrix2.M22) > Double.Epsilon
+                || Math.Abs(matrix1.M32 - matrix2.M32) > Double.Epsilon
+                || Math.Abs(matrix1.M42 - matrix2.M42) > Double.Epsilon
+                || Math.Abs(matrix1.M52 - matrix2.M52) > Double.Epsilon
+                || Math.Abs(matrix1.M62 - matrix2.M62) > Double.Epsilon
+                || Math.Abs(matrix1.M72 - matrix2.M72) > Double.Epsilon
+                || Math.Abs(matrix1.M82 - matrix2.M82) > Double.Epsilon
+                || Math.Abs(matrix1.M13 - matrix2.M13) > Double.Epsilon
+                || Math.Abs(matrix1.M23 - matrix2.M23) > Double.Epsilon
+                || Math.Abs(matrix1.M33 - matrix2.M33) > Double.Epsilon
+                || Math.Abs(matrix1.M43 - matrix2.M43) > Double.Epsilon
+                || Math.Abs(matrix1.M53 - matrix2.M53) > Double.Epsilon
+                || Math.Abs(matrix1.M63 - matrix2.M63) > Double.Epsilon
+                || Math.Abs(matrix1.M73 - matrix2.M73) > Double.Epsilon
+                || Math.Abs(matrix1.M83 - matrix2.M83) > Double.Epsilon
+                || Math.Abs(matrix1.M14 - matrix2.M14) > Double.Epsilon
+                || Math.Abs(matrix1.M24 - matrix2.M24) > Double.Epsilon
+                || Math.Abs(matrix1.M34 - matrix2.M34) > Double.Epsilon
+                || Math.Abs(matrix1.M44 - matrix2.M44) > Double.Epsilon
+                || Math.Abs(matrix1.M54 - matrix2.M54) > Double.Epsilon
+                || Math.Abs(matrix1.M64 - matrix2.M64) > Double.Epsilon
+                || Math.Abs(matrix1.M74 - matrix2.M74) > Double.Epsilon
+                || Math.Abs(matrix1.M84 - matrix2.M84) > Double.Epsilon
+                || Math.Abs(matrix1.M15 - matrix2.M15) > Double.Epsilon
+                || Math.Abs(matrix1.M25 - matrix2.M25) > Double.Epsilon
+                || Math.Abs(matrix1.M35 - matrix2.M35) > Double.Epsilon
+                || Math.Abs(matrix1.M45 - matrix2.M45) > Double.Epsilon
+                || Math.Abs(matrix1.M55 - matrix2.M55) > Double.Epsilon
+                || Math.Abs(matrix1.M65 - matrix2.M65) > Double.Epsilon
+                || Math.Abs(matrix1.M75 - matrix2.M75) > Double.Epsilon
+                || Math.Abs(matrix1.M85 - matrix2.M85) > Double.Epsilon
+                || Math.Abs(matrix1.M16 - matrix2.M16) > Double.Epsilon
+                || Math.Abs(matrix1.M26 - matrix2.M26) > Double.Epsilon
+                || Math.Abs(matrix1.M36 - matrix2.M36) > Double.Epsilon
+                || Math.Abs(matrix1.M46 - matrix2.M46) > Double.Epsilon
+                || Math.Abs(matrix1.M56 - matrix2.M56) > Double.Epsilon
+                || Math.Abs(matrix1.M66 - matrix2.M66) > Double.Epsilon
+                || Math.Abs(matrix1.M76 - matrix2.M76) > Double.Epsilon
+                || Math.Abs(matrix1.M86 - matrix2.M86) > Double.Epsilon
+                || Math.Abs(matrix1.M17 - matrix2.M17) > Double.Epsilon
+                || Math.Abs(matrix1.M27 - matrix2.M27) > Double.Epsilon
+                || Math.Abs(matrix1.M37 - matrix2.M37) > Double.Epsilon
+                || Math.Abs(matrix1.M47 - matrix2.M47) > Double.Epsilon
+                || Math.Abs(matrix1.M57 - matrix2.M57) > Double.Epsilon
+                || Math.Abs(matrix1.M67 - matrix2.M67) > Double.Epsilon
+                || Math.Abs(matrix1.M77 - matrix2.M77) > Double.Epsilon
+                || Math.Abs(matrix1.M87 - matrix2.M87) > Double.Epsilon
+                || Math.Abs(matrix1.M18 - matrix2.M18) > Double.Epsilon
+                || Math.Abs(matrix1.M28 - matrix2.M28) > Double.Epsilon
+                || Math.Abs(matrix1.M38 - matrix2.M38) > Double.Epsilon
+                || Math.Abs(matrix1.M48 - matrix2.M48) > Double.Epsilon
+                || Math.Abs(matrix1.M58 - matrix2.M58) > Double.Epsilon
+                || Math.Abs(matrix1.M68 - matrix2.M68) > Double.Epsilon
+                || Math.Abs(matrix1.M78 - matrix2.M78) > Double.Epsilon
+                || Math.Abs(matrix1.M88 - matrix2.M88) > Double.Epsilon;
+        }
+
+        public static Matrix8x8 operator +(Matrix8x8 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m51 = matrix1.M51 + matrix2.M51;
+            double m61 = matrix1.M61 + matrix2.M61;
+            double m71 = matrix1.M71 + matrix2.M71;
+            double m81 = matrix1.M81 + matrix2.M81;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m52 = matrix1.M52 + matrix2.M52;
+            double m62 = matrix1.M62 + matrix2.M62;
+            double m72 = matrix1.M72 + matrix2.M72;
+            double m82 = matrix1.M82 + matrix2.M82;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m53 = matrix1.M53 + matrix2.M53;
+            double m63 = matrix1.M63 + matrix2.M63;
+            double m73 = matrix1.M73 + matrix2.M73;
+            double m83 = matrix1.M83 + matrix2.M83;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+            double m54 = matrix1.M54 + matrix2.M54;
+            double m64 = matrix1.M64 + matrix2.M64;
+            double m74 = matrix1.M74 + matrix2.M74;
+            double m84 = matrix1.M84 + matrix2.M84;
+            double m15 = matrix1.M15 + matrix2.M15;
+            double m25 = matrix1.M25 + matrix2.M25;
+            double m35 = matrix1.M35 + matrix2.M35;
+            double m45 = matrix1.M45 + matrix2.M45;
+            double m55 = matrix1.M55 + matrix2.M55;
+            double m65 = matrix1.M65 + matrix2.M65;
+            double m75 = matrix1.M75 + matrix2.M75;
+            double m85 = matrix1.M85 + matrix2.M85;
+            double m16 = matrix1.M16 + matrix2.M16;
+            double m26 = matrix1.M26 + matrix2.M26;
+            double m36 = matrix1.M36 + matrix2.M36;
+            double m46 = matrix1.M46 + matrix2.M46;
+            double m56 = matrix1.M56 + matrix2.M56;
+            double m66 = matrix1.M66 + matrix2.M66;
+            double m76 = matrix1.M76 + matrix2.M76;
+            double m86 = matrix1.M86 + matrix2.M86;
+            double m17 = matrix1.M17 + matrix2.M17;
+            double m27 = matrix1.M27 + matrix2.M27;
+            double m37 = matrix1.M37 + matrix2.M37;
+            double m47 = matrix1.M47 + matrix2.M47;
+            double m57 = matrix1.M57 + matrix2.M57;
+            double m67 = matrix1.M67 + matrix2.M67;
+            double m77 = matrix1.M77 + matrix2.M77;
+            double m87 = matrix1.M87 + matrix2.M87;
+            double m18 = matrix1.M18 + matrix2.M18;
+            double m28 = matrix1.M28 + matrix2.M28;
+            double m38 = matrix1.M38 + matrix2.M38;
+            double m48 = matrix1.M48 + matrix2.M48;
+            double m58 = matrix1.M58 + matrix2.M58;
+            double m68 = matrix1.M68 + matrix2.M68;
+            double m78 = matrix1.M78 + matrix2.M78;
+            double m88 = matrix1.M88 + matrix2.M88;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+
+        public static Matrix8x8 operator -(Matrix8x8 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m51 = matrix1.M51 - matrix2.M51;
+            double m61 = matrix1.M61 - matrix2.M61;
+            double m71 = matrix1.M71 - matrix2.M71;
+            double m81 = matrix1.M81 - matrix2.M81;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m52 = matrix1.M52 - matrix2.M52;
+            double m62 = matrix1.M62 - matrix2.M62;
+            double m72 = matrix1.M72 - matrix2.M72;
+            double m82 = matrix1.M82 - matrix2.M82;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m53 = matrix1.M53 - matrix2.M53;
+            double m63 = matrix1.M63 - matrix2.M63;
+            double m73 = matrix1.M73 - matrix2.M73;
+            double m83 = matrix1.M83 - matrix2.M83;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+            double m54 = matrix1.M54 - matrix2.M54;
+            double m64 = matrix1.M64 - matrix2.M64;
+            double m74 = matrix1.M74 - matrix2.M74;
+            double m84 = matrix1.M84 - matrix2.M84;
+            double m15 = matrix1.M15 - matrix2.M15;
+            double m25 = matrix1.M25 - matrix2.M25;
+            double m35 = matrix1.M35 - matrix2.M35;
+            double m45 = matrix1.M45 - matrix2.M45;
+            double m55 = matrix1.M55 - matrix2.M55;
+            double m65 = matrix1.M65 - matrix2.M65;
+            double m75 = matrix1.M75 - matrix2.M75;
+            double m85 = matrix1.M85 - matrix2.M85;
+            double m16 = matrix1.M16 - matrix2.M16;
+            double m26 = matrix1.M26 - matrix2.M26;
+            double m36 = matrix1.M36 - matrix2.M36;
+            double m46 = matrix1.M46 - matrix2.M46;
+            double m56 = matrix1.M56 - matrix2.M56;
+            double m66 = matrix1.M66 - matrix2.M66;
+            double m76 = matrix1.M76 - matrix2.M76;
+            double m86 = matrix1.M86 - matrix2.M86;
+            double m17 = matrix1.M17 - matrix2.M17;
+            double m27 = matrix1.M27 - matrix2.M27;
+            double m37 = matrix1.M37 - matrix2.M37;
+            double m47 = matrix1.M47 - matrix2.M47;
+            double m57 = matrix1.M57 - matrix2.M57;
+            double m67 = matrix1.M67 - matrix2.M67;
+            double m77 = matrix1.M77 - matrix2.M77;
+            double m87 = matrix1.M87 - matrix2.M87;
+            double m18 = matrix1.M18 - matrix2.M18;
+            double m28 = matrix1.M28 - matrix2.M28;
+            double m38 = matrix1.M38 - matrix2.M38;
+            double m48 = matrix1.M48 - matrix2.M48;
+            double m58 = matrix1.M58 - matrix2.M58;
+            double m68 = matrix1.M68 - matrix2.M68;
+            double m78 = matrix1.M78 - matrix2.M78;
+            double m88 = matrix1.M88 - matrix2.M88;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+
+        public static Matrix8x8 operator *(Matrix8x8 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m51 = matrix.M51 * scalar;
+            double m61 = matrix.M61 * scalar;
+            double m71 = matrix.M71 * scalar;
+            double m81 = matrix.M81 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m52 = matrix.M52 * scalar;
+            double m62 = matrix.M62 * scalar;
+            double m72 = matrix.M72 * scalar;
+            double m82 = matrix.M82 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m53 = matrix.M53 * scalar;
+            double m63 = matrix.M63 * scalar;
+            double m73 = matrix.M73 * scalar;
+            double m83 = matrix.M83 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+            double m54 = matrix.M54 * scalar;
+            double m64 = matrix.M64 * scalar;
+            double m74 = matrix.M74 * scalar;
+            double m84 = matrix.M84 * scalar;
+            double m15 = matrix.M15 * scalar;
+            double m25 = matrix.M25 * scalar;
+            double m35 = matrix.M35 * scalar;
+            double m45 = matrix.M45 * scalar;
+            double m55 = matrix.M55 * scalar;
+            double m65 = matrix.M65 * scalar;
+            double m75 = matrix.M75 * scalar;
+            double m85 = matrix.M85 * scalar;
+            double m16 = matrix.M16 * scalar;
+            double m26 = matrix.M26 * scalar;
+            double m36 = matrix.M36 * scalar;
+            double m46 = matrix.M46 * scalar;
+            double m56 = matrix.M56 * scalar;
+            double m66 = matrix.M66 * scalar;
+            double m76 = matrix.M76 * scalar;
+            double m86 = matrix.M86 * scalar;
+            double m17 = matrix.M17 * scalar;
+            double m27 = matrix.M27 * scalar;
+            double m37 = matrix.M37 * scalar;
+            double m47 = matrix.M47 * scalar;
+            double m57 = matrix.M57 * scalar;
+            double m67 = matrix.M67 * scalar;
+            double m77 = matrix.M77 * scalar;
+            double m87 = matrix.M87 * scalar;
+            double m18 = matrix.M18 * scalar;
+            double m28 = matrix.M28 * scalar;
+            double m38 = matrix.M38 * scalar;
+            double m48 = matrix.M48 * scalar;
+            double m58 = matrix.M58 * scalar;
+            double m68 = matrix.M68 * scalar;
+            double m78 = matrix.M78 * scalar;
+            double m88 = matrix.M88 * scalar;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+
+        public static Matrix8x8 operator *(double scalar, Matrix8x8 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m51 = scalar * matrix.M51;
+            double m61 = scalar * matrix.M61;
+            double m71 = scalar * matrix.M71;
+            double m81 = scalar * matrix.M81;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m52 = scalar * matrix.M52;
+            double m62 = scalar * matrix.M62;
+            double m72 = scalar * matrix.M72;
+            double m82 = scalar * matrix.M82;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m53 = scalar * matrix.M53;
+            double m63 = scalar * matrix.M63;
+            double m73 = scalar * matrix.M73;
+            double m83 = scalar * matrix.M83;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+            double m54 = scalar * matrix.M54;
+            double m64 = scalar * matrix.M64;
+            double m74 = scalar * matrix.M74;
+            double m84 = scalar * matrix.M84;
+            double m15 = scalar * matrix.M15;
+            double m25 = scalar * matrix.M25;
+            double m35 = scalar * matrix.M35;
+            double m45 = scalar * matrix.M45;
+            double m55 = scalar * matrix.M55;
+            double m65 = scalar * matrix.M65;
+            double m75 = scalar * matrix.M75;
+            double m85 = scalar * matrix.M85;
+            double m16 = scalar * matrix.M16;
+            double m26 = scalar * matrix.M26;
+            double m36 = scalar * matrix.M36;
+            double m46 = scalar * matrix.M46;
+            double m56 = scalar * matrix.M56;
+            double m66 = scalar * matrix.M66;
+            double m76 = scalar * matrix.M76;
+            double m86 = scalar * matrix.M86;
+            double m17 = scalar * matrix.M17;
+            double m27 = scalar * matrix.M27;
+            double m37 = scalar * matrix.M37;
+            double m47 = scalar * matrix.M47;
+            double m57 = scalar * matrix.M57;
+            double m67 = scalar * matrix.M67;
+            double m77 = scalar * matrix.M77;
+            double m87 = scalar * matrix.M87;
+            double m18 = scalar * matrix.M18;
+            double m28 = scalar * matrix.M28;
+            double m38 = scalar * matrix.M38;
+            double m48 = scalar * matrix.M48;
+            double m58 = scalar * matrix.M58;
+            double m68 = scalar * matrix.M68;
+            double m78 = scalar * matrix.M78;
+            double m88 = scalar * matrix.M88;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+
+        public static Matrix1x8 operator *(Matrix8x8 matrix1, Matrix1x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+
+            return new Matrix1x8(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14, 
+                                 m15, 
+                                 m16, 
+                                 m17, 
+                                 m18);
+        }
+        public static Matrix2x8 operator *(Matrix8x8 matrix1, Matrix2x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+
+            return new Matrix2x8(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24, 
+                                 m15, m25, 
+                                 m16, m26, 
+                                 m17, m27, 
+                                 m18, m28);
+        }
+        public static Matrix3x8 operator *(Matrix8x8 matrix1, Matrix3x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37 + matrix1.M88 * matrix2.M38;
+
+            return new Matrix3x8(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34, 
+                                 m15, m25, m35, 
+                                 m16, m26, m36, 
+                                 m17, m27, m37, 
+                                 m18, m28, m38);
+        }
+        public static Matrix4x8 operator *(Matrix8x8 matrix1, Matrix4x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37 + matrix1.M88 * matrix2.M38;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47 + matrix1.M88 * matrix2.M48;
+
+            return new Matrix4x8(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44, 
+                                 m15, m25, m35, m45, 
+                                 m16, m26, m36, m46, 
+                                 m17, m27, m37, m47, 
+                                 m18, m28, m38, m48);
+        }
+        public static Matrix5x8 operator *(Matrix8x8 matrix1, Matrix5x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37 + matrix1.M88 * matrix2.M38;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47 + matrix1.M88 * matrix2.M48;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57 + matrix1.M88 * matrix2.M58;
+
+            return new Matrix5x8(m11, m21, m31, m41, m51, 
+                                 m12, m22, m32, m42, m52, 
+                                 m13, m23, m33, m43, m53, 
+                                 m14, m24, m34, m44, m54, 
+                                 m15, m25, m35, m45, m55, 
+                                 m16, m26, m36, m46, m56, 
+                                 m17, m27, m37, m47, m57, 
+                                 m18, m28, m38, m48, m58);
+        }
+        public static Matrix6x8 operator *(Matrix8x8 matrix1, Matrix6x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67 + matrix1.M87 * matrix2.M68;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37 + matrix1.M88 * matrix2.M38;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47 + matrix1.M88 * matrix2.M48;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57 + matrix1.M88 * matrix2.M58;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66 + matrix1.M78 * matrix2.M67 + matrix1.M88 * matrix2.M68;
+
+            return new Matrix6x8(m11, m21, m31, m41, m51, m61, 
+                                 m12, m22, m32, m42, m52, m62, 
+                                 m13, m23, m33, m43, m53, m63, 
+                                 m14, m24, m34, m44, m54, m64, 
+                                 m15, m25, m35, m45, m55, m65, 
+                                 m16, m26, m36, m46, m56, m66, 
+                                 m17, m27, m37, m47, m57, m67, 
+                                 m18, m28, m38, m48, m58, m68);
+        }
+        public static Matrix7x8 operator *(Matrix8x8 matrix1, Matrix7x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77 + matrix1.M86 * matrix2.M78;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67 + matrix1.M87 * matrix2.M68;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77 + matrix1.M87 * matrix2.M78;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37 + matrix1.M88 * matrix2.M38;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47 + matrix1.M88 * matrix2.M48;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57 + matrix1.M88 * matrix2.M58;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66 + matrix1.M78 * matrix2.M67 + matrix1.M88 * matrix2.M68;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75 + matrix1.M68 * matrix2.M76 + matrix1.M78 * matrix2.M77 + matrix1.M88 * matrix2.M78;
+
+            return new Matrix7x8(m11, m21, m31, m41, m51, m61, m71, 
+                                 m12, m22, m32, m42, m52, m62, m72, 
+                                 m13, m23, m33, m43, m53, m63, m73, 
+                                 m14, m24, m34, m44, m54, m64, m74, 
+                                 m15, m25, m35, m45, m55, m65, m75, 
+                                 m16, m26, m36, m46, m56, m66, m76, 
+                                 m17, m27, m37, m47, m57, m67, m77, 
+                                 m18, m28, m38, m48, m58, m68, m78);
+        }
+        public static Matrix8x8 operator *(Matrix8x8 matrix1, Matrix8x8 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14 + matrix1.M51 * matrix2.M15 + matrix1.M61 * matrix2.M16 + matrix1.M71 * matrix2.M17 + matrix1.M81 * matrix2.M18;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24 + matrix1.M51 * matrix2.M25 + matrix1.M61 * matrix2.M26 + matrix1.M71 * matrix2.M27 + matrix1.M81 * matrix2.M28;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34 + matrix1.M51 * matrix2.M35 + matrix1.M61 * matrix2.M36 + matrix1.M71 * matrix2.M37 + matrix1.M81 * matrix2.M38;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44 + matrix1.M51 * matrix2.M45 + matrix1.M61 * matrix2.M46 + matrix1.M71 * matrix2.M47 + matrix1.M81 * matrix2.M48;
+            double m51 = matrix1.M11 * matrix2.M51 + matrix1.M21 * matrix2.M52 + matrix1.M31 * matrix2.M53 + matrix1.M41 * matrix2.M54 + matrix1.M51 * matrix2.M55 + matrix1.M61 * matrix2.M56 + matrix1.M71 * matrix2.M57 + matrix1.M81 * matrix2.M58;
+            double m61 = matrix1.M11 * matrix2.M61 + matrix1.M21 * matrix2.M62 + matrix1.M31 * matrix2.M63 + matrix1.M41 * matrix2.M64 + matrix1.M51 * matrix2.M65 + matrix1.M61 * matrix2.M66 + matrix1.M71 * matrix2.M67 + matrix1.M81 * matrix2.M68;
+            double m71 = matrix1.M11 * matrix2.M71 + matrix1.M21 * matrix2.M72 + matrix1.M31 * matrix2.M73 + matrix1.M41 * matrix2.M74 + matrix1.M51 * matrix2.M75 + matrix1.M61 * matrix2.M76 + matrix1.M71 * matrix2.M77 + matrix1.M81 * matrix2.M78;
+            double m81 = matrix1.M11 * matrix2.M81 + matrix1.M21 * matrix2.M82 + matrix1.M31 * matrix2.M83 + matrix1.M41 * matrix2.M84 + matrix1.M51 * matrix2.M85 + matrix1.M61 * matrix2.M86 + matrix1.M71 * matrix2.M87 + matrix1.M81 * matrix2.M88;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14 + matrix1.M52 * matrix2.M15 + matrix1.M62 * matrix2.M16 + matrix1.M72 * matrix2.M17 + matrix1.M82 * matrix2.M18;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24 + matrix1.M52 * matrix2.M25 + matrix1.M62 * matrix2.M26 + matrix1.M72 * matrix2.M27 + matrix1.M82 * matrix2.M28;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34 + matrix1.M52 * matrix2.M35 + matrix1.M62 * matrix2.M36 + matrix1.M72 * matrix2.M37 + matrix1.M82 * matrix2.M38;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44 + matrix1.M52 * matrix2.M45 + matrix1.M62 * matrix2.M46 + matrix1.M72 * matrix2.M47 + matrix1.M82 * matrix2.M48;
+            double m52 = matrix1.M12 * matrix2.M51 + matrix1.M22 * matrix2.M52 + matrix1.M32 * matrix2.M53 + matrix1.M42 * matrix2.M54 + matrix1.M52 * matrix2.M55 + matrix1.M62 * matrix2.M56 + matrix1.M72 * matrix2.M57 + matrix1.M82 * matrix2.M58;
+            double m62 = matrix1.M12 * matrix2.M61 + matrix1.M22 * matrix2.M62 + matrix1.M32 * matrix2.M63 + matrix1.M42 * matrix2.M64 + matrix1.M52 * matrix2.M65 + matrix1.M62 * matrix2.M66 + matrix1.M72 * matrix2.M67 + matrix1.M82 * matrix2.M68;
+            double m72 = matrix1.M12 * matrix2.M71 + matrix1.M22 * matrix2.M72 + matrix1.M32 * matrix2.M73 + matrix1.M42 * matrix2.M74 + matrix1.M52 * matrix2.M75 + matrix1.M62 * matrix2.M76 + matrix1.M72 * matrix2.M77 + matrix1.M82 * matrix2.M78;
+            double m82 = matrix1.M12 * matrix2.M81 + matrix1.M22 * matrix2.M82 + matrix1.M32 * matrix2.M83 + matrix1.M42 * matrix2.M84 + matrix1.M52 * matrix2.M85 + matrix1.M62 * matrix2.M86 + matrix1.M72 * matrix2.M87 + matrix1.M82 * matrix2.M88;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14 + matrix1.M53 * matrix2.M15 + matrix1.M63 * matrix2.M16 + matrix1.M73 * matrix2.M17 + matrix1.M83 * matrix2.M18;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24 + matrix1.M53 * matrix2.M25 + matrix1.M63 * matrix2.M26 + matrix1.M73 * matrix2.M27 + matrix1.M83 * matrix2.M28;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34 + matrix1.M53 * matrix2.M35 + matrix1.M63 * matrix2.M36 + matrix1.M73 * matrix2.M37 + matrix1.M83 * matrix2.M38;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44 + matrix1.M53 * matrix2.M45 + matrix1.M63 * matrix2.M46 + matrix1.M73 * matrix2.M47 + matrix1.M83 * matrix2.M48;
+            double m53 = matrix1.M13 * matrix2.M51 + matrix1.M23 * matrix2.M52 + matrix1.M33 * matrix2.M53 + matrix1.M43 * matrix2.M54 + matrix1.M53 * matrix2.M55 + matrix1.M63 * matrix2.M56 + matrix1.M73 * matrix2.M57 + matrix1.M83 * matrix2.M58;
+            double m63 = matrix1.M13 * matrix2.M61 + matrix1.M23 * matrix2.M62 + matrix1.M33 * matrix2.M63 + matrix1.M43 * matrix2.M64 + matrix1.M53 * matrix2.M65 + matrix1.M63 * matrix2.M66 + matrix1.M73 * matrix2.M67 + matrix1.M83 * matrix2.M68;
+            double m73 = matrix1.M13 * matrix2.M71 + matrix1.M23 * matrix2.M72 + matrix1.M33 * matrix2.M73 + matrix1.M43 * matrix2.M74 + matrix1.M53 * matrix2.M75 + matrix1.M63 * matrix2.M76 + matrix1.M73 * matrix2.M77 + matrix1.M83 * matrix2.M78;
+            double m83 = matrix1.M13 * matrix2.M81 + matrix1.M23 * matrix2.M82 + matrix1.M33 * matrix2.M83 + matrix1.M43 * matrix2.M84 + matrix1.M53 * matrix2.M85 + matrix1.M63 * matrix2.M86 + matrix1.M73 * matrix2.M87 + matrix1.M83 * matrix2.M88;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14 + matrix1.M54 * matrix2.M15 + matrix1.M64 * matrix2.M16 + matrix1.M74 * matrix2.M17 + matrix1.M84 * matrix2.M18;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24 + matrix1.M54 * matrix2.M25 + matrix1.M64 * matrix2.M26 + matrix1.M74 * matrix2.M27 + matrix1.M84 * matrix2.M28;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34 + matrix1.M54 * matrix2.M35 + matrix1.M64 * matrix2.M36 + matrix1.M74 * matrix2.M37 + matrix1.M84 * matrix2.M38;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44 + matrix1.M54 * matrix2.M45 + matrix1.M64 * matrix2.M46 + matrix1.M74 * matrix2.M47 + matrix1.M84 * matrix2.M48;
+            double m54 = matrix1.M14 * matrix2.M51 + matrix1.M24 * matrix2.M52 + matrix1.M34 * matrix2.M53 + matrix1.M44 * matrix2.M54 + matrix1.M54 * matrix2.M55 + matrix1.M64 * matrix2.M56 + matrix1.M74 * matrix2.M57 + matrix1.M84 * matrix2.M58;
+            double m64 = matrix1.M14 * matrix2.M61 + matrix1.M24 * matrix2.M62 + matrix1.M34 * matrix2.M63 + matrix1.M44 * matrix2.M64 + matrix1.M54 * matrix2.M65 + matrix1.M64 * matrix2.M66 + matrix1.M74 * matrix2.M67 + matrix1.M84 * matrix2.M68;
+            double m74 = matrix1.M14 * matrix2.M71 + matrix1.M24 * matrix2.M72 + matrix1.M34 * matrix2.M73 + matrix1.M44 * matrix2.M74 + matrix1.M54 * matrix2.M75 + matrix1.M64 * matrix2.M76 + matrix1.M74 * matrix2.M77 + matrix1.M84 * matrix2.M78;
+            double m84 = matrix1.M14 * matrix2.M81 + matrix1.M24 * matrix2.M82 + matrix1.M34 * matrix2.M83 + matrix1.M44 * matrix2.M84 + matrix1.M54 * matrix2.M85 + matrix1.M64 * matrix2.M86 + matrix1.M74 * matrix2.M87 + matrix1.M84 * matrix2.M88;
+            double m15 = matrix1.M15 * matrix2.M11 + matrix1.M25 * matrix2.M12 + matrix1.M35 * matrix2.M13 + matrix1.M45 * matrix2.M14 + matrix1.M55 * matrix2.M15 + matrix1.M65 * matrix2.M16 + matrix1.M75 * matrix2.M17 + matrix1.M85 * matrix2.M18;
+            double m25 = matrix1.M15 * matrix2.M21 + matrix1.M25 * matrix2.M22 + matrix1.M35 * matrix2.M23 + matrix1.M45 * matrix2.M24 + matrix1.M55 * matrix2.M25 + matrix1.M65 * matrix2.M26 + matrix1.M75 * matrix2.M27 + matrix1.M85 * matrix2.M28;
+            double m35 = matrix1.M15 * matrix2.M31 + matrix1.M25 * matrix2.M32 + matrix1.M35 * matrix2.M33 + matrix1.M45 * matrix2.M34 + matrix1.M55 * matrix2.M35 + matrix1.M65 * matrix2.M36 + matrix1.M75 * matrix2.M37 + matrix1.M85 * matrix2.M38;
+            double m45 = matrix1.M15 * matrix2.M41 + matrix1.M25 * matrix2.M42 + matrix1.M35 * matrix2.M43 + matrix1.M45 * matrix2.M44 + matrix1.M55 * matrix2.M45 + matrix1.M65 * matrix2.M46 + matrix1.M75 * matrix2.M47 + matrix1.M85 * matrix2.M48;
+            double m55 = matrix1.M15 * matrix2.M51 + matrix1.M25 * matrix2.M52 + matrix1.M35 * matrix2.M53 + matrix1.M45 * matrix2.M54 + matrix1.M55 * matrix2.M55 + matrix1.M65 * matrix2.M56 + matrix1.M75 * matrix2.M57 + matrix1.M85 * matrix2.M58;
+            double m65 = matrix1.M15 * matrix2.M61 + matrix1.M25 * matrix2.M62 + matrix1.M35 * matrix2.M63 + matrix1.M45 * matrix2.M64 + matrix1.M55 * matrix2.M65 + matrix1.M65 * matrix2.M66 + matrix1.M75 * matrix2.M67 + matrix1.M85 * matrix2.M68;
+            double m75 = matrix1.M15 * matrix2.M71 + matrix1.M25 * matrix2.M72 + matrix1.M35 * matrix2.M73 + matrix1.M45 * matrix2.M74 + matrix1.M55 * matrix2.M75 + matrix1.M65 * matrix2.M76 + matrix1.M75 * matrix2.M77 + matrix1.M85 * matrix2.M78;
+            double m85 = matrix1.M15 * matrix2.M81 + matrix1.M25 * matrix2.M82 + matrix1.M35 * matrix2.M83 + matrix1.M45 * matrix2.M84 + matrix1.M55 * matrix2.M85 + matrix1.M65 * matrix2.M86 + matrix1.M75 * matrix2.M87 + matrix1.M85 * matrix2.M88;
+            double m16 = matrix1.M16 * matrix2.M11 + matrix1.M26 * matrix2.M12 + matrix1.M36 * matrix2.M13 + matrix1.M46 * matrix2.M14 + matrix1.M56 * matrix2.M15 + matrix1.M66 * matrix2.M16 + matrix1.M76 * matrix2.M17 + matrix1.M86 * matrix2.M18;
+            double m26 = matrix1.M16 * matrix2.M21 + matrix1.M26 * matrix2.M22 + matrix1.M36 * matrix2.M23 + matrix1.M46 * matrix2.M24 + matrix1.M56 * matrix2.M25 + matrix1.M66 * matrix2.M26 + matrix1.M76 * matrix2.M27 + matrix1.M86 * matrix2.M28;
+            double m36 = matrix1.M16 * matrix2.M31 + matrix1.M26 * matrix2.M32 + matrix1.M36 * matrix2.M33 + matrix1.M46 * matrix2.M34 + matrix1.M56 * matrix2.M35 + matrix1.M66 * matrix2.M36 + matrix1.M76 * matrix2.M37 + matrix1.M86 * matrix2.M38;
+            double m46 = matrix1.M16 * matrix2.M41 + matrix1.M26 * matrix2.M42 + matrix1.M36 * matrix2.M43 + matrix1.M46 * matrix2.M44 + matrix1.M56 * matrix2.M45 + matrix1.M66 * matrix2.M46 + matrix1.M76 * matrix2.M47 + matrix1.M86 * matrix2.M48;
+            double m56 = matrix1.M16 * matrix2.M51 + matrix1.M26 * matrix2.M52 + matrix1.M36 * matrix2.M53 + matrix1.M46 * matrix2.M54 + matrix1.M56 * matrix2.M55 + matrix1.M66 * matrix2.M56 + matrix1.M76 * matrix2.M57 + matrix1.M86 * matrix2.M58;
+            double m66 = matrix1.M16 * matrix2.M61 + matrix1.M26 * matrix2.M62 + matrix1.M36 * matrix2.M63 + matrix1.M46 * matrix2.M64 + matrix1.M56 * matrix2.M65 + matrix1.M66 * matrix2.M66 + matrix1.M76 * matrix2.M67 + matrix1.M86 * matrix2.M68;
+            double m76 = matrix1.M16 * matrix2.M71 + matrix1.M26 * matrix2.M72 + matrix1.M36 * matrix2.M73 + matrix1.M46 * matrix2.M74 + matrix1.M56 * matrix2.M75 + matrix1.M66 * matrix2.M76 + matrix1.M76 * matrix2.M77 + matrix1.M86 * matrix2.M78;
+            double m86 = matrix1.M16 * matrix2.M81 + matrix1.M26 * matrix2.M82 + matrix1.M36 * matrix2.M83 + matrix1.M46 * matrix2.M84 + matrix1.M56 * matrix2.M85 + matrix1.M66 * matrix2.M86 + matrix1.M76 * matrix2.M87 + matrix1.M86 * matrix2.M88;
+            double m17 = matrix1.M17 * matrix2.M11 + matrix1.M27 * matrix2.M12 + matrix1.M37 * matrix2.M13 + matrix1.M47 * matrix2.M14 + matrix1.M57 * matrix2.M15 + matrix1.M67 * matrix2.M16 + matrix1.M77 * matrix2.M17 + matrix1.M87 * matrix2.M18;
+            double m27 = matrix1.M17 * matrix2.M21 + matrix1.M27 * matrix2.M22 + matrix1.M37 * matrix2.M23 + matrix1.M47 * matrix2.M24 + matrix1.M57 * matrix2.M25 + matrix1.M67 * matrix2.M26 + matrix1.M77 * matrix2.M27 + matrix1.M87 * matrix2.M28;
+            double m37 = matrix1.M17 * matrix2.M31 + matrix1.M27 * matrix2.M32 + matrix1.M37 * matrix2.M33 + matrix1.M47 * matrix2.M34 + matrix1.M57 * matrix2.M35 + matrix1.M67 * matrix2.M36 + matrix1.M77 * matrix2.M37 + matrix1.M87 * matrix2.M38;
+            double m47 = matrix1.M17 * matrix2.M41 + matrix1.M27 * matrix2.M42 + matrix1.M37 * matrix2.M43 + matrix1.M47 * matrix2.M44 + matrix1.M57 * matrix2.M45 + matrix1.M67 * matrix2.M46 + matrix1.M77 * matrix2.M47 + matrix1.M87 * matrix2.M48;
+            double m57 = matrix1.M17 * matrix2.M51 + matrix1.M27 * matrix2.M52 + matrix1.M37 * matrix2.M53 + matrix1.M47 * matrix2.M54 + matrix1.M57 * matrix2.M55 + matrix1.M67 * matrix2.M56 + matrix1.M77 * matrix2.M57 + matrix1.M87 * matrix2.M58;
+            double m67 = matrix1.M17 * matrix2.M61 + matrix1.M27 * matrix2.M62 + matrix1.M37 * matrix2.M63 + matrix1.M47 * matrix2.M64 + matrix1.M57 * matrix2.M65 + matrix1.M67 * matrix2.M66 + matrix1.M77 * matrix2.M67 + matrix1.M87 * matrix2.M68;
+            double m77 = matrix1.M17 * matrix2.M71 + matrix1.M27 * matrix2.M72 + matrix1.M37 * matrix2.M73 + matrix1.M47 * matrix2.M74 + matrix1.M57 * matrix2.M75 + matrix1.M67 * matrix2.M76 + matrix1.M77 * matrix2.M77 + matrix1.M87 * matrix2.M78;
+            double m87 = matrix1.M17 * matrix2.M81 + matrix1.M27 * matrix2.M82 + matrix1.M37 * matrix2.M83 + matrix1.M47 * matrix2.M84 + matrix1.M57 * matrix2.M85 + matrix1.M67 * matrix2.M86 + matrix1.M77 * matrix2.M87 + matrix1.M87 * matrix2.M88;
+            double m18 = matrix1.M18 * matrix2.M11 + matrix1.M28 * matrix2.M12 + matrix1.M38 * matrix2.M13 + matrix1.M48 * matrix2.M14 + matrix1.M58 * matrix2.M15 + matrix1.M68 * matrix2.M16 + matrix1.M78 * matrix2.M17 + matrix1.M88 * matrix2.M18;
+            double m28 = matrix1.M18 * matrix2.M21 + matrix1.M28 * matrix2.M22 + matrix1.M38 * matrix2.M23 + matrix1.M48 * matrix2.M24 + matrix1.M58 * matrix2.M25 + matrix1.M68 * matrix2.M26 + matrix1.M78 * matrix2.M27 + matrix1.M88 * matrix2.M28;
+            double m38 = matrix1.M18 * matrix2.M31 + matrix1.M28 * matrix2.M32 + matrix1.M38 * matrix2.M33 + matrix1.M48 * matrix2.M34 + matrix1.M58 * matrix2.M35 + matrix1.M68 * matrix2.M36 + matrix1.M78 * matrix2.M37 + matrix1.M88 * matrix2.M38;
+            double m48 = matrix1.M18 * matrix2.M41 + matrix1.M28 * matrix2.M42 + matrix1.M38 * matrix2.M43 + matrix1.M48 * matrix2.M44 + matrix1.M58 * matrix2.M45 + matrix1.M68 * matrix2.M46 + matrix1.M78 * matrix2.M47 + matrix1.M88 * matrix2.M48;
+            double m58 = matrix1.M18 * matrix2.M51 + matrix1.M28 * matrix2.M52 + matrix1.M38 * matrix2.M53 + matrix1.M48 * matrix2.M54 + matrix1.M58 * matrix2.M55 + matrix1.M68 * matrix2.M56 + matrix1.M78 * matrix2.M57 + matrix1.M88 * matrix2.M58;
+            double m68 = matrix1.M18 * matrix2.M61 + matrix1.M28 * matrix2.M62 + matrix1.M38 * matrix2.M63 + matrix1.M48 * matrix2.M64 + matrix1.M58 * matrix2.M65 + matrix1.M68 * matrix2.M66 + matrix1.M78 * matrix2.M67 + matrix1.M88 * matrix2.M68;
+            double m78 = matrix1.M18 * matrix2.M71 + matrix1.M28 * matrix2.M72 + matrix1.M38 * matrix2.M73 + matrix1.M48 * matrix2.M74 + matrix1.M58 * matrix2.M75 + matrix1.M68 * matrix2.M76 + matrix1.M78 * matrix2.M77 + matrix1.M88 * matrix2.M78;
+            double m88 = matrix1.M18 * matrix2.M81 + matrix1.M28 * matrix2.M82 + matrix1.M38 * matrix2.M83 + matrix1.M48 * matrix2.M84 + matrix1.M58 * matrix2.M85 + matrix1.M68 * matrix2.M86 + matrix1.M78 * matrix2.M87 + matrix1.M88 * matrix2.M88;
+
+            return new Matrix8x8(m11, m21, m31, m41, m51, m61, m71, m81, 
+                                 m12, m22, m32, m42, m52, m62, m72, m82, 
+                                 m13, m23, m33, m43, m53, m63, m73, m83, 
+                                 m14, m24, m34, m44, m54, m64, m74, m84, 
+                                 m15, m25, m35, m45, m55, m65, m75, m85, 
+                                 m16, m26, m36, m46, m56, m66, m76, m86, 
+                                 m17, m27, m37, m47, m57, m67, m77, m87, 
+                                 m18, m28, m38, m48, m58, m68, m78, m88);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/MatrixTemplate.tt
+++ b/src/System.Numerics.Matrices/src/System/Numerics/MatrixTemplate.tt
@@ -1,0 +1,642 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Text" #>
+<#@ output extension=".txt" #>
+<#
+    const int MinColCount = 1;
+    const int MaxColCount = 8;
+    const int MinRowCount = 1;
+    const int MaxRowCount = 8;
+
+    for (int rowCount = MinRowCount; rowCount <= MaxRowCount; rowCount ++)
+    {
+        for (int colCount = MinColCount; colCount <= MaxColCount; colCount++)
+        {
+            if (rowCount == MinRowCount && colCount == MinColCount)
+                continue;
+
+            string structName = String.Format("Matrix{0}x{1}", colCount, rowCount);
+            string outputFileName = structName + ".cs";
+#>
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct <#= structName #>: IEquatable<<#= structName #>>, IMatrix
+    {
+        public const int ColumnCount = <#= colCount #>;
+        public const int RowCount = <#= rowCount #>;
+
+        static <#= structName #>()
+        {
+            Zero = new <#= structName #>(0);
+<#
+            if (rowCount == colCount)
+            {
+#>			Identitiy = new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == y)
+                    {
+                        #>1<#
+                    }
+                    else 
+                    {
+                        #>0<#
+                    }
+
+                    if (x + 1 < colCount || y + 1 < rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (y + 1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                                      <#
+                }
+            }
+#>);
+<#
+            }
+#>
+        }
+
+        /// <summary>
+        /// Constant <#= structName #> with all values initialized to zero
+        /// </summary>
+        public static readonly <#= structName #> Zero;
+<#
+            if (rowCount == colCount)
+            {
+#>        
+        /// <summary>
+        /// Constant <#= structName #> with value intialized to the identity of a <#= colCount #> x <#= rowCount #> matrix
+        /// </summary>
+        public static readonly <#= structName #> Identitiy;
+<#
+            }
+#>
+
+        /// <summary>
+        /// Initializes a <#= structName #> with all of it values specifically set
+        /// </summary>
+<#
+        for (int y = 0; y < rowCount; y++)
+        {
+            for (int x = 0; x < colCount; x++)
+            {
+                #>        /// <param name="m<#= x + 1 #><#= y + 1 #>">The column <#= x + 1 #>, row <#= y + 1 #> value</param><#
+                #><#= Environment.NewLine #><#
+            }
+        }
+#>
+        public <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("double m{0}{1}", x + 1, y + 1) #><#
+
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (y + 1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                         <#
+                }
+            }
+#>)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+#>			<#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("M{0}{1} = m{0}{1}; ", x + 1, y + 1) #><#
+                }
+                #><#= Environment.NewLine #><#
+            }
+#>
+        }
+
+        /// <summary>
+        /// Initialized a <#= structName #> with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public <#= structName #>(double value)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+#>			<#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("M{0}{1} = ", x + 1, y + 1) #><#
+
+                    if (x + 1 == colCount && y + 1 == rowCount)
+                    {
+                        #>value;<#
+                    }
+                }
+                #><#= Environment.NewLine #><#
+            }
+#>
+        }
+
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>		<#
+                    #><#= String.Format("public double M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (<#= structName #>* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException("col");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException("col");
+
+                fixed (<#= structName #>* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return <#= structName #>.ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return <#= structName #>.RowCount; } }
+
+<#
+        if (rowCount > 1 && colCount > 1)
+        {
+            for (int x = 0; x < colCount; x++)
+            {
+                string retType = String.Format("Matrix1x{0}", rowCount);
+#>
+        /// <summary>
+        /// Gets a new <#= retType #> containing the values of column <#= x + 1 #>
+        /// </summary>
+        public <#= retType #> Column<#= x + 1 #> { get { return new <#= retType #>(<#
+                for (int y = 0; y < rowCount; y++)
+                {
+                    #><#= String.Format("M{0}{1}", x + 1, y + 1) #><#
+
+                    if (y + 1 < rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+                #>); } }
+<#
+            }
+
+            for (int y = 0; y < rowCount; y++)
+            {
+                string retType = String.Format("Matrix{0}x1", colCount);
+#>
+        /// <summary>
+        /// Gets a new <#= retType #> containing the values of column <#= y + 1 #>
+        /// </summary>
+        public <#= retType #> Row<#= y + 1 #> { get { return new <#= retType #>(<#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("M{0}{1}", x + 1, y + 1) #><#
+
+                    if (x + 1 < colCount)
+                    {
+                        #>, <#
+                    }
+                }
+                #>); } }
+<#
+            }
+        }
+#>
+
+        public override bool Equals(object obj)
+        {
+            if (obj is <#= structName #>)
+                return this == (<#= structName #>)obj;
+
+            return false;
+        }
+
+        public bool Equals(<#= structName #> other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (<#= structName #>* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return <#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == 0 && y != 0)
+                    {
+                            #>                         + <#
+                    }
+            
+                    #><#= String.Format("(x[{0:00}] ^ x[{1:00}])", y * colCount + x * 2, y * colCount + x * 2 + 1) #><#
+            
+                    if (x + 1 == colCount)
+                    {
+                        if (y + 1 == rowCount)
+                        {
+                            #>;<#
+                        }
+                        #><#= Environment.NewLine #><#
+                    }
+                    else
+                    {
+                        #> + <#
+                    }
+                }
+            }
+#>
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("<#= structName #>: "<#
+            #><#= Environment.NewLine #><#
+            for (int y = 0; y < rowCount; y++)
+            {
+                #>                               + "{{<#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>|{<#= String.Format("{0:00}", y * colCount + x) #>}<#
+                }
+                #>|}}"<#
+                #><#= Environment.NewLine #><#
+            }
+            
+            for (int y = 0; y < rowCount; y++)
+            {				
+                #>                               <#					 
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format(", M{0}{1}", x + 1, y + 1) #><#
+                }
+                
+                if (y +1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                }
+            }
+
+            #>); 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public <#= String.Format("Matrix{0}x{1}", rowCount, colCount) #> Transpose()
+        {
+            return new <#= String.Format("Matrix{0}x{1}", rowCount, colCount) #>(<#
+
+            for (int y = 0; y < colCount; y++)
+            {
+                for (int x = 0; x < rowCount; x++)
+                {
+                    #><#= String.Format("M{1}{0}", x + 1, y + 1) #><#
+
+                    if (x + 1 < rowCount || y + 1 < colCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (y + 1 < colCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                                 <#
+                }
+            }
+            
+            #>);
+        }
+
+        public static bool operator ==(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == 0 && y == 0)
+                    {
+                        #>            return <#
+                    }
+                    else
+                    {
+                        #>                && <#
+                    }
+
+                    #><#= String.Format("(matrix1 == matrix2 || Math.Abs(matrix1.M{0}{1} - matrix2.M{0}{1}) <= Double.Epsilon)", x + 1, y + 1) #><#
+
+                    if (x + 1 == colCount && y + 1 == rowCount)
+                    {
+                        #>;<#
+                    }
+            
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+        }
+
+        public static bool operator !=(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == 0 && y == 0)
+                    {
+                        #>            return <#
+                    }
+                    else
+                    {
+                        #>                || <#
+                    }
+
+                    #><#= String.Format("Math.Abs(matrix1.M{0}{1} - matrix2.M{0}{1}) > Double.Epsilon", x + 1, y + 1) #><#
+
+                    if (x + 1 == colCount && y + 1 == rowCount)
+                    {
+                        #>;<#
+                    }
+            
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+        }
+
+        public static <#= structName #> operator +(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = matrix1.M{0}{1} + matrix2.M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #>
+
+                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+        public static <#= structName #> operator -(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = matrix1.M{0}{1} - matrix2.M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #>
+
+                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+        public static <#= structName #> operator *(<#= structName #> matrix, double scalar)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = matrix.M{0}{1} * scalar", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #>
+
+                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+        public static <#= structName #> operator *(double scalar, <#= structName #> matrix)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = scalar * matrix.M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #><#= Environment.NewLine #><#
+						#>                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+<#
+                for (int j = MinColCount; j <= MaxColCount; j++)
+                {
+                    int srcCols = j;
+                    int srcRows = colCount;
+                    int dstCols = srcCols;
+                    int dstRows = rowCount;
+
+                    if ((srcCols == MinColCount && srcRows == MinRowCount) || (dstCols == MinColCount && dstRows == MinRowCount))
+                        continue;
+
+                    string mulName = String.Format("Matrix{0}x{1}", srcCols, srcRows);
+                    string prodName = String.Format("Matrix{0}x{1}", dstCols, dstRows);
+#>
+        public static <#= prodName #> operator *(<#= structName #> matrix1, <#= mulName #> matrix2)
+        {
+<#
+                    for (int y = 0; y < dstRows; y++)
+                    {
+                        for (int x = 0; x < dstCols; x++)
+                        {
+                            #>            <#= String.Format("double m{0}{1} = ", x + 1, y + 1) #><#
+
+                            for (int y1 = 0, x1 = 0; y1 < srcRows && x1 < colCount; y1++, x1++)
+                            {
+                                #><#= String.Format("matrix1.M{0}{1} * matrix2.M{2}{3}", x1 + 1, y + 1, x + 1, y1 + 1) #><#
+
+                                if (y1 + 1 < srcRows && x1 + 1 < colCount)
+                                {
+                                    #> + <#
+                                }
+                            }
+
+                            #>;<#= Environment.NewLine #><#
+                        
+                        }
+                    }
+#>
+
+            return new <#= prodName #>(<#			
+                    for (int y = 0; y < dstRows; y++)
+                    {
+                        for (int x = 0; x < dstCols; x++)
+                        {
+                            #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+
+                            if (x + 1 < dstCols || y + 1 < dstRows)
+                            {
+                                #>, <#
+                            }
+							if (x + 1 == dstCols && y + 1 < dstRows)
+							{
+								#><#= Environment.NewLine #><#
+								#>                                 <#
+							}
+                        }
+                    }
+                    #>);
+        }
+<#
+                }
+#>
+    }
+}
+<#
+            string templateDirectory = Path.GetDirectoryName(Host.TemplateFile);
+            string outputFilePath = Path.Combine(templateDirectory, outputFileName);
+            File.WriteAllText(outputFilePath, this.GenerationEnvironment.ToString()); 
+
+            this.GenerationEnvironment.Remove(0, this.GenerationEnvironment.Length);
+        }
+    }
+#>


### PR DESCRIPTION
This pull request is primarily to take the temperature of the maintainers and community with regards to the following:

* Adding library level matrix support.
* Adding a namespace (System.Numerics.Matrices) for adding matrix support.
* Use of structs (instead of classes) for Matrices
* Lack of graphics specific matrix functions (I believe they belong in a graphics namespace)
* Supporting up to 8x8 matrices.
* Use of text templates in code generation.

The important file to look at is the MatrixTemplate.tt - all other code is generated from that. I believe I got my matrix logic correct, thought I have not spent a ton of time validating it yet. I fully plan to do so once I get some community feedback on my approach.

There are no tests written yet. I fully plan to write the appropriate tests once my approach is validated.

added new MatrixTemplate.tt for generating matrix classes
added 1 - 8 column by 1 - 8 row matrices classes