### PR TITLE
Implement FileVersionInfo on Unix (for managed assemblies)

### DIFF
--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -15,7 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)System.Collections.Immutable.xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
-    <AssemblyVersion>1.1.34</AssemblyVersion>
+    <AssemblyVersion>1.1.9999</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
 namespace System.Diagnostics
 {
     public sealed partial class FileVersionInfo
@@ -9,42 +14,236 @@ namespace System.Diagnostics
         {
             _fileName = fileName;
 
-            // TODO: Implement this
-
-            _companyName = string.Empty;
-            _fileDescription = string.Empty;
-            _fileVersion = string.Empty;
-            _internalName = string.Empty;
-            _legalCopyright = string.Empty;
-            _originalFilename = string.Empty;
-            _productName = string.Empty;
-            _productVersion = string.Empty;
-            _comments = string.Empty;
-            _legalTrademarks = string.Empty;
-            _privateBuild = string.Empty;
-            _specialBuild = string.Empty;
-
-            _language = string.Empty;
-
-            _fileMajor = 0;
-            _fileMinor = 0;
-            _fileBuild = 0;
-            _filePrivate = 0;
-            _productMajor = 0;
-            _productMinor = 0;
-            _productBuild = 0;
-            _productPrivate = 0;
-
-            _isDebug = false;
-            _isPatched = false;
-            _isPrivateBuild = false;
-            _isPreRelease = false;
-            _isSpecialBuild = false;
+            // For managed assemblies, read the file version information from the assembly's metadata.
+            // This isn't quite what's done on Windows, which uses the Win32 GetFileVersionInfo to read
+            // the Win32 resource information from the file, and the managed compiler uses these attributes
+            // to fill in that resource information when compiling the assembly.  It's possible
+            // that after compilation, someone could have modified the resource information such that it
+            // no longer matches what was or wasn't in the assembly.  But that's a rare enough case
+            // that this should match for all intents and purposes.  If this ever becomes a problem,
+            // we can implement a full-fledged Win32 resource parser; that would also enable support
+            // for native Win32 PE files on Unix, but that should also be an extremely rare case.
+            if (!TryLoadManagedAssemblyMetadata())
+            {
+                // We could try to parse Executable and Linkable Format (ELF) files, but at present
+                // for executables they don't store version information, which is typically just
+                // available in the filename itself.  For now, we won't do anything special, but
+                // we can add more cases here as we find need and opportunity.
+            }
         }
 
         // -----------------------------
         // ---- PAL layer ends here ----
         // -----------------------------
+
+        /// <summary>Attempt to load our fields from the metadata of the file, if it's a managed assembly.</summary>
+        /// <returns>true if the file is a managed assembly; otherwise, false.</returns>
+        private bool TryLoadManagedAssemblyMetadata()
+        {
+            try
+            {
+                // Try to load the file using the managed metadata reader
+                using (FileStream assemblyStream = File.OpenRead(_fileName))
+                using (PEReader peReader = new PEReader(assemblyStream))
+                {
+                    if (peReader.HasMetadata)
+                    {
+                        MetadataReader metadataReader = peReader.GetMetadataReader();
+                        if (metadataReader.IsAssembly)
+                        {
+                            LoadManagedAssemblyMetadata(metadataReader);
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch (BadImageFormatException) { }
+            return false;
+        }
+
+        /// <summary>Load our fields from the metadata of the file as represented by the provided metadata reader.</summary>
+        /// <param name="metadataReader">The metadata reader for the CLI file this represents.</param>
+        private void LoadManagedAssemblyMetadata(MetadataReader metadataReader)
+        {
+            AssemblyDefinition assemblyDefinition = metadataReader.GetAssemblyDefinition();
+
+            // Set the internal and original names based on the file name.
+            _internalName = _originalFilename = Path.GetFileName(_fileName);
+
+            // Set the product version based on the assembly's version (this may be overwritten 
+            // later in the method).
+            Version productVersion = assemblyDefinition.Version;
+            _productVersion = productVersion.ToString(4);
+            _productMajor = productVersion.Major;
+            _productMinor = productVersion.Minor;
+            _productBuild = productVersion.Build;
+            _productPrivate = productVersion.Revision;
+
+            // "Language Neutral" is used on Win32 for unknown language identifiers.
+            _language = "Language Neutral";
+
+            // Set other fields to default values in case they're not overwritten by attributes
+            _companyName = string.Empty;
+            _comments = string.Empty;
+            _fileDescription = " "; // this is what the managed compiler outputs when value isn't set
+            _fileVersion = string.Empty;
+            _legalCopyright = " "; // this is what the managed compiler outputs when value isn't set
+            _legalTrademarks = string.Empty;
+            _productName = string.Empty;
+            _privateBuild = string.Empty;
+            _specialBuild = string.Empty;
+
+            // Be explicit about initialization to suppress warning about fields not being set
+            _isDebug = false;
+            _isPatched = false;
+            _isPreRelease = false;
+            _isPrivateBuild = false;
+            _isSpecialBuild = false;
+
+            // Everything else is parsed from assembly attributes
+            MetadataStringComparer comparer = metadataReader.StringComparer;
+            foreach (CustomAttributeHandle attrHandle in assemblyDefinition.GetCustomAttributes())
+            {
+                CustomAttribute attr = metadataReader.GetCustomAttribute(attrHandle);
+                StringHandle typeNamespaceHandle = default(StringHandle), typeNameHandle = default(StringHandle);
+                if (TryGetAttributeName(metadataReader, attr, out typeNamespaceHandle, out typeNameHandle) &&
+                    comparer.Equals(typeNamespaceHandle, "System.Reflection"))
+                {
+                    if (comparer.Equals(typeNameHandle, "AssemblyCompanyAttribute"))
+                    {
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref _companyName);
+                    }
+                    else if (comparer.Equals(typeNameHandle, "AssemblyCopyrightAttribute"))
+                    {
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref _legalCopyright);
+                    }
+                    else if (comparer.Equals(typeNameHandle, "AssemblyDescriptionAttribute"))
+                    {
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref _comments);
+                    }
+                    else if (comparer.Equals(typeNameHandle, "AssemblyFileVersionAttribute"))
+                    {
+                        string versionString = string.Empty;
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref versionString);
+                        Version v;
+                        if (Version.TryParse(versionString, out v))
+                        {
+                            _fileVersion = v.ToString(4);
+                            _fileMajor = v.Major;
+                            _fileMinor = v.Minor;
+                            _fileBuild = v.Build;
+                            _filePrivate = v.Revision;
+
+                            // When the managed compiler sees an [AssemblyVersion(...)] attribute, it uses that to set 
+                            // both the assembly version and the product version in the Win32 resources. If it doesn't 
+                            // see an [AssemblyVersion(...)], then it sets the assembly version to 0.0.0.0, however it 
+                            // sets the product version in the Win32 resources to whatever was defined in the 
+                            // [AssemblyFileVersionAttribute(...)] if there was one.  Without parsing the Win32 resources,
+                            // we can't differentiate these two cases, so given the rarity of explicitly setting an 
+                            // assembly's version number to 0.0.0.0, we assume that if it is 0.0.0.0 then the attribute 
+                            // wasn't specified and we use the file version.
+                            if (_productVersion == "0.0.0.0")
+                            {
+                                _productVersion = _fileVersion;
+                                _productMajor = _fileMajor;
+                                _productMinor = _fileMinor;
+                                _productBuild = _fileBuild;
+                                _productPrivate = _filePrivate;
+                            }
+                        }
+                    }
+                    else if (comparer.Equals(typeNameHandle, "AssemblyProductAttribute"))
+                    {
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref _productName);
+                    }
+                    else if (comparer.Equals(typeNameHandle, "AssemblyTrademarkAttribute"))
+                    {
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref _legalTrademarks);
+                    }
+                    else if (comparer.Equals(typeNameHandle, "AssemblyTitleAttribute"))
+                    {
+                        GetStringAttributeArgumentValue(metadataReader, attr, ref _fileDescription);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Gets the name of an attribute.</summary>
+        /// <param name="reader">The metadata reader.</param>
+        /// <param name="attr">The attribute.</param>
+        /// <param name="typeNamespaceHandle">The namespace of the attribute.</param>
+        /// <param name="typeNameHandle">The name of the attribute.</param>
+        /// <returns>true if the name could be retrieved; otherwise, false.</returns>
+        private static bool TryGetAttributeName(MetadataReader reader, CustomAttribute attr, out StringHandle typeNamespaceHandle, out StringHandle typeNameHandle)
+        {
+            EntityHandle ctorHandle = attr.Constructor;
+            switch (ctorHandle.Kind)
+            {
+                case HandleKind.MemberReference:
+                    EntityHandle container = reader.GetMemberReference((MemberReferenceHandle)ctorHandle).Parent;
+                    if (container.Kind == HandleKind.TypeReference)
+                    {
+                        TypeReference tr = reader.GetTypeReference((TypeReferenceHandle)container);
+                        typeNamespaceHandle = tr.Namespace;
+                        typeNameHandle = tr.Name;
+                        return true;
+                    }
+                    break;
+
+                case HandleKind.MethodDefinition:
+                    MethodDefinition md = reader.GetMethodDefinition((MethodDefinitionHandle)ctorHandle);
+                    TypeDefinition td = reader.GetTypeDefinition(md.GetDeclaringType());
+                    typeNamespaceHandle = td.Namespace;
+                    typeNameHandle = td.Name;
+                    return true;
+            }
+
+            // Unusual case, potentially invalid IL
+            typeNamespaceHandle = default(StringHandle);
+            typeNameHandle = default(StringHandle);
+            return false;
+        }
+
+        /// <summary>Gets the string argument value of an attribute with a single fixed string argument.</summary>
+        /// <param name="reader">The metadata reader.</param>
+        /// <param name="attr">The attribute.</param>
+        /// <param name="value">The value parsed from the attribute, if it could be retrieved; otherwise, the value is left unmodified.</param>
+        private static void GetStringAttributeArgumentValue(MetadataReader reader, CustomAttribute attr, ref string value)
+        {
+            EntityHandle ctorHandle = attr.Constructor;
+            BlobHandle signature;
+            switch (ctorHandle.Kind)
+            {
+                case HandleKind.MemberReference:
+                    signature = reader.GetMemberReference((MemberReferenceHandle)ctorHandle).Signature;
+                    break;
+                case HandleKind.MethodDefinition:
+                    signature = reader.GetMethodDefinition((MethodDefinitionHandle)ctorHandle).Signature;
+                    break;
+                default:
+                    // Unusual case, potentially invalid IL
+                    return;
+            }
+
+            BlobReader signatureReader = reader.GetBlobReader(signature);
+            BlobReader valueReader = reader.GetBlobReader(attr.Value);
+
+            const ushort Prolog = 1; // two-byte "prolog" defined by Ecma 335 (II.23.3) to be at the beginning of attribute value blobs
+            if (valueReader.ReadUInt16() == Prolog)
+            {
+                SignatureHeader header = signatureReader.ReadSignatureHeader();
+                int parameterCount;
+                if (header.Kind == SignatureKind.Method &&                               // attr ctor must be a method
+                    !header.IsGeneric &&                                                 // attr ctor must be non-generic
+                    signatureReader.TryReadCompressedInteger(out parameterCount) &&      // read parameter count
+                    parameterCount == 1 &&                                               // attr ctor must have 1 parameter
+                    signatureReader.ReadSignatureTypeCode() == SignatureTypeCode.Void && // attr ctor return type must be void
+                    signatureReader.ReadSignatureTypeCode() == SignatureTypeCode.String) // attr ctor first parameter must be string
+                {
+                    value = valueReader.ReadSerializedString();
+                }
+            }
+        }
 
     }
 }

--- a/src/System.Diagnostics.FileVersionInfo/src/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/src/project.json
@@ -7,6 +7,7 @@
     "System.IO.FileSystem": "4.0.0-beta-*",
     "System.IO.FileSystem.Primitives": "4.0.0-beta-*",
     "System.Reflection": "4.0.10-beta-*",
+    "System.Reflection.Metadata": "1.0.21",
     "System.Reflection.Primitives": "4.0.0-beta-*",
     "System.Runtime": "4.0.20-beta-*",
     "System.Runtime.Extensions": "4.0.10-beta-*",

--- a/src/System.Diagnostics.FileVersionInfo/src/project.lock.json
+++ b/src/System.Diagnostics.FileVersionInfo/src/project.lock.json
@@ -14,6 +14,14 @@
           "lib/DNXCore50/System.Collections.dll"
         ]
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": [
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll"
+        ]
+      },
       "System.Diagnostics.Debug/4.0.10-beta-22927": {
         "dependencies": {
           "System.Runtime": "4.0.0-beta-22927"
@@ -110,6 +118,17 @@
         ],
         "runtime": [
           "lib/DNXCore50/System.Reflection.dll"
+        ]
+      },
+      "System.Reflection.Metadata/1.0.21": {
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.36"
+        },
+        "compile": [
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll"
         ]
       },
       "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -258,6 +277,18 @@
         "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
