### PR TITLE
Fix CS0067 warning for unused event in reflection tests

### DIFF
--- a/src/System.Reflection/tests/TypeInfo/TypeInfo_MethodTests.cs
+++ b/src/System.Reflection/tests/TypeInfo/TypeInfo_MethodTests.cs
@@ -694,7 +694,9 @@ namespace System.Reflection.Tests
 
         public int PublicProperty { get { return default(int); } set { } }
 
-        public event System.EventHandler EventPublic;
+        #pragma warning disable 0067 // unused event (only used via reflection)
+        public event EventHandler EventPublic;
+        #pragma warning restore 0067
     }
 
     public interface MethodITest { }


### PR DESCRIPTION
The reflection tests are verifying that an event can be accessed using reflection.  As it's never used directly, the compiler is warning that it's unused.  This commit just uses a pragma to suppress the warning.