### PR TITLE
Fix Obsolete build warnings in System.Security.Cryptography.Encoding

### DIFF
--- a/src/Common/src/Interop/Windows/Crypt32/OidInfo.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/OidInfo.cs
@@ -80,7 +80,7 @@ namespace Internal.NativeCrypto
                     IntPtr localOidInfo = CryptFindOIDInfo(keyType, rawKey, localGroup);
                     if (localOidInfo != IntPtr.Zero)
                     {
-                        return (CRYPT_OID_INFO)Marshal.PtrToStructure(localOidInfo, typeof(CRYPT_OID_INFO));
+                        return Marshal.PtrToStructure<CRYPT_OID_INFO>(localOidInfo);
                     }
                 }
 
@@ -88,7 +88,7 @@ namespace Internal.NativeCrypto
                 IntPtr fullOidInfo = CryptFindOIDInfo(keyType, rawKey, group);
                 if (fullOidInfo != IntPtr.Zero)
                 {
-                    return (CRYPT_OID_INFO)Marshal.PtrToStructure(fullOidInfo, typeof(CRYPT_OID_INFO));
+                    return Marshal.PtrToStructure<CRYPT_OID_INFO>(fullOidInfo);
                 }
 
                 if (fallBackToAllGroups && group != OidGroup.All)
@@ -98,7 +98,7 @@ namespace Internal.NativeCrypto
                     IntPtr allGroupOidInfo = CryptFindOIDInfo(keyType, rawKey, OidGroup.All);
                     if (allGroupOidInfo != IntPtr.Zero)
                     {
-                        return (CRYPT_OID_INFO)Marshal.PtrToStructure(fullOidInfo, typeof(CRYPT_OID_INFO));
+                        return Marshal.PtrToStructure<CRYPT_OID_INFO>(fullOidInfo);
                     }
                 }
 


### PR DESCRIPTION
The build had these three warnings:
```
\corefx\src\Common\src\Interop\Windows\Crypt32\OidInfo.cs(83,48): warning CS0618: 'Marshal.PtrToStructure(IntPtr, Type)' is obsolete
: 'PtrToStructure(IntPtr, Type) may be unavailable in future releases. Instead, use PtrToStructure<T>(IntPtr). For more info, go to http://go.microsoft.com/fwl
ink/?LinkID=296513' [\corefx\src\System.Security.Cryptography.Encoding\src\System.Security.Cryptography.Encoding.csproj]
\corefx\src\Common\src\Interop\Windows\Crypt32\OidInfo.cs(91,44): warning CS0618: 'Marshal.PtrToStructure(IntPtr, Type)' is obsolete
: 'PtrToStructure(IntPtr, Type) may be unavailable in future releases. Instead, use PtrToStructure<T>(IntPtr). For more info, go to http://go.microsoft.com/fwl
ink/?LinkID=296513' [\corefx\src\System.Security.Cryptography.Encoding\src\System.Security.Cryptography.Encoding.csproj]
\corefx\src\Common\src\Interop\Windows\Crypt32\OidInfo.cs(101,48): warning CS0618: 'Marshal.PtrToStructure(IntPtr, Type)' is obsolet
e: 'PtrToStructure(IntPtr, Type) may be unavailable in future releases. Instead, use PtrToStructure<T>(IntPtr). For more info, go to http://go.microsoft.com/fw
link/?LinkID=296513' [\corefx\src\System.Security.Cryptography.Encoding\src\System.Security.Cryptography.Encoding.csproj]
```