+    "System.Collections.Immutable/1.1.36": {
+      "serviceable": true,
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "files": [
+        "License-Stable.rtf",
+        "System.Collections.Immutable.1.1.36.nupkg",
+        "System.Collections.Immutable.1.1.36.nupkg.sha512",
+        "System.Collections.Immutable.nuspec",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+      ]
+    },
     "System.Diagnostics.Debug/4.0.10-beta-22927": {
       "sha512": "uhcpTHJXFOXz1BHrZ2I37p28nW+HkWEYssFDQ3I6Jvt/OrMHOOZ7un1ANIICBnKjH3IM2LAznyvEZDJ9DourSw==",
       "files": [
@@ -364,6 +395,18 @@
         "ref/any/System.Reflection.dll",
         "ref/net46/System.Reflection.dll",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+      ]
+    },
+    "System.Reflection.Metadata/1.0.21": {
+      "serviceable": true,
+      "sha512": "CAhcY0EJFLXfxo5YRV/ytkTOeTBho8zKjLu+9LvEI5NIVmanp1yMUzYQdjvXpHbyV0Qt1KuLXcTCc9t9FVH3Wg==",
+      "files": [
+        "License-Stable.rtf",
+        "System.Reflection.Metadata.1.0.21.nupkg",
+        "System.Reflection.Metadata.1.0.21.nupkg.sha512",
+        "System.Reflection.Metadata.nuspec",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
       ]
     },
     "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -529,6 +572,7 @@
       "System.IO.FileSystem >= 4.0.0-beta-*",
       "System.IO.FileSystem.Primitives >= 4.0.0-beta-*",
       "System.Reflection >= 4.0.10-beta-*",
+      "System.Reflection.Metadata >= 1.0.21",
       "System.Reflection.Primitives >= 4.0.0-beta-*",
       "System.Runtime >= 4.0.20-beta-*",
       "System.Runtime.Extensions >= 4.0.10-beta-*",

--- a/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
@@ -27,7 +27,7 @@ public class FileVersionInfoTest
     private MyFVI _fviAssembly1_cs;
 
     [Fact]
-    [ActiveIssue(811, PlatformID.AnyUnix)]
+    [PlatformSpecific(PlatformID.Windows)]
     public void FileVersionInfo_Normal()
     {
         EnsureExpectedValuesInitialized();
@@ -35,7 +35,7 @@ public class FileVersionInfoTest
     }
 
     [Fact]
-    [ActiveIssue(811, PlatformID.AnyUnix)]
+    [PlatformSpecific(PlatformID.Windows)]
     public void FileVersionInfo_Chinese()
     {
         EnsureExpectedValuesInitialized();
@@ -43,7 +43,7 @@ public class FileVersionInfoTest
     }
 
     [Fact]
-    [ActiveIssue(811, PlatformID.AnyUnix)]
+    [PlatformSpecific(PlatformID.Windows)]
     public void FileVersionInfo_DifferentFileVersionAndProductVersion()
     {
         EnsureExpectedValuesInitialized();
@@ -51,7 +51,6 @@ public class FileVersionInfoTest
     }
 
     [Fact]
-    [ActiveIssue(811, PlatformID.AnyUnix)]
     public void FileVersionInfo_CustomManagedAssembly()
     {
         EnsureExpectedValuesInitialized();
@@ -59,7 +58,6 @@ public class FileVersionInfoTest
     }
 
     [Fact]
-    [ActiveIssue(811, PlatformID.AnyUnix)]
     public void FileVersionInfo_EmptyFVI()
     {
         EnsureExpectedValuesInitialized();

--- a/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
+++ b/src/System.Diagnostics.FileVersionInfo/tests/FileVersionInfoTest.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
-using System.Text;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
+using System.Text;
 using Xunit;
 
-//
-// System.Diagnostics.FileVersionInfo Test
-//
 public class FileVersionInfoTest
 {
     private const string NativeConsoleAppFileName = "NativeConsoleApp.exe";
@@ -20,54 +17,195 @@ public class FileVersionInfoTest
     private const string TestCsFileName = "Assembly1.cs";
     private const string TestNotFoundFileName = "notfound.dll";
 
-    private MyFVI _fviNativeConsoleApp;
-    private MyFVI _fviNativeLibrary;
-    private MyFVI _fviSecondNativeLibrary;
-    private MyFVI _fviAssembly1;
-    private MyFVI _fviAssembly1_cs;
-
     [Fact]
-    [PlatformSpecific(PlatformID.Windows)]
+    [PlatformSpecific(PlatformID.Windows)] // native PE files only supported on Windows
     public void FileVersionInfo_Normal()
     {
-        EnsureExpectedValuesInitialized();
-        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName), _fviNativeConsoleApp);
+        // NativeConsoleApp (English)
+        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName), new MyFVI()
+        {
+            Comments = "",
+            CompanyName = "This is not a real company name.",
+            FileBuildPart = 3,
+            FileDescription = "This is the description for the native console application.",
+            FileMajorPart = 5,
+            FileMinorPart = 4,
+            FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName),
+            FilePrivatePart = 2,
+            FileVersion = "5.4.3.2",
+            InternalName = NativeConsoleAppFileName,
+            IsDebug = false,
+            IsPatched = false,
+            IsPrivateBuild = false,
+            IsPreRelease = true,
+            IsSpecialBuild = true,
+            Language = GetFileVersionLanguage(0x0409), //English (United States)
+            LegalCopyright = "Copyright (C) 2050",
+            LegalTrademarks = "",
+            OriginalFilename = NativeConsoleAppFileName,
+            PrivateBuild = "",
+            ProductBuildPart = 3,
+            ProductMajorPart = 5,
+            ProductMinorPart = 4,
+            ProductName = Path.GetFileNameWithoutExtension(NativeConsoleAppFileName),
+            ProductPrivatePart = 2,
+            ProductVersion = "5.4.3.2",
+            SpecialBuild = ""
+        });
     }
 
     [Fact]
-    [PlatformSpecific(PlatformID.Windows)]
+    [PlatformSpecific(PlatformID.Windows)] // native PE files only supported on Windows
     public void FileVersionInfo_Chinese()
     {
-        EnsureExpectedValuesInitialized();
-        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName), _fviNativeLibrary);
+        // NativeLibrary.dll (Chinese)
+        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName), new MyFVI()
+        {
+            Comments = "",
+            CompanyName = "A non-existent company",
+            FileBuildPart = 3,
+            FileDescription = "Here is the description of the native library.",
+            FileMajorPart = 9,
+            FileMinorPart = 9,
+            FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName),
+            FilePrivatePart = 3,
+            FileVersion = "9.9.3.3",
+            InternalName = "NativeLi.dll",
+            IsDebug = false,
+            IsPatched = true,
+            IsPrivateBuild = false,
+            IsPreRelease = true,
+            IsSpecialBuild = false,
+            Language = GetFileVersionLanguage(0x0004),//Chinese (Simplified)
+            Language2 = GetFileVersionLanguage(0x0804),//Chinese (Simplified, PRC) - changed, but not yet on all platforms
+            LegalCopyright = "None",
+            LegalTrademarks = "",
+            OriginalFilename = "NativeLi.dll",
+            PrivateBuild = "",
+            ProductBuildPart = 40,
+            ProductMajorPart = 20,
+            ProductMinorPart = 30,
+            ProductName = "I was never given a name.",
+            ProductPrivatePart = 50,
+            ProductVersion = "20.30.40.50",
+            SpecialBuild = "",
+        });
     }
 
     [Fact]
-    [PlatformSpecific(PlatformID.Windows)]
+    [PlatformSpecific(PlatformID.Windows)] // native PE files only supported on Windows
     public void FileVersionInfo_DifferentFileVersionAndProductVersion()
     {
-        EnsureExpectedValuesInitialized();
-        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName), _fviSecondNativeLibrary);
+        // Mtxex.dll
+        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName), new MyFVI()
+        {
+            Comments = "",
+            CompanyName = "",
+            FileBuildPart = 0,
+            FileDescription = "",
+            FileMajorPart = 0,
+            FileMinorPart = 65535,
+            FileName = Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName),
+            FilePrivatePart = 2,
+            FileVersion = "0.65535.0.2",
+            InternalName = "SecondNa.dll",
+            IsDebug = false,
+            IsPatched = false,
+            IsPrivateBuild = false,
+            IsPreRelease = false,
+            IsSpecialBuild = false,
+            Language = GetFileVersionLanguage(0x0400),//Process Default Language
+            LegalCopyright = "Copyright (C) 1 - 2014",
+            LegalTrademarks = "",
+            OriginalFilename = "SecondNa.dll",
+            PrivateBuild = "",
+            ProductBuildPart = 0,
+            ProductMajorPart = 1,
+            ProductMinorPart = 0,
+            ProductName = "Unkown_Product_Name",
+            ProductPrivatePart = 1,
+            ProductVersion = "1.0.0.1",
+            SpecialBuild = "",
+        });
     }
 
     [Fact]
     public void FileVersionInfo_CustomManagedAssembly()
     {
-        EnsureExpectedValuesInitialized();
-        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName), _fviAssembly1);
+        // Assembly1.dll
+        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName), new MyFVI()
+        {
+            Comments = "Have you played a Contoso amusement device today?",
+            CompanyName = "The name of the company.",
+            FileBuildPart = 2,
+            FileDescription = "My File",
+            FileMajorPart = 4,
+            FileMinorPart = 3,
+            FileName = Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName),
+            FilePrivatePart = 1,
+            FileVersion = "4.3.2.1",
+            InternalName = TestAssemblyFileName,
+            IsDebug = false,
+            IsPatched = false,
+            IsPrivateBuild = false,
+            IsPreRelease = false,
+            IsSpecialBuild = false,
+            Language = Interop.IsWindows ? GetFileVersionLanguage(0x0000) : "Language Neutral", //Language Neutral
+            LegalCopyright = "Copyright, you betcha!",
+            LegalTrademarks = "TM",
+            OriginalFilename = TestAssemblyFileName,
+            PrivateBuild = "",
+            ProductBuildPart = 2,
+            ProductMajorPart = 4,
+            ProductMinorPart = 3,
+            ProductName = "The greatest product EVER",
+            ProductPrivatePart = 1,
+            ProductVersion = "4.3.2.1",
+            SpecialBuild = "",
+        });
     }
 
     [Fact]
     public void FileVersionInfo_EmptyFVI()
     {
-        EnsureExpectedValuesInitialized();
-        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), TestCsFileName), _fviAssembly1_cs);
+        // Assembly1.cs
+        VerifyVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), TestCsFileName), new MyFVI()
+        {
+            Comments = null,
+            CompanyName = null,
+            FileBuildPart = 0,
+            FileDescription = null,
+            FileMajorPart = 0,
+            FileMinorPart = 0,
+            FileName = Path.Combine(Directory.GetCurrentDirectory(), TestCsFileName),
+            FilePrivatePart = 0,
+            FileVersion = null,
+            InternalName = null,
+            IsDebug = false,
+            IsPatched = false,
+            IsPrivateBuild = false,
+            IsPreRelease = false,
+            IsSpecialBuild = false,
+            Language = null,
+            LegalCopyright = null,
+            LegalTrademarks = null,
+            OriginalFilename = null,
+            PrivateBuild = null,
+            ProductBuildPart = 0,
+            ProductMajorPart = 0,
+            ProductMinorPart = 0,
+            ProductName = null,
+            ProductPrivatePart = 0,
+            ProductVersion = null,
+            SpecialBuild = null,
+        });
     }
 
     [Fact]
     public void FileVersionInfo_FileNotFound()
     {
-        VerifyVersionInfoException<FileNotFoundException>(Path.Combine(Directory.GetCurrentDirectory(), TestNotFoundFileName));
+        Assert.Throws<FileNotFoundException>(() =>
+            FileVersionInfo.GetVersionInfo(Path.Combine(Directory.GetCurrentDirectory(), TestNotFoundFileName)));
     }
 
     // Additional Tests Wanted:
@@ -125,11 +263,6 @@ public class FileVersionInfoTest
                                false);
     }
 
-    private void VerifyVersionInfoException<T>(String filePath) where T : Exception
-    {
-        Assert.Throws<T>(() => FileVersionInfo.GetVersionInfo(filePath));
-    }
-
     private void TestStringProperty(String propertyName, String actual, String expected)
     {
         TestStringProperty(propertyName, actual, expected, true);
@@ -156,165 +289,6 @@ public class FileVersionInfoTest
     private void TestProperty<T>(String propertyName, T actual, T expected)
     {
         Assert.Equal(expected, actual);
-    }
-
-    private void EnsureExpectedValuesInitialized()
-    {
-        if (_fviNativeConsoleApp != null)
-        {
-            return;
-        }
-
-        // NativeConsoleApp (English)
-        _fviNativeConsoleApp = new MyFVI();
-        _fviNativeConsoleApp.Comments = "";
-        _fviNativeConsoleApp.CompanyName = "This is not a real company name.";
-        _fviNativeConsoleApp.FileBuildPart = 3;
-        _fviNativeConsoleApp.FileDescription = "This is the description for the native console application.";
-        _fviNativeConsoleApp.FileMajorPart = 5;
-        _fviNativeConsoleApp.FileMinorPart = 4;
-        _fviNativeConsoleApp.FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeConsoleAppFileName);
-        _fviNativeConsoleApp.FilePrivatePart = 2;
-        _fviNativeConsoleApp.FileVersion = "5.4.3.2";
-        _fviNativeConsoleApp.InternalName = NativeConsoleAppFileName;
-        _fviNativeConsoleApp.IsDebug = false;
-        _fviNativeConsoleApp.IsPatched = false;
-        _fviNativeConsoleApp.IsPrivateBuild = false;
-        _fviNativeConsoleApp.IsPreRelease = true;
-        _fviNativeConsoleApp.IsSpecialBuild = true;
-        _fviNativeConsoleApp.Language = GetFileVersionLanguage(0x0409);//English (United States)
-        _fviNativeConsoleApp.LegalCopyright = "Copyright (C) 2050";
-        _fviNativeConsoleApp.LegalTrademarks = "";
-        _fviNativeConsoleApp.OriginalFilename = NativeConsoleAppFileName;
-        _fviNativeConsoleApp.PrivateBuild = "";
-        _fviNativeConsoleApp.ProductBuildPart = 3;
-        _fviNativeConsoleApp.ProductMajorPart = 5;
-        _fviNativeConsoleApp.ProductMinorPart = 4;
-        _fviNativeConsoleApp.ProductName = Path.GetFileNameWithoutExtension(NativeConsoleAppFileName);
-        _fviNativeConsoleApp.ProductPrivatePart = 2;
-        _fviNativeConsoleApp.ProductVersion = "5.4.3.2";
-        _fviNativeConsoleApp.SpecialBuild = "";
-
-        // NativeLibrary.dll (Chinese)
-        _fviNativeLibrary = new MyFVI();
-        _fviNativeLibrary.Comments = "";
-        _fviNativeLibrary.CompanyName = "A non-existent company";
-        _fviNativeLibrary.FileBuildPart = 3;
-        _fviNativeLibrary.FileDescription = "Here is the description of the native library.";
-        _fviNativeLibrary.FileMajorPart = 9;
-        _fviNativeLibrary.FileMinorPart = 9;
-        _fviNativeLibrary.FileName = Path.Combine(Directory.GetCurrentDirectory(), NativeLibraryFileName);
-        _fviNativeLibrary.FilePrivatePart = 3;
-        _fviNativeLibrary.FileVersion = "9.9.3.3";
-        _fviNativeLibrary.InternalName = "NativeLi.dll";
-        _fviNativeLibrary.IsDebug = false;
-        _fviNativeLibrary.IsPatched = true;
-        _fviNativeLibrary.IsPrivateBuild = false;
-        _fviNativeLibrary.IsPreRelease = true;
-        _fviNativeLibrary.IsSpecialBuild = false;
-        _fviNativeLibrary.Language = GetFileVersionLanguage(0x0004);//Chinese (Simplified)
-        _fviNativeLibrary.Language2 = GetFileVersionLanguage(0x0804);//Chinese (Simplified, PRC) - changed, but not yet on all platforms
-        _fviNativeLibrary.LegalCopyright = "None";
-        _fviNativeLibrary.LegalTrademarks = "";
-        _fviNativeLibrary.OriginalFilename = "NativeLi.dll";
-        _fviNativeLibrary.PrivateBuild = "";
-        _fviNativeLibrary.ProductBuildPart = 40;
-        _fviNativeLibrary.ProductMajorPart = 20;
-        _fviNativeLibrary.ProductMinorPart = 30;
-        _fviNativeLibrary.ProductName = "I was never given a name.";
-        _fviNativeLibrary.ProductPrivatePart = 50;
-        _fviNativeLibrary.ProductVersion = "20.30.40.50";
-        _fviNativeLibrary.SpecialBuild = "";
-
-        // Mtxex.dll
-        _fviSecondNativeLibrary = new MyFVI();
-        _fviSecondNativeLibrary.Comments = "";
-        _fviSecondNativeLibrary.CompanyName = "";
-        _fviSecondNativeLibrary.FileBuildPart = 0;
-        _fviSecondNativeLibrary.FileDescription = "";
-        _fviSecondNativeLibrary.FileMajorPart = 0;
-        _fviSecondNativeLibrary.FileMinorPart = 65535;
-        _fviSecondNativeLibrary.FileName = Path.Combine(Directory.GetCurrentDirectory(), SecondNativeLibraryFileName);
-        _fviSecondNativeLibrary.FilePrivatePart = 2;
-        _fviSecondNativeLibrary.FileVersion = "0.65535.0.2";
-        _fviSecondNativeLibrary.InternalName = "SecondNa.dll";
-        _fviSecondNativeLibrary.IsDebug = false;
-        _fviSecondNativeLibrary.IsPatched = false;
-        _fviSecondNativeLibrary.IsPrivateBuild = false;
-        _fviSecondNativeLibrary.IsPreRelease = false;
-        _fviSecondNativeLibrary.IsSpecialBuild = false;
-        _fviSecondNativeLibrary.Language = GetFileVersionLanguage(0x0400);//Process Default Language
-        _fviSecondNativeLibrary.LegalCopyright = "Copyright (C) 1 - 2014";
-        _fviSecondNativeLibrary.LegalTrademarks = "";
-        _fviSecondNativeLibrary.OriginalFilename = "SecondNa.dll";
-        _fviSecondNativeLibrary.PrivateBuild = "";
-        _fviSecondNativeLibrary.ProductBuildPart = 0;
-        _fviSecondNativeLibrary.ProductMajorPart = 1;
-        _fviSecondNativeLibrary.ProductMinorPart = 0;
-        _fviSecondNativeLibrary.ProductName = "Unkown_Product_Name";
-        _fviSecondNativeLibrary.ProductPrivatePart = 1;
-        _fviSecondNativeLibrary.ProductVersion = "1.0.0.1";
-        _fviSecondNativeLibrary.SpecialBuild = "";
-
-        // Assembly1.dll
-        _fviAssembly1 = new MyFVI();
-        _fviAssembly1.Comments = "Have you played a Contoso amusement device today?";
-        _fviAssembly1.CompanyName = "The name of the company.";
-        _fviAssembly1.FileBuildPart = 2;
-        _fviAssembly1.FileDescription = "My File";
-        _fviAssembly1.FileMajorPart = 4;
-        _fviAssembly1.FileMinorPart = 3;
-        _fviAssembly1.FileName = Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName);
-        _fviAssembly1.FilePrivatePart = 1;
-        _fviAssembly1.FileVersion = "4.3.2.1";
-        _fviAssembly1.InternalName = TestAssemblyFileName;
-        _fviAssembly1.IsDebug = false;
-        _fviAssembly1.IsPatched = false;
-        _fviAssembly1.IsPrivateBuild = false;
-        _fviAssembly1.IsPreRelease = false;
-        _fviAssembly1.IsSpecialBuild = false;
-        _fviAssembly1.Language = GetFileVersionLanguage(0x0000);//Language Neutral
-        _fviAssembly1.LegalCopyright = "Copyright, you betcha!";
-        _fviAssembly1.LegalTrademarks = "TM";
-        _fviAssembly1.OriginalFilename = TestAssemblyFileName;
-        _fviAssembly1.PrivateBuild = "";
-        _fviAssembly1.ProductBuildPart = 2;
-        _fviAssembly1.ProductMajorPart = 4;
-        _fviAssembly1.ProductMinorPart = 3;
-        _fviAssembly1.ProductName = "The greatest product EVER";
-        _fviAssembly1.ProductPrivatePart = 1;
-        _fviAssembly1.ProductVersion = "4.3.2.1";
-        _fviAssembly1.SpecialBuild = "";
-
-        // Assembly1.cs
-        _fviAssembly1_cs = new MyFVI();
-        _fviAssembly1_cs.Comments = null;
-        _fviAssembly1_cs.CompanyName = null;
-        _fviAssembly1_cs.FileBuildPart = 0;
-        _fviAssembly1_cs.FileDescription = null;
-        _fviAssembly1_cs.FileMajorPart = 0;
-        _fviAssembly1_cs.FileMinorPart = 0;
-        _fviAssembly1_cs.FileName = Path.Combine(Directory.GetCurrentDirectory(), TestCsFileName);
-        _fviAssembly1_cs.FilePrivatePart = 0;
-        _fviAssembly1_cs.FileVersion = null;
-        _fviAssembly1_cs.InternalName = null;
-        _fviAssembly1_cs.IsDebug = false;
-        _fviAssembly1_cs.IsPatched = false;
-        _fviAssembly1_cs.IsPrivateBuild = false;
-        _fviAssembly1_cs.IsPreRelease = false;
-        _fviAssembly1_cs.IsSpecialBuild = false;
-        _fviAssembly1_cs.Language = null;
-        _fviAssembly1_cs.LegalCopyright = null;
-        _fviAssembly1_cs.LegalTrademarks = null;
-        _fviAssembly1_cs.OriginalFilename = null;
-        _fviAssembly1_cs.PrivateBuild = null;
-        _fviAssembly1_cs.ProductBuildPart = 0;
-        _fviAssembly1_cs.ProductMajorPart = 0;
-        _fviAssembly1_cs.ProductMinorPart = 0;
-        _fviAssembly1_cs.ProductName = null;
-        _fviAssembly1_cs.ProductPrivatePart = 0;
-        _fviAssembly1_cs.ProductVersion = null;
-        _fviAssembly1_cs.SpecialBuild = null;
     }
 
     internal class MyFVI
@@ -349,7 +323,7 @@ public class FileVersionInfoTest
         public string SpecialBuild;
     }
 
-    static String GetUnicodeString(String str)
+    static string GetUnicodeString(String str)
     {
         if (str == null)
             return "<null>";

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="FileVersionInfoTest.cs" />
     <Compile Include="Interop\Interop.Windows.cs" />
+    <Compile Include="$(CommonPath)\Interop\Interop.PlatformDetection.cs" />
   </ItemGroup>
   <!-- References used -->
   <ItemGroup>

--- a/src/System.Diagnostics.FileVersionInfo/tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/project.json
@@ -5,6 +5,7 @@
     "System.IO": "4.0.10-beta-*",
     "System.IO.FileSystem": "4.0.0-beta-*",
     "System.IO.FileSystem.Primitives": "4.0.0-beta-*",
+    "System.Reflection.Metadata": "1.0.21",
     "System.Runtime": "4.0.20-beta-*",
     "System.Runtime.Extensions": "4.0.10-beta-*",
     "System.Runtime.InteropServices": "4.0.20-beta-*",

--- a/src/System.Diagnostics.FileVersionInfo/tests/project.lock.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/project.lock.json
@@ -14,6 +14,14 @@
           "lib/DNXCore50/System.Collections.dll"
         ]
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": [
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll"
+        ]
+      },
       "System.Console/4.0.0-beta-22927": {
         "dependencies": {
           "System.Runtime": "4.0.20-beta-22927",
@@ -130,6 +138,17 @@
         ],
         "runtime": [
           "lib/aspnetcore50/System.Reflection.dll"
+        ]
+      },
+      "System.Reflection.Metadata/1.0.21": {
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.36"
+        },
+        "compile": [
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll"
+        ],
+        "runtime": [
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll"
         ]
       },
       "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -354,6 +373,18 @@
         "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
+    "System.Collections.Immutable/1.1.36": {
+      "serviceable": true,
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "files": [
+        "License-Stable.rtf",
+        "System.Collections.Immutable.1.1.36.nupkg",
+        "System.Collections.Immutable.1.1.36.nupkg.sha512",
+        "System.Collections.Immutable.nuspec",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+      ]
+    },
     "System.Console/4.0.0-beta-22927": {
       "sha512": "KZRrlvSx0nqsWaUlVhA79tt3RsDl2KuCJoy1vti55Az6QT24Uni/NedtZFrMaKtn90fWvT5hmT7cGQwgUJZ/OQ==",
       "files": [
@@ -470,6 +501,18 @@
         "lib/contract/System.Reflection.dll",
         "lib/net45/System.Reflection.dll",
         "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Reflection.dll"
+      ]
+    },
+    "System.Reflection.Metadata/1.0.21": {
+      "serviceable": true,
+      "sha512": "CAhcY0EJFLXfxo5YRV/ytkTOeTBho8zKjLu+9LvEI5NIVmanp1yMUzYQdjvXpHbyV0Qt1KuLXcTCc9t9FVH3Wg==",
+      "files": [
+        "License-Stable.rtf",
+        "System.Reflection.Metadata.1.0.21.nupkg",
+        "System.Reflection.Metadata.1.0.21.nupkg.sha512",
+        "System.Reflection.Metadata.nuspec",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
       ]
     },
     "System.Reflection.Primitives/4.0.0-beta-22927": {
@@ -732,6 +775,7 @@
       "System.IO >= 4.0.10-beta-*",
       "System.IO.FileSystem >= 4.0.0-beta-*",
       "System.IO.FileSystem.Primitives >= 4.0.0-beta-*",
+      "System.Reflection.Metadata >= 1.0.21",
       "System.Runtime >= 4.0.20-beta-*",
       "System.Runtime.Extensions >= 4.0.10-beta-*",
       "System.Runtime.InteropServices >= 4.0.20-beta-*",

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -16,7 +16,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoWarn>1591</NoWarn>
     <CLSCompliant>false</CLSCompliant>
-    <AssemblyVersion>1.0.19.0</AssemblyVersion>
+    <AssemblyVersion>1.0.9999.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Provides an implementation of System.Diagnostics.FileVersionInfo on Unix when the file in question is a managed assembly.  The implementation uses the assembly's metadata as read via System.Reflection.Metadata.

Fixes #811.