### PR TITLE
Open source System.Net.Http unit tests

### DIFF
--- a/src/System.Net.Http/System.Net.Http.sln
+++ b/src/System.Net.Http/System.Net.Http.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22816.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.Http.UnitTests", "tests\UnitTests\System.Net.Http.Unit.Tests.csproj", "{5F9C3C9F-652E-461E-B2D6-85D264F5A733}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Net.Http/tests/UnitTests/Fakes/HttpClientHandler.cs
+++ b/src/System.Net.Http/tests/UnitTests/Fakes/HttpClientHandler.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    public class HttpClientHandler : HttpMessageHandler
+    {
+        #region Properties
+
+        public virtual bool SupportsAutomaticDecompression
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public virtual bool SupportsProxy
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public virtual bool SupportsRedirectConfiguration
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public bool UseCookies
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public CookieContainer CookieContainer
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public ClientCertificateOption ClientCertificateOptions
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public DecompressionMethods AutomaticDecompression
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public bool UseProxy
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public IWebProxy Proxy
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public bool PreAuthenticate
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public bool UseDefaultCredentials
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public ICredentials Credentials
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public bool AllowAutoRedirect
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public int MaxAutomaticRedirections
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        public long MaxRequestContentBufferSize
+        {
+            get { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+            set { throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented"); }
+        }
+
+        #endregion Properties
+
+        #region De/Constructors
+
+        public HttpClientHandler()
+        {
+            throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented");
+        }
+
+        #endregion De/Constructors
+
+        #region Request Execution
+
+        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            throw NotImplemented.ByDesignWithMessage("HTTP stack not implemented");
+        }
+
+        #endregion Request Execution
+    }
+}
+

--- a/src/System.Net.Http/tests/UnitTests/Headers/AuthenticationHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/AuthenticationHeaderValueTest.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class AuthenticationHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_SetBothSchemeAndParameters_MatchExpectation()
+        {
+            AuthenticationHeaderValue auth = new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\"");
+            Assert.Equal("Basic", auth.Scheme);
+            Assert.Equal("realm=\"contoso.com\"", auth.Parameter);
+
+            Assert.Throws<ArgumentException>(() => { new AuthenticationHeaderValue(null, "x"); });
+            Assert.Throws<ArgumentException>(() => { new AuthenticationHeaderValue("", "x"); });
+            Assert.Throws<FormatException>(() => { new AuthenticationHeaderValue(" x", "x"); });
+            Assert.Throws<FormatException>(() => { new AuthenticationHeaderValue("x ", "x"); });
+            Assert.Throws<FormatException>(() => { new AuthenticationHeaderValue("x y", "x"); });
+        }
+
+        [Fact]
+        public void Ctor_SetSchemeOnly_MatchExpectation()
+        {
+            // Just verify that this ctor forwards the call to the overload taking 2 parameters.
+            AuthenticationHeaderValue auth = new AuthenticationHeaderValue("NTLM");
+            Assert.Equal("NTLM", auth.Scheme);
+            Assert.Null(auth.Parameter);
+        }
+
+        [Fact]
+        public void ToString_UseBothNoParameterAndSetParameter_AllSerializedCorrectly()
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            string input = string.Empty;
+
+            AuthenticationHeaderValue auth = new AuthenticationHeaderValue("Digest",
+                "qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"");
+
+            Assert.Equal(
+                "Digest qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"",
+                auth.ToString());
+            response.Headers.ProxyAuthenticate.Add(auth);
+            input += auth.ToString();
+
+            auth = new AuthenticationHeaderValue("Negotiate");
+            Assert.Equal("Negotiate", auth.ToString());
+            response.Headers.ProxyAuthenticate.Add(auth);
+            input += ", " + auth.ToString();
+
+            auth = new AuthenticationHeaderValue("Custom", ""); // empty string should be treated like 'null'.
+            Assert.Equal("Custom", auth.ToString());
+            response.Headers.ProxyAuthenticate.Add(auth);
+            input += ", " + auth.ToString();
+
+            string result = response.Headers.ProxyAuthenticate.ToString();
+            Assert.Equal(input, result);
+        }
+
+        [Fact]
+        public void Parse_GoodValues_Success()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+
+            string input = " Digest qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8 ";
+
+            request.Headers.Authorization = AuthenticationHeaderValue.Parse(input);
+            Assert.Equal(input.Trim(), request.Headers.Authorization.ToString());
+        }
+
+        [Fact]
+        public void TryParse_GoodValues_Success()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+
+            string input = " Digest qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",realm=\"Digest\" ";
+
+            AuthenticationHeaderValue parsedValue;
+            Assert.True(AuthenticationHeaderValue.TryParse(input, out parsedValue));
+            request.Headers.Authorization = parsedValue;
+            Assert.Equal(input.Trim(), request.Headers.Authorization.ToString());
+        }
+
+        [Fact]
+        public void Parse_BadValues_Throws()
+        {
+            string input = "D\rigest qop=\"auth\",algorithm=MD5-sess,charset=utf-8,realm=\"Digest\"";
+
+            Assert.Throws<FormatException>(() => { AuthenticationHeaderValue.Parse(input); });
+        }
+
+        [Fact]
+        public void TryParse_BadValues_False()
+        {
+            string input = ", Digest qop=\"auth\",nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\"";
+
+            AuthenticationHeaderValue parsedValue;
+            Assert.False(AuthenticationHeaderValue.TryParse(input, out parsedValue));
+        }
+
+        [Fact]
+        public void Add_BadValues_Throws()
+        {
+            string x = SR.net_http_message_not_success_statuscode;
+            string input = "Digest algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\", ";
+
+            HttpRequestMessage request = new HttpRequestMessage();
+            Assert.Throws<FormatException>(() => { request.Headers.Add(HttpKnownHeaderNames.Authorization, input); });
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentAuth_SameOrDifferentHashCodes()
+        {
+            AuthenticationHeaderValue auth1 = new AuthenticationHeaderValue("A", "b");
+            AuthenticationHeaderValue auth2 = new AuthenticationHeaderValue("a", "b");
+            AuthenticationHeaderValue auth3 = new AuthenticationHeaderValue("A", "B");
+            AuthenticationHeaderValue auth4 = new AuthenticationHeaderValue("A");
+            AuthenticationHeaderValue auth5 = new AuthenticationHeaderValue("A", "");
+            AuthenticationHeaderValue auth6 = new AuthenticationHeaderValue("X", "b");
+
+            Assert.Equal(auth1.GetHashCode(), auth2.GetHashCode());
+            Assert.NotEqual(auth1.GetHashCode(), auth3.GetHashCode());
+            Assert.NotEqual(auth1.GetHashCode(), auth4.GetHashCode());
+            Assert.Equal(auth4.GetHashCode(), auth5.GetHashCode());
+            Assert.NotEqual(auth1.GetHashCode(), auth6.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentAuth_EqualOrNotEqualNoExceptions()
+        {
+            AuthenticationHeaderValue auth1 = new AuthenticationHeaderValue("A", "b");
+            AuthenticationHeaderValue auth2 = new AuthenticationHeaderValue("a", "b");
+            AuthenticationHeaderValue auth3 = new AuthenticationHeaderValue("A", "B");
+            AuthenticationHeaderValue auth4 = new AuthenticationHeaderValue("A");
+            AuthenticationHeaderValue auth5 = new AuthenticationHeaderValue("A", "");
+            AuthenticationHeaderValue auth6 = new AuthenticationHeaderValue("X", "b");
+
+            Assert.False(auth1.Equals(null));
+            Assert.True(auth1.Equals(auth2));
+            Assert.False(auth1.Equals(auth3));
+            Assert.False(auth1.Equals(auth4));
+            Assert.False(auth4.Equals(auth1));
+            Assert.False(auth1.Equals(auth5));
+            Assert.False(auth5.Equals(auth1));
+            Assert.True(auth4.Equals(auth5));
+            Assert.True(auth5.Equals(auth4));
+            Assert.False(auth1.Equals(auth6));
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            AuthenticationHeaderValue source = new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+            AuthenticationHeaderValue clone = (AuthenticationHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Scheme, clone.Scheme);
+            Assert.Equal(source.Parameter, clone.Parameter);
+
+            source = new AuthenticationHeaderValue("Kerberos");
+            clone = (AuthenticationHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Scheme, clone.Scheme);
+            Assert.Null(clone.Parameter);
+        }
+
+        [Fact]
+        public void GetAuthenticationLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            CallGetAuthenticationLength(" Basic  QWxhZGRpbjpvcGVuIHNlc2FtZQ==  ", 1, 37,
+                new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="));
+            CallGetAuthenticationLength(" Basic  QWxhZGRpbjpvcGVuIHNlc2FtZQ==  , ", 1, 37,
+                new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="));
+            CallGetAuthenticationLength(" Basic realm=\"example.com\"", 1, 25,
+                new AuthenticationHeaderValue("Basic", "realm=\"example.com\""));
+            CallGetAuthenticationLength(" Basic realm=\"exam,,ple.com\",", 1, 27,
+                new AuthenticationHeaderValue("Basic", "realm=\"exam,,ple.com\""));
+            CallGetAuthenticationLength(" Basic realm=\"exam,ple.com\",", 1, 26,
+                new AuthenticationHeaderValue("Basic", "realm=\"exam,ple.com\""));
+            CallGetAuthenticationLength("NTLM   ", 0, 7, new AuthenticationHeaderValue("NTLM"));
+            CallGetAuthenticationLength("Digest", 0, 6, new AuthenticationHeaderValue("Digest"));
+            CallGetAuthenticationLength("Digest,,", 0, 6, new AuthenticationHeaderValue("Digest"));
+            CallGetAuthenticationLength("Digest a=b, c=d,,", 0, 15, new AuthenticationHeaderValue("Digest", "a=b, c=d"));
+            CallGetAuthenticationLength("Kerberos,", 0, 8, new AuthenticationHeaderValue("Kerberos"));
+            CallGetAuthenticationLength("Basic,NTLM", 0, 5, new AuthenticationHeaderValue("Basic"));
+            CallGetAuthenticationLength("Digest a=b,c=\"d\", e=f, NTLM", 0, 21,
+                new AuthenticationHeaderValue("Digest", "a=b,c=\"d\", e=f"));
+            CallGetAuthenticationLength("Digest a = b , c = \"d\" ,  e = f ,NTLM", 0, 32,
+                new AuthenticationHeaderValue("Digest", "a = b , c = \"d\" ,  e = f"));
+            CallGetAuthenticationLength("Digest a = b , c = \"d\" ,  e = f , NTLM AbCdEf==", 0, 32,
+                new AuthenticationHeaderValue("Digest", "a = b , c = \"d\" ,  e = f"));
+            CallGetAuthenticationLength("Digest a = \"b\", c= \"d\" ,  e = f,NTLM AbC=,", 0, 31,
+                new AuthenticationHeaderValue("Digest", "a = \"b\", c= \"d\" ,  e = f"));
+            CallGetAuthenticationLength("Digest a=\"b\", c=d", 0, 17,
+                new AuthenticationHeaderValue("Digest", "a=\"b\", c=d"));
+            CallGetAuthenticationLength("Digest a=\"b\", c=d,", 0, 17,
+                new AuthenticationHeaderValue("Digest", "a=\"b\", c=d"));
+            CallGetAuthenticationLength("Digest a=\"b\", c=d ,", 0, 18,
+                new AuthenticationHeaderValue("Digest", "a=\"b\", c=d"));
+            CallGetAuthenticationLength("Digest a=\"b\", c=d  ", 0, 19,
+                new AuthenticationHeaderValue("Digest", "a=\"b\", c=d"));
+            CallGetAuthenticationLength("Custom \"blob\", c=d,Custom2 \"blob\"", 0, 18,
+                new AuthenticationHeaderValue("Custom", "\"blob\", c=d"));
+            CallGetAuthenticationLength("Custom \"blob\", a=b,,,c=d,Custom2 \"blob\"", 0, 24,
+                new AuthenticationHeaderValue("Custom", "\"blob\", a=b,,,c=d"));
+            CallGetAuthenticationLength("Custom \"blob\", a=b,c=d,,,Custom2 \"blob\"", 0, 22,
+                new AuthenticationHeaderValue("Custom", "\"blob\", a=b,c=d"));
+            CallGetAuthenticationLength("Custom a=b, c=d,,,InvalidNextScheme\u670D", 0, 15,
+                new AuthenticationHeaderValue("Custom", "a=b, c=d"));
+        }
+
+        [Fact]
+        public void GetAuthenticationLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetAuthenticationLength(" NTLM", 0); // no leading whitespaces allowed
+            CheckInvalidGetAuthenticationLength("Basic=", 0);
+            CheckInvalidGetAuthenticationLength("=Basic", 0);
+            CheckInvalidGetAuthenticationLength("Digest a=b, \u670D", 0);
+            CheckInvalidGetAuthenticationLength("Digest a=b, c=d, \u670D", 0);
+            CheckInvalidGetAuthenticationLength("Digest a=b, c=", 0);
+            CheckInvalidGetAuthenticationLength("Digest a=\"b, c", 0);
+            CheckInvalidGetAuthenticationLength("Digest a=\"b", 0);
+            CheckInvalidGetAuthenticationLength("Digest a=b, c=\u670D", 0);
+
+            CheckInvalidGetAuthenticationLength("", 0);
+            CheckInvalidGetAuthenticationLength(null, 0);
+        }
+
+        #region Helper methods
+
+        private static void CallGetAuthenticationLength(string input, int startIndex, int expectedLength,
+            AuthenticationHeaderValue expectedResult)
+        {
+            object result = null;
+            Assert.Equal(expectedLength, AuthenticationHeaderValue.GetAuthenticationLength(input, startIndex, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private static void CheckInvalidGetAuthenticationLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, AuthenticationHeaderValue.GetAuthenticationLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ByteArrayHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ByteArrayHeaderParserTest.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ByteArrayHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            ByteArrayHeaderParser parser = ByteArrayHeaderParser.Parser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_NullValue_Throw()
+        {
+            ByteArrayHeaderParser parser = ByteArrayHeaderParser.Parser;
+            int index = 0;
+            Assert.Throws<FormatException>(() => { parser.ParseValue(null, null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X  A/b+CQ== ", 1, new byte[] { 3, 246, 254, 9 }, 12);
+            CheckValidParsedValue("AQ==", 0, new byte[] { 1 }, 4);
+
+            // Note that Convert.FromBase64String() is tolerant with whitespace characters in the middle of the Base64
+            // string:
+            CheckValidParsedValue(" AbCdE fGhI  jKl+/Mn \r\n \t", 0,
+                new byte[] { 1, 176, 157, 17, 241, 161, 34, 50, 165, 251, 243, 39 }, 25);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("", 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("a", 0);
+            CheckInvalidParsedValue("AQ", 0);
+            CheckInvalidParsedValue("AQ== X", 0);
+            CheckInvalidParsedValue("AQ==,", 0);
+            CheckInvalidParsedValue("AQ==A", 0);
+            CheckInvalidParsedValue("AQ== ,", 0);
+            CheckInvalidParsedValue(", AQ==", 0);
+            CheckInvalidParsedValue(" ,AQ==", 0);
+            CheckInvalidParsedValue("=", 0);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentValues_MatchExpectation()
+        {
+            ByteArrayHeaderParser parser = ByteArrayHeaderParser.Parser;
+            Assert.Equal("A/b+CQ==", parser.ToString(new byte[] { 3, 246, 254, 9 }));
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, byte[] expectedResult, int expectedIndex)
+        {
+            ByteArrayHeaderParser parser = ByteArrayHeaderParser.Parser;
+            object result = 0;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result));
+            Assert.Equal(expectedIndex, startIndex);
+
+            if (result == null)
+            {
+                Assert.Null(expectedResult);
+            }
+            else
+            {
+                byte[] arrayResult = (byte[])result;
+                Assert.Equal(expectedResult, arrayResult);
+            }
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            ByteArrayHeaderParser parser = ByteArrayHeaderParser.Parser;
+            object result = 0;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/CacheControlHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/CacheControlHeaderParserTest.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class CacheControlHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = CacheControlHeaderParser.Parser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Just verify parser is implemented correctly. Don't try to test syntax parsed by CacheControlHeaderValue.
+            CacheControlHeaderValue expected = new CacheControlHeaderValue();
+            expected.NoStore = true;
+            expected.MinFresh = new TimeSpan(0, 2, 3);
+            CheckValidParsedValue("X , , no-store, min-fresh=123", 1, expected, 29);
+
+            expected = new CacheControlHeaderValue();
+            expected.MaxStale = true;
+            expected.NoCache = true;
+            expected.NoCacheHeaders.Add("t");
+            CheckValidParsedValue("max-stale, no-cache=\"t\", ,,", 0, expected, 27);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("no-cache,=", 0);
+            CheckInvalidParsedValue("max-age=123x", 0);
+            CheckInvalidParsedValue("=no-cache", 0);
+            CheckInvalidParsedValue("no-cache no-store", 0);
+            CheckInvalidParsedValue("invalid =", 0);
+            CheckInvalidParsedValue("\u4F1A", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, CacheControlHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = CacheControlHeaderParser.Parser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = CacheControlHeaderParser.Parser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/CacheControlHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/CacheControlHeaderValueTest.cs
@@ -1,0 +1,707 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class CacheControlHeaderValueTest
+    {
+        [Fact]
+        public void Properties_SetAndGetAllProperties_SetValueReturnedInGetter()
+        {
+            CacheControlHeaderValue cacheControl = new CacheControlHeaderValue();
+
+            // Bool properties
+            cacheControl.NoCache = true;
+            Assert.True(cacheControl.NoCache);
+            cacheControl.NoStore = true;
+            Assert.True(cacheControl.NoStore);
+            cacheControl.MaxStale = true;
+            Assert.True(cacheControl.MaxStale);
+            cacheControl.NoTransform = true;
+            Assert.True(cacheControl.NoTransform);
+            cacheControl.OnlyIfCached = true;
+            Assert.True(cacheControl.OnlyIfCached);
+            cacheControl.Public = true;
+            Assert.True(cacheControl.Public);
+            cacheControl.Private = true;
+            Assert.True(cacheControl.Private);
+            cacheControl.MustRevalidate = true;
+            Assert.True(cacheControl.MustRevalidate);
+            cacheControl.ProxyRevalidate = true;
+            Assert.True(cacheControl.ProxyRevalidate);
+
+            // TimeSpan properties
+            TimeSpan timeSpan = new TimeSpan(1, 2, 3);
+            cacheControl.MaxAge = timeSpan;
+            Assert.Equal(timeSpan, cacheControl.MaxAge);
+            cacheControl.SharedMaxAge = timeSpan;
+            Assert.Equal(timeSpan, cacheControl.SharedMaxAge);
+            cacheControl.MaxStaleLimit = timeSpan;
+            Assert.Equal(timeSpan, cacheControl.MaxStaleLimit);
+            cacheControl.MinFresh = timeSpan;
+            Assert.Equal(timeSpan, cacheControl.MinFresh);
+
+            // String collection properties
+            Assert.NotNull(cacheControl.NoCacheHeaders);
+            Assert.Throws<ArgumentException>(() => { cacheControl.NoCacheHeaders.Add(null); });
+            Assert.Throws<FormatException>(() => { cacheControl.NoCacheHeaders.Add("invalid token"); });
+            cacheControl.NoCacheHeaders.Add("token");
+            Assert.Equal(1, cacheControl.NoCacheHeaders.Count);
+            Assert.Equal("token", cacheControl.NoCacheHeaders.First());
+
+            Assert.NotNull(cacheControl.PrivateHeaders);
+            Assert.Throws<ArgumentException>(() => { cacheControl.PrivateHeaders.Add(null); });
+            Assert.Throws<FormatException>(() => { cacheControl.PrivateHeaders.Add("invalid token"); });
+            cacheControl.PrivateHeaders.Add("token");
+            Assert.Equal(1, cacheControl.PrivateHeaders.Count);
+            Assert.Equal("token", cacheControl.PrivateHeaders.First());
+
+            // NameValueHeaderValue collection property
+            Assert.NotNull(cacheControl.Extensions);
+            Assert.Throws<ArgumentNullException>(() => { cacheControl.Extensions.Add(null); });
+            cacheControl.Extensions.Add(new NameValueHeaderValue("name", "value"));
+            Assert.Equal(1, cacheControl.Extensions.Count);
+            Assert.Equal(new NameValueHeaderValue("name", "value"), cacheControl.Extensions.First());
+        }
+
+        [Fact]
+        public void ToString_UseRequestDirectiveValues_AllSerializedCorrectly()
+        {
+            CacheControlHeaderValue cacheControl = new CacheControlHeaderValue();
+            Assert.Equal("", cacheControl.ToString());
+
+            // Note that we allow all combinations of all properties even though the RFC specifies rules what value
+            // can be used together.
+            // Also for property pairs (bool property + collection property) like 'NoCache' and 'NoCacheHeaders' the
+            // caller needs to set the bool property in order for the collection to be populated as string.
+
+            // Cache Request Directive sample
+            cacheControl.NoStore = true;
+            Assert.Equal("no-store", cacheControl.ToString());
+            cacheControl.NoCache = true;
+            Assert.Equal("no-store, no-cache", cacheControl.ToString());
+            cacheControl.MaxAge = new TimeSpan(0, 1, 10);
+            Assert.Equal("no-store, no-cache, max-age=70", cacheControl.ToString());
+            cacheControl.MaxStale = true;
+            Assert.Equal("no-store, no-cache, max-age=70, max-stale", cacheControl.ToString());
+            cacheControl.MaxStaleLimit = new TimeSpan(0, 2, 5);
+            Assert.Equal("no-store, no-cache, max-age=70, max-stale=125", cacheControl.ToString());
+            cacheControl.MinFresh = new TimeSpan(0, 3, 0);
+            Assert.Equal("no-store, no-cache, max-age=70, max-stale=125, min-fresh=180", cacheControl.ToString());
+
+            cacheControl = new CacheControlHeaderValue();
+            cacheControl.NoTransform = true;
+            Assert.Equal("no-transform", cacheControl.ToString());
+            cacheControl.OnlyIfCached = true;
+            Assert.Equal("no-transform, only-if-cached", cacheControl.ToString());
+            cacheControl.Extensions.Add(new NameValueHeaderValue("custom"));
+            cacheControl.Extensions.Add(new NameValueHeaderValue("customName", "customValue"));
+            Assert.Equal("no-transform, only-if-cached, custom, customName=customValue", cacheControl.ToString());
+
+            cacheControl = new CacheControlHeaderValue();
+            cacheControl.Extensions.Add(new NameValueHeaderValue("custom"));
+            Assert.Equal("custom", cacheControl.ToString());
+        }
+
+        [Fact]
+        public void ToString_UseResponseDirectiveValues_AllSerializedCorrectly()
+        {
+            CacheControlHeaderValue cacheControl = new CacheControlHeaderValue();
+            Assert.Equal("", cacheControl.ToString());
+
+            cacheControl.NoCache = true;
+            Assert.Equal("no-cache", cacheControl.ToString());
+            cacheControl.NoCacheHeaders.Add("token1");
+            Assert.Equal("no-cache=\"token1\"", cacheControl.ToString());
+            cacheControl.Public = true;
+            Assert.Equal("public, no-cache=\"token1\"", cacheControl.ToString());
+
+            cacheControl = new CacheControlHeaderValue();
+            cacheControl.Private = true;
+            Assert.Equal("private", cacheControl.ToString());
+            cacheControl.PrivateHeaders.Add("token2");
+            cacheControl.PrivateHeaders.Add("token3");
+            Assert.Equal("private=\"token2, token3\"", cacheControl.ToString());
+            cacheControl.MustRevalidate = true;
+            Assert.Equal("must-revalidate, private=\"token2, token3\"", cacheControl.ToString());
+            cacheControl.ProxyRevalidate = true;
+            Assert.Equal("must-revalidate, proxy-revalidate, private=\"token2, token3\"", cacheControl.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_CompareValuesWithBoolFieldsSet_MatchExpectation()
+        {
+            // Verify that different bool fields return different hash values.
+            CacheControlHeaderValue[] values = new CacheControlHeaderValue[9];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = new CacheControlHeaderValue();
+            }
+
+            values[0].ProxyRevalidate = true;
+            values[1].NoCache = true;
+            values[2].NoStore = true;
+            values[3].MaxStale = true;
+            values[4].NoTransform = true;
+            values[5].OnlyIfCached = true;
+            values[6].Public = true;
+            values[7].Private = true;
+            values[8].MustRevalidate = true;
+
+            // Only one bool field set. All hash codes should differ
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    if (i != j)
+                    {
+                        CompareHashCodes(values[i], values[j], false);
+                    }
+                }
+            }
+
+            // Validate that two instances with the same bool fields set are equal.
+            values[0].NoCache = true;
+            CompareHashCodes(values[0], values[1], false);
+            values[1].ProxyRevalidate = true;
+            CompareHashCodes(values[0], values[1], true);
+        }
+
+        [Fact]
+        public void GetHashCode_CompareValuesWithTimeSpanFieldsSet_MatchExpectation()
+        {
+            // Verify that different timespan fields return different hash values.
+            CacheControlHeaderValue[] values = new CacheControlHeaderValue[4];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = new CacheControlHeaderValue();
+            }
+
+            values[0].MaxAge = new TimeSpan(0, 1, 1);
+            values[1].MaxStaleLimit = new TimeSpan(0, 1, 1);
+            values[2].MinFresh = new TimeSpan(0, 1, 1);
+            values[3].SharedMaxAge = new TimeSpan(0, 1, 1);
+
+            // Only one timespan field set. All hash codes should differ
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    if (i != j)
+                    {
+                        CompareHashCodes(values[i], values[j], false);
+                    }
+                }
+            }
+
+            values[0].MaxStaleLimit = new TimeSpan(0, 1, 2);
+            CompareHashCodes(values[0], values[1], false);
+
+            values[1].MaxAge = new TimeSpan(0, 1, 1);
+            values[1].MaxStaleLimit = new TimeSpan(0, 1, 2);
+            CompareHashCodes(values[0], values[1], true);
+        }
+
+        [Fact]
+        public void GetHashCode_CompareCollectionFieldsSet_MatchExpectation()
+        {
+            CacheControlHeaderValue cacheControl1 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl2 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl3 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl4 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl5 = new CacheControlHeaderValue();
+
+            cacheControl1.NoCache = true;
+            cacheControl1.NoCacheHeaders.Add("token2");
+
+            cacheControl2.NoCache = true;
+            cacheControl2.NoCacheHeaders.Add("token1");
+            cacheControl2.NoCacheHeaders.Add("token2");
+
+            CompareHashCodes(cacheControl1, cacheControl2, false);
+
+            cacheControl1.NoCacheHeaders.Add("token1");
+            CompareHashCodes(cacheControl1, cacheControl2, true);
+
+            // Since NoCache and Private generate different hash codes, even if NoCacheHeaders and PrivateHeaders 
+            // have the same values, the hash code will be different.
+            cacheControl3.Private = true;
+            cacheControl3.PrivateHeaders.Add("token2");
+            CompareHashCodes(cacheControl1, cacheControl3, false);
+
+
+            cacheControl4.Extensions.Add(new NameValueHeaderValue("custom"));
+            CompareHashCodes(cacheControl1, cacheControl4, false);
+
+            cacheControl5.Extensions.Add(new NameValueHeaderValue("customN", "customV"));
+            cacheControl5.Extensions.Add(new NameValueHeaderValue("custom"));
+            CompareHashCodes(cacheControl4, cacheControl5, false);
+
+            cacheControl4.Extensions.Add(new NameValueHeaderValue("customN", "customV"));
+            CompareHashCodes(cacheControl4, cacheControl5, true);
+        }
+
+        [Fact]
+        public void Equals_CompareValuesWithBoolFieldsSet_MatchExpectation()
+        {
+            // Verify that different bool fields return different hash values.
+            CacheControlHeaderValue[] values = new CacheControlHeaderValue[9];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = new CacheControlHeaderValue();
+            }
+
+            values[0].ProxyRevalidate = true;
+            values[1].NoCache = true;
+            values[2].NoStore = true;
+            values[3].MaxStale = true;
+            values[4].NoTransform = true;
+            values[5].OnlyIfCached = true;
+            values[6].Public = true;
+            values[7].Private = true;
+            values[8].MustRevalidate = true;
+
+            // Only one bool field set. All hash codes should differ
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    if (i != j)
+                    {
+                        CompareValues(values[i], values[j], false);
+                    }
+                }
+            }
+
+            // Validate that two instances with the same bool fields set are equal.
+            values[0].NoCache = true;
+            CompareValues(values[0], values[1], false);
+            values[1].ProxyRevalidate = true;
+            CompareValues(values[0], values[1], true);
+        }
+
+        [Fact]
+        public void Equals_CompareValuesWithTimeSpanFieldsSet_MatchExpectation()
+        {
+            // Verify that different timespan fields return different hash values.
+            CacheControlHeaderValue[] values = new CacheControlHeaderValue[4];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = new CacheControlHeaderValue();
+            }
+
+            values[0].MaxAge = new TimeSpan(0, 1, 1);
+            values[1].MaxStaleLimit = new TimeSpan(0, 1, 1);
+            values[2].MinFresh = new TimeSpan(0, 1, 1);
+            values[3].SharedMaxAge = new TimeSpan(0, 1, 1);
+
+            // Only one timespan field set. All hash codes should differ
+            for (int i = 0; i < values.Length; i++)
+            {
+                for (int j = 0; j < values.Length; j++)
+                {
+                    if (i != j)
+                    {
+                        CompareValues(values[i], values[j], false);
+                    }
+                }
+            }
+
+            values[0].MaxStaleLimit = new TimeSpan(0, 1, 2);
+            CompareValues(values[0], values[1], false);
+
+            values[1].MaxAge = new TimeSpan(0, 1, 1);
+            values[1].MaxStaleLimit = new TimeSpan(0, 1, 2);
+            CompareValues(values[0], values[1], true);
+
+            CacheControlHeaderValue value1 = new CacheControlHeaderValue();
+            value1.MaxStale = true;
+            CacheControlHeaderValue value2 = new CacheControlHeaderValue();
+            value2.MaxStale = true;
+            CompareValues(value1, value2, true);
+
+            value2.MaxStaleLimit = new TimeSpan(1, 2, 3);
+            CompareValues(value1, value2, false);
+        }
+
+        [Fact]
+        public void Equals_CompareCollectionFieldsSet_MatchExpectation()
+        {
+            CacheControlHeaderValue cacheControl1 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl2 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl3 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl4 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl5 = new CacheControlHeaderValue();
+            CacheControlHeaderValue cacheControl6 = new CacheControlHeaderValue();
+
+            cacheControl1.NoCache = true;
+            cacheControl1.NoCacheHeaders.Add("token2");
+
+            Assert.False(cacheControl1.Equals(null), "Compare with 'null'");
+
+            cacheControl2.NoCache = true;
+            cacheControl2.NoCacheHeaders.Add("token1");
+            cacheControl2.NoCacheHeaders.Add("token2");
+
+            CompareValues(cacheControl1, cacheControl2, false);
+
+            cacheControl1.NoCacheHeaders.Add("token1");
+            CompareValues(cacheControl1, cacheControl2, true);
+
+            // Since NoCache and Private generate different hash codes, even if NoCacheHeaders and PrivateHeaders 
+            // have the same values, the hash code will be different.
+            cacheControl3.Private = true;
+            cacheControl3.PrivateHeaders.Add("token2");
+            CompareValues(cacheControl1, cacheControl3, false);
+
+            cacheControl4.Private = true;
+            cacheControl4.PrivateHeaders.Add("token3");
+            CompareValues(cacheControl3, cacheControl4, false);
+
+            cacheControl5.Extensions.Add(new NameValueHeaderValue("custom"));
+            CompareValues(cacheControl1, cacheControl5, false);
+
+            cacheControl6.Extensions.Add(new NameValueHeaderValue("customN", "customV"));
+            cacheControl6.Extensions.Add(new NameValueHeaderValue("custom"));
+            CompareValues(cacheControl5, cacheControl6, false);
+
+            cacheControl5.Extensions.Add(new NameValueHeaderValue("customN", "customV"));
+            CompareValues(cacheControl5, cacheControl6, true);
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            CacheControlHeaderValue source = new CacheControlHeaderValue();
+            source.Extensions.Add(new NameValueHeaderValue("custom"));
+            source.Extensions.Add(new NameValueHeaderValue("customN", "customV"));
+            source.MaxAge = new TimeSpan(1, 1, 1);
+            source.MaxStale = true;
+            source.MaxStaleLimit = new TimeSpan(1, 1, 2);
+            source.MinFresh = new TimeSpan(1, 1, 3);
+            source.MustRevalidate = true;
+            source.NoCache = true;
+            source.NoCacheHeaders.Add("token1");
+            source.NoStore = true;
+            source.NoTransform = true;
+            source.OnlyIfCached = true;
+            source.Private = true;
+            source.PrivateHeaders.Add("token2");
+            source.ProxyRevalidate = true;
+            source.Public = true;
+            source.SharedMaxAge = new TimeSpan(1, 1, 4);
+            CacheControlHeaderValue clone = (CacheControlHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source, clone);
+        }
+
+        [Fact]
+        public void GetCacheControlLength_DifferentValidScenariosAndNoExistingCacheControl_AllReturnNonZero()
+        {
+            CacheControlHeaderValue expected = new CacheControlHeaderValue();
+            expected.NoCache = true;
+            CheckGetCacheControlLength("X , , no-cache ,,", 1, null, 16, expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.NoCache = true;
+            expected.NoCacheHeaders.Add("token1");
+            expected.NoCacheHeaders.Add("token2");
+            CheckGetCacheControlLength("no-cache=\"token1, token2\"", 0, null, 25, expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.NoStore = true;
+            expected.MaxAge = new TimeSpan(0, 0, 125);
+            expected.MaxStale = true;
+            CheckGetCacheControlLength("X no-store , max-age = 125, max-stale,", 1, null, 37, expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.MinFresh = new TimeSpan(0, 0, 123);
+            expected.NoTransform = true;
+            expected.OnlyIfCached = true;
+            expected.Extensions.Add(new NameValueHeaderValue("custom"));
+            CheckGetCacheControlLength("min-fresh=123, no-transform, only-if-cached, custom", 0, null, 51, expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.Public = true;
+            expected.Private = true;
+            expected.PrivateHeaders.Add("token1");
+            expected.MustRevalidate = true;
+            expected.ProxyRevalidate = true;
+            expected.Extensions.Add(new NameValueHeaderValue("c", "d"));
+            expected.Extensions.Add(new NameValueHeaderValue("a", "b"));
+            CheckGetCacheControlLength(",public, , private=\"token1\", must-revalidate, c=d, proxy-revalidate, a=b", 0,
+                null, 72, expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.Private = true;
+            expected.SharedMaxAge = new TimeSpan(0, 0, 1234567890);
+            expected.MaxAge = new TimeSpan(0, 0, 987654321);
+            CheckGetCacheControlLength("s-maxage=1234567890, private, max-age = 987654321,", 0, null, 50, expected);
+        }
+
+        [Fact]
+        public void GetCacheControlLength_DifferentValidScenariosAndExistingCacheControl_AllReturnNonZero()
+        {
+            CacheControlHeaderValue storeValue = new CacheControlHeaderValue();
+            storeValue.NoStore = true;
+            CacheControlHeaderValue expected = new CacheControlHeaderValue();
+            expected.NoCache = true;
+            expected.NoStore = true;
+            CheckGetCacheControlLength("X no-cache", 1, storeValue, 9, expected);
+
+            storeValue = new CacheControlHeaderValue();
+            storeValue.Private = true;
+            storeValue.PrivateHeaders.Add("token1");
+            storeValue.NoCache = true;
+            expected.NoCacheHeaders.Add("token1");
+            expected.NoCacheHeaders.Clear(); // just make sure we have an assigned (empty) collection.
+            expected = new CacheControlHeaderValue();
+            expected.Private = true;
+            expected.PrivateHeaders.Add("token1");
+            expected.PrivateHeaders.Add("token2");
+            expected.NoCache = true;
+            expected.NoCacheHeaders.Add("token1");
+            expected.NoCacheHeaders.Add("token2");
+            CheckGetCacheControlLength("private=\"token2\", no-cache=\"token1, , token2,\"", 0, storeValue, 46,
+                expected);
+
+            storeValue = new CacheControlHeaderValue();
+            storeValue.Extensions.Add(new NameValueHeaderValue("x", "y"));
+            storeValue.NoTransform = true;
+            storeValue.OnlyIfCached = true;
+            expected = new CacheControlHeaderValue();
+            expected.Public = true;
+            expected.Private = true;
+            expected.PrivateHeaders.Add("token1");
+            expected.MustRevalidate = true;
+            expected.ProxyRevalidate = true;
+            expected.NoTransform = true;
+            expected.OnlyIfCached = true;
+            expected.Extensions.Add(new NameValueHeaderValue("a", "\"b\""));
+            expected.Extensions.Add(new NameValueHeaderValue("c", "d"));
+            expected.Extensions.Add(new NameValueHeaderValue("x", "y")); // from store result
+            CheckGetCacheControlLength(",public, , private=\"token1\", must-revalidate, c=d, proxy-revalidate, a=\"b\"",
+                0, storeValue, 74, expected);
+
+            storeValue = new CacheControlHeaderValue();
+            storeValue.MaxStale = true;
+            storeValue.MinFresh = new TimeSpan(1, 2, 3);
+            expected = new CacheControlHeaderValue();
+            expected.MaxStale = true;
+            expected.MaxStaleLimit = new TimeSpan(0, 0, 5);
+            expected.MinFresh = new TimeSpan(0, 0, 10); // note that the last header value overwrites existing ones
+            CheckGetCacheControlLength("  ,,max-stale=5,,min-fresh = 10,,", 0, storeValue, 33, expected);
+
+            storeValue = new CacheControlHeaderValue();
+            storeValue.SharedMaxAge = new TimeSpan(1, 2, 3);
+            storeValue.NoTransform = true;
+            expected = new CacheControlHeaderValue();
+            expected.SharedMaxAge = new TimeSpan(1, 2, 3);
+            expected.NoTransform = true;
+        }
+
+        [Fact]
+        public void GetCacheControlLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            // Token-only values
+            CheckInvalidCacheControlLength("no-store=15", 0);
+            CheckInvalidCacheControlLength("no-store=", 0);
+
+            CheckInvalidCacheControlLength("no-transform=a", 0);
+            CheckInvalidCacheControlLength("no-transform=", 0);
+
+            CheckInvalidCacheControlLength("only-if-cached=\"x\"", 0);
+            CheckInvalidCacheControlLength("only-if-cached=", 0);
+
+            CheckInvalidCacheControlLength("public=\"x\"", 0);
+            CheckInvalidCacheControlLength("public=", 0);
+
+            CheckInvalidCacheControlLength("must-revalidate=\"1\"", 0);
+            CheckInvalidCacheControlLength("must-revalidate=", 0);
+
+            CheckInvalidCacheControlLength("proxy-revalidate=x", 0);
+            CheckInvalidCacheControlLength("proxy-revalidate=", 0);
+
+            // Token with optional field-name list
+            CheckInvalidCacheControlLength("no-cache=", 0);
+            CheckInvalidCacheControlLength("no-cache=token", 0);
+            CheckInvalidCacheControlLength("no-cache=\"token", 0);
+            CheckInvalidCacheControlLength("no-cache=\"\"", 0); // at least one token expected as value
+
+            CheckInvalidCacheControlLength("private=", 0);
+            CheckInvalidCacheControlLength("private=token", 0);
+            CheckInvalidCacheControlLength("private=\"token", 0);
+            CheckInvalidCacheControlLength("private=\",\"", 0); // at least one token expected as value
+            CheckInvalidCacheControlLength("private=\"=\"", 0);
+
+            // Token with delta-seconds value
+            CheckInvalidCacheControlLength("max-age", 0);
+            CheckInvalidCacheControlLength("max-age=", 0);
+            CheckInvalidCacheControlLength("max-age=a", 0);
+            CheckInvalidCacheControlLength("max-age=\"1\"", 0);
+            CheckInvalidCacheControlLength("max-age=1.5", 0);
+
+            CheckInvalidCacheControlLength("max-stale=", 0);
+            CheckInvalidCacheControlLength("max-stale=a", 0);
+            CheckInvalidCacheControlLength("max-stale=\"1\"", 0);
+            CheckInvalidCacheControlLength("max-stale=1.5", 0);
+
+            CheckInvalidCacheControlLength("min-fresh", 0);
+            CheckInvalidCacheControlLength("min-fresh=", 0);
+            CheckInvalidCacheControlLength("min-fresh=a", 0);
+            CheckInvalidCacheControlLength("min-fresh=\"1\"", 0);
+            CheckInvalidCacheControlLength("min-fresh=1.5", 0);
+
+            CheckInvalidCacheControlLength("s-maxage", 0);
+            CheckInvalidCacheControlLength("s-maxage=", 0);
+            CheckInvalidCacheControlLength("s-maxage=a", 0);
+            CheckInvalidCacheControlLength("s-maxage=\"1\"", 0);
+            CheckInvalidCacheControlLength("s-maxage=1.5", 0);
+
+            // Invalid Extension values
+            CheckInvalidCacheControlLength("custom=", 0);
+            CheckInvalidCacheControlLength("custom value", 0);
+
+            CheckInvalidCacheControlLength(null, 0);
+            CheckInvalidCacheControlLength("", 0);
+            CheckInvalidCacheControlLength("", 1);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Just verify parser is implemented correctly. Don't try to test syntax parsed by CacheControlHeaderValue.
+            CacheControlHeaderValue expected = new CacheControlHeaderValue();
+            expected.NoStore = true;
+            expected.MinFresh = new TimeSpan(0, 2, 3);
+            CheckValidParse(" , no-store, min-fresh=123", expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.MaxStale = true;
+            expected.NoCache = true;
+            expected.NoCacheHeaders.Add("t");
+            CheckValidParse("max-stale, no-cache=\"t\", ,,", expected);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("no-cache,=", 0);
+            CheckInvalidParse("max-age=123x", 0);
+            CheckInvalidParse("=no-cache", 0);
+            CheckInvalidParse("no-cache no-store", 0);
+            CheckInvalidParse("invalid =", 0);
+            CheckInvalidParse("\u4F1A", 0);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Just verify parser is implemented correctly. Don't try to test syntax parsed by CacheControlHeaderValue.
+            CacheControlHeaderValue expected = new CacheControlHeaderValue();
+            expected.NoStore = true;
+            expected.MinFresh = new TimeSpan(0, 2, 3);
+            CheckValidTryParse(" , no-store, min-fresh=123", expected);
+
+            expected = new CacheControlHeaderValue();
+            expected.MaxStale = true;
+            expected.NoCache = true;
+            expected.NoCacheHeaders.Add("t");
+            CheckValidTryParse("max-stale, no-cache=\"t\", ,,", expected);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("no-cache,=", 0);
+            CheckInvalidTryParse("max-age=123x", 0);
+            CheckInvalidTryParse("=no-cache", 0);
+            CheckInvalidTryParse("no-cache no-store", 0);
+            CheckInvalidTryParse("invalid =", 0);
+            CheckInvalidTryParse("\u4F1A", 0);
+        }
+
+        #region Helper methods
+
+        private void CompareHashCodes(CacheControlHeaderValue x, CacheControlHeaderValue y, bool areEqual)
+        {
+            if (areEqual)
+            {
+                Assert.Equal(x.GetHashCode(), y.GetHashCode());
+            }
+            else
+            {
+                Assert.NotEqual(x.GetHashCode(), y.GetHashCode());
+            }
+        }
+
+        private void CompareValues(CacheControlHeaderValue x, CacheControlHeaderValue y, bool areEqual)
+        {
+            Assert.Equal(areEqual, x.Equals(y));
+            Assert.Equal(areEqual, y.Equals(x));
+        }
+
+        private static void CheckGetCacheControlLength(string input, int startIndex, CacheControlHeaderValue storeValue,
+            int expectedLength, CacheControlHeaderValue expectedResult)
+        {
+            CacheControlHeaderValue result = null;
+            Assert.Equal(expectedLength, CacheControlHeaderValue.GetCacheControlLength(input, startIndex, storeValue, out result));
+
+            if (storeValue == null)
+            {
+                Assert.Equal(expectedResult, result);
+            }
+            else
+            {
+                // If we provide a 'storeValue', then that instance will be updated and result will be 'null'
+                Assert.Null(result);
+                Assert.Equal(expectedResult, storeValue);
+            }
+        }
+
+        private static void CheckInvalidCacheControlLength(string input, int startIndex)
+        {
+            CacheControlHeaderValue result = null;
+            Assert.Equal(0, CacheControlHeaderValue.GetCacheControlLength(input, startIndex, null, out result));
+            Assert.Null(result);
+        }
+
+        private void CheckValidParse(string input, CacheControlHeaderValue expectedResult)
+        {
+            CacheControlHeaderValue result = CacheControlHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input, int startIndex)
+        {
+            Assert.Throws<FormatException>(() => { CacheControlHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, CacheControlHeaderValue expectedResult)
+        {
+            CacheControlHeaderValue result = null;
+            Assert.True(CacheControlHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input, int startIndex)
+        {
+            CacheControlHeaderValue result = null;
+            Assert.False(CacheControlHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
@@ -1,0 +1,1215 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ContentDispositionHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_ContentDispositionNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { new ContentDispositionHeaderValue(null); });
+        }
+
+        [Fact]
+        public void Ctor_ContentDispositionEmpty_Throw()
+        {
+            // null and empty should be treated the same. So we also throw for empty strings.
+            Assert.Throws<ArgumentException>(() => { new ContentDispositionHeaderValue(string.Empty); });
+        }
+
+        [Fact]
+        public void Ctor_ContentDispositionInvalidFormat_ThrowFormatException()
+        {
+            // When adding values using strongly typed objects, no leading/trailing LWS (whitespaces) are allowed.
+            AssertFormatException(" inline ");
+            AssertFormatException(" inline");
+            AssertFormatException("inline ");
+            AssertFormatException("\"inline\"");
+            AssertFormatException("te xt");
+            AssertFormatException("te=xt");
+            AssertFormatException("teäxt");
+            AssertFormatException("text;");
+            AssertFormatException("te/xt;");
+            AssertFormatException("inline; name=someName; ");
+            AssertFormatException("text;name=someName"); // ctor takes only disposition-type name, no parameters
+        }
+
+        [Fact]
+        public void Ctor_ContentDispositionValidFormat_SuccessfullyCreated()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+            Assert.Equal("inline", contentDisposition.DispositionType);
+            Assert.Equal(0, contentDisposition.Parameters.Count);
+            Assert.Null(contentDisposition.Name);
+            Assert.Null(contentDisposition.FileName);
+            Assert.Null(contentDisposition.CreationDate);
+            Assert.Null(contentDisposition.ModificationDate);
+            Assert.Null(contentDisposition.ReadDate);
+            Assert.Null(contentDisposition.Size);
+        }
+
+        [Fact]
+        public void Parameters_AddNull_Throw()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+            Assert.Throws<ArgumentNullException>(() => { contentDisposition.Parameters.Add(null); });
+        }
+
+        [Fact]
+        public void ContentDisposition_SetAndGetContentDisposition_MatchExpectations()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+            Assert.Equal("inline", contentDisposition.DispositionType);
+
+            contentDisposition.DispositionType = "attachment";
+            Assert.Equal("attachment", contentDisposition.DispositionType);
+        }
+
+        [Fact]
+        public void Name_SetNameAndValidateObject_ParametersEntryForNameAdded()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+            contentDisposition.Name = "myname";
+            Assert.Equal("myname", contentDisposition.Name);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("name", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Name = null;
+            Assert.Null(contentDisposition.Name);
+            Assert.Equal(0, contentDisposition.Parameters.Count);
+            contentDisposition.Name = null; // It's OK to set it again to null; no exception.
+        }
+
+        [Fact]
+        public void Name_AddNameParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue name = new NameValueHeaderValue("NAME", "old_name");
+            contentDisposition.Parameters.Add(name);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("NAME", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Name = "new_name";
+            Assert.Equal("new_name", contentDisposition.Name);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("NAME", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Parameters.Remove(name);
+            Assert.Null(contentDisposition.Name);
+        }
+
+        [Fact]
+        public void FileName_AddNameParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue fileName = new NameValueHeaderValue("FILENAME", "old_name");
+            contentDisposition.Parameters.Add(fileName);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.FileName = "new_name";
+            Assert.Equal("new_name", contentDisposition.FileName);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Parameters.Remove(fileName);
+            Assert.Null(contentDisposition.FileName);
+        }
+
+        [Fact]
+        public void FileName_NeedsEncoding_EncodedAndDecodedCorrectly()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            contentDisposition.FileName = "File\u00C3Name.bat";
+            Assert.Equal("File\u00C3Name.bat", contentDisposition.FileName);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("filename", contentDisposition.Parameters.First().Name);
+            Assert.Equal("\"=?utf-8?B?RmlsZcODTmFtZS5iYXQ=?=\"", contentDisposition.Parameters.First().Value);
+
+            contentDisposition.Parameters.Remove(contentDisposition.Parameters.First());
+            Assert.Null(contentDisposition.FileName);
+        }
+
+        [Fact]
+        public void FileName_UnknownOrBadEncoding_PropertyFails()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue fileName = new NameValueHeaderValue("FILENAME", "\"=?utf-99?Q?R=mlsZcODTmFtZS5iYXQ=?=\"");
+            contentDisposition.Parameters.Add(fileName);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
+            Assert.Equal("\"=?utf-99?Q?R=mlsZcODTmFtZS5iYXQ=?=\"", contentDisposition.Parameters.First().Value);
+            Assert.Equal("\"=?utf-99?Q?R=mlsZcODTmFtZS5iYXQ=?=\"", contentDisposition.FileName);
+
+            contentDisposition.FileName = "new_name";
+            Assert.Equal("new_name", contentDisposition.FileName);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Parameters.Remove(fileName);
+            Assert.Null(contentDisposition.FileName);
+        }
+
+        [Fact]
+        public void FileNameStar_AddNameParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue fileNameStar = new NameValueHeaderValue("FILENAME*", "old_name");
+            contentDisposition.Parameters.Add(fileNameStar);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
+            Assert.Null(contentDisposition.FileNameStar); // Decode failure
+
+            contentDisposition.FileNameStar = "new_name";
+            Assert.Equal("new_name", contentDisposition.FileNameStar);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
+            Assert.Equal("utf-8\'\'new_name", contentDisposition.Parameters.First().Value);
+
+            contentDisposition.Parameters.Remove(fileNameStar);
+            Assert.Null(contentDisposition.FileNameStar);
+        }
+
+        [Fact]
+        public void FileNameStar_NeedsEncoding_EncodedAndDecodedCorrectly()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            contentDisposition.FileNameStar = "File\u00C3Name.bat";
+            Assert.Equal("File\u00C3Name.bat", contentDisposition.FileNameStar);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("filename*", contentDisposition.Parameters.First().Name);
+            Assert.Equal("utf-8\'\'File%C3%83Name.bat", contentDisposition.Parameters.First().Value);
+
+            contentDisposition.Parameters.Remove(contentDisposition.Parameters.First());
+            Assert.Null(contentDisposition.FileNameStar);
+        }
+
+        [Fact]
+        public void FileNameStar_UnknownOrBadEncoding_PropertyFails()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue fileNameStar = new NameValueHeaderValue("FILENAME*", "utf-99'lang'File%CZName.bat");
+            contentDisposition.Parameters.Add(fileNameStar);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
+            Assert.Equal("utf-99'lang'File%CZName.bat", contentDisposition.Parameters.First().Value);
+            Assert.Null(contentDisposition.FileNameStar); // Decode failure
+
+            contentDisposition.FileNameStar = "new_name";
+            Assert.Equal("new_name", contentDisposition.FileNameStar);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Parameters.Remove(fileNameStar);
+            Assert.Null(contentDisposition.FileNameStar);
+        }
+
+        [Fact]
+        public void Dates_AddDateParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            string validDateString = "\"Tue, 15 Nov 1994 08:12:31 GMT\"";
+            DateTimeOffset validDate = DateTimeOffset.Parse("Tue, 15 Nov 1994 08:12:31 GMT");
+
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue dateParameter = new NameValueHeaderValue("Creation-DATE", validDateString);
+            contentDisposition.Parameters.Add(dateParameter);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("Creation-DATE", contentDisposition.Parameters.First().Name);
+
+            Assert.Equal(validDate, contentDisposition.CreationDate);
+
+            DateTimeOffset newDate = validDate.AddSeconds(1);
+            contentDisposition.CreationDate = newDate;
+            Assert.Equal(newDate, contentDisposition.CreationDate);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("Creation-DATE", contentDisposition.Parameters.First().Name);
+            Assert.Equal("\"Tue, 15 Nov 1994 08:12:32 GMT\"", contentDisposition.Parameters.First().Value);
+
+            contentDisposition.Parameters.Remove(dateParameter);
+            Assert.Null(contentDisposition.CreationDate);
+        }
+
+        [Fact]
+        public void Dates_InvalidDates_PropertyFails()
+        {
+            string invalidDateString = "\"Tue, 15 Nov 94 08:12 GMT\"";
+
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue dateParameter = new NameValueHeaderValue("read-DATE", invalidDateString);
+            contentDisposition.Parameters.Add(dateParameter);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("read-DATE", contentDisposition.Parameters.First().Name);
+
+            Assert.Null(contentDisposition.ReadDate);
+
+            contentDisposition.ReadDate = null;
+            Assert.Null(contentDisposition.ReadDate);
+            Assert.Equal(0, contentDisposition.Parameters.Count);
+        }
+
+        [Fact]
+        public void Size_AddSizeParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue sizeParameter = new NameValueHeaderValue("SIZE", "279172874239");
+            contentDisposition.Parameters.Add(sizeParameter);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("SIZE", contentDisposition.Parameters.First().Name);
+            Assert.Equal(279172874239, contentDisposition.Size);
+
+            contentDisposition.Size = 279172874240;
+            Assert.Equal(279172874240, contentDisposition.Size);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("SIZE", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Parameters.Remove(sizeParameter);
+            Assert.Null(contentDisposition.Size);
+        }
+
+        [Fact]
+        public void Size_InvalidSizes_PropertyFails()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue sizeParameter = new NameValueHeaderValue("SIZE", "-279172874239");
+            contentDisposition.Parameters.Add(sizeParameter);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("SIZE", contentDisposition.Parameters.First().Name);
+            Assert.Null(contentDisposition.Size);
+
+            // Negatives not allowed
+            Assert.Throws<ArgumentOutOfRangeException>(() => { contentDisposition.Size = -279172874240; });
+            
+            Assert.Null(contentDisposition.Size);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Equal("SIZE", contentDisposition.Parameters.First().Name);
+
+            contentDisposition.Parameters.Remove(sizeParameter);
+            Assert.Null(contentDisposition.Size);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentContentDispositions_AllSerializedCorrectly()
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+            Assert.Equal("inline", contentDisposition.ToString());
+
+            contentDisposition.Name = "myname";
+            Assert.Equal("inline; name=myname", contentDisposition.ToString());
+
+            contentDisposition.FileName = "my File Name";
+            Assert.Equal("inline; name=myname; filename=\"my File Name\"", contentDisposition.ToString());
+
+            contentDisposition.CreationDate = new DateTimeOffset(new DateTime(2011, 2, 15, 8, 0, 0, DateTimeKind.Utc));
+            Assert.Equal("inline; name=myname; filename=\"my File Name\"; creation-date="
+                + "\"Tue, 15 Feb 2011 08:00:00 GMT\"", contentDisposition.ToString());
+
+            contentDisposition.Parameters.Add(new NameValueHeaderValue("custom", "\"custom value\""));
+            Assert.Equal("inline; name=myname; filename=\"my File Name\"; creation-date="
+                + "\"Tue, 15 Feb 2011 08:00:00 GMT\"; custom=\"custom value\"", contentDisposition.ToString());
+
+            contentDisposition.Name = null;
+            Assert.Equal("inline; filename=\"my File Name\"; creation-date="
+                + "\"Tue, 15 Feb 2011 08:00:00 GMT\"; custom=\"custom value\"", contentDisposition.ToString());
+
+            contentDisposition.FileNameStar = "File%Name";
+            Assert.Equal("inline; filename=\"my File Name\"; creation-date="
+                + "\"Tue, 15 Feb 2011 08:00:00 GMT\"; custom=\"custom value\"; filename*=utf-8\'\'File%25Name",
+                contentDisposition.ToString());
+
+            contentDisposition.FileName = null;
+            Assert.Equal("inline; creation-date=\"Tue, 15 Feb 2011 08:00:00 GMT\"; custom=\"custom value\";"
+                + " filename*=utf-8\'\'File%25Name", contentDisposition.ToString());
+
+            contentDisposition.CreationDate = null;
+            Assert.Equal("inline; custom=\"custom value\"; filename*=utf-8\'\'File%25Name",
+                contentDisposition.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseContentDispositionWithAndWithoutParameters_SameOrDifferentHashCodes()
+        {
+            ContentDispositionHeaderValue contentDisposition1 = new ContentDispositionHeaderValue("inline");
+            ContentDispositionHeaderValue contentDisposition2 = new ContentDispositionHeaderValue("inline");
+            contentDisposition2.Name = "myname";
+            ContentDispositionHeaderValue contentDisposition3 = new ContentDispositionHeaderValue("inline");
+            contentDisposition3.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            ContentDispositionHeaderValue contentDisposition4 = new ContentDispositionHeaderValue("INLINE");
+            ContentDispositionHeaderValue contentDisposition5 = new ContentDispositionHeaderValue("INLINE");
+            contentDisposition5.Parameters.Add(new NameValueHeaderValue("NAME", "MYNAME"));
+
+            Assert.NotEqual(contentDisposition1.GetHashCode(), contentDisposition2.GetHashCode()); // "No params vs. name."
+            Assert.NotEqual(contentDisposition1.GetHashCode(), contentDisposition3.GetHashCode()); // "No params vs. custom param."
+            Assert.NotEqual(contentDisposition2.GetHashCode(), contentDisposition3.GetHashCode()); // "name vs. custom param."
+            Assert.Equal(contentDisposition1.GetHashCode(), contentDisposition4.GetHashCode()); // "Different casing."
+            Assert.Equal(contentDisposition2.GetHashCode(), contentDisposition5.GetHashCode()); // "Different casing in name."
+        }
+
+        [Fact]
+        public void Equals_UseContentDispositionWithAndWithoutParameters_EqualOrNotEqualNoExceptions()
+        {
+            ContentDispositionHeaderValue contentDisposition1 = new ContentDispositionHeaderValue("inline");
+            ContentDispositionHeaderValue contentDisposition2 = new ContentDispositionHeaderValue("inline");
+            contentDisposition2.Name = "myName";
+            ContentDispositionHeaderValue contentDisposition3 = new ContentDispositionHeaderValue("inline");
+            contentDisposition3.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            ContentDispositionHeaderValue contentDisposition4 = new ContentDispositionHeaderValue("INLINE");
+            ContentDispositionHeaderValue contentDisposition5 = new ContentDispositionHeaderValue("INLINE");
+            contentDisposition5.Parameters.Add(new NameValueHeaderValue("NAME", "MYNAME"));
+            ContentDispositionHeaderValue contentDisposition6 = new ContentDispositionHeaderValue("INLINE");
+            contentDisposition6.Parameters.Add(new NameValueHeaderValue("NAME", "MYNAME"));
+            contentDisposition6.Parameters.Add(new NameValueHeaderValue("custom", "value"));
+            ContentDispositionHeaderValue contentDisposition7 = new ContentDispositionHeaderValue("attachment");
+
+            Assert.False(contentDisposition1.Equals(contentDisposition2)); // "No params vs. name."
+            Assert.False(contentDisposition2.Equals(contentDisposition1)); // "name vs. no params."
+            Assert.False(contentDisposition1.Equals(null)); // "No params vs. <null>."
+            Assert.False(contentDisposition1.Equals(contentDisposition3)); // "No params vs. custom param."
+            Assert.False(contentDisposition2.Equals(contentDisposition3)); // "name vs. custom param."
+            Assert.True(contentDisposition1.Equals(contentDisposition4)); // "Different casing."
+            Assert.True(contentDisposition2.Equals(contentDisposition5)); // "Different casing in name."
+            Assert.False(contentDisposition5.Equals(contentDisposition6)); // "name vs. custom param."
+            Assert.False(contentDisposition1.Equals(contentDisposition7)); // "inline vs. text/other."
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            ContentDispositionHeaderValue source = new ContentDispositionHeaderValue("attachment");
+            ContentDispositionHeaderValue clone = (ContentDispositionHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.DispositionType, clone.DispositionType);
+            Assert.Equal(0, clone.Parameters.Count);
+
+            source.Name = "myName";
+            clone = (ContentDispositionHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.DispositionType, clone.DispositionType);
+            Assert.Equal("myName", clone.Name);
+            Assert.Equal(1, clone.Parameters.Count);
+
+            source.Parameters.Add(new NameValueHeaderValue("custom", "customValue"));
+            clone = (ContentDispositionHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.DispositionType, clone.DispositionType);
+            Assert.Equal("myName", clone.Name);
+            Assert.Equal(2, clone.Parameters.Count);
+            Assert.Equal("custom", clone.Parameters.ElementAt(1).Name);
+            Assert.Equal("customValue", clone.Parameters.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void GetDispositionTypeLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            object result = null;
+            ContentDispositionHeaderValue value = null;
+
+            Assert.Equal(7, ContentDispositionHeaderValue.GetDispositionTypeLength("inline , other/name", 0,
+                out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Equal(0, value.Parameters.Count);
+
+            Assert.Equal(6, ContentDispositionHeaderValue.GetDispositionTypeLength("inline", 0, out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Equal(0, value.Parameters.Count);
+
+            Assert.Equal(19, ContentDispositionHeaderValue.GetDispositionTypeLength("inline; name=MyName", 0,
+                out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Equal("MyName", value.Name);
+            Assert.Equal(1, value.Parameters.Count);
+
+            Assert.Equal(32, ContentDispositionHeaderValue.GetDispositionTypeLength(" inline; custom=value;name=myName",
+                1, out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Equal("myName", value.Name);
+            Assert.Equal(2, value.Parameters.Count);
+
+            Assert.Equal(14, ContentDispositionHeaderValue.GetDispositionTypeLength(" inline; custom, next",
+                1, out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Null(value.Name);
+            Assert.Equal(1, value.Parameters.Count);
+            Assert.Equal("custom", value.Parameters.ElementAt(0).Name);
+            Assert.Null(value.Parameters.ElementAt(0).Value);
+
+            Assert.Equal(40, ContentDispositionHeaderValue.GetDispositionTypeLength(
+                "inline ; custom =\r\n \"x\" ; name = myName , next", 0, out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Equal("myName", value.Name);
+            Assert.Equal(2, value.Parameters.Count);
+            Assert.Equal("custom", value.Parameters.ElementAt(0).Name);
+            Assert.Equal("\"x\"", value.Parameters.ElementAt(0).Value);
+            Assert.Equal("name", value.Parameters.ElementAt(1).Name);
+            Assert.Equal("myName", value.Parameters.ElementAt(1).Value);
+
+            Assert.Equal(29, ContentDispositionHeaderValue.GetDispositionTypeLength(
+                "inline;custom=\"x\";name=myName,next", 0, out result));
+            value = (ContentDispositionHeaderValue)result;
+            Assert.Equal("inline", value.DispositionType);
+            Assert.Equal("myName", value.Name);
+            Assert.Equal(2, value.Parameters.Count);
+            Assert.Equal("custom", value.Parameters.ElementAt(0).Name);
+            Assert.Equal("\"x\"", value.Parameters.ElementAt(0).Value);
+            Assert.Equal("name", value.Parameters.ElementAt(1).Name);
+            Assert.Equal("myName", value.Parameters.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void GetDispositionTypeLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            object result = null;
+
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength(" inline", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength("inline;", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength("inline;name=", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength("inline;name=value;", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength("inline;", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength(null, 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, ContentDispositionHeaderValue.GetDispositionTypeLength(string.Empty, 0, out result));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            ContentDispositionHeaderValue expected = new ContentDispositionHeaderValue("inline");
+            CheckValidParse("\r\n inline  ", expected);
+            CheckValidParse("inline", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // Content-Disposition parser.
+            expected.Name = "myName";
+            CheckValidParse("\r\n inline  ;  name =   myName ", expected);
+            CheckValidParse("  inline;name=myName", expected);
+
+            expected.Name = null;
+            expected.DispositionType = "attachment";
+            expected.FileName = "foo-ae.html";
+            expected.Parameters.Add(new NameValueHeaderValue("filename*", "UTF-8''foo-%c3%a4.html"));
+            CheckValidParse(@"attachment; filename*=UTF-8''foo-%c3%a4.html; filename=foo-ae.html", expected);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("");
+            CheckInvalidParse("  ");
+            CheckInvalidParse(null);
+            CheckInvalidParse("inline\u4F1A");
+            CheckInvalidParse("inline ,");
+            CheckInvalidParse("inline,");
+            CheckInvalidParse("inline; name=myName ,");
+            CheckInvalidParse("inline; name=myName,");
+            CheckInvalidParse("inline; name=my\u4F1AName");
+            CheckInvalidParse("inline/");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            ContentDispositionHeaderValue expected = new ContentDispositionHeaderValue("inline");
+            CheckValidTryParse("\r\n inline  ", expected);
+            CheckValidTryParse("inline", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // Content-Disposition parser.
+            expected.Name = "myName";
+            CheckValidTryParse("\r\n inline  ;  name =   myName ", expected);
+            CheckValidTryParse("  inline;name=myName", expected);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("");
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse("inline\u4F1A");
+            CheckInvalidTryParse("inline ,");
+            CheckInvalidTryParse("inline,");
+            CheckInvalidTryParse("inline; name=myName ,");
+            CheckInvalidTryParse("inline; name=myName,");
+            CheckInvalidTryParse("text/");
+        }
+
+        #region Tests from HenrikN
+
+
+        private static Dictionary<string, ContentDispositionValue> ContentDispositionTestCases = new Dictionary<string, ContentDispositionValue>()
+        {
+            // Valid values
+            { "valid1", new ContentDispositionValue(@"inline", @"This should be equivalent to not including the header at all.", true) },
+            { "valid2", new ContentDispositionValue(@"inline; filename=""foo.html""", @"'inline', specifying a filename of foo.html", true) },
+            { "valid3", new ContentDispositionValue(@"inline; filename=""Not an attachment!""", @"'inline', specifying a filename of Not an attachment! - this checks for proper parsing for disposition types.", true) },
+            { "valid4", new ContentDispositionValue(@"inline; filename=""foo.pdf""", @"'inline', specifying a filename of foo.pdf", true) },
+            { "valid5", new ContentDispositionValue(@"attachment", @"'attachment' only", true) },
+            { "valid6", new ContentDispositionValue(@"ATTACHMENT", @"'ATTACHMENT' only", true) },
+            { "valid7", new ContentDispositionValue(@"attachment; filename=""foo.html""", @"'attachment', specifying a filename of foo.html", true) },
+            { "valid8", new ContentDispositionValue(@"attachment; filename=""f\oo.html""", @"'attachment', specifying a filename of f\oo.html (the first 'o' being escaped)", true) },
+            { "valid9", new ContentDispositionValue(@"attachment; filename=""\""quoting\"" tested.html""", @"'attachment', specifying a filename of \""quoting\"" tested.html (using double quotes around ""quoting"" to test... quoting)", true) },
+            { "valid10", new ContentDispositionValue(@"attachment; filename=""Here's a semicolon;.html""", @"'attachment', specifying a filename of Here's a semicolon;.html - this checks for proper parsing for parameters. ", true) },
+            { "valid11", new ContentDispositionValue(@"attachment; foo=""bar""; filename=""foo.html""", @"'attachment', specifying a filename of foo.html and an extension parameter ""foo"" which should be ignored (see <a href=""http://greenbytes.de/tech/webdav/rfc2183.html#rfc.section.2.8"">Section 2.8 of RFC 2183</a>.).", true) },
+            { "valid12", new ContentDispositionValue(@"attachment; foo=""\""\\"";filename=""foo.html""", @"'attachment', specifying a filename of foo.html and an extension parameter ""foo"" which should be ignored (see <a href=""http://greenbytes.de/tech/webdav/rfc2183.html#rfc.section.2.8"">Section 2.8 of RFC 2183</a>.). The extension parameter actually uses backslash-escapes. This tests whether the UA properly skips the parameter.", true) },
+            { "valid13", new ContentDispositionValue(@"attachment; FILENAME=""foo.html""", @"'attachment', specifying a filename of foo.html", true) },
+            { "valid14", new ContentDispositionValue(@"attachment; filename=foo.html", @"'attachment', specifying a filename of foo.html using a token instead of a quoted-string.", true) },
+            { "valid15", new ContentDispositionValue(@"attachment; filename='foo.bar'", @"'attachment', specifying a filename of 'foo.bar' using single quotes. ", true) },
+            { "valid16", new ContentDispositionValue(@"attachment; filename=""foo-ä.html""", @"'attachment', specifying a filename of foo-ä.html, using plain ISO-8859-1", true) },
+            { "valid17", new ContentDispositionValue(@"attachment; filename=""foo-&#xc3;&#xa4;.html""", @"'attachment', specifying a filename of foo-&#xc3;&#xa4;.html, which happens to be foo-ä.html using UTF-8 encoding.", true) },
+            { "valid18", new ContentDispositionValue(@"attachment; filename=""foo-%41.html""", @"'attachment', specifying a filename of foo-%41.html", true) },
+            { "valid19", new ContentDispositionValue(@"attachment; filename=""50%.html""", @"'attachment', specifying a filename of 50%.html", true) },
+            { "valid20", new ContentDispositionValue(@"attachment; filename=""foo-%\41.html""", @"'attachment', specifying a filename of foo-%41.html, using an escape character (this tests whether adding an escape character inside a %xx sequence can be used to disable the non-conformant %xx-unescaping).", true) },
+            { "valid21", new ContentDispositionValue(@"attachment; name=""foo-%41.html""", @"'attachment', specifying a <i>name</i> parameter of foo-%41.html. (this test was added to observe the behavior of the (unspecified) treatment of ""name"" as synonym for ""filename""; see <a href=""http://www.imc.org/ietf-smtp/mail-archive/msg05023.html"">Ned Freed's summary</a> where this comes from in MIME messages)", true) },
+            { "valid22", new ContentDispositionValue(@"attachment; filename=""ä-%41.html""", @"'attachment', specifying a filename parameter of ä-%41.html. (this test was added to observe the behavior when non-ASCII characters and percent-hexdig sequences are combined)", true) },
+            { "valid23", new ContentDispositionValue(@"attachment; filename=""foo-%c3%a4-%e2%82%ac.html""", @"'attachment', specifying a filename of foo-%c3%a4-%e2%82%ac.html, using raw percent encoded UTF-8 to represent foo-ä-&#x20ac;.html", true) },
+            { "valid24", new ContentDispositionValue(@"attachment; filename =""foo.html""", @"'attachment', specifying a filename of foo.html, with one blank space <em>before</em> the equals character.", true) },
+            { "valid25", new ContentDispositionValue(@"attachment; xfilename=foo.html", @"'attachment', specifying an ""xfilename"" parameter.", true) },
+            { "valid26", new ContentDispositionValue(@"attachment; filename=""/foo.html""", @"'attachment', specifying an absolute filename in the filesystem root.", true) },
+            { "valid27", new ContentDispositionValue(@"attachment; filename=""\\foo.html""", @"'attachment', specifying an absolute filename in the filesystem root.", true) },
+            { "valid28", new ContentDispositionValue(@"attachment; creation-date=""Wed, 12 Feb 1997 16:29:51 -0500""", @"'attachment', plus creation-date (see <a href=""http://greenbytes.de/tech/webdav/rfc2183.html#rfc.section.2.4"">Section 2.4 of RFC 2183</a>)", true) },
+            { "valid29", new ContentDispositionValue(@"attachment; modification-date=""Wed, 12 Feb 1997 16:29:51 -0500""", @"'attachment', plus modification-date (see <a href=""http://greenbytes.de/tech/webdav/rfc2183.html#rfc.section.2.5"">Section 2.5 of RFC 2183</a>)", true) },
+            { "valid30", new ContentDispositionValue(@"foobar", @"This should be equivalent to using ""attachment"".", true) },
+            { "valid31", new ContentDispositionValue(@"attachment; example=""filename=example.txt""", @"'attachment', with no filename parameter", true) },
+            { "valid32", new ContentDispositionValue(@"attachment; filename*=iso-8859-1''foo-%E4.html", @"'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded ISO-8859-1", true) },
+            { "valid33", new ContentDispositionValue(@"attachment; filename*=UTF-8''foo-%c3%a4-%e2%82%ac.html", @"'attachment', specifying a filename of foo-ä-&#x20ac;.html, using RFC2231 encoded UTF-8", true) },
+            { "valid34", new ContentDispositionValue(@"attachment; filename*=''foo-%c3%a4-%e2%82%ac.html", @"Behavior is undefined in RFC 2231, the charset part is missing, although UTF-8 was used.", true) },
+            { "valid35", new ContentDispositionValue(@"attachment; filename*=UTF-8''foo-a%cc%88.html", @"'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, but choosing the decomposed form (lowercase a plus COMBINING DIAERESIS) -- on a Windows target system, this should be translated to the preferred Unicode normal form (composed).", true) },
+            { "valid36", new ContentDispositionValue(@"attachment; filename*= UTF-8''foo-%c3%a4.html", @"'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, with whitespace after ""*=""", true) },
+            { "valid37", new ContentDispositionValue(@"attachment; filename* =UTF-8''foo-%c3%a4.html", @"'attachment', specifying a filename of foo-ä.html, using RFC2231 encoded UTF-8, with whitespace inside ""* =""", true) },
+            { "valid38", new ContentDispositionValue(@"attachment; filename*=UTF-8''A-%2541.html", @"'attachment', specifying a filename of A-%41.html, using RFC2231 encoded UTF-8.", true) },
+            { "valid39", new ContentDispositionValue(@"attachment; filename*=UTF-8''%5cfoo.html", @"'attachment', specifying a filename of /foo.html, using RFC2231 encoded UTF-8.", true) },
+            { "valid40", new ContentDispositionValue(@"attachment; filename*0=""foo.""; filename*1=""html""", @"'attachment', specifying a filename of foo.html, using RFC2231-style parameter continuations.", true) },
+            { "valid41", new ContentDispositionValue(@"attachment; filename*0*=UTF-8''foo-%c3%a4; filename*1="".html""", @"'attachment', specifying a filename of foo-ä.html, using both RFC2231-style parameter continuations and UTF-8 encoding.", true) },
+            { "valid42", new ContentDispositionValue(@"attachment; filename*0=""foo""; filename*01=""bar""", @"'attachment', specifying a filename of foo (the parameter filename*01 should be ignored because of the leading zero)", true) },
+            { "valid43", new ContentDispositionValue(@"attachment; filename*0=""foo""; filename*2=""bar""", @"'attachment', specifying a filename of foo (the parameter filename*2 should be ignored because there's no filename*1 parameter)", true) },
+            { "valid44", new ContentDispositionValue(@"attachment; filename*1=""foo.""; filename*2=""html""", @"'attachment' (the filename* parameters should be ignored because filename*0 is missing)", true) },
+            { "valid45", new ContentDispositionValue(@"attachment; filename*1=""bar""; filename*0=""foo""", "'attachment', specifying a filename of foobar", true) },
+            { "valid46", new ContentDispositionValue(@"attachment; filename=""foo-ae.html""; filename*=UTF-8''foo-%c3%a4.html", @"'attachment', specifying a filename of foo-ae.html in the traditional format, and foo-ä.html in RFC2231 format.", true) },
+            { "valid47", new ContentDispositionValue(@"attachment; filename*=UTF-8''foo-%c3%a4.html; filename=""foo-ae.html""", @"'attachment', specifying a filename of foo-ae.html in the traditional format, and foo-ä.html in RFC2231 format.", true) },
+            { "valid48", new ContentDispositionValue(@"attachment; foobar=x; filename=""foo.html""", @"'attachment', specifying a new parameter ""foobar"", plus a filename of foo.html in the traditional format.", true) },
+            { "valid49", new ContentDispositionValue(@"attachment; filename=""=?ISO-8859-1?Q?foo-=E4.html?=""", @"attachment; filename=""=?ISO-8859-1?Q?foo-=E4.html?=""", true) },
+            { "valid50", new ContentDispositionValue(@"attachment; filename=""=?utf-8?B?Zm9vLeQuaHRtbA==?=""", @"attachment; filename=""=?utf-8?B?Zm9vLeQuaHRtbA==?=""", true) },
+
+            // Invalid values
+            { "invalid1", new ContentDispositionValue(@"""inline""", @"'inline' only, using double quotes", false) },
+            { "invalid2", new ContentDispositionValue(@"""attachment""", @"'attachment' only, using double quotes", false) },
+            { "invalid3", new ContentDispositionValue(@"attachment; filename=foo.html ;", @"'attachment', specifying a filename of foo.html using a token instead of a quoted-string, and adding a trailing semicolon.", false) },
+            { "invalid4", new ContentDispositionValue(@"attachment; filename=foo bar.html", @"'attachment', specifying a filename of foo bar.html without using quoting.", false) },
+            { "invalid6", new ContentDispositionValue(@"attachment; filename=foo[1](2).html", @"'attachment', specifying a filename of foo[1](2).html, but missing the quotes. Also, ""["", ""]"", ""("" and "")"" are not allowed in the HTTP <a href=""http://greenbytes.de/tech/webdav/draft-ietf-httpbis-p1-messaging-latest.html#rfc.section.1.2.2"">token</a> production.", false) },
+            { "invalid7", new ContentDispositionValue(@"attachment; filename=foo-ä.html", @"'attachment', specifying a filename of foo-ä.html, but missing the quotes.", false) },
+            { "invalid9", new ContentDispositionValue(@"filename=foo.html", @"Disposition type missing, filename specified.", false) },
+            { "invalid10", new ContentDispositionValue(@"x=y; filename=foo.html", @"Disposition type missing, filename specified after extension parameter.", false) },
+            { "invalid11", new ContentDispositionValue(@"""foo; filename=bar;baz""; filename=qux", @"Disposition type missing, filename ""qux"". Can it be more broken? (Probably)", false) },
+            { "invalid12", new ContentDispositionValue(@"filename=foo.html, filename=bar.html", @"Disposition type missing, two filenames specified separated by a comma (this is syntactically equivalent to have two instances of the header with one filename parameter each).", false) },
+            { "invalid13", new ContentDispositionValue(@"; filename=foo.html", @"Disposition type missing (but delimiter present), filename specified.", false) },
+            { "invalid16", new ContentDispositionValue(@"attachment; filename=""foo.html"".txt", @"'attachment', specifying a filename parameter that is broken (quoted-string followed by more characters). This is invalid syntax. ", false) },
+            { "invalid17", new ContentDispositionValue(@"attachment; filename=""bar", @"'attachment', specifying a filename parameter that is broken (missing ending double quote). This is invalid syntax.", false) },
+            { "invalid18", new ContentDispositionValue(@"attachment; filename=foo""bar;baz""qux", @"'attachment', specifying a filename parameter that is broken (disallowed characters in token syntax). This is invalid syntax.", false) },
+            { "invalid19", new ContentDispositionValue(@"attachment; filename=foo.html, attachment; filename=bar.html", @"'attachment', two comma-separated instances of the header field. As Content-Disposition doesn't use a list-style syntax, this is invalid syntax and, according to <a href=""http://greenbytes.de/tech/webdav/rfc2616.html#rfc.section.4.2.p.5"">RFC 2616, Section 4.2</a>, roughly equivalent to having two separate header field instances.", false) },
+            { "invalid20", new ContentDispositionValue(@"filename=foo.html; attachment", @"filename parameter and disposion type reversed.", false) },
+            { "invalid24", new ContentDispositionValue(@"attachment; filename==?ISO-8859-1?Q?foo-=E4.html?=", @"Uses RFC 2047 style encoded word. ""="" is invalid inside the token production, so this is invalid.", false) },
+            { "invalid25", new ContentDispositionValue(@"attachment; filename==?utf-8?B?Zm9vLeQuaHRtbA==?=", @"Uses RFC 2047 style encoded word. ""="" is invalid inside the token production, so this is invalid.", false) },
+        };
+
+        #region Parsing
+
+        [Fact]
+        public void ContentDispositionHeaderValue_Parse_ExpectedResult()
+        {
+            foreach (var cd in ContentDispositionTestCases.Values)
+            {
+                ContentDispositionHeaderValue header = Parse(cd);
+            }
+        }
+
+        [Fact]
+        public void ContentDispositionHeaderValue_TryParse_ExpectedResult()
+        {
+            foreach (var cd in ContentDispositionTestCases.Values)
+            {
+                ContentDispositionHeaderValue header = TryParse(cd);
+            }
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid1_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid1"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "inline", null);
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid2_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid2"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "inline", @"""foo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid3_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid3"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "inline", @"""Not an attachment!""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid4_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid4"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "inline", @"""foo.pdf""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid5_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid5"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid6_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid6"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "ATTACHMENT", null);
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid7_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid7"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid8_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid8"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""f\oo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid9_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid9"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""\""quoting\"" tested.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid10_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid10"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""Here's a semicolon;.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid11_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid11"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo.html""");
+            ValidateExtensionParameter(header, "foo", @"""bar""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid12_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid12"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo.html""");
+            ValidateExtensionParameter(header, "foo", @"""\""\\""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid13_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid13"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid14_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid14"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"foo.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid15_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid15"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"'foo.bar'");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid16_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid16"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-ä.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid17_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid17"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-&#xc3;&#xa4;.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid18_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid18"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-%41.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid19_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid19"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""50%.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid20_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid20"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-%\41.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid21_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid21"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "name", @"""foo-%41.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid22_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid22"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""ä-%41.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid23_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid23"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-%c3%a4-%e2%82%ac.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid24_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid24"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid25_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid25"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "xfilename", @"foo.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid26_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid26"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""/foo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid27_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid27"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""\\foo.html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid28_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid28"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "creation-date", @"""Wed, 12 Feb 1997 16:29:51 -0500""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid29_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid29"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "modification-date", @"""Wed, 12 Feb 1997 16:29:51 -0500""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid30_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid30"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "foobar", null);
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid31_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid31"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "example", @"""filename=example.txt""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid32_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid32"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"iso-8859-1''foo-%E4.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid33_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid33"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''foo-%c3%a4-%e2%82%ac.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid34_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid34"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"''foo-%c3%a4-%e2%82%ac.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid35_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid35"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''foo-a%cc%88.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid36_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid36"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''foo-%c3%a4.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid37_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid37"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''foo-%c3%a4.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid38_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid38"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''A-%2541.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid39_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid39"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''%5cfoo.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid40_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid40"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*0", @"""foo.""");
+            ValidateExtensionParameter(header, "filename*1", @"""html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid41_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid41"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*0*", @"UTF-8''foo-%c3%a4");
+            ValidateExtensionParameter(header, "filename*1", @""".html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid42_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid42"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*0", @"""foo""");
+            ValidateExtensionParameter(header, "filename*01", @"""bar""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid43_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid43"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*0", @"""foo""");
+            ValidateExtensionParameter(header, "filename*2", @"""bar""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid44_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid44"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*1", @"""foo.""");
+            ValidateExtensionParameter(header, "filename*2", @"""html""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid45_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid45"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", null);
+            ValidateExtensionParameter(header, "filename*0", @"""foo""");
+            ValidateExtensionParameter(header, "filename*1", @"""bar""");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid46_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid46"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-ae.html""");
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''foo-%c3%a4.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid47_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid47"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo-ae.html""");
+            ValidateExtensionParameter(header, "filename*", @"UTF-8''foo-%c3%a4.html");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid48_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid48"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""foo.html""");
+            ValidateExtensionParameter(header, "foobar", @"x");
+        }
+
+        [Fact]
+        public void ContentDispositionHeader_Valid49_Success()
+        {
+            ContentDispositionValue cd = ContentDispositionTestCases["valid49"];
+            ContentDispositionHeaderValue header = TryParse(cd);
+            ValidateHeaderValues(header, "attachment", @"""=?ISO-8859-1?Q?foo-=E4.html?=""");
+        }
+
+        #endregion
+
+        private static void ValidateHeaderValues(ContentDispositionHeaderValue header, string expectedDispositionType, string expectedFilename)
+        {
+            Assert.NotNull(header);
+            Assert.Equal(expectedDispositionType, header.DispositionType);
+            Assert.Equal(expectedFilename, header.FileName);
+        }
+
+        private static void ValidateExtensionParameter(ContentDispositionHeaderValue header, string name, string expectedValue)
+        {
+            Assert.NotNull(header);
+            NameValueHeaderValue parameter = FindParameter(header.Parameters, name);
+            Assert.NotNull(parameter);
+            Assert.Equal(expectedValue, parameter.Value);
+        }
+
+        private static NameValueHeaderValue FindParameter(ICollection<NameValueHeaderValue> values, string name)
+        {
+            if ((values == null) || (values.Count == 0))
+            {
+                return null;
+            }
+
+            foreach (var value in values)
+            {
+                if (string.Compare(value.Name, name, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    return value;
+                }
+            }
+            return null;
+        }
+
+        private static ContentDispositionHeaderValue Parse(ContentDispositionValue cd)
+        {
+            Assert.NotNull(cd);
+            ContentDispositionHeaderValue header = null;
+            if (cd.Valid)
+            {
+                header = ContentDispositionHeaderValue.Parse(cd.Value);
+                Assert.NotNull(header);
+            }
+            else
+            {
+                Assert.Throws<FormatException>(() => { header = ContentDispositionHeaderValue.Parse(cd.Value); });
+            }
+
+            return header;
+        }
+
+        private static ContentDispositionHeaderValue TryParse(ContentDispositionValue cd)
+        {
+            Assert.NotNull(cd);
+            ContentDispositionHeaderValue header;
+            if (cd.Valid)
+            {
+                Assert.True(ContentDispositionHeaderValue.TryParse(cd.Value, out header));
+                Assert.NotNull(header);
+            }
+            else
+            {
+                Assert.False(ContentDispositionHeaderValue.TryParse(cd.Value, out header));
+                Assert.Null(header);
+            }
+
+            return header;
+        }
+
+        public class ContentDispositionValue
+        {
+            public ContentDispositionValue(string value, string description, bool valid)
+            {
+                this.Value = value;
+                this.Description = description;
+                this.Valid = valid;
+            }
+
+            public string Value { get; private set; }
+
+            public string Description { get; private set; }
+
+            public bool Valid { get; private set; }
+        }
+
+        #endregion Tests from HenrikN
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, ContentDispositionHeaderValue expectedResult)
+        {
+            ContentDispositionHeaderValue result = ContentDispositionHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { ContentDispositionHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, ContentDispositionHeaderValue expectedResult)
+        {
+            ContentDispositionHeaderValue result = null;
+            Assert.True(ContentDispositionHeaderValue.TryParse(input, out result), input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            ContentDispositionHeaderValue result = null;
+            Assert.False(ContentDispositionHeaderValue.TryParse(input, out result), input);
+            Assert.Null(result);
+        }
+
+        private static void AssertFormatException(string contentDisposition)
+        {
+            Assert.Throws<FormatException>(() => { new ContentDispositionHeaderValue(contentDisposition); });
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ContentRangeHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ContentRangeHeaderValueTest.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ContentRangeHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_LengthOnlyOverloadUseInvalidValues_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { ContentRangeHeaderValue v = new ContentRangeHeaderValue(-1); });
+        }
+
+        [Fact]
+        public void Ctor_LengthOnlyOverloadValidValues_ValuesCorrectlySet()
+        {
+            ContentRangeHeaderValue range = new ContentRangeHeaderValue(5);
+
+            Assert.False(range.HasRange);
+            Assert.True(range.HasLength);
+            Assert.Equal("bytes", range.Unit);
+            Assert.Null(range.From);
+            Assert.Null(range.To);
+            Assert.Equal(5, range.Length);
+        }
+
+        [Fact]
+        public void Ctor_FromAndToOverloadUseInvalidValues_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(-1, 1); }); // "Negative 'from'"
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(0, -1); }); // "Negative 'to'"
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(2, 1); }); // "'from' > 'to'"
+        }
+
+        [Fact]
+        public void Ctor_FromAndToOverloadValidValues_ValuesCorrectlySet()
+        {
+            ContentRangeHeaderValue range = new ContentRangeHeaderValue(0, 1);
+
+            Assert.True(range.HasRange);
+            Assert.False(range.HasLength);
+            Assert.Equal("bytes", range.Unit);
+            Assert.Equal(0, range.From);
+            Assert.Equal(1, range.To);
+            Assert.Null(range.Length);
+        }
+
+        [Fact]
+        public void Ctor_FromToAndLengthOverloadUseInvalidValues_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(-1, 1, 2); }); // "Negative 'from'"
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(0, -1, 2); }); // "Negative 'to'"
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(0, 1, -1); }); // "Negative 'length'"
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(2, 1, 3); }); // "'from' > 'to'"
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new ContentRangeHeaderValue(1, 2, 1); }); // "'to' > 'length'"
+        }
+
+        [Fact]
+        public void Ctor_FromToAndLengthOverloadValidValues_ValuesCorrectlySet()
+        {
+            ContentRangeHeaderValue range = new ContentRangeHeaderValue(0, 1, 2);
+
+            Assert.True(range.HasRange);
+            Assert.True(range.HasLength);
+            Assert.Equal("bytes", range.Unit);
+            Assert.Equal(0, range.From);
+            Assert.Equal(1, range.To);
+            Assert.Equal(2, range.Length);
+        }
+
+        [Fact]
+        public void Unit_GetAndSetValidAndInvalidValues_MatchExpectation()
+        {
+            ContentRangeHeaderValue range = new ContentRangeHeaderValue(0);
+            range.Unit = "myunit";
+            Assert.Equal("myunit", range.Unit); // "Unit (custom value)"
+
+            Assert.Throws<ArgumentException>(() => { range.Unit = null; }); // "<null>"
+            Assert.Throws<ArgumentException>(() => { range.Unit = ""; }); // "empty string"
+            Assert.Throws<FormatException>(() => { range.Unit = " x"; }); // "leading space"
+            Assert.Throws<FormatException>(() => { range.Unit = "x "; }); // "trailing space"
+            Assert.Throws<FormatException>(() => { range.Unit = "x y"; }); // "invalid token"
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRanges_AllSerializedCorrectly()
+        {
+            ContentRangeHeaderValue range = new ContentRangeHeaderValue(1, 2, 3);
+            range.Unit = "myunit";
+            Assert.Equal("myunit 1-2/3", range.ToString()); // "Range with all fields set"
+
+            range = new ContentRangeHeaderValue(123456789012345678, 123456789012345679);
+            Assert.Equal("bytes 123456789012345678-123456789012345679/*", range.ToString()); // "Only range, no length"
+
+            range = new ContentRangeHeaderValue(150);
+            Assert.Equal("bytes */150", range.ToString()); // "Only length, no range"
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRanges_SameOrDifferentHashCodes()
+        {
+            ContentRangeHeaderValue range1 = new ContentRangeHeaderValue(1, 2, 5);
+            ContentRangeHeaderValue range2 = new ContentRangeHeaderValue(1, 2);
+            ContentRangeHeaderValue range3 = new ContentRangeHeaderValue(5);
+            ContentRangeHeaderValue range4 = new ContentRangeHeaderValue(1, 2, 5);
+            range4.Unit = "BYTES";
+            ContentRangeHeaderValue range5 = new ContentRangeHeaderValue(1, 2, 5);
+            range5.Unit = "myunit";
+
+            Assert.NotEqual(range1.GetHashCode(), range2.GetHashCode()); // "bytes 1-2/5 vs. bytes 1-2/*"
+            Assert.NotEqual(range1.GetHashCode(), range3.GetHashCode()); // "bytes 1-2/5 vs. bytes */5"
+            Assert.NotEqual(range2.GetHashCode(), range3.GetHashCode()); // "bytes 1-2/* vs. bytes */5"
+            Assert.Equal(range1.GetHashCode(), range4.GetHashCode()); // "bytes 1-2/5 vs. BYTES 1-2/5"
+            Assert.NotEqual(range1.GetHashCode(), range5.GetHashCode()); // "bytes 1-2/5 vs. myunit 1-2/5"
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            ContentRangeHeaderValue range1 = new ContentRangeHeaderValue(1, 2, 5);
+            ContentRangeHeaderValue range2 = new ContentRangeHeaderValue(1, 2);
+            ContentRangeHeaderValue range3 = new ContentRangeHeaderValue(5);
+            ContentRangeHeaderValue range4 = new ContentRangeHeaderValue(1, 2, 5);
+            range4.Unit = "BYTES";
+            ContentRangeHeaderValue range5 = new ContentRangeHeaderValue(1, 2, 5);
+            range5.Unit = "myunit";
+            ContentRangeHeaderValue range6 = new ContentRangeHeaderValue(1, 3, 5);
+            ContentRangeHeaderValue range7 = new ContentRangeHeaderValue(2, 2, 5);
+            ContentRangeHeaderValue range8 = new ContentRangeHeaderValue(1, 2, 6);
+
+            Assert.False(range1.Equals(null)); // "bytes 1-2/5 vs. <null>"
+            Assert.False(range1.Equals(range2)); // "bytes 1-2/5 vs. bytes 1-2/*"
+            Assert.False(range1.Equals(range3)); // "bytes 1-2/5 vs. bytes */5"
+            Assert.False(range2.Equals(range3)); // "bytes 1-2/* vs. bytes */5"
+            Assert.True(range1.Equals(range4)); // "bytes 1-2/5 vs. BYTES 1-2/5"
+            Assert.True(range4.Equals(range1)); // "BYTES 1-2/5 vs. bytes 1-2/5"
+            Assert.False(range1.Equals(range5)); // "bytes 1-2/5 vs. myunit 1-2/5"
+            Assert.False(range1.Equals(range6)); // "bytes 1-2/5 vs. bytes 1-3/5"
+            Assert.False(range1.Equals(range7)); // "bytes 1-2/5 vs. bytes 2-2/5"
+            Assert.False(range1.Equals(range8)); // "bytes 1-2/5 vs. bytes 1-2/6"
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            ContentRangeHeaderValue source = new ContentRangeHeaderValue(1, 2, 5);
+            source.Unit = "custom";
+            ContentRangeHeaderValue clone = (ContentRangeHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source.Unit, clone.Unit);
+            Assert.Equal(source.From, clone.From);
+            Assert.Equal(source.To, clone.To);
+            Assert.Equal(source.Length, clone.Length);
+        }
+
+        [Fact]
+        public void GetContentRangeLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            ContentRangeHeaderValue result = null;
+
+            CallGetContentRangeLength("bytes 1-2/3", 0, 11, out result);
+            Assert.Equal("bytes", result.Unit);
+            Assert.Equal(1, result.From);
+            Assert.Equal(2, result.To);
+            Assert.Equal(3, result.Length);
+            Assert.True(result.HasRange);
+            Assert.True(result.HasLength);
+
+            CallGetContentRangeLength(" custom 1234567890123456789-1234567890123456799/*", 1, 48, out result);
+            Assert.Equal("custom", result.Unit);
+            Assert.Equal(1234567890123456789, result.From);
+            Assert.Equal(1234567890123456799, result.To);
+            Assert.Null(result.Length);
+            Assert.True(result.HasRange);
+            Assert.False(result.HasLength);
+
+            // Note that the final space should be skipped by GetContentRangeLength() and be considered by the returned
+            // value.            
+            CallGetContentRangeLength(" custom * / 123 ", 1, 15, out result);
+            Assert.Equal("custom", result.Unit);
+            Assert.Null(result.From);
+            Assert.Null(result.To);
+            Assert.Equal(123, result.Length);
+            Assert.False(result.HasRange);
+            Assert.True(result.HasLength);
+
+            // Note that we don't have a public constructor for value 'bytes */*' since the RFC doesn't mentione a 
+            // scenario for it. However, if a server returns this value, we're flexible and accept it.
+            CallGetContentRangeLength("bytes */*", 0, 9, out result);
+            Assert.Equal("bytes", result.Unit);
+            Assert.Null(result.From);
+            Assert.Null(result.To);
+            Assert.Null(result.Length);
+            Assert.False(result.HasRange);
+            Assert.False(result.HasLength);
+        }
+
+        [Fact]
+        public void GetContentRangeLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetContentRangeLength(" bytes 1-2/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 3-2/5", 0);
+            CheckInvalidGetContentRangeLength("bytes 6-6/5", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-6/5", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-2/", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-2", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-/", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-", 0);
+            CheckInvalidGetContentRangeLength("bytes 1", 0);
+            CheckInvalidGetContentRangeLength("bytes ", 0);
+            CheckInvalidGetContentRangeLength("bytes a-2/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-b/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-2/c", 0);
+            CheckInvalidGetContentRangeLength("bytes1-2/3", 0);
+
+            // More than 19 digits >>Int64.MaxValue
+            CheckInvalidGetContentRangeLength("bytes 1-12345678901234567890/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 12345678901234567890-3/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-2/12345678901234567890", 0);
+
+            // Exceed Int64.MaxValue, but use 19 digits
+            CheckInvalidGetContentRangeLength("bytes 1-9999999999999999999/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 9999999999999999999-3/3", 0);
+            CheckInvalidGetContentRangeLength("bytes 1-2/9999999999999999999", 0);
+
+            CheckInvalidGetContentRangeLength(string.Empty, 0);
+            CheckInvalidGetContentRangeLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Only verify parser functionality (i.e. ContentRangeHeaderParser.TryParse()). We don't need to validate
+            // all possible range values (verification done by tests for ContentRangeHeaderValue.GetContentRangeLength()).
+            CheckValidParse(" bytes 1-2/3 ", new ContentRangeHeaderValue(1, 2, 3));
+            CheckValidParse("bytes  *  /  3", new ContentRangeHeaderValue(3));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("bytes 1-2/3,"); // no character after 'length' allowed
+            CheckInvalidParse("x bytes 1-2/3");
+            CheckInvalidParse("bytes 1-2/3.4");
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Only verify parser functionality (i.e. ContentRangeHeaderParser.TryParse()). We don't need to validate
+            // all possible range values (verification done by tests for ContentRangeHeaderValue.GetContentRangeLength()).
+            CheckValidTryParse(" bytes 1-2/3 ", new ContentRangeHeaderValue(1, 2, 3));
+            CheckValidTryParse("bytes  *  /  3", new ContentRangeHeaderValue(3));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("bytes 1-2/3,"); // no character after 'length' allowed
+            CheckInvalidTryParse("x bytes 1-2/3");
+            CheckInvalidTryParse("bytes 1-2/3.4");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, ContentRangeHeaderValue expectedResult)
+        {
+            ContentRangeHeaderValue result = ContentRangeHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { ContentRangeHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, ContentRangeHeaderValue expectedResult)
+        {
+            ContentRangeHeaderValue result = null;
+            Assert.True(ContentRangeHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            ContentRangeHeaderValue result = null;
+            Assert.False(ContentRangeHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetContentRangeLength(string input, int startIndex, int expectedLength,
+            out ContentRangeHeaderValue result)
+        {
+            object temp = null;
+            Assert.Equal(expectedLength, ContentRangeHeaderValue.GetContentRangeLength(input, startIndex, out temp));
+            result = temp as ContentRangeHeaderValue;
+        }
+
+        private static void CheckInvalidGetContentRangeLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, ContentRangeHeaderValue.GetContentRangeLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/DateHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/DateHeaderParserTest.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class DateHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            DateHeaderParser parser = DateHeaderParser.Parser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // We don't need to validate all possible date values, since they're already tested in HttpRuleParserTest.
+            // Just make sure the parser calls HttpRuleParser methods correctly.
+            CheckValidParsedValue("Tue, 15 Nov 1994 08:12:31 GMT", 0,
+                new DateTimeOffset(1994, 11, 15, 8, 12, 31, TimeSpan.Zero), 29);
+            CheckValidParsedValue("!!      Sunday, 06-Nov-94 08:49:37 GMT   ", 2,
+                new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), 41);
+            CheckValidParsedValue("\r\n Tue,\r\n 15 Nov\r\n 1994 08:12:31 GMT   ", 2,
+                new DateTimeOffset(1994, 11, 15, 8, 12, 31, TimeSpan.Zero), 39);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("!!Sunday, 06-Nov-94 08:49:37 GMT", 0);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentValues_MatchExpectation()
+        {
+            DateHeaderParser parser = DateHeaderParser.Parser;
+
+            Assert.Equal("Sat, 31 Jul 2010 15:38:57 GMT",
+                parser.ToString(new DateTimeOffset(2010, 7, 31, 15, 38, 57, TimeSpan.Zero)));
+
+            Assert.Equal("Fri, 01 Jan 2010 01:01:01 GMT",
+                parser.ToString(new DateTimeOffset(2010, 1, 1, 1, 1, 1, TimeSpan.Zero)));
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, DateTimeOffset expectedResult,
+            int expectedIndex)
+        {
+            DateHeaderParser parser = DateHeaderParser.Parser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            DateHeaderParser parser = DateHeaderParser.Parser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/EntityTagHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/EntityTagHeaderValueTest.cs
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class EntityTagHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_ETagNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { new EntityTagHeaderValue(null); });
+        }
+
+        [Fact]
+        public void Ctor_ETagEmpty_Throw()
+        {
+            // null and empty should be treated the same. So we also throw for empty strings.
+            Assert.Throws<ArgumentException>(() => { new EntityTagHeaderValue(string.Empty); });
+        }
+
+        [Fact]
+        public void Ctor_ETagInvalidFormat_ThrowFormatException()
+        {
+            // When adding values using strongly typed objects, no leading/trailing LWS (whitespaces) are allowed.
+            AssertFormatException("tag");
+            AssertFormatException("*");
+            AssertFormatException(" tag ");
+            AssertFormatException("\"tag\" invalid");
+            AssertFormatException("\"tag");
+            AssertFormatException("tag\"");
+            AssertFormatException("\"tag\"\"");
+            AssertFormatException("\"\"tag\"\"");
+            AssertFormatException("\"\"tag\"");
+            AssertFormatException("W/\"tag\"");
+        }
+
+        [Fact]
+        public void Ctor_ETagValidFormat_SuccessfullyCreated()
+        {
+            EntityTagHeaderValue etag = new EntityTagHeaderValue("\"tag\"");
+            Assert.Equal("\"tag\"", etag.Tag);
+            Assert.False(etag.IsWeak);
+        }
+
+        [Fact]
+        public void Ctor_ETagValidFormatAndIsWeak_SuccessfullyCreated()
+        {
+            EntityTagHeaderValue etag = new EntityTagHeaderValue("\"e tag\"", true);
+            Assert.Equal("\"e tag\"", etag.Tag);
+            Assert.True(etag.IsWeak);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentETags_AllSerializedCorrectly()
+        {
+            EntityTagHeaderValue etag = new EntityTagHeaderValue("\"e tag\"");
+            Assert.Equal("\"e tag\"", etag.ToString());
+
+            etag = new EntityTagHeaderValue("\"e tag\"", true);
+            Assert.Equal("W/\"e tag\"", etag.ToString());
+
+            etag = new EntityTagHeaderValue("\"\"", false);
+            Assert.Equal("\"\"", etag.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentETags_SameOrDifferentHashCodes()
+        {
+            EntityTagHeaderValue etag1 = new EntityTagHeaderValue("\"tag\"");
+            EntityTagHeaderValue etag2 = new EntityTagHeaderValue("\"TAG\"");
+            EntityTagHeaderValue etag3 = new EntityTagHeaderValue("\"tag\"", true);
+            EntityTagHeaderValue etag4 = new EntityTagHeaderValue("\"tag1\"");
+            EntityTagHeaderValue etag5 = new EntityTagHeaderValue("\"tag\"");
+            EntityTagHeaderValue etag6 = EntityTagHeaderValue.Any;
+
+            Assert.NotEqual(etag1.GetHashCode(), etag2.GetHashCode());
+            Assert.NotEqual(etag1.GetHashCode(), etag3.GetHashCode());
+            Assert.NotEqual(etag1.GetHashCode(), etag4.GetHashCode());
+            Assert.NotEqual(etag1.GetHashCode(), etag6.GetHashCode());
+            Assert.Equal(etag1.GetHashCode(), etag5.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentETags_EqualOrNotEqualNoExceptions()
+        {
+            EntityTagHeaderValue etag1 = new EntityTagHeaderValue("\"tag\"");
+            EntityTagHeaderValue etag2 = new EntityTagHeaderValue("\"TAG\"");
+            EntityTagHeaderValue etag3 = new EntityTagHeaderValue("\"tag\"", true);
+            EntityTagHeaderValue etag4 = new EntityTagHeaderValue("\"tag1\"");
+            EntityTagHeaderValue etag5 = new EntityTagHeaderValue("\"tag\"");
+            EntityTagHeaderValue etag6 = EntityTagHeaderValue.Any;
+
+            Assert.False(etag1.Equals(etag2));
+            Assert.False(etag2.Equals(etag1));
+            Assert.False(etag1.Equals(null));
+            Assert.False(etag1.Equals(etag3));
+            Assert.False(etag3.Equals(etag1));
+            Assert.False(etag1.Equals(etag4));
+            Assert.False(etag1.Equals(etag6));
+            Assert.True(etag1.Equals(etag5));
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            EntityTagHeaderValue source = new EntityTagHeaderValue("\"tag\"");
+            EntityTagHeaderValue clone = (EntityTagHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Tag, clone.Tag);
+            Assert.Equal(source.IsWeak, clone.IsWeak);
+
+            source = new EntityTagHeaderValue("\"tag\"", true);
+            clone = (EntityTagHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Tag, clone.Tag);
+            Assert.Equal(source.IsWeak, clone.IsWeak);
+
+            Assert.Same(EntityTagHeaderValue.Any, ((ICloneable)EntityTagHeaderValue.Any).Clone());
+        }
+
+        [Fact]
+        public void GetEntityTagLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            EntityTagHeaderValue result = null;
+
+            Assert.Equal(6, EntityTagHeaderValue.GetEntityTagLength("\"ta\u4F1Ag\"", 0, out result));
+            Assert.Equal("\"ta\u4F1Ag\"", result.Tag);
+            Assert.False(result.IsWeak);
+
+            Assert.Equal(9, EntityTagHeaderValue.GetEntityTagLength("W/\"tag\"  ", 0, out result));
+            Assert.Equal("\"tag\"", result.Tag);
+            Assert.True(result.IsWeak);
+
+            // Note that even if after a valid tag & whitespaces there are invalid characters, GetEntityTagLength()
+            // will return the length of the valid tag and ignore the invalid characters at the end. It is the callers
+            // responsibility to consider the whole string invalid if after a valid ETag there are invalid chars.
+            Assert.Equal(11, EntityTagHeaderValue.GetEntityTagLength("\"tag\"  \r\n  !!", 0, out result));
+            Assert.Equal("\"tag\"", result.Tag);
+            Assert.False(result.IsWeak);
+
+            Assert.Equal(7, EntityTagHeaderValue.GetEntityTagLength("\"W/tag\"", 0, out result));
+            Assert.Equal("\"W/tag\"", result.Tag);
+            Assert.False(result.IsWeak);
+
+            Assert.Equal(9, EntityTagHeaderValue.GetEntityTagLength("W/  \"tag\"", 0, out result));
+            Assert.Equal("\"tag\"", result.Tag);
+            Assert.True(result.IsWeak);
+
+            // We also accept lower-case 'w': e.g. 'w/"tag"' rather than 'W/"tag"'
+            Assert.Equal(4, EntityTagHeaderValue.GetEntityTagLength("w/\"\"", 0, out result));
+            Assert.Equal("\"\"", result.Tag);
+            Assert.True(result.IsWeak);
+
+            Assert.Equal(2, EntityTagHeaderValue.GetEntityTagLength("\"\"", 0, out result));
+            Assert.Equal("\"\"", result.Tag);
+            Assert.False(result.IsWeak);
+
+            Assert.Equal(2, EntityTagHeaderValue.GetEntityTagLength(",* , ", 1, out result));
+            Assert.Same(EntityTagHeaderValue.Any, result);
+        }
+
+        [Fact]
+        public void GetEntityTagLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            EntityTagHeaderValue result = null;
+
+            // no leading spaces allowed.
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength(" \"tag\"", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("\"tag", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("tag\"", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("a/\"tag\"", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("W//\"tag\"", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("W", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("W/", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength("W/\"", 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength(null, 0, out result));
+            Assert.Null(result);
+            Assert.Equal(0, EntityTagHeaderValue.GetEntityTagLength(string.Empty, 0, out result));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse("\"tag\"", new EntityTagHeaderValue("\"tag\""));
+            CheckValidParse(" \"tag\" ", new EntityTagHeaderValue("\"tag\""));
+            CheckValidParse("\r\n \"tag\"\r\n ", new EntityTagHeaderValue("\"tag\""));
+            CheckValidParse("\"tag\"", new EntityTagHeaderValue("\"tag\""));
+            CheckValidParse("\"tag\u4F1A\"", new EntityTagHeaderValue("\"tag\u4F1A\""));
+            CheckValidParse("W/\"tag\"", new EntityTagHeaderValue("\"tag\"", true));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  !");
+            CheckInvalidParse("tag\"  !");
+            CheckInvalidParse("!\"tag\"");
+            CheckInvalidParse("\"tag\",");
+            CheckInvalidParse("\"tag\" \"tag2\"");
+            CheckInvalidParse("/\"tag\"");
+            CheckInvalidParse("*"); // "any" is not allowed as ETag value.
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse("\"tag\"", new EntityTagHeaderValue("\"tag\""));
+            CheckValidTryParse(" \"tag\" ", new EntityTagHeaderValue("\"tag\""));
+            CheckValidTryParse("\r\n \"tag\"\r\n ", new EntityTagHeaderValue("\"tag\""));
+            CheckValidTryParse("\"tag\"", new EntityTagHeaderValue("\"tag\""));
+            CheckValidTryParse("\"tag\u4F1A\"", new EntityTagHeaderValue("\"tag\u4F1A\""));
+            CheckValidTryParse("W/\"tag\"", new EntityTagHeaderValue("\"tag\"", true));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  !");
+            CheckInvalidTryParse("tag\"  !");
+            CheckInvalidTryParse("!\"tag\"");
+            CheckInvalidTryParse("\"tag\",");
+            CheckInvalidTryParse("\"tag\" \"tag2\"");
+            CheckInvalidTryParse("/\"tag\"");
+            CheckInvalidTryParse("*"); // "any" is not allowed as ETag value.
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, EntityTagHeaderValue expectedResult)
+        {
+            EntityTagHeaderValue result = EntityTagHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { EntityTagHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, EntityTagHeaderValue expectedResult)
+        {
+            EntityTagHeaderValue result = null;
+            Assert.True(EntityTagHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            EntityTagHeaderValue result = null;
+            Assert.False(EntityTagHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void AssertFormatException(string tag)
+        {
+            Assert.Throws<FormatException>(() => { new EntityTagHeaderValue(tag); });
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/AuthenticationParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/AuthenticationParserTest.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class AuthenticationParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueAuthenticationParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueAuthenticationParser;
+            Assert.False(parser.SupportsMultipleValues);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Note that there is no difference between setting "SupportMultipleValues" to true or false: The parser
+            // is only able to parse one authentication information per string. Setting "SupportMultipleValues" just
+            // tells the caller (HttpHeaders) that parsing multiple strings is allowed.
+            CheckValidParsedValue("X NTLM ", 1, new AuthenticationHeaderValue("NTLM"), 7, true);
+            CheckValidParsedValue("X NTLM ", 1, new AuthenticationHeaderValue("NTLM"), 7, false);
+            CheckValidParsedValue("custom x=y", 0, new AuthenticationHeaderValue("Custom", "x=y"), 10, true);
+            CheckValidParsedValue("custom x=y", 0, new AuthenticationHeaderValue("Custom", "x=y"), 10, false);
+            CheckValidParsedValue("C x=y, other", 0, new AuthenticationHeaderValue("C", "x=y"), 7, true);
+
+            CheckValidParsedValue("  ", 0, null, 2, true);
+            CheckValidParsedValue(null, 0, null, 0, true);
+            CheckValidParsedValue("", 0, null, 0, true);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("NTLM[", 0, true); // only delimiter ',' allowed after last range
+            CheckInvalidParsedValue("NTLM[", 0, false); // only delimiter ',' allowed after last range
+            CheckInvalidParsedValue("]NTLM", 0, true);
+            CheckInvalidParsedValue("]NTLM", 0, false);
+            CheckInvalidParsedValue("C x=y, other", 0, false);
+            CheckInvalidParsedValue("C x=y,", 0, false);
+            CheckInvalidParsedValue("  ", 0, false);
+            CheckInvalidParsedValue(null, 0, false);
+            CheckInvalidParsedValue(string.Empty, 0, false);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, AuthenticationHeaderValue expectedResult,
+            int expectedIndex, bool supportMultipleValues)
+        {
+            HttpHeaderParser parser = null;
+            if (supportMultipleValues)
+            {
+                parser = GenericHeaderParser.MultipleValueAuthenticationParser;
+            }
+            else
+            {
+                parser = GenericHeaderParser.SingleValueAuthenticationParser;
+            }
+
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex, bool supportMultipleValues)
+        {
+            HttpHeaderParser parser = null;
+            if (supportMultipleValues)
+            {
+                parser = GenericHeaderParser.MultipleValueAuthenticationParser;
+            }
+            else
+            {
+                parser = GenericHeaderParser.SingleValueAuthenticationParser;
+            }
+
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/ContentRangeParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/ContentRangeParserTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ContentRangeParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.ContentRangeParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // Only verify parser functionality (i.e. ContentRangeHeaderParser.TryParse()). We don't need to validate
+            // all possible range values (verification done by tests for ContentRangeHeaderValue.GetContentRangeLength()).
+            CheckValidParsedValue("X bytes 1-2/3 ", 1, new ContentRangeHeaderValue(1, 2, 3), 14);
+            CheckValidParsedValue("bytes  *  /  3", 0, new ContentRangeHeaderValue(3), 14);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("bytes 1-2/3,", 0); // no character after 'length' allowed
+            CheckInvalidParsedValue("x bytes 1-2/3", 0);
+            CheckInvalidParsedValue("bytes 1-2/3.4", 0);
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, ContentRangeHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.ContentRangeParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.ContentRangeParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/EntityTagParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/EntityTagParserTest.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class EntityTagParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueEntityTagParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueEntityTagParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("\"tag\"", 0, new EntityTagHeaderValue("\"tag\""), 5, true);
+            CheckValidParsedValue("\"tag\"", 0, new EntityTagHeaderValue("\"tag\""), 5, false);
+            CheckValidParsedValue("*", 0, EntityTagHeaderValue.Any, 1, true);
+            CheckValidParsedValue(" *  ,", 1, EntityTagHeaderValue.Any, 5, true);
+            CheckValidParsedValue(" \"tag\" ", 0, new EntityTagHeaderValue("\"tag\""), 7, false);
+            CheckValidParsedValue(" \"tag\" ,", 0, new EntityTagHeaderValue("\"tag\""), 8, true);
+            CheckValidParsedValue("\r\n \"tag\"\r\n ", 0, new EntityTagHeaderValue("\"tag\""), 11, false);
+            CheckValidParsedValue("\r\n \"tag\"\r\n ,  ", 0, new EntityTagHeaderValue("\"tag\""), 14, true);
+            CheckValidParsedValue("!\"tag\"", 1, new EntityTagHeaderValue("\"tag\""), 6, false);
+            CheckValidParsedValue("!\"tag\"", 1, new EntityTagHeaderValue("\"tag\""), 6, true);
+            CheckValidParsedValue("//\"tag\u4F1A\"", 2, new EntityTagHeaderValue("\"tag\u4F1A\""), 8, false);
+            CheckValidParsedValue("//\"tag\u4F1A\"", 2, new EntityTagHeaderValue("\"tag\u4F1A\""), 8, true);
+            CheckValidParsedValue("!W/\"tag\"", 1, new EntityTagHeaderValue("\"tag\"", true), 8, false);
+            CheckValidParsedValue("!W/\"tag\",", 1, new EntityTagHeaderValue("\"tag\"", true), 9, true);
+
+            CheckValidParsedValue(null, 0, null, 0, true);
+            CheckValidParsedValue(string.Empty, 0, null, 0, true);
+            CheckValidParsedValue("   ", 0, null, 3, true);
+            CheckValidParsedValue("  ,,", 0, null, 4, true);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue(null, 0, false);
+            CheckInvalidParsedValue(string.Empty, 0, false);
+            CheckInvalidParsedValue("  ", 0, false);
+            CheckInvalidParsedValue(" *  !", 2, false);
+            CheckInvalidParsedValue(" \"tag\"  !", 2, false);
+            CheckInvalidParsedValue("!\"tag\"", 0, false);
+            CheckInvalidParsedValue("\"tag\",", 0, false);
+            CheckInvalidParsedValue("\"tag\" \"tag2\"", 0, false);
+            CheckInvalidParsedValue("W/\"tag\"", 1, false);
+            CheckInvalidParsedValue("*", 0, false); // "any" is not allowed as ETag value.
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, EntityTagHeaderValue expectedResult,
+            int expectedIndex, bool supportsMultipleValues)
+        {
+            HttpHeaderParser parser = null;
+            if (supportsMultipleValues)
+            {
+                parser = GenericHeaderParser.MultipleValueEntityTagParser;
+            }
+            else
+            {
+                parser = GenericHeaderParser.SingleValueEntityTagParser;
+            }
+
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}', AllowMultipleValues/Any: {1}", input,
+                supportsMultipleValues));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex, bool supportsMultipleValues)
+        {
+            HttpHeaderParser parser = null;
+            if (supportsMultipleValues)
+            {
+                parser = GenericHeaderParser.MultipleValueEntityTagParser;
+            }
+            else
+            {
+                parser = GenericHeaderParser.SingleValueEntityTagParser;
+            }
+
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}', AllowMultipleValues/Any: {1}", input,
+                supportsMultipleValues));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/HostParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/HostParserTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HostParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.HostParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Equal(StringComparer.OrdinalIgnoreCase, parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("host", 0, "host", 4);
+            CheckValidParsedValue(" host ", 0, "host", 6);
+            CheckValidParsedValue("\r\n host\r\n ", 0, "host", 10);
+            CheckValidParsedValue("!host", 1, "host", 5);
+            CheckValidParsedValue("!host:50", 1, "host:50", 8);
+            CheckValidParsedValue("//host会", 2, "host会", 7);
+            CheckValidParsedValue("192.168.0.1", 0, "192.168.0.1", 11);
+            CheckValidParsedValue(" 192.168.0.1:80 ", 0, "192.168.0.1:80", 16);
+            CheckValidParsedValue("[::1]", 0, "[::1]", 5);
+            CheckValidParsedValue(" [::1] ", 0, "[::1]", 7);
+            CheckValidParsedValue("[::1]:1234", 0, "[::1]:1234", 10);
+            CheckValidParsedValue(" [::1]:1234 ", 0, "[::1]:1234", 12);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("  ", 0);
+            CheckInvalidParsedValue("host:xx", 0);
+            CheckInvalidParsedValue("host/", 0);
+            CheckInvalidParsedValue(".host", 0); // Even though this is a valid token, "Host" expects valid URI hosts.
+            CheckInvalidParsedValue("host/path", 0);
+            CheckInvalidParsedValue("host: 80", 0);
+            CheckInvalidParsedValue("host:123456789", 0);
+            CheckInvalidParsedValue("[FE80::12]: 80", 0);
+            CheckInvalidParsedValue("[FE80 ::12]", 0);
+            CheckInvalidParsedValue("host host", 0);
+            CheckInvalidParsedValue("host,", 0);
+            CheckInvalidParsedValue("host ,", 0);
+            CheckInvalidParsedValue("/", 0);
+            CheckInvalidParsedValue(" , ", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, string expectedResult, int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.HostParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.HostParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/MailAddressParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/MailAddressParserTest.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class MailAddressParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MailAddressParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // We don't need to validate all possible date values, since they're already tested MailAddress.
+            // Just make sure the parser calls MailAddressParser with correct parameters (like startIndex must be
+            // honored).
+
+            // Note that we still have trailing whitespaces since we don't do the parsing of the email address.
+            CheckValidParsedValue("!!      info@example.com   ", 2, "info@example.com   ", 27);
+            CheckValidParsedValue("\r\n \"My name\" info@example.com", 0,
+                "\"My name\" info@example.com", 29);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("[info@example.com", 0);
+            CheckInvalidParsedValue("info@example.com\r\nother", 0);
+            CheckInvalidParsedValue("info@example.com\r\n other", 0);
+            CheckInvalidParsedValue("info@example.com\r\n", 0);
+            CheckInvalidParsedValue("info@example.com,", 0);
+            CheckInvalidParsedValue("\r\ninfo@example.com", 0);
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+            CheckInvalidParsedValue("  ", 2);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, string expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MailAddressParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MailAddressParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/NameValueParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/NameValueParserTest.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class NameValueParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueNameValueParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X , , name = value  ,  ,next", 1, new NameValueHeaderValue("name", "value"), 24);
+            CheckValidParsedValue("X name,", 1, new NameValueHeaderValue("name"), 7);
+            CheckValidParsedValue(" ,name=\"value\"", 0, new NameValueHeaderValue("name", "\"value\""), 14);
+            CheckValidParsedValue("name=value", 0, new NameValueHeaderValue("name", "value"), 10);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("name[value", 0);
+            CheckInvalidParsedValue("name=value=", 0);
+            CheckInvalidParsedValue("name=会", 0);
+            CheckInvalidParsedValue("name==value", 0);
+            CheckInvalidParsedValue("=value", 0);
+            CheckInvalidParsedValue("name value", 0);
+            CheckInvalidParsedValue("name=,value", 0);
+            CheckInvalidParsedValue("会", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, NameValueHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/NameValueWithParametersParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/NameValueWithParametersParserTest.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class NameValueWithParametersParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueWithParametersParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueNameValueWithParametersParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_ValidValue_ReturnsNameValueWithParametersHeaderValue()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueWithParametersParser;
+            int index = 2;
+
+            NameValueWithParametersHeaderValue expected = new NameValueWithParametersHeaderValue("custom");
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            Assert.True(expected.Equals(parser.ParseValue("   custom ; name = value ", null, ref index)));
+            Assert.Equal(25, index);
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throw()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueWithParametersParser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue("custom;=value", null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            NameValueWithParametersHeaderValue expected = new NameValueWithParametersHeaderValue("custom");
+            CheckValidParsedValue("\r\n custom  ", 0, expected, 11);
+            CheckValidParsedValue("custom", 0, expected, 6);
+            CheckValidParsedValue(",, ,\r\n custom  , chunked", 0, expected, 17);
+
+            // Note that even if the whole string is invalid, the first "Expect" value is valid. When the parser
+            // gets called again using the result-index (9), then it fails: I.e. we have 1 valid "Expect" value
+            // and an invalid one.
+            CheckValidParsedValue("custom , 会", 0, expected, 9);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidParsedValue("\r\n custom ;  name =   value ", 0, expected, 28);
+            CheckValidParsedValue("  custom;name=value", 2, expected, 19);
+            CheckValidParsedValue("  custom ; name=value", 2, expected, 21);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("custom会", 0);
+            CheckInvalidParsedValue("custom; name=value;", 0);
+            CheckInvalidParsedValue("custom; name1=value1; name2=value2;", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex,
+            NameValueWithParametersHeaderValue expectedResult, int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueWithParametersParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}', Index: {1}", input, startIndex));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueNameValueWithParametersParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}', Index: {1}", input, startIndex));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/ProductParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/ProductParserTest.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ProductParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueProductParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueProductParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X y/1 ", 1, new ProductHeaderValue("y", "1"), 6);
+            CheckValidParsedValue(", , custom / 1.0 ,,Y", 0, new ProductHeaderValue("custom", "1.0"), 19);
+            CheckValidParsedValue(", , custom / 1.0 ,,", 0, new ProductHeaderValue("custom", "1.0"), 19);
+            CheckValidParsedValue(", , custom / 1.0", 0, new ProductHeaderValue("custom", "1.0"), 16);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("product/version=", 0); // only delimiter ',' allowed after last product
+            CheckInvalidParsedValue("product otherproduct", 0);
+            CheckInvalidParsedValue("product[", 0);
+            CheckInvalidParsedValue("=", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, ProductHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueProductParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueProductParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/RangeConditionParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/RangeConditionParserTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RangeConditionParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RangeConditionParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X  \"x\" ", 1, new RangeConditionHeaderValue("\"x\""), 7);
+            CheckValidParsedValue("  Sun, 06 Nov 1994 08:49:37 GMT ", 0,
+                new RangeConditionHeaderValue(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero)), 32);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("\"x\" ,", 0); // no delimiter allowed
+            CheckInvalidParsedValue("Sun, 06 Nov 1994 08:49:37 GMT ,", 0); // no delimiter allowed
+            CheckInvalidParsedValue("\"x\" Sun, 06 Nov 1994 08:49:37 GMT", 0);
+            CheckInvalidParsedValue("Sun, 06 Nov 1994 08:49:37 GMT \"x\"", 0);
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, RangeConditionHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RangeConditionParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RangeConditionParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/RangeParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/RangeParserTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RangeParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RangeParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X bytes=1-2 ", 1, new RangeHeaderValue(1, 2), 12);
+
+            RangeHeaderValue expected = new RangeHeaderValue();
+            expected.Unit = "custom";
+            expected.Ranges.Add(new RangeItemHeaderValue(null, 5));
+            expected.Ranges.Add(new RangeItemHeaderValue(1, 4));
+            CheckValidParsedValue("custom = -  5 , 1 - 4 ,,", 0, expected, 24);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("bytes=1-2x", 0); // only delimiter ',' allowed after last range
+            CheckInvalidParsedValue("x bytes=1-2", 0);
+            CheckInvalidParsedValue("bytes=1-2.4", 0);
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, RangeHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RangeParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RangeParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/RetryConditionParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/RetryConditionParserTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RetryConditionParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RetryConditionParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X  123456789 ", 1, new RetryConditionHeaderValue(new TimeSpan(0, 0, 123456789)), 13);
+            CheckValidParsedValue("  Sun, 06 Nov 1994 08:49:37 GMT ", 0,
+                new RetryConditionHeaderValue(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero)), 32);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("123 ,", 0); // no delimiter allowed
+            CheckInvalidParsedValue("Sun, 06 Nov 1994 08:49:37 GMT ,", 0); // no delimiter allowed
+            CheckInvalidParsedValue("123 Sun, 06 Nov 1994 08:49:37 GMT", 0);
+            CheckInvalidParsedValue("Sun, 06 Nov 1994 08:49:37 GMT \"x\"", 0);
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, RetryConditionHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RetryConditionParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.RetryConditionParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/StringWithQualityParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/StringWithQualityParserTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class StringWithQualityParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueStringWithQualityParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueStringWithQualityParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("text", 0, new StringWithQualityHeaderValue("text"), 4);
+            CheckValidParsedValue("text,", 0, new StringWithQualityHeaderValue("text"), 5);
+            CheckValidParsedValue("\r\n text ; q = 0.5, next_text  ", 0, new StringWithQualityHeaderValue("text", 0.5), 19);
+            CheckValidParsedValue("  text,next_text  ", 2, new StringWithQualityHeaderValue("text"), 7);
+            CheckValidParsedValue(" ,, text, , ,next", 0, new StringWithQualityHeaderValue("text"), 13);
+            CheckValidParsedValue(" ,, text, , ,", 0, new StringWithQualityHeaderValue("text"), 13);
+            CheckValidParsedValue(", \r\n text \r\n ; \r\n q = 0.123", 0,
+                new StringWithQualityHeaderValue("text", 0.123), 27);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("teäxt", 0);
+            CheckInvalidParsedValue("text会", 0);
+            CheckInvalidParsedValue("会", 0);
+            CheckInvalidParsedValue("t;q=会", 0);
+            CheckInvalidParsedValue("t;q=", 0);
+            CheckInvalidParsedValue("t;q", 0);
+            CheckInvalidParsedValue("t;会=1", 0);
+            CheckInvalidParsedValue("t;q会=1", 0);
+            CheckInvalidParsedValue("t y", 0);
+            CheckInvalidParsedValue("t;q=1 y", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, StringWithQualityHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueStringWithQualityParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueStringWithQualityParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/TokenListParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/TokenListParserTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class TokenListParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.TokenListParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Equal(StringComparer.OrdinalIgnoreCase, parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("text", 0, "text", 4);
+            CheckValidParsedValue("text,", 0, "text", 5);
+            CheckValidParsedValue("\r\n text , next_text  ", 0, "text", 10);
+            CheckValidParsedValue("  text,next_text  ", 2, "text", 7);
+            CheckValidParsedValue(" ,, text, , ,next", 0, "text", 13);
+            CheckValidParsedValue(" ,, text, , ,", 0, "text", 13);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("   ", 0, null, 3);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("teäxt", 0);
+            CheckInvalidParsedValue("text会", 0);
+            CheckInvalidParsedValue("会", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, string expectedResult, int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.TokenListParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.TokenListParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/ViaParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/ViaParserTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ViaParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueViaParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueViaParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X , , 1.1   host, ,next", 1, new ViaHeaderValue("1.1", "host"), 19);
+            CheckValidParsedValue("X HTTP  /  x11   192.168.0.1\r\n (comment) , ,next", 1,
+                new ViaHeaderValue("x11", "192.168.0.1", "HTTP", "(comment)"), 44);
+            CheckValidParsedValue(" ,HTTP/1.1 [::1]", 0, new ViaHeaderValue("1.1", "[::1]", "HTTP"), 16);
+            CheckValidParsedValue("1.1 host", 0, new ViaHeaderValue("1.1", "host"), 8);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("HTTP/1.1 host (comment)invalid", 0);
+            CheckInvalidParsedValue("HTTP/1.1 host (comment)=", 0);
+            CheckInvalidParsedValue("HTTP/1.1 host (comment) invalid", 0);
+            CheckInvalidParsedValue("HTTP/1.1 host (comment) =", 0);
+            CheckInvalidParsedValue("HTTP/1.1 host invalid", 0);
+            CheckInvalidParsedValue("HTTP/1.1 host =", 0);
+            CheckInvalidParsedValue("1.1 host invalid", 0);
+            CheckInvalidParsedValue("1.1 host =", 0);
+            CheckInvalidParsedValue("会", 0);
+            CheckInvalidParsedValue("HTTP/test [::1]:80\r(comment)", 0);
+            CheckInvalidParsedValue("HTTP/test [::1]:80\n(comment)", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, ViaHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueViaParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueViaParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/WarningParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/WarningParserTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class WarningParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueWarningParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = GenericHeaderParser.SingleValueWarningParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X , , 123   host \"text\", ,next", 1,
+                new WarningHeaderValue(123, "host", "\"text\""), 26);
+            CheckValidParsedValue("X 50  192.168.0.1  \"text  \"  \"Tue, 20 Jul 2010 01:02:03 GMT\" , ,next", 1,
+                new WarningHeaderValue(50, "192.168.0.1", "\"text  \"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)), 64);
+            CheckValidParsedValue(" ,123 h \"t\",", 0, new WarningHeaderValue(123, "h", "\"t\""), 12);
+            CheckValidParsedValue("1 h \"t\"", 0, new WarningHeaderValue(1, "h", "\"t\""), 7);
+            CheckValidParsedValue("1 h \"t\" \"Tue, 20 Jul 2010 01:02:03 GMT\"", 0,
+                new WarningHeaderValue(1, "h", "\"t\"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)), 39);
+            CheckValidParsedValue("1 会 \"t\" ,,", 0, new WarningHeaderValue(1, "会", "\"t\""), 10);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("1.1 host \"text\"", 0);
+            CheckInvalidParsedValue("11 host text", 0);
+            CheckInvalidParsedValue("11 host \"text\" Tue, 20 Jul 2010 01:02:03 GMT", 0);
+            CheckInvalidParsedValue("11 host \"text\" 123 next \"text\"", 0);
+            CheckInvalidParsedValue("会", 0);
+            CheckInvalidParsedValue("123 会", 0);
+            CheckInvalidParsedValue("111 [::1]:80\r(comment) \"text\"", 0);
+            CheckInvalidParsedValue("111 [::1]:80\n(comment) \"text\"", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, WarningHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueWarningParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            HttpHeaderParser parser = GenericHeaderParser.MultipleValueWarningParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/HeaderUtilitiesTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HeaderUtilitiesTest.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HeaderUtilitiesTest
+    {
+        [Fact]
+        public void AreEqualCollections_UseSetOfEqualCollections_ReturnsTrue()
+        {
+            ICollection<NameValueHeaderValue> x = new List<NameValueHeaderValue>();
+            ICollection<NameValueHeaderValue> y = new List<NameValueHeaderValue>();
+
+            Assert.True(HeaderUtilities.AreEqualCollections(x, y));
+
+            x.Add(new NameValueHeaderValue("a"));
+            x.Add(new NameValueHeaderValue("c"));
+            x.Add(new NameValueHeaderValue("b"));
+            x.Add(new NameValueHeaderValue("c"));
+
+            y.Add(new NameValueHeaderValue("c"));
+            y.Add(new NameValueHeaderValue("c"));
+            y.Add(new NameValueHeaderValue("b"));
+            y.Add(new NameValueHeaderValue("a"));
+
+            Assert.True(HeaderUtilities.AreEqualCollections(x, y));
+            Assert.True(HeaderUtilities.AreEqualCollections(y, x));
+        }
+
+        [Fact]
+        public void AreEqualCollections_UseSetOfNotEqualCollections_ReturnsFalse()
+        {
+            ICollection<NameValueHeaderValue> x = new List<NameValueHeaderValue>();
+            ICollection<NameValueHeaderValue> y = new List<NameValueHeaderValue>();
+
+            Assert.True(HeaderUtilities.AreEqualCollections(x, y), "Expected '<empty>' == '<empty>'");
+
+            x.Add(new NameValueHeaderValue("a"));
+            x.Add(new NameValueHeaderValue("c"));
+            x.Add(new NameValueHeaderValue("b"));
+            x.Add(new NameValueHeaderValue("c"));
+
+            y.Add(new NameValueHeaderValue("a"));
+            y.Add(new NameValueHeaderValue("b"));
+            y.Add(new NameValueHeaderValue("c"));
+            y.Add(new NameValueHeaderValue("d"));
+
+            Assert.False(HeaderUtilities.AreEqualCollections(x, y));
+            Assert.False(HeaderUtilities.AreEqualCollections(y, x));
+
+            y.Clear();
+            y.Add(new NameValueHeaderValue("a"));
+            y.Add(new NameValueHeaderValue("b"));
+            y.Add(new NameValueHeaderValue("b"));
+            y.Add(new NameValueHeaderValue("c"));
+
+            Assert.False(HeaderUtilities.AreEqualCollections(x, y));
+            Assert.False(HeaderUtilities.AreEqualCollections(y, x));
+        }
+
+        [Fact]
+        public void GetNextNonEmptyOrWhitespaceIndex_UseDifferentInput_MatchExpectation()
+        {
+            CheckGetNextNonEmptyOrWhitespaceIndex("x , , ,,  ,\t\r\n , ,x", 1, true, 18, true);
+            CheckGetNextNonEmptyOrWhitespaceIndex("x , ,   ", 1, false, 4, true); // stop at the second ','
+            CheckGetNextNonEmptyOrWhitespaceIndex("x , ,   ", 1, true, 8, true);
+            CheckGetNextNonEmptyOrWhitespaceIndex(" x", 0, true, 1, false);
+            CheckGetNextNonEmptyOrWhitespaceIndex(" ,x", 0, true, 2, true);
+            CheckGetNextNonEmptyOrWhitespaceIndex(" ,x", 0, false, 2, true);
+            CheckGetNextNonEmptyOrWhitespaceIndex(" ,,x", 0, true, 3, true);
+            CheckGetNextNonEmptyOrWhitespaceIndex(" ,,x", 0, false, 2, true);
+        }
+
+        [Fact]
+        public void CheckValidQuotedString_ValidAndInvalidvalues_MatchExpectation()
+        {
+            // No exception expected for the following input.
+            HeaderUtilities.CheckValidQuotedString("\"x\"", "param");
+            HeaderUtilities.CheckValidQuotedString("\"x y\"", "param");
+
+            Assert.Throws<ArgumentException>(() => { HeaderUtilities.CheckValidQuotedString(null, "param"); });
+            Assert.Throws<ArgumentException>(() => { HeaderUtilities.CheckValidQuotedString("", "param"); });
+            Assert.Throws<FormatException>(() => { HeaderUtilities.CheckValidQuotedString("\"x", "param"); });
+            Assert.Throws<FormatException>(() => { HeaderUtilities.CheckValidQuotedString("\"x\"y", "param"); });
+        }
+
+        #region Helper methods
+
+        private static void CheckGetNextNonEmptyOrWhitespaceIndex(string input, int startIndex,
+            bool supportsEmptyValues, int expectedIndex, bool expectedSeparatorFound)
+        {
+            bool separatorFound = false;
+            Assert.Equal(expectedIndex, HeaderUtilities.GetNextNonEmptyOrWhitespaceIndex(input, startIndex,
+                supportsEmptyValues, out separatorFound));
+            Assert.Equal(expectedSeparatorFound, separatorFound);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpContentHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpContentHeadersTest.cs
@@ -1,0 +1,503 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpContentHeadersTest
+    {
+        private HttpContentHeaders _headers;
+
+        public HttpContentHeadersTest()
+        {
+            _headers = new HttpContentHeaders(null);
+        }
+
+        [Fact]
+        public void ContentLength_AddInvalidValueUsingUnusualCasing_ParserRetrievedUsingCaseInsensitiveComparison()
+        {
+            _headers = new HttpContentHeaders(() => { return 15; });
+
+            // Use uppercase header name to make sure the parser gets retrieved using case-insensitive comparison.
+            Assert.Throws<FormatException>(() => { _headers.Add("CoNtEnT-LeNgTh", "this is invalid"); });
+        }
+
+        [Fact]
+        public void ContentLength_ReadValue_DelegateInvoked()
+        {
+            _headers = new HttpContentHeaders(() => { return 15; });
+
+            // The delegate is invoked to return the length.
+            Assert.Equal(15, _headers.ContentLength);
+            Assert.Equal((long)15, _headers.GetParsedValues(HttpKnownHeaderNames.ContentLength));
+
+            // After getting the calculated content length, set it to null.
+            _headers.ContentLength = null;
+            Assert.Equal(null, _headers.ContentLength);
+            Assert.False(_headers.Contains(HttpKnownHeaderNames.ContentLength));
+
+            _headers.ContentLength = 27;
+            Assert.Equal((long)27, _headers.ContentLength);
+            Assert.Equal((long)27, _headers.GetParsedValues(HttpKnownHeaderNames.ContentLength));
+        }
+
+        [Fact]
+        public void ContentLength_SetCustomValue_DelegateNotInvoked()
+        {
+            _headers = new HttpContentHeaders(() => { Assert.True(false, "Delegate called."); return 0; });
+
+            _headers.ContentLength = 27;
+            Assert.Equal((long)27, _headers.ContentLength);
+            Assert.Equal((long)27, _headers.GetParsedValues(HttpKnownHeaderNames.ContentLength));
+
+            // After explicitly setting the content length, set it to null.
+            _headers.ContentLength = null;
+            Assert.Equal(null, _headers.ContentLength);
+            Assert.False(_headers.Contains(HttpKnownHeaderNames.ContentLength));
+
+            // Make sure the header gets serialized correctly
+            _headers.ContentLength = 12345;
+            Assert.Equal("12345", _headers.GetValues("Content-Length").First());
+        }
+
+        [Fact]
+        public void ContentLength_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers = new HttpContentHeaders(() => { Assert.True(false, "Delegate called."); return 0; });
+            _headers.TryAddWithoutValidation(HttpKnownHeaderNames.ContentLength, " 68 \r\n ");
+
+            Assert.Equal(68, _headers.ContentLength);
+        }
+
+        [Fact]
+        public void ContentType_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            MediaTypeHeaderValue value = new MediaTypeHeaderValue("text/plain");
+            value.CharSet = "utf-8";
+            value.Parameters.Add(new NameValueHeaderValue("custom", "value"));
+
+            Assert.Null(_headers.ContentType);
+
+            _headers.ContentType = value;
+            Assert.Same(value, _headers.ContentType);
+
+            _headers.ContentType = null;
+            Assert.Null(_headers.ContentType);
+        }
+
+        [Fact]
+        public void ContentType_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Content-Type", "text/plain; charset=utf-8; custom=value");
+
+            MediaTypeHeaderValue value = new MediaTypeHeaderValue("text/plain");
+            value.CharSet = "utf-8";
+            value.Parameters.Add(new NameValueHeaderValue("custom", "value"));
+
+            Assert.Equal(value, _headers.ContentType);
+        }
+
+        [Fact]
+        public void ContentType_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Content-Type", "text/plain; charset=utf-8; custom=value, other/type");
+            Assert.Null(_headers.ContentType);
+            Assert.Equal(1, _headers.GetValues("Content-Type").Count());
+            Assert.Equal("text/plain; charset=utf-8; custom=value, other/type",
+                _headers.GetValues("Content-Type").First());
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Content-Type", ",text/plain"); // leading separator
+            Assert.Null(_headers.ContentType);
+            Assert.Equal(1, _headers.GetValues("Content-Type").Count());
+            Assert.Equal(",text/plain", _headers.GetValues("Content-Type").First());
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Content-Type", "text/plain,"); // trailing separator
+            Assert.Null(_headers.ContentType);
+            Assert.Equal(1, _headers.GetValues("Content-Type").Count());
+            Assert.Equal("text/plain,", _headers.GetValues("Content-Type").First());
+        }
+
+        [Fact]
+        public void ContentRange_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(_headers.ContentRange);
+            ContentRangeHeaderValue value = new ContentRangeHeaderValue(1, 2, 3);
+
+            _headers.ContentRange = value;
+            Assert.Equal(value, _headers.ContentRange);
+
+            _headers.ContentRange = null;
+            Assert.Null(_headers.ContentRange);
+        }
+
+        [Fact]
+        public void ContentRange_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Content-Range", "custom 1-2/*");
+
+            ContentRangeHeaderValue value = new ContentRangeHeaderValue(1, 2);
+            value.Unit = "custom";
+
+            Assert.Equal(value, _headers.ContentRange);
+        }
+
+        [Fact]
+        public void ContentLocation_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(_headers.ContentLocation);
+
+            Uri expected = new Uri("http://example.com/path/");
+            _headers.ContentLocation = expected;
+            Assert.Equal(expected, _headers.ContentLocation);
+
+            _headers.ContentLocation = null;
+            Assert.Null(_headers.ContentLocation);
+            Assert.False(_headers.Contains("Content-Location"));
+        }
+
+        [Fact]
+        public void ContentLocation_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Content-Location", "  http://www.example.com/path/?q=v  ");
+            Assert.Equal(new Uri("http://www.example.com/path/?q=v"), _headers.ContentLocation);
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Content-Location", "/relative/uri/");
+            Assert.Equal(new Uri("/relative/uri/", UriKind.Relative), _headers.ContentLocation);
+        }
+
+        [Fact]
+        public void ContentLocation_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Content-Location", " http://example.com http://other");
+            Assert.Null(_headers.GetParsedValues("Content-Location"));
+            Assert.Equal(1, _headers.GetValues("Content-Location").Count());
+            Assert.Equal(" http://example.com http://other", _headers.GetValues("Content-Location").First());
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Content-Location", "http://host /other");
+            Assert.Null(_headers.GetParsedValues("Content-Location"));
+            Assert.Equal(1, _headers.GetValues("Content-Location").Count());
+            Assert.Equal("http://host /other", _headers.GetValues("Content-Location").First());
+        }
+
+        [Fact]
+        public void ContentEncoding_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, _headers.ContentEncoding.Count);
+
+            _headers.ContentEncoding.Add("custom1");
+            _headers.ContentEncoding.Add("custom2");
+
+            Assert.Equal(2, _headers.ContentEncoding.Count);
+            Assert.Equal(2, _headers.GetValues("Content-Encoding").Count());
+
+            Assert.Equal("custom1", _headers.ContentEncoding.ElementAt(0));
+            Assert.Equal("custom2", _headers.ContentEncoding.ElementAt(1));
+
+            _headers.ContentEncoding.Clear();
+            Assert.Equal(0, _headers.ContentEncoding.Count);
+            Assert.False(_headers.Contains("Content-Encoding"));
+        }
+
+        [Fact]
+        public void ContentEncoding_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Content-Encoding", ",custom1, custom2, custom3,");
+
+            Assert.Equal(3, _headers.ContentEncoding.Count);
+            Assert.Equal(3, _headers.GetValues("Content-Encoding").Count());
+
+            Assert.Equal("custom1", _headers.ContentEncoding.ElementAt(0));
+            Assert.Equal("custom2", _headers.ContentEncoding.ElementAt(1));
+            Assert.Equal("custom3", _headers.ContentEncoding.ElementAt(2));
+
+            _headers.ContentEncoding.Clear();
+            Assert.Equal(0, _headers.ContentEncoding.Count);
+            Assert.False(_headers.Contains("Content-Encoding"));
+        }
+
+        [Fact]
+        public void ContentEncoding_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Content-Encoding", "custom1 custom2"); // no separator
+
+            Assert.Equal(0, _headers.ContentEncoding.Count);
+            Assert.Equal(1, _headers.GetValues("Content-Encoding").Count());
+            Assert.Equal("custom1 custom2", _headers.GetValues("Content-Encoding").First());
+        }
+
+        [Fact]
+        public void ContentLanguage_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, _headers.ContentLanguage.Count);
+
+            // Note that Content-Language for us is just a list of tokens. We don't verify if the format is a valid
+            // language tag. Users will pass the language tag to other classes like Encoding.GetEncoding() to retrieve
+            // an encoding. These classes will do not only syntax checking but also verify if the language tag exists.
+            _headers.ContentLanguage.Add("custom1");
+            _headers.ContentLanguage.Add("custom2");
+
+            Assert.Equal(2, _headers.ContentLanguage.Count);
+            Assert.Equal(2, _headers.GetValues("Content-Language").Count());
+
+            Assert.Equal("custom1", _headers.ContentLanguage.ElementAt(0));
+            Assert.Equal("custom2", _headers.ContentLanguage.ElementAt(1));
+
+            _headers.ContentLanguage.Clear();
+            Assert.Equal(0, _headers.ContentLanguage.Count);
+            Assert.False(_headers.Contains("Content-Language"));
+        }
+
+        [Fact]
+        public void ContentLanguage_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Content-Language", ",custom1, custom2, custom3,");
+
+            Assert.Equal(3, _headers.ContentLanguage.Count);
+            Assert.Equal(3, _headers.GetValues("Content-Language").Count());
+
+            Assert.Equal("custom1", _headers.ContentLanguage.ElementAt(0));
+            Assert.Equal("custom2", _headers.ContentLanguage.ElementAt(1));
+            Assert.Equal("custom3", _headers.ContentLanguage.ElementAt(2));
+
+            _headers.ContentLanguage.Clear();
+            Assert.Equal(0, _headers.ContentLanguage.Count);
+            Assert.False(_headers.Contains("Content-Language"));
+        }
+
+        [Fact]
+        public void ContentLanguage_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Content-Language", "custom1 custom2"); // no separator
+
+            Assert.Equal(0, _headers.ContentLanguage.Count);
+            Assert.Equal(1, _headers.GetValues("Content-Language").Count());
+            Assert.Equal("custom1 custom2", _headers.GetValues("Content-Language").First());
+        }
+
+        [Fact]
+        public void ContentMD5_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(_headers.ContentMD5);
+
+            byte[] expected = new byte[] { 1, 2, 3, 4, 5, 6, 7 };
+            _headers.ContentMD5 = expected;
+            Assert.Equal(expected, _headers.ContentMD5); // must be the same object reference
+
+            // Make sure the header gets serialized correctly
+            Assert.Equal("AQIDBAUGBw==", _headers.GetValues("Content-MD5").First());
+
+            _headers.ContentMD5 = null;
+            Assert.Null(_headers.ContentMD5);
+            Assert.False(_headers.Contains("Content-MD5"));
+        }
+
+        [Fact]
+        public void ContentMD5_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Content-MD5", "  lvpAKQ==  ");
+            Assert.Equal(new byte[] { 150, 250, 64, 41 }, _headers.ContentMD5);
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Content-MD5", "+dIkS/MnOP8=");
+            Assert.Equal(new byte[] { 249, 210, 36, 75, 243, 39, 56, 255 }, _headers.ContentMD5);
+        }
+
+        [Fact]
+        public void ContentMD5_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Content-MD5", "AQ--");
+            Assert.Null(_headers.GetParsedValues("Content-MD5"));
+            Assert.Equal(1, _headers.GetValues("Content-MD5").Count());
+            Assert.Equal("AQ--", _headers.GetValues("Content-MD5").First());
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Content-MD5", "AQ==, CD");
+            Assert.Null(_headers.GetParsedValues("Content-MD5"));
+            Assert.Equal(1, _headers.GetValues("Content-MD5").Count());
+            Assert.Equal("AQ==, CD", _headers.GetValues("Content-MD5").First());
+        }
+
+        [Fact]
+        public void Allow_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, _headers.Allow.Count);
+
+            _headers.Allow.Add("custom1");
+            _headers.Allow.Add("custom2");
+
+            Assert.Equal(2, _headers.Allow.Count);
+            Assert.Equal(2, _headers.GetValues("Allow").Count());
+
+            Assert.Equal("custom1", _headers.Allow.ElementAt(0));
+            Assert.Equal("custom2", _headers.Allow.ElementAt(1));
+
+            _headers.Allow.Clear();
+            Assert.Equal(0, _headers.Allow.Count);
+            Assert.False(_headers.Contains("Allow"));
+        }
+
+        [Fact]
+        public void Allow_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Allow", ",custom1, custom2, custom3,");
+
+            Assert.Equal(3, _headers.Allow.Count);
+            Assert.Equal(3, _headers.GetValues("Allow").Count());
+
+            Assert.Equal("custom1", _headers.Allow.ElementAt(0));
+            Assert.Equal("custom2", _headers.Allow.ElementAt(1));
+            Assert.Equal("custom3", _headers.Allow.ElementAt(2));
+
+            _headers.Allow.Clear();
+            Assert.Equal(0, _headers.Allow.Count);
+            Assert.False(_headers.Contains("Allow"));
+        }
+
+        [Fact]
+        public void Allow_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Allow", "custom1 custom2"); // no separator
+
+            Assert.Equal(0, _headers.Allow.Count);
+            Assert.Equal(1, _headers.GetValues("Allow").Count());
+            Assert.Equal("custom1 custom2", _headers.GetValues("Allow").First());
+        }
+
+        [Fact]
+        public void Expires_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(_headers.Expires);
+
+            DateTimeOffset expected = DateTimeOffset.Now;
+            _headers.Expires = expected;
+            Assert.Equal(expected, _headers.Expires);
+
+            _headers.Expires = null;
+            Assert.Null(_headers.Expires);
+            Assert.False(_headers.Contains("Expires"));
+        }
+
+        [Fact]
+        public void Expires_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Expires", "  Sun, 06 Nov 1994 08:49:37 GMT  ");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), _headers.Expires);
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Expires", "Sun, 06 Nov 1994 08:49:37 GMT");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), _headers.Expires);
+        }
+
+        [Fact]
+        public void Expires_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Expires", " Sun, 06 Nov 1994 08:49:37 GMT ,");
+            Assert.Null(_headers.GetParsedValues("Expires"));
+            Assert.Equal(1, _headers.GetValues("Expires").Count());
+            Assert.Equal(" Sun, 06 Nov 1994 08:49:37 GMT ,", _headers.GetValues("Expires").First());
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Expires", " Sun, 06 Nov ");
+            Assert.Null(_headers.GetParsedValues("Expires"));
+            Assert.Equal(1, _headers.GetValues("Expires").Count());
+            Assert.Equal(" Sun, 06 Nov ", _headers.GetValues("Expires").First());
+        }
+
+        [Fact]
+        public void LastModified_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(_headers.LastModified);
+
+            DateTimeOffset expected = DateTimeOffset.Now;
+            _headers.LastModified = expected;
+            Assert.Equal(expected, _headers.LastModified);
+
+            _headers.LastModified = null;
+            Assert.Null(_headers.LastModified);
+            Assert.False(_headers.Contains("Last-Modified"));
+        }
+
+        [Fact]
+        public void LastModified_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            _headers.TryAddWithoutValidation("Last-Modified", "  Sun, 06 Nov 1994 08:49:37 GMT  ");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), _headers.LastModified);
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Last-Modified", "Sun, 06 Nov 1994 08:49:37 GMT");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), _headers.LastModified);
+        }
+
+        [Fact]
+        public void LastModified_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            _headers.TryAddWithoutValidation("Last-Modified", " Sun, 06 Nov 1994 08:49:37 GMT ,");
+            Assert.Null(_headers.GetParsedValues("Last-Modified"));
+            Assert.Equal(1, _headers.GetValues("Last-Modified").Count());
+            Assert.Equal(" Sun, 06 Nov 1994 08:49:37 GMT ,", _headers.GetValues("Last-Modified").First());
+
+            _headers.Clear();
+            _headers.TryAddWithoutValidation("Last-Modified", " Sun, 06 Nov ");
+            Assert.Null(_headers.GetParsedValues("Last-Modified"));
+            Assert.Equal(1, _headers.GetValues("Last-Modified").Count());
+            Assert.Equal(" Sun, 06 Nov ", _headers.GetValues("Last-Modified").First());
+        }
+
+        [Fact]
+        public void InvalidHeaders_AddRequestAndResponseHeaders_Throw()
+        {
+            // Try adding request, response, and general _headers. Use different casing to make sure case-insensitive
+            // comparison is used.
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Accept-Ranges", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("age", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("ETag", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Location", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Proxy-Authenticate", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Retry-After", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Server", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Vary", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("WWW-Authenticate", "v"); });
+
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Accept", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Accept-Charset", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Accept-Encoding", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Accept-Language", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Authorization", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Expect", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("From", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Host", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("If-Match", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("If-Modified-Since", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("If-None-Match", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("If-Range", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("If-Unmodified-Since", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Max-Forwards", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Proxy-Authorization", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Range", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Referer", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("TE", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("User-Agent", "v"); });
+
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Cache-Control", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Connection", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Date", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Pragma", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Trailer", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Transfer-Encoding", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Upgrade", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Via", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { _headers.Add("Warning", "v"); });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
@@ -1,0 +1,983 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpHeaderValueCollectionTest
+    {
+        private const string knownHeader = "known-header";
+        private static readonly Uri specialValue = new Uri("http://special/");
+        private static readonly Uri invalidValue = new Uri("http://invalid/");
+        private static readonly TransferCodingHeaderValue specialChunked = new TransferCodingHeaderValue("chunked");
+
+        // Note that this type just forwards calls to HttpHeaders. So this test method focusses on making sure 
+        // the correct calls to HttpHeaders are made. This test suite will not test HttpHeaders functionality.
+
+        [Fact]
+        public void IsReadOnly_CallProperty_AlwaysFalse()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(string)));
+            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownHeader, headers);
+
+            Assert.False(collection.IsReadOnly);
+        }
+
+        [Fact]
+        public void Count_AddSingleValueThenQueryCount_ReturnsValueCountWithSpecialValues()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(string)));
+            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownHeader, headers,
+                "special");
+
+            Assert.Equal(0, collection.Count);
+
+            headers.Add(knownHeader, "value2");
+            Assert.Equal(1, collection.Count);
+
+            headers.Clear();
+            headers.Add(knownHeader, "special");
+            Assert.Equal(1, collection.Count);
+            headers.Add(knownHeader, "special");
+            headers.Add(knownHeader, "special");
+            Assert.Equal(3, collection.Count);
+        }
+
+        [Fact]
+        public void Count_AddMultipleValuesThenQueryCount_ReturnsValueCountWithSpecialValues()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(string)));
+            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownHeader, headers,
+                "special");
+
+            Assert.Equal(0, collection.Count);
+
+            collection.Add("value1");
+            headers.Add(knownHeader, "special");
+            Assert.Equal(2, collection.Count);
+
+            headers.Add(knownHeader, "special");
+            headers.Add(knownHeader, "value2");
+            headers.Add(knownHeader, "special");
+            Assert.Equal(5, collection.Count);
+        }
+
+        [Fact]
+        public void Add_CallWithNullValue_Throw()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            Assert.Throws<ArgumentNullException>(() => { collection.Add(null); });
+        }
+
+        [Fact]
+        public void Add_AddValues_AllValuesAdded()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Assert.Equal(3, collection.Count);
+        }
+
+        [Fact]
+        public void Add_UseSpecialValue_Success()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+            Assert.Null(headers.TransferEncodingChunked);
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.Equal(String.Empty, headers.TransferEncoding.ToString());
+
+            headers.TransferEncoding.Add(specialChunked);
+
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+            Assert.Equal(specialChunked, headers.TransferEncoding.First());
+            Assert.Equal(specialChunked.ToString(), headers.TransferEncoding.ToString());
+        }
+
+        [Fact]
+        public void Add_UseSpecialValueWithSpecialAlreadyPresent_AddsDuplicate()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+            headers.TransferEncodingChunked = true;
+
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+            Assert.Equal(specialChunked.ToString(), headers.TransferEncoding.ToString());
+
+            headers.TransferEncoding.Add(specialChunked);
+
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(2, headers.TransferEncoding.Count);
+            Assert.Equal("chunked, chunked", headers.TransferEncoding.ToString());
+
+            // removes first instance of
+            headers.TransferEncodingChunked = false;
+
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+            Assert.Equal(specialChunked.ToString(), headers.TransferEncoding.ToString());
+
+            // does not add duplicate
+            headers.TransferEncodingChunked = true;
+
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+            Assert.Equal(specialChunked.ToString(), headers.TransferEncoding.ToString());
+        }
+
+        [Fact]
+        public void ParseAdd_CallWithNullValue_NothingAdded()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.ParseAdd(null);
+            Assert.False(collection.IsSpecialValueSet);
+            Assert.Equal(0, collection.Count);
+            Assert.Equal(String.Empty, collection.ToString());
+        }
+
+        [Fact]
+        public void ParseAdd_AddValues_AllValuesAdded()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.ParseAdd("http://www.example.org/1/");
+            collection.ParseAdd("http://www.example.org/2/");
+            collection.ParseAdd("http://www.example.org/3/");
+
+            Assert.Equal(3, collection.Count);
+        }
+
+        [Fact]
+        public void ParseAdd_UseSpecialValue_Added()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.ParseAdd(specialValue.AbsoluteUri);
+
+            Assert.True(collection.IsSpecialValueSet);
+            Assert.Equal(specialValue.ToString(), collection.ToString());
+        }
+
+        [Fact]
+        public void ParseAdd_AddBadValue_Throws()
+        {
+            HttpResponseHeaders headers = new HttpResponseHeaders();
+            string input = "Basic, D\rigest qop=\"auth\",algorithm=MD5-sess";
+            
+            Assert.Throws<FormatException>(() => { headers.WwwAuthenticate.ParseAdd(input); });
+        }
+
+        [Fact]
+        public void TryParseAdd_CallWithNullValue_NothingAdded()
+        {
+            HttpResponseHeaders headers = new HttpResponseHeaders();
+
+            Assert.True(headers.WwwAuthenticate.TryParseAdd(null));
+
+            Assert.False(headers.WwwAuthenticate.IsSpecialValueSet);
+            Assert.Equal(0, headers.WwwAuthenticate.Count);
+            Assert.Equal(String.Empty, headers.WwwAuthenticate.ToString());
+        }
+
+        [Fact]
+        public void TryParseAdd_AddValues_AllAdded()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            Assert.True(collection.TryParseAdd("http://www.example.org/1/"));
+            Assert.True(collection.TryParseAdd("http://www.example.org/2/"));
+            Assert.True(collection.TryParseAdd("http://www.example.org/3/"));
+
+            Assert.Equal(3, collection.Count);
+        }
+
+        [Fact]
+        public void TryParseAdd_UseSpecialValue_Added()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            Assert.True(collection.TryParseAdd(specialValue.AbsoluteUri));
+
+            Assert.True(collection.IsSpecialValueSet);
+            Assert.Equal(specialValue.ToString(), collection.ToString());
+        }
+
+        [Fact]
+        public void TryParseAdd_AddBadValue_False()
+        {
+            HttpResponseHeaders headers = new HttpResponseHeaders();
+            string input = "Basic, D\rigest qop=\"auth\",algorithm=MD5-sess";
+            Assert.False(headers.WwwAuthenticate.TryParseAdd(input));
+            Assert.Equal(string.Empty, headers.WwwAuthenticate.ToString());
+            Assert.Equal(string.Empty, headers.ToString());
+        }
+
+        [Fact]
+        public void TryParseAdd_AddBadAfterGoodValue_False()
+        {
+            HttpResponseHeaders headers = new HttpResponseHeaders();
+            headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("Negotiate"));
+            string input = "Basic, D\rigest qop=\"auth\",algorithm=MD5-sess";
+            Assert.False(headers.WwwAuthenticate.TryParseAdd(input));
+            Assert.Equal("Negotiate", headers.WwwAuthenticate.ToString());
+            Assert.Equal("WWW-Authenticate: Negotiate\r\n", headers.ToString());
+        }
+
+        [Fact]
+        public void Clear_AddValuesThenClear_NoElementsInCollection()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Assert.Equal(3, collection.Count);
+
+            collection.Clear();
+
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void Clear_AddValuesAndSpecialValueThenClear_EverythingCleared()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.SetSpecialValue();
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Assert.Equal(4, collection.Count);
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+
+            collection.Clear();
+
+            Assert.Equal(0, collection.Count);
+            Assert.False(collection.IsSpecialValueSet, "Special value was removed by Clear().");
+        }
+
+        [Fact]
+        public void Contains_CallWithNullValue_Throw()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            Assert.Throws<ArgumentNullException>(() => { collection.Contains(null); });
+        }
+
+        [Fact]
+        public void Contains_AddValuesThenCallContains_ReturnsTrueForExistingItemsFalseOtherwise()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Assert.True(collection.Contains(new Uri("http://www.example.org/2/")), "Expected true for existing item.");
+            Assert.False(collection.Contains(new Uri("http://www.example.org/4/")),
+                "Expected false for non-existing item.");
+        }
+
+        [Fact]
+        public void Contains_UseSpecialValueWhenEmpty_False()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+
+            Assert.False(headers.TransferEncoding.Contains(specialChunked));
+        }
+
+        [Fact]
+        public void Contains_UseSpecialValueWithProperty_True()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+
+            headers.TransferEncodingChunked = true;
+            Assert.True(headers.TransferEncoding.Contains(specialChunked));
+
+            headers.TransferEncodingChunked = false;
+            Assert.False(headers.TransferEncoding.Contains(specialChunked));
+        }
+
+        [Fact]
+        public void Contains_UseSpecialValueWhenSpecilValueIsPresent_True()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+
+            headers.TransferEncoding.Add(specialChunked);
+            Assert.True(headers.TransferEncoding.Contains(specialChunked));
+
+            headers.TransferEncoding.Remove(specialChunked);
+            Assert.False(headers.TransferEncoding.Contains(specialChunked));
+        }
+
+        [Fact]
+        public void CopyTo_CallWithStartIndexPlusElementCountGreaterArrayLength_Throw()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+
+            Uri[] array = new Uri[2];
+            
+            // startIndex + Count = 1 + 2 > array.Length
+            Assert.Throws<ArgumentException>(() => { collection.CopyTo(array, 1); });
+        }
+
+        [Fact]
+        public void CopyTo_EmptyToEmpty_Success()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            Uri[] array = new Uri[0];
+            collection.CopyTo(array, 0);
+        }
+
+        [Fact]
+        public void CopyTo_NoValues_DoesNotChangeArray()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            Uri[] array = new Uri[4];
+            collection.CopyTo(array, 0);
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                Assert.Null(array[i]);
+            }
+        }
+
+        [Fact]
+        public void CopyTo_AddSingleValue_ContainsSingleValue()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/"));
+
+            Uri[] array = new Uri[1];
+            collection.CopyTo(array, 0);
+            Assert.Equal(new Uri("http://www.example.org/"), array[0]);
+
+            // Now only set the special value: nothing should be added to the array.
+            headers.Clear();
+            headers.Add(knownHeader, specialValue.ToString());
+            array[0] = null;
+            collection.CopyTo(array, 0);
+            Assert.Equal(specialValue, array[0]);
+        }
+
+        [Fact]
+        public void CopyTo_AddMultipleValues_ContainsAllValuesInTheRightOrder()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Uri[] array = new Uri[5];
+            collection.CopyTo(array, 1);
+
+            Assert.Null(array[0]);
+            Assert.Equal(new Uri("http://www.example.org/1/"), array[1]);
+            Assert.Equal(new Uri("http://www.example.org/2/"), array[2]);
+            Assert.Equal(new Uri("http://www.example.org/3/"), array[3]);
+            Assert.Null(array[4]);
+        }
+
+        [Fact]
+        public void CopyTo_AddValuesAndSpecialValue_AllValuesCopied()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.SetSpecialValue();
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Uri[] array = new Uri[5];
+            collection.CopyTo(array, 1);
+
+            Assert.Null(array[0]);
+            Assert.Equal(new Uri("http://www.example.org/1/"), array[1]);
+            Assert.Equal(new Uri("http://www.example.org/2/"), array[2]);
+            Assert.Equal(specialValue, array[3]);
+            Assert.Equal(new Uri("http://www.example.org/3/"), array[4]);
+
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+        }
+
+        [Fact]
+        public void CopyTo_OnlySpecialValue_Copied()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.SetSpecialValue();
+            headers.Add(knownHeader, specialValue.ToString());
+            headers.Add(knownHeader, specialValue.ToString());
+            headers.Add(knownHeader, specialValue.ToString());
+
+            Uri[] array = new Uri[4];
+            array[0] = null;
+            collection.CopyTo(array, 0);
+
+            Assert.Equal(specialValue, array[0]);
+            Assert.Equal(specialValue, array[1]);
+            Assert.Equal(specialValue, array[2]);
+            Assert.Equal(specialValue, array[3]);
+
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+        }
+
+        [Fact]
+        public void CopyTo_OnlySpecialValueEmptyDestination_Copied()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.SetSpecialValue();
+            headers.Add(knownHeader, specialValue.ToString());
+
+            Uri[] array = new Uri[2];
+            collection.CopyTo(array, 0);
+
+            Assert.Equal(specialValue, array[0]);
+            Assert.Equal(specialValue, array[1]);
+
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+        }
+
+        [Fact]
+        public void CopyTo_ArrayTooSmall_Throw()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(string)));
+            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownHeader, headers,
+                "special");
+
+            string[] array = new string[1];
+            array[0] = null;
+
+            collection.CopyTo(array, 0); // no exception
+            Assert.Null(array[0]);
+
+            Assert.Throws<ArgumentNullException>(() => { collection.CopyTo(null, 0); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { collection.CopyTo(array, -1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { collection.CopyTo(array, 2); });
+
+            headers.Add(knownHeader, "special");
+            array = new string[0];
+            Assert.Throws<ArgumentException>(() => { collection.CopyTo(array, 0); });
+
+            headers.Add(knownHeader, "special");
+            headers.Add(knownHeader, "special");
+            array = new string[1];
+            Assert.Throws<ArgumentException>(() => { collection.CopyTo(array, 0); });
+
+            headers.Add(knownHeader, "value1");
+            array = new string[0];
+            Assert.Throws<ArgumentException>(() => { collection.CopyTo(array, 0); });
+
+            headers.Add(knownHeader, "value2");
+            array = new string[1];
+            Assert.Throws<ArgumentException>(() => { collection.CopyTo(array, 0); });
+
+            array = new string[2];
+            Assert.Throws<ArgumentException>(() => { collection.CopyTo(array, 1); });
+        }
+
+        [Fact]
+        public void Remove_CallWithNullValue_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            Assert.Throws<ArgumentNullException>(() => { collection.Remove(null); });
+        }
+
+        [Fact]
+        public void Remove_AddValuesThenCallRemove_ReturnsTrueWhenRemovingExistingValuesFalseOtherwise()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            Assert.True(collection.Remove(new Uri("http://www.example.org/2/")), "Expected true for existing item.");
+            Assert.False(collection.Remove(new Uri("http://www.example.org/4/")),
+                "Expected false for non-existing item.");
+        }
+
+        [Fact]
+        public void Remove_UseSpecialValue_FalseWhenEmpty()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+            Assert.Null(headers.TransferEncodingChunked);
+            Assert.Equal(0, headers.TransferEncoding.Count);
+
+            Assert.False(headers.TransferEncoding.Remove(specialChunked));
+
+            Assert.Null(headers.TransferEncodingChunked);
+            Assert.Equal(0, headers.TransferEncoding.Count);
+        }
+
+        [Fact]
+        public void Remove_UseSpecialValueWhenSetWithProperty_True()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+            headers.TransferEncodingChunked = true;
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+            Assert.True(headers.TransferEncoding.Contains(specialChunked));
+
+            Assert.True(headers.TransferEncoding.Remove(specialChunked));
+
+            Assert.False((bool)headers.TransferEncodingChunked);
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.False(headers.TransferEncoding.Contains(specialChunked));
+        }
+
+        [Fact]
+        public void Remove_UseSpecialValueWhenAdded_True()
+        {
+            HttpRequestHeaders headers = new HttpRequestHeaders();
+            headers.TransferEncoding.Add(specialChunked);
+            Assert.True((bool)headers.TransferEncodingChunked);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+            Assert.True(headers.TransferEncoding.Contains(specialChunked));
+
+            Assert.True(headers.TransferEncoding.Remove(specialChunked));
+
+            Assert.Null(headers.TransferEncodingChunked);
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.False(headers.TransferEncoding.Contains(specialChunked));
+        }
+
+        [Fact]
+        public void GetEnumerator_AddSingleValueAndGetEnumerator_AllValuesReturned()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/"));
+
+            bool started = false;
+            foreach (var item in collection)
+            {
+                Assert.False(started, "We have more than one element returned by the enumerator.");
+                Assert.Equal(new Uri("http://www.example.org/"), item);
+            }
+        }
+
+        [Fact]
+        public void GetEnumerator_AddValuesAndGetEnumerator_AllValuesReturned()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            int i = 1;
+            foreach (var item in collection)
+            {
+                Assert.Equal(new Uri("http://www.example.org/" + i + "/"), item);
+                i++;
+            }
+        }
+
+        [Fact]
+        public void GetEnumerator_NoValues_EmptyEnumerator()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            IEnumerator<Uri> enumerator = collection.GetEnumerator();
+
+            Assert.False(enumerator.MoveNext(), "No items expected in enumerator.");
+        }
+
+        [Fact]
+        public void GetEnumerator_AddValuesAndGetEnumeratorFromInterface_AllValuesReturned()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            System.Collections.IEnumerable enumerable = collection;
+
+            int i = 1;
+            foreach (var item in enumerable)
+            {
+                Assert.Equal(new Uri("http://www.example.org/" + i + "/"), item);
+                i++;
+            }
+        }
+
+        [Fact]
+        public void GetEnumerator_AddValuesAndSpecialValueAndGetEnumeratorFromInterface_AllValuesReturned()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.Add(new Uri("http://www.example.org/3/"));
+            collection.SetSpecialValue();
+
+            System.Collections.IEnumerable enumerable = collection;
+
+            // The "special value" should be ignored and not part of the resulting collection.
+            int i = 1;
+            bool specialFound = false;
+            foreach (var item in enumerable)
+            {
+                if (item.Equals(specialValue))
+                {
+                    specialFound = true;
+                }
+                else
+                {
+                    Assert.Equal(new Uri("http://www.example.org/" + i + "/"), item);
+                    i++;
+                }
+            }
+
+            Assert.True(specialFound);
+
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+        }
+
+        [Fact]
+        public void GetEnumerator_AddValuesAndSpecialValue_AllValuesReturned()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.SetSpecialValue();
+            collection.Add(new Uri("http://www.example.org/3/"));
+
+            System.Collections.IEnumerable enumerable = collection;
+
+            // The special value we added above, must be part of the collection returned by GetEnumerator().
+            int i = 1;
+            bool specialFound = false;
+            foreach (var item in enumerable)
+            {
+                if (item.Equals(specialValue))
+                {
+                    specialFound = true;
+                }
+                else
+                {
+                    Assert.Equal(new Uri("http://www.example.org/" + i + "/"), item);
+                    i++;
+                }
+            }
+
+            Assert.True(specialFound);
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+        }
+
+        [Fact]
+        public void IsSpecialValueSet_NoSpecialValueUsed_ReturnsFalse()
+        {
+            // Create a new collection _without_ specifying a special value.
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                null, null);
+
+            Assert.False(collection.IsSpecialValueSet,
+                "Special value is set even though collection doesn't define a special value.");
+        }
+
+        [Fact]
+        public void RemoveSpecialValue_AddRemoveSpecialValue_SpecialValueGetsRemoved()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.SetSpecialValue();
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+            Assert.Equal(1, headers.GetValues(knownHeader).Count());
+
+            collection.RemoveSpecialValue();
+            Assert.False(collection.IsSpecialValueSet, "Special value is set.");
+
+            // Since the only header value was the "special value", removing it will remove the whole header
+            // from the collection.
+            Assert.False(headers.Contains(knownHeader));
+        }
+
+        [Fact]
+        public void RemoveSpecialValue_AddValueAndSpecialValueThenRemoveSpecialValue_SpecialValueGetsRemoved()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/"));
+            collection.SetSpecialValue();
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+            Assert.Equal(2, headers.GetValues(knownHeader).Count());
+
+            collection.RemoveSpecialValue();
+            Assert.False(collection.IsSpecialValueSet, "Special value is set.");
+            Assert.Equal(1, headers.GetValues(knownHeader).Count());
+        }
+
+        [Fact]
+        public void RemoveSpecialValue_AddTwoValuesAndSpecialValueThenRemoveSpecialValue_SpecialValueGetsRemoved()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue);
+
+            collection.Add(new Uri("http://www.example.org/1/"));
+            collection.Add(new Uri("http://www.example.org/2/"));
+            collection.SetSpecialValue();
+            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
+            Assert.Equal(3, headers.GetValues(knownHeader).Count());
+
+            // The difference between this test and the previous one is that HttpHeaders in this case will use
+            // a List<T> to store the two remaining values, whereas in the previous case it will just store
+            // the remaining value (no list).
+            collection.RemoveSpecialValue();
+            Assert.False(collection.IsSpecialValueSet, "Special value is set.");
+            Assert.Equal(2, headers.GetValues(knownHeader).Count());
+        }
+
+        [Fact]
+        public void Ctor_ProvideValidator_ValidatorIsUsedWhenAddingValues()
+        {
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                MockValidator);
+
+            // Adding an arbitrary Uri should not throw.
+            collection.Add(new Uri("http://some/"));
+
+            // When we add 'invalidValue' our MockValidator will throw.
+            Assert.Throws<MockException>(() => { collection.Add(invalidValue); });
+        }
+
+        [Fact]
+        public void Ctor_ProvideValidator_ValidatorIsUsedWhenRemovingValues()
+        {
+            // Use different ctor overload than in previous test to make sure all ctor overloads work correctly.
+            MockHeaders headers = new MockHeaders(knownHeader, new MockHeaderParser(typeof(Uri)));
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownHeader, headers,
+                specialValue, MockValidator);
+
+            // When we remove 'invalidValue' our MockValidator will throw.
+            Assert.Throws<MockException>(() => { collection.Remove(invalidValue); });
+        }
+
+        [Fact]
+        public void ToString_SpecialValues_Success()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+
+            request.Headers.TransferEncodingChunked = true;
+            string result = request.Headers.TransferEncoding.ToString();
+            Assert.Equal("chunked", result);
+
+            request.Headers.ExpectContinue = true;
+            result = request.Headers.Expect.ToString();
+            Assert.Equal("100-continue", result);
+
+            request.Headers.ConnectionClose = true;
+            result = request.Headers.Connection.ToString();
+            Assert.Equal("close", result);
+        }
+
+        [Fact]
+        public void ToString_SpecialValueAndExtra_Success()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+
+            request.Headers.Add(HttpKnownHeaderNames.TransferEncoding, "bla1");
+            request.Headers.TransferEncodingChunked = true;
+            request.Headers.Add(HttpKnownHeaderNames.TransferEncoding, "bla2");
+            string result = request.Headers.TransferEncoding.ToString();
+            Assert.Equal("bla1, chunked, bla2", result);
+        }
+
+        [Fact]
+        public void ToString_SingleValue_Success()
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            string input = "Basic";
+            response.Headers.Add(HttpKnownHeaderNames.WWWAuthenticate, input);
+            string result = response.Headers.WwwAuthenticate.ToString();
+            Assert.Equal(input, result);
+        }
+
+        [Fact]
+        public void ToString_MultipleValue_Success()
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            string input = "Basic, NTLM, Negotiate, Custom";
+            response.Headers.Add(HttpKnownHeaderNames.WWWAuthenticate, input);
+            string result = response.Headers.WwwAuthenticate.ToString();
+            Assert.Equal(input, result);
+        }
+
+        [Fact]
+        public void ToString_EmptyValue_Success()
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            string result = response.Headers.WwwAuthenticate.ToString();
+            Assert.Equal(string.Empty, result);
+        }
+
+        #region Helper methods
+
+        private static void MockValidator(HttpHeaderValueCollection<Uri> collection, Uri value)
+        {
+            if (value == invalidValue)
+            {
+                throw new MockException();
+            }
+        }
+
+        public class MockException : Exception
+        {
+            public MockException() { }
+            public MockException(string message) : base(message) { }
+            public MockException(string message, Exception inner) : base(message, inner) { }
+        }
+
+        private class MockHeaders : HttpHeaders
+        {
+            public MockHeaders()
+            {
+            }
+
+            public MockHeaders(string headerName, HttpHeaderParser parser)
+            {
+                Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+                parserStore.Add(headerName, parser);
+                SetConfiguration(parserStore, new HashSet<string>());
+            }
+        }
+
+        private class MockHeaderParser : HttpHeaderParser
+        {
+            private static MockComparer comparer = new MockComparer();
+            private Type valueType;
+
+            public override IEqualityComparer Comparer
+            {
+                get { return comparer; }
+            }
+
+            public MockHeaderParser(Type valueType)
+                : base(true)
+            {
+                this.valueType = valueType;
+            }
+
+            public override bool TryParseValue(string value, object storeValue, ref int index, out object parsedValue)
+            {
+                parsedValue = null;
+                if (value == null)
+                {
+                    return true;
+                }
+
+                index = value.Length;
+
+                // Just return the raw string (as string or Uri depending on the value type)
+                if (valueType == typeof(string))
+                {
+                    parsedValue = value;
+                }
+                else if (valueType == typeof(Uri))
+                {
+                    parsedValue = new Uri(value);
+                }
+                else
+                {
+                    Assert.True(false, string.Format("Parser: Unknown value type '{0}'", valueType.ToString()));
+                }
+
+                return true;
+            }
+        }
+        private class MockComparer : IEqualityComparer
+        {
+            public int EqualsCount { get; private set; }
+            public int GetHashCodeCount { get; private set; }
+
+            #region IEqualityComparer Members
+
+            public new bool Equals(object x, object y)
+            {
+                EqualsCount++;
+                return x.Equals(y);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                GetHashCodeCount++;
+                return obj.GetHashCode();
+            }
+            #endregion
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1,0 +1,2223 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpHeadersTest
+    {
+        private const string knownHeader = "known-header";
+        private const string customHeader = "custom-header";
+        private const string rawPrefix = "raw";
+        private const string parsedPrefix = "parsed";
+        private const string invalidHeaderValue = "invalid";
+
+        [Fact]
+        public void TryAddWithoutValidation_UseNullHeader_False()
+        {
+            MockHeaders headers = new MockHeaders();
+            Assert.False(headers.TryAddWithoutValidation(null, "value"));
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_UseInvalidHeader_False()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Spaces are not allowed in header names. This test is used to validate private method
+            // HttpHeaders.CheckHeaders(). Since that helper method is used in all other public methods, this
+            // test is not repeated for other public methods.
+            Assert.False(headers.TryAddWithoutValidation("invalid header", "value"));
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddSingleValue_ValueParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix, headers.First().Value.First());
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddTwoSingleValues_BothValuesParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddTwoValidValuesAsOneString_BothValuesParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1," + rawPrefix + "2");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+
+            // The parser gets called for each value in the raw string. I.e. if we have 1 raw string containing two
+            // values, the parser gets called twice.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddTwoValuesOneValidOneInvalidAsOneString_RawStringAddedAsInvalid()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1," + invalidHeaderValue);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+
+            // We expect the value to be returned without change since it couldn't be parsed in its entirety.
+            Assert.Equal(rawPrefix + "1," + invalidHeaderValue, headers.First().Value.ElementAt(0));
+
+            // The parser gets called twice, but the second time it returns false, because it tries to parse
+            // 'invalidHeaderValue'.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddTwoValueStringAndThirdValue_AllValuesParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1," + rawPrefix + "2");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "3");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(3, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(2));
+
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddInvalidAndValidValueString_BothValuesParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix, headers.First().Value.ElementAt(0));
+            Assert.Equal(invalidHeaderValue, headers.First().Value.ElementAt(1));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddEmptyValueString_HeaderWithNoValueAfterParsing()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // The parser returns 'true' to indicate that it could parse the value (empty values allowed) and an 
+            // value of 'null'. HttpHeaders will remove the header from the collection since the known header doesn't
+            // have a value.
+            headers.TryAddWithoutValidation(knownHeader, string.Empty);
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+            Assert.Equal(0, headers.Count());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("custom", (string)null);
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(string.Empty, headers.GetValues("custom").First());
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddValidAndInvalidValueString_BothValuesParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            // If you compare this test with the previous one: Note that we reversed the order of adding the invalid
+            // string and the valid string. However, when enumerating header values the order is still the same as in
+            // the previous test.
+            // We don't keep track of the order if we have both invalid & valid values. This would add complexity
+            // and additional memory to store the information. Given how rare this scenario is we consider this
+            // by design. Note that this scenario is only an issue if:
+            // - The header value has an invalid format (very rare for standard headers) AND
+            // - There are multiple header values (some valid, some invalid) AND
+            // - The order of the headers matters (e.g. Transfer-Encoding)
+            Assert.Equal(parsedPrefix, headers.First().Value.ElementAt(0));
+            Assert.Equal(invalidHeaderValue, headers.First().Value.ElementAt(1));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            string expected = knownHeader + ": " + parsedPrefix + ", " + invalidHeaderValue + "\r\n";
+            Assert.Equal(expected, headers.ToString());
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddNullValueForKnownHeader_ParserRejectsNullEmptyStringAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, (string)null);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            // MockParser is called with an empty string and decides that it is OK to have empty values but they
+            // shouldn't be added to the list of header values. HttpHeaders will remove the header since it doesn't 
+            // have values.
+            Assert.Equal(0, headers.Count());
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddNullValueForUnknownHeader_EmptyStringAddedAsValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(customHeader, (string)null);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+
+            // 'null' values are internally stored as string.Empty. Since we added a custom header, there is no
+            // parser and the empty string is just added to the list of 'parsed values'.
+            Assert.Equal(string.Empty, headers.First().Value.First());
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddValueForUnknownHeader_ValueAddedToStore()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(customHeader, "custom value");
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+
+            Assert.Equal("custom value", headers.First().Value.First());
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddNullAndEmptyValuesToKnownHeader_HeaderRemovedFromCollection()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, (string)null);
+            headers.TryAddWithoutValidation(knownHeader, string.Empty);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+            Assert.Equal(0, headers.Count());
+
+            // TryAddWithoutValidation() adds 'null' as string.empty to distinguish between an empty raw value and no raw
+            // value. When the parser is called later, the parser can decide whether empty strings are valid or not.
+            // In our case the MockParser returns 'success' with a parsed value of 'null' indicating that it is OK to
+            // have empty values, but they should be ignored. 
+            Assert.Equal(2, headers.Parser.EmptyValueCount);
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddNullAndEmptyValuesToUnknownHeader_TwoEmptyStringsAddedAsValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(customHeader, (string)null);
+            headers.TryAddWithoutValidation(customHeader, string.Empty);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            // TryAddWithoutValidation() adds 'null' as string.empty to distinguish between an empty raw value and no raw
+            // value. For custom headers we just add what the user gives us. I.e. the result is a header with two empty
+            // values.
+            Assert.Equal(string.Empty, headers.First().Value.ElementAt(0));
+            Assert.Equal(string.Empty, headers.First().Value.ElementAt(1));
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddMultipleValueToSingleValueHeaders_FirstHeaderAddedOthersAreInvalid()
+        {
+            MockHeaderParser parser = new MockHeaderParser(false); // doesn't support multiple values.
+            MockHeaders headers = new MockHeaders(parser);
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            // Note that the first value was parsed and added to the 'parsed values' list. The second value however
+            // was added to the 'invalid values' list since the header doesn't support multiple values.
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(rawPrefix + "2", headers.First().Value.ElementAt(1));
+
+            // The parser is only called once for the first value. HttpHeaders doesn't invoke the parser for
+            // additional values if the parser only supports one value.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddMultipleValueStringToSingleValueHeaders_MultipleValueStringAddedAsInvalid()
+        {
+            MockHeaderParser parser = new MockHeaderParser(false); // doesn't support multiple values.
+            MockHeaders headers = new MockHeaders(parser);
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1," + rawPrefix + "2");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            // Since parsing the header value fails because it is composed of 2 values, the original string is added
+            // to the list of 'invalid values'. Therefore we only have 1 header value (the original string).
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(rawPrefix + "1," + rawPrefix + "2", headers.First().Value.First());
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_AddValueContainingNewLine_NewLineFollowedByWhitespaceIsOKButNewLineFollowedByNonWhitespaceIsRejected()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // The header parser rejects both of the following values. Both values contain new line chars. According
+            // to the RFC, LWS supports newlines followed by whitespaces. I.e. the first value gets rejected by the
+            // parser, but added to the list of invalid values.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\n other: value"); // OK, LWS is allowed
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(invalidHeaderValue + "\r\n other: value", headers.First().Value.First());
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // This value is considered invalid (newline char followed by non-whitepace). However, since
+            // TryAddWithoutValidation() only causes the header value to be analyzed when it gets actually accessed, no
+            // exception is thrown. Instead the value is discarded and a warning is logged.
+            headers.Clear();
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\nother:value");
+            Assert.False(headers.Contains(knownHeader));
+            Assert.Equal(0, headers.Count());
+
+            // Adding newline followed by whitespace to a custom header is OK.
+            headers.Clear();
+            headers.TryAddWithoutValidation("custom", "value\r\n other: value"); // OK, LWS is allowed
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal("value\r\n other: value", headers.First().Value.First());
+
+            // Adding newline followed by non-whitespace chars is invalid. The value is discarded and a warning is
+            // logged.
+            headers.Clear();
+            headers.TryAddWithoutValidation("custom", "value\r\nother: value");
+            Assert.False(headers.Contains("custom"));
+            Assert.Equal(0, headers.Count());
+
+            // Also ending a value with newline is invalid. Verify that valid values are added.
+            headers.Clear();
+            headers.Parser.TryParseValueCallCount = 0;
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "\rvalid");
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\n");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "\n," + invalidHeaderValue + "\r\nother");
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "\rvalid", headers.First().Value.First());
+            Assert.Equal(4, headers.Parser.TryParseValueCallCount);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("custom", "value\r\ninvalid");
+            headers.TryAddWithoutValidation("custom", "value\r\n valid");
+            headers.TryAddWithoutValidation("custom", "validvalue, invalid\r\nvalue");
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal("value\r\n valid", headers.First().Value.First());
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_MultipleAddInvalidValuesToNonExistingHeader_AddHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, new string[] { invalidHeaderValue });
+
+            // Make sure the header did not get added since we just tried to add an invalid value.
+            Assert.True(headers.Contains(knownHeader));
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(invalidHeaderValue, headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_MultipleAddValidValueThenAddInvalidValuesToExistingHeader_AddValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, new string[] { rawPrefix + "2", invalidHeaderValue });
+
+            Assert.True(headers.Contains(knownHeader));
+            Assert.Equal(3, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(invalidHeaderValue, headers.First().Value.ElementAt(2));
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_MultipleAddValidValueThenAddInvalidValuesToNonExistingHeader_AddHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, new string[] { rawPrefix + "1", invalidHeaderValue });
+
+            Assert.True(headers.Contains(knownHeader));
+            Assert.Equal(2, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(invalidHeaderValue, headers.First().Value.ElementAt(1));
+        }
+
+        [Fact]
+        public void TryAddWithoutValidation_MultipleAddNullValueCollection_Throws()
+        {
+            MockHeaders headers = new MockHeaders();
+            string[] values = null;
+            
+            Assert.Throws<ArgumentNullException>(() => { headers.TryAddWithoutValidation(knownHeader, values); });
+        }
+
+        [Fact]
+        public void Add_SingleUseNullHeaderName_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            
+            Assert.Throws<ArgumentException>(() => { headers.Add(null, "value"); });
+        }
+
+        [Fact]
+        public void Add_SingleUseStoreWithNoParserStore_AllHeadersConsideredCustom()
+        {
+            CustomTypeHeaders headers = new CustomTypeHeaders();
+            headers.Add("custom", "value");
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal("value", headers.First().Value.First());
+        }
+
+        [Fact]
+        public void Add_SingleAddValidValue_ValueParsedCorrectly()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix);
+
+            // Add() should trigger parsing.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix, headers.First().Value.ElementAt(0));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleAddEmptyValueMultipleTimes_EmptyHeaderAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, (string)null);
+            headers.Add(knownHeader, string.Empty);
+            headers.Add(knownHeader, string.Empty);
+
+            // Add() should trigger parsing.
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(0, headers.Count());
+        }
+
+        [Fact]
+        public void Add_SingleAddInvalidValueToNonExistingHeader_ThrowAndDontAddHeader()
+        {
+            // Since Add() immediately parses the value, it will throw an exception if the value is invalid.
+            MockHeaders headers = new MockHeaders();
+            Assert.Throws<FormatException>(() => { headers.Add(knownHeader, invalidHeaderValue); });
+
+            // Make sure the header did not get added to the store.
+            Assert.False(headers.Contains(knownHeader),
+                "No header expected to be added since header value was invalid.");
+        }
+
+        [Fact]
+        public void Add_SingleAddValidValueThenAddInvalidValue_ThrowAndHeaderContainsValidValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix);
+
+            Assert.Throws<FormatException>(() => { headers.Add(knownHeader, invalidHeaderValue); });
+
+            // Make sure the header did not get removed due to the failed add.
+            Assert.True(headers.Contains(knownHeader), "Header was removed even if there is a valid header value.");
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix, headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void Add_MultipleAddInvalidValuesToNonExistingHeader_ThrowAndDontAddHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            Assert.Throws<FormatException>(() => { headers.Add(knownHeader, new string[] { invalidHeaderValue }); });
+
+            // Make sure the header did not get added since we just tried to add an invalid value.
+            Assert.False(headers.Contains(knownHeader), "Header was added even if we just added an invalid value.");
+        }
+
+        [Fact]
+        public void Add_MultipleAddValidValueThenAddInvalidValuesToExistingHeader_ThrowAndDontAddHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+
+            Assert.Throws<FormatException>(() => { headers.Add(knownHeader, new string[] { rawPrefix + "2", invalidHeaderValue }); });
+
+            // Make sure the header did not get removed due to the failed add. Note that the first value in the array
+            // is valid, so it gets added. I.e. we have 2 values.
+            Assert.True(headers.Contains(knownHeader), "Header was removed even if there is a valid header value.");
+            Assert.Equal(2, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+        }
+
+        [Fact]
+        public void Add_MultipleAddValidValueThenAddInvalidValuesToNonExistingHeader_ThrowAndDontAddHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            Assert.Throws<FormatException>(() => { headers.Add(knownHeader, new string[] { rawPrefix + "1", invalidHeaderValue }); });
+
+            // Make sure the header got added due to the valid add. Note that the first value in the array
+            // is valid, so it gets added.
+            Assert.True(headers.Contains(knownHeader), "Header was not added even though we added 1 valid value.");
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void Add_SingleAddThreeValidValues_ValuesParsedCorrectly()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.Add(knownHeader, rawPrefix + "2");
+            headers.Add(knownHeader, rawPrefix + "3");
+
+            // Add() should trigger parsing.
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(3, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(2));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleAddTwoValidValuesToHeaderWithSingleValue_Throw()
+        {
+            MockHeaderParser parser = new MockHeaderParser(false); // doesn't support multiple values.
+            MockHeaders headers = new MockHeaders(parser);
+
+            try
+            {
+                headers.Add(knownHeader, rawPrefix + "1");
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, string.Format("Adding the first header already threw exception: {0}", e));
+            }
+
+            Assert.Throws<FormatException>(() => { headers.Add(knownHeader, rawPrefix + "2"); });
+
+            // Verify that the first header value is still there.
+            Assert.Equal(1, headers.First().Value.Count());
+        }
+
+        [Fact]
+        public void Add_SingleFirstTryAddWithoutValidationForValidValueThenAdd_TwoParsedValuesAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+            headers.Add(knownHeader, rawPrefix + "2");
+
+            // Add() should trigger parsing. TryAddWithoutValidation() doesn't trigger parsing, but Add() triggers
+            // parsing of raw header values (TryParseValue() is called)
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleFirstTryAddWithoutValidationForInvalidValueThenAdd_TwoParsedValuesAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+            headers.Add(knownHeader, rawPrefix + "1");
+
+            // Add() should trigger parsing. TryAddWithoutValidation() doesn't trigger parsing, but Add() triggers
+            // parsing of raw header values (TryParseValue() is called)
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(invalidHeaderValue, headers.First().Value.ElementAt(1));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleFirstTryAddWithoutValidationForEmptyValueThenAdd_OneParsedValueAddedEmptyIgnored()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, string.Empty);
+            headers.Add(knownHeader, rawPrefix + "1");
+
+            // Add() should trigger parsing. TryAddWithoutValidation() doesn't trigger parsing, but Add() triggers
+            // parsing of raw header values (TryParseValue() is called)
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleFirstAddThenTryAddWithoutValidation_TwoParsedValuesAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            // Add() should trigger parsing. Since TryAddWithoutValidation() is called afterwards the second value is
+            // not parsed yet.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleAddThenTryAddWithoutValidationThenAdd_ThreeParsedValuesAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+            headers.Add(knownHeader, rawPrefix + "3");
+
+            // The second Add() triggers also parsing of the value added by TryAddWithoutValidation()
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(3, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(2));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleFirstTryAddWithoutValidationThenAddToSingleValueHeader_AddThrows()
+        {
+            MockHeaderParser parser = new MockHeaderParser(false); // doesn't support multiple values.
+            MockHeaders headers = new MockHeaders(parser);
+
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+            Assert.Throws<FormatException>(() => {headers.Add(knownHeader, rawPrefix + "2"); });
+        }
+
+        [Fact]
+        public void Add_SingleFirstAddThenTryAddWithoutValidationToSingleValueHeader_BothParsedAndInvalidValue()
+        {
+            MockHeaderParser parser = new MockHeaderParser(false); // doesn't support multiple values.
+            MockHeaders headers = new MockHeaders(parser);
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // Add() succeeds since we don't have a value added yet. TryAddWithoutValidation() also succeeds, however
+            // the value is added to the 'invalid values' list when retrieved.
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(2, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(rawPrefix + "2", headers.First().Value.ElementAt(1));
+
+            // Note that TryParseValue() is not called because HttpHeaders sees that there is already a value
+            // so it adds the raw value to 'invalid values'.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_MultipleAddThreeValidValuesWithOneCall_ValuesParsedCorrectly()
+        {
+            MockHeaders headers = new MockHeaders();
+            string[] values = new string[] { rawPrefix + "1", rawPrefix + "2", rawPrefix + "3" };
+            headers.Add(knownHeader, values);
+
+            // Add() should trigger parsing.
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(3, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(2));
+
+            // Value is already parsed. There shouldn't be additional calls to the parser.
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_MultipleAddThreeValidValuesAsOneString_BothValuesParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1," + rawPrefix + "2," + rawPrefix + "3");
+
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(3, headers.First().Value.Count());
+
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(2));
+        }
+
+        [Fact]
+        public void Add_MultipleAddNullValueCollection_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            string[] values = null;
+            
+            Assert.Throws<ArgumentNullException>(() => { headers.Add(knownHeader, values); });
+        }
+
+        [Fact]
+        public void Add_SingleAddCustomHeaderWithNullValue_HeaderIsAddedWithEmptyStringValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(customHeader, (string)null);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+
+            Assert.Equal(string.Empty, headers.First().Value.ElementAt(0));
+
+            // We're using a custom header. No parsing should be triggered.
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Add_SingleAddHeadersWithDifferentCasing_ConsideredTheSameHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom-header", "value1");
+            headers.Add("Custom-Header", "value2");
+            headers.Add("CUSTOM-HEADER", "value2");
+
+            Assert.Equal(3, headers.GetValues("custom-header").Count());
+            Assert.Equal(3, headers.GetValues("Custom-Header").Count());
+            Assert.Equal(3, headers.GetValues("CUSTOM-HEADER").Count());
+            Assert.Equal(3, headers.GetValues("CuStOm-HeAdEr").Count());
+        }
+
+        [Fact]
+        public void Add_AddValueContainingNewLine_NewLineFollowedByWhitespaceIsOKButNewLineFollowedByNonWhitespaceIsRejected()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            headers.Clear();
+            headers.Add("custom", "value\r");
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal("value\r", headers.First().Value.First());
+
+            headers.Clear();
+            Assert.Throws<FormatException>(() => { headers.Add("custom", new string[] { "valid\n", "invalid\r\nother" }); });
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal("valid\n", headers.First().Value.First());
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddValueAndRemoveIt_NoHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+
+            // Remove the parsed value (note the original string 'raw1' was "parsed" to 'parsed1')
+            Assert.True(headers.RemoveParsedValue(knownHeader, parsedPrefix + "1"));
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // Note that when the last value of a header gets removed, the whole header gets removed.
+            Assert.Equal(0, headers.Count());
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // Remove the value again: It shouldn't be found in the store.
+            Assert.False(headers.RemoveParsedValue(knownHeader, parsedPrefix + "1"));
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddInvalidValueAndRemoveValidValue_InvalidValueRemains()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+
+            // Remove a valid value which is not in the store.
+            Assert.False(headers.RemoveParsedValue(knownHeader, parsedPrefix));
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // Note that when the last value of a header gets removed, the whole header gets removed.
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(invalidHeaderValue, headers.GetValues(knownHeader).First());
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // Remove the value again: It shouldn't be found in the store.
+            Assert.False(headers.RemoveParsedValue(knownHeader, parsedPrefix + "1"));
+        }
+
+        [Fact]
+        public void RemoveParsedValue_ParserWithNoEqualityComparer_CaseSensitiveComparison()
+        {
+            CustomTypeHeaders headers = new CustomTypeHeaders("noComparerHeader", new NoComparerHeaderParser());
+            headers.AddParsedValue("noComparerHeader", "lowercasevalue");
+
+            // Since we don't provide a comparer, the default string.Equals() is called which is case-sensitive. So
+            // the following call should return false.
+            Assert.False(headers.RemoveParsedValue("noComparerHeader", "LOWERCASEVALUE"));
+
+            // Now we try to remove the value using the correct casing. This should work.
+            Assert.True(headers.RemoveParsedValue("noComparerHeader", "lowercasevalue"));
+
+            // Note that when the last value of a header gets removed, the whole header gets removed.
+            Assert.Equal(0, headers.Count());
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddTwoValuesAndRemoveThem_NoHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.Add(knownHeader, rawPrefix + "2");
+
+            // Remove the parsed value (note the original string 'raw1' was "parsed" to 'parsed1')
+            Assert.True(headers.RemoveParsedValue(knownHeader, parsedPrefix + "1"));
+            Assert.True(headers.RemoveParsedValue(knownHeader, parsedPrefix + "2"));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            // Note that when the last value of a header gets removed, the whole header gets removed.
+            Assert.Equal(0, headers.Count());
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddTwoValuesAndRemoveFirstOne_SecondValueRemains()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.Add(knownHeader, rawPrefix + "2");
+
+            // Remove the parsed value (note the original string 'raw1' was "parsed" to 'parsed1')
+            Assert.True(headers.RemoveParsedValue(knownHeader, parsedPrefix + "1"));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            // Note that when the last value of a header gets removed, the whole header gets removed.
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(0));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddTwoValuesAndRemoveSecondOne_FirstValueRemains()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.Add(knownHeader, rawPrefix + "2");
+
+            // Remove the parsed value (note the original string 'raw2' was "parsed" to 'parsed2')
+            Assert.True(headers.RemoveParsedValue(knownHeader, parsedPrefix + "2"));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            // Note that when the last value of a header gets removed, the whole header gets removed.
+            Assert.Equal(1, headers.Count());
+            Assert.Equal(1, headers.First().Value.Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void RemoveParsedValue_RemoveFromNonExistingHeader_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix);
+
+            // Header 'non-existing-header' can't be found, so false is returned.
+            Assert.False(headers.RemoveParsedValue("non-existing-header", "doesntexist"));
+        }
+
+        [Fact]
+        public void RemoveParsedValue_RemoveFromUninitializedHeaderStore_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // If we never add a header value, the whole header (and also the header store) doesn't exist.
+            // Make sure we considered this case.
+            Assert.False(headers.RemoveParsedValue(knownHeader, "doesntexist"));
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddOneValueToKnownHeaderAndCompareWithValueThatDiffersInCase_CustomComparerUsedForComparison()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.AddParsedValue(knownHeader, "value");
+
+            // Our custom comparer (MockComparer) does case-insensitive value comparison. Verify that our custom
+            // comparer is used to compare the header value.
+            Assert.True(headers.RemoveParsedValue(knownHeader, "VALUE"));
+            Assert.False(headers.Contains(knownHeader), "Header should be removed after removing value.");
+            Assert.Equal(1, headers.Parser.MockComparer.EqualsCount);
+        }
+
+        [Fact]
+        public void RemoveParsedValue_AddTwoValuesToKnownHeaderAndCompareWithValueThatDiffersInCase_CustomComparerUsedForComparison()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.AddParsedValue(knownHeader, "differentvalue");
+            headers.AddParsedValue(knownHeader, "value");
+
+            // Our custom comparer (MockComparer) does case-insensitive value comparison. Verify that our custom
+            // comparer is used to compare the header value.
+            // Note that since we added 2 values a different code path than in the previous test is used. In this
+            // case we have stored the values as List<string> internally.
+            Assert.True(headers.RemoveParsedValue(knownHeader, "VALUE"));
+            Assert.Equal(1, headers.GetValues(knownHeader).Count());
+            Assert.Equal(2, headers.Parser.MockComparer.EqualsCount);
+        }
+
+        [Fact]
+        public void RemoveParsedValue_FirstAddInvalidNewlineCharsValueThenCallRemoveParsedValue_HeaderRemoved()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Add header value with invalid newline chars.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            headers.RemoveParsedValue(knownHeader, "");
+
+            Assert.False(headers.Contains(knownHeader), "Store should not have an entry for 'knownHeader'.");
+        }
+
+        [Fact]
+        public void RemoveParsedValue_FirstAddInvalidNewlineCharsValueThenAddValidValueThenCallAddParsedValue_HeaderRemoved()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Add header value with invalid newline chars.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            headers.RemoveParsedValue(knownHeader, parsedPrefix + "1");
+
+            Assert.False(headers.Contains(knownHeader), "Store should not have an entry for 'knownHeader'.");
+        }
+
+        [Fact]
+        public void Clear_AddMultipleHeadersAndThenClear_NoHeadersInCollection()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+            headers.Add("custom1", "customValue1");
+            headers.Add("custom2", "customValue2");
+            headers.Add("custom3", "customValue3");
+
+            // Only 1 value should get parsed (call to Add() with known header value).
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // We added 4 different headers
+            Assert.Equal(4, headers.Count());
+
+            headers.Clear();
+
+            Assert.Equal(0, headers.Count());
+
+            // The call to Count() triggers a TryParseValue for the TryAddWithoutValidation() value. Clear() should
+            // not cause any additional parsing operations.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Remove_UseNullHeader_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            
+            Assert.Throws<ArgumentException>(() => { headers.Remove(null); });
+        }
+
+        [Fact]
+        public void Remove_AddMultipleHeadersAndDeleteFirstAndLast_FirstAndLastHeaderRemoved()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+            headers.Add("custom1", "customValue1");
+            headers.Add("custom2", "customValue2");
+            headers.Add("lastheader", "customValue3");
+
+            // Only 1 value should get parsed (call to Add() with known header value).
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            // We added 4 different headers
+            Assert.Equal(4, headers.Count());
+
+            // Remove first header
+            Assert.True(headers.Remove(knownHeader));
+            Assert.Equal(3, headers.Count());
+
+            // Remove last header
+            Assert.True(headers.Remove("lastheader"));
+            Assert.Equal(2, headers.Count());
+
+            // The call to Count() triggers a TryParseValue for the TryAddWithoutValidation() value. Clear() should
+            // not cause any additional parsing operations.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Remove_RemoveHeaderFromUninitializedHeaderStore_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Remove header from uninitialized store (store collection is null)
+            Assert.False(headers.Remove(knownHeader));
+            Assert.Equal(0, headers.Count());
+        }
+
+        [Fact]
+        public void Remove_RemoveNonExistingHeader_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+
+            Assert.Equal(1, headers.Count());
+
+            // Remove header from empty store
+            Assert.False(headers.Remove("doesntexist"));
+            Assert.Equal(1, headers.Count());
+        }
+
+        [Fact]
+        public void TryGetValues_UseNullHeader_False()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            IEnumerable<string> values = null;
+
+            Assert.False(headers.TryGetValues(null, out values));
+        }
+
+        [Fact]
+        public void TryGetValues_GetValuesFromUninitializedHeaderStore_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            IEnumerable<string> values = null;
+
+            // Get header values from uninitialized store (store collection is null)
+            Assert.False(headers.TryGetValues("doesntexist", out values));
+            Assert.Equal(0, headers.Count());
+        }
+
+        [Fact]
+        public void TryGetValues_GetValuesForNonExistingHeader_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+
+            IEnumerable<string> values = null;
+
+            // Get header values from uninitialized store (store collection is null)
+            Assert.False(headers.TryGetValues("doesntexist", out values));
+            Assert.Equal(1, headers.Count());
+        }
+
+        [Fact]
+        public void TryGetValues_GetValuesForExistingHeader_ReturnsTrueAndListOfValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+            headers.TryAddWithoutValidation(knownHeader, string.Empty);
+
+            // Only 1 value should get parsed (call to Add() with known header value).
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            IEnumerable<string> values = null;
+
+            Assert.True(headers.TryGetValues(knownHeader, out values));
+            Assert.NotNull(values);
+
+            // TryGetValues() should trigger parsing of values added with TryAddWithoutValidation()
+            Assert.Equal(3, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(2, values.Count());
+
+            // Check returned values
+            Assert.Equal(parsedPrefix + "1", values.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", values.ElementAt(1));
+        }
+
+        [Fact]
+        public void GetValues_UseNullHeader_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            
+            Assert.Throws<ArgumentException>(() => { headers.GetValues(null); });
+        }
+
+        [Fact]
+        public void GetValues_GetValuesFromUninitializedHeaderStore_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Get header values from uninitialized store (store collection is null). This will throw.
+            Assert.Throws<InvalidOperationException>(() => { headers.GetValues("doesntexist"); });
+        }
+
+        [Fact]
+        public void GetValues_GetValuesForNonExistingHeader_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+
+            // Get header values for non-existing header (but other headers exist in the store).
+            Assert.Throws<InvalidOperationException>(() => { headers.GetValues("doesntexist"); });
+        }
+
+        [Fact]
+        public void GetValues_GetValuesForExistingHeader_ReturnsTrueAndListOfValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation("custom", rawPrefix + "0"); // this must not influence the result.
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            // Only 1 value should get parsed (call to Add() with known header value).
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            IEnumerable<string> values = headers.GetValues(knownHeader);
+            Assert.NotNull(values);
+
+            // GetValues() should trigger parsing of values added with TryAddWithoutValidation()
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(2, values.Count());
+
+            // Check returned values
+            Assert.Equal(parsedPrefix + "1", values.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", values.ElementAt(1));
+        }
+
+        [Fact]
+        public void GetValues_HeadersWithEmptyValues_ReturnsEmptyArray()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(customHeader, (string)null);
+            headers.Add(knownHeader, string.Empty);
+
+            // In the known header case, the MockParser accepts empty values but tells the store to not add the value.
+            // Since no value is added for 'knownHeader', HttpHeaders removes the header from the store. This is only
+            // done for known headers. Custom headers are allowed to have empty/null values as shown by 
+            // 'valuesForCustomHeaders' below
+            Assert.False(headers.Contains(knownHeader));
+
+            // In the custom header case, we add whatever the users adds (besides that we add string.Empty if the
+            // user adds null). So here we do have 1 value: string.Empty.
+            IEnumerable<string> valuesForCustomHeader = headers.GetValues(customHeader);
+            Assert.NotNull(valuesForCustomHeader);
+            Assert.Equal(1, valuesForCustomHeader.Count());
+            Assert.Equal(string.Empty, valuesForCustomHeader.First());
+        }
+
+        [Fact]
+        public void GetParsedValues_GetValuesFromUninitializedHeaderStore_ReturnsNull()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Get header values from uninitialized store (store collection is null).
+            object storeValue = headers.GetParsedValues("doesntexist");
+            Assert.Null(storeValue);
+        }
+
+        [Fact]
+        public void GetParsedValues_GetValuesForNonExistingHeader_ReturnsNull()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+
+            // Get header values for non-existing header (but other headers exist in the store).
+            object storeValue = headers.GetParsedValues("doesntexist");
+            Assert.Null(storeValue);
+        }
+
+        [Fact]
+        public void GetParsedValues_GetSingleValueForExistingHeader_ReturnsAddedValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+
+            // Get header values for non-existing header (but other headers exist in the store).
+            object storeValue = headers.GetParsedValues("custom1");
+            Assert.NotNull(storeValue);
+
+            // If we only have one value, then GetValues() should return just the value and not wrap it in a List<T>.
+            Assert.Equal("customValue1", storeValue);
+        }
+
+        [Fact]
+        public void GetParsedValues_HeaderWithEmptyValues_ReturnsEmpty()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, string.Empty);
+
+            object storeValue = headers.GetParsedValues(knownHeader);
+            Assert.Null(storeValue);
+        }
+
+        [Fact]
+        public void GetParsedValues_GetMultipleValuesForExistingHeader_ReturnsListOfValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation("custom", rawPrefix + "0"); // this must not influence the result.
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            // Only 1 value should get parsed (call to Add() with known header value).
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            object storeValue = headers.GetParsedValues(knownHeader);
+            Assert.NotNull(storeValue);
+
+            // GetValues<T>() should trigger parsing of values added with TryAddWithoutValidation()
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            // Since we added 2 values to header 'knownHeader', we expect GetValues() to return a List<T> with
+            // two values.
+            List<object> storeValues = storeValue as List<object>;
+            Assert.NotNull(storeValues);
+            Assert.Equal(2, storeValues.Count);
+            Assert.Equal(parsedPrefix + "1", storeValues[0]);
+            Assert.Equal(parsedPrefix + "2", storeValues[1]);
+        }
+
+        [Fact]
+        public void GetParsedValues_GetValuesForExistingHeaderWithInvalidValues_ReturnsOnlyParsedValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix);
+
+            // Here we add an invalid value. GetValues<T> only returns parsable values. So this value should get
+            // parsed, however it will be added to the 'invalid values' list and thus is not part of the collection
+            // returned by the enumerator.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+
+            // Only 1 value should get parsed (call to Add() with known header value).
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            object storeValue = headers.GetParsedValues(knownHeader);
+            Assert.NotNull(storeValue);
+
+            // GetValues<T>() should trigger parsing of values added with TryAddWithoutValidation()
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            // Since we added only one valid value to 'knownHeader', we expect GetValues() to return a that value.
+            Assert.Equal(parsedPrefix, storeValue);
+        }
+
+        [Fact]
+        public void GetParsedValues_GetValuesForExistingHeaderWithOnlyInvalidValues_ReturnsEmptyEnumerator()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Here we add an invalid value. GetValues<T> only returns parsable values. So this value should get
+            // parsed, however it will be added to the 'invalid values' list and thus is not part of the collection
+            // returned by the enumerator.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            object storeValue = headers.GetParsedValues(knownHeader);
+            Assert.Null(storeValue);
+
+            // GetValues<T>() should trigger parsing of values added with TryAddWithoutValidation()
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void GetParsedValues_AddInvalidValueToHeader_HeaderGetsRemovedAndNullReturned()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            object storeValue = headers.GetParsedValues(knownHeader);
+            Assert.Null(storeValue);
+            Assert.False(headers.Contains(knownHeader));
+        }
+
+        [Fact]
+        public void GetParsedValues_GetParsedValuesForKnownHeaderWithInvalidNewlineChars_ReturnsNull()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Add header value with invalid newline chars.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+            Assert.Null(headers.GetParsedValues(knownHeader));
+            Assert.Equal(0, headers.Count());
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void GetHeaderStrings_SetValidAndInvalidHeaderValues_AllHeaderValuesReturned()
+        {
+            MockHeaderParser parser = new MockHeaderParser("---");
+            MockHeaders headers = new MockHeaders(parser);
+
+            // Add header value with invalid newline chars.
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, "value2,value3");
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+
+            foreach (var header in headers.GetHeaderStrings())
+            {
+                Assert.Equal(knownHeader, header.Key);
+                // Note that raw values don't get parsed but just added to the result.
+                Assert.Equal("value2,value3---" + invalidHeaderValue + "---" + parsedPrefix + "1", header.Value);
+            }
+        }
+
+        [Fact]
+        public void GetHeaderStrings_SetMultipleHeaders_AllHeaderValuesReturned()
+        {
+            MockHeaderParser parser = new MockHeaderParser(true);
+            MockHeaders headers = new MockHeaders(parser);
+
+            // Add header value with invalid newline chars.
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.Add("header2", "value2");
+            headers.Add("header3", (string)null);
+            headers.Add("header4", "value41");
+            headers.Add("header4", "value42");
+
+            string[] expectedHeaderNames = { knownHeader, "header2", "header3", "header4" };
+            string[] expectedHeaderValues = { parsedPrefix + "1", "value2", "", "value41, value42" };
+            int i = 0;
+
+            foreach (var header in headers.GetHeaderStrings())
+            {
+                Assert.NotEqual(expectedHeaderNames.Length, i);
+                Assert.Equal(expectedHeaderNames[i], header.Key);
+                Assert.Equal(expectedHeaderValues[i], header.Value);
+                i++;
+            }
+        }
+
+        [Fact]
+        public void GetHeaderStrings_SetMultipleValuesOnSingleValueHeader_AllHeaderValuesReturned()
+        {
+            MockHeaderParser parser = new MockHeaderParser(false);
+            MockHeaders headers = new MockHeaders(parser);
+
+            headers.TryAddWithoutValidation(knownHeader, "value1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+
+            foreach (var header in headers.GetHeaderStrings())
+            {
+                Assert.Equal(knownHeader, header.Key);
+                // Note that the added rawPrefix did not get parsed
+                Assert.Equal("value1, " + rawPrefix, header.Value);
+            }
+        }
+
+        [Fact]
+        public void Contains_UseNullHeader_Throw()
+        {
+            MockHeaders headers = new MockHeaders();
+            
+            Assert.Throws<ArgumentException>(() => { headers.Contains(null); });
+        }
+
+        [Fact]
+        public void Contains_CallContainsFromUninitializedHeaderStore_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            Assert.False(headers.Contains("doesntexist"));
+        }
+
+        [Fact]
+        public void Contains_CallContainsForNonExistingHeader_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix);
+            Assert.False(headers.Contains("doesntexist"));
+        }
+
+        [Fact]
+        public void Contains_CallContainsForEmptyHeader_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, string.Empty);
+            Assert.False(headers.Contains(knownHeader));
+        }
+
+        [Fact]
+        public void Contains_CallContainsForExistingHeader_ReturnsTrue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+            headers.Add("custom2", "customValue2");
+            headers.Add("custom3", "customValue3");
+            headers.Add("custom4", "customValue4");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+
+            // Nothing got parsed so far since we just added custom headers and for the known header we called
+            // TryAddWithoutValidation().
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.True(headers.Contains(knownHeader));
+
+            // Contains() should trigger parsing of values added with TryAddWithoutValidation(): If the value was invalid,
+            // i.e. contains invalid newline chars, then the header will be removed from the collection.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void Contains_AddValuesWithInvalidNewlineChars_HeadersGetRemovedWhenCallingContains()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+            headers.TryAddWithoutValidation("custom", "invalid\r\nvalue");
+
+            Assert.False(headers.Contains(knownHeader), "Store should not have an entry for 'knownHeader'.");
+            Assert.False(headers.Contains("custom"), "Store should not have an entry for 'custom'.");
+        }
+
+        [Fact]
+        public void GetEnumerator_GetEnumeratorFromUninitializedHeaderStore_ReturnsEmptyEnumerator()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            var enumerator = headers.GetEnumerator();
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void GetEnumerator_FirstHeaderWithOneValueSecondHeaderWithTwoValues_EnumeratorReturnsTwoHeaders()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(customHeader, "custom0");
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            // The value added with TryAddWithoutValidation() wasn't parsed yet.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            var enumerator = headers.GetEnumerator();
+
+            // Getting the enumerator doesn't trigger parsing.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(customHeader, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal("custom0", enumerator.Current.Value.ElementAt(0));
+
+            // Starting using the enumerator will trigger parsing of raw values. The first header is not a known
+            // header, so there shouldn't be any parsing.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(knownHeader, enumerator.Current.Key);
+            Assert.Equal(2, enumerator.Current.Value.Count());
+            Assert.Equal(parsedPrefix + "1", enumerator.Current.Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", enumerator.Current.Value.ElementAt(1));
+
+            // The second header is a known header, so parsing raw values should get executed.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.False(enumerator.MoveNext(), "Only 2 values expected, but enumerator returns a third one.");
+        }
+
+        [Fact]
+        public void GetEnumerator_FirstCustomHeaderWithEmptyValueSecondKnownHeaderWithEmptyValue_EnumeratorReturnsOneHeader()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(customHeader, string.Empty);
+            headers.Add(knownHeader, string.Empty);
+
+            var enumerator = headers.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(customHeader, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(string.Empty, enumerator.Current.Value.ElementAt(0));
+
+            Assert.False(enumerator.MoveNext(), "Only the (empty) custom value should be returned.");
+        }
+
+        [Fact]
+        public void GetEnumerator_UseExplicitInterfaceImplementation_EnumeratorReturnsNoOfHeaders()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add("custom1", "customValue1");
+            headers.Add("custom2", "customValue2");
+            headers.Add("custom3", "customValue3");
+            headers.Add("custom4", "customValue4");
+
+            System.Collections.IEnumerable headersAsIEnumerable = headers;
+
+            var enumerator = headersAsIEnumerable.GetEnumerator();
+
+            KeyValuePair<string, IEnumerable<string>> currentValue;
+
+            for (int i = 1; i <= 4; i++)
+            {
+                Assert.True(enumerator.MoveNext());
+                currentValue = (KeyValuePair<string, IEnumerable<string>>)enumerator.Current;
+                Assert.Equal("custom" + i, currentValue.Key);
+                Assert.Equal(1, currentValue.Value.Count());
+            }
+
+            Assert.False(enumerator.MoveNext(), "Only 2 values expected, but enumerator returns a third one.");
+        }
+
+        [Fact]
+        public void AddParsedValue_AddSingleValueToNonExistingHeader_HeaderGetsCreatedAndValueAdded()
+        {
+            Uri headerValue = new Uri("http://example.org/");
+
+            CustomTypeHeaders headers = new CustomTypeHeaders("myheader", new CustomTypeHeaderParser());
+            headers.AddParsedValue("myheader", headerValue);
+
+            Assert.True(headers.Contains("myheader"), "Store doesn't have the header after adding a value to it.");
+
+            Assert.Equal(headerValue.ToString(), headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void AddParsedValue_AddValueTypeValueToNonExistingHeader_HeaderGetsCreatedAndBoxedValueAdded()
+        {
+            int headerValue = 5;
+
+            CustomTypeHeaders headers = new CustomTypeHeaders("myheader", new CustomTypeHeaderParser());
+            headers.AddParsedValue("myheader", headerValue);
+
+            Assert.True(headers.Contains("myheader"), "Store doesn't have the header after adding a value to it.");
+
+            Assert.Equal(headerValue.ToString(), headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void AddParsedValue_AddTwoValuesToNonExistingHeader_HeaderGetsCreatedAndValuesAdded()
+        {
+            Uri headerValue1 = new Uri("http://example.org/1/");
+            Uri headerValue2 = new Uri("http://example.org/2/");
+
+            CustomTypeHeaders headers = new CustomTypeHeaders("myheader", new CustomTypeHeaderParser());
+            headers.AddParsedValue("myheader", headerValue1);
+
+            // Adding a second value will cause a List<T> to be created in order to store values. If we just add
+            // one value, no List<T> is created, but the header is just added as store value.
+            headers.AddParsedValue("myheader", headerValue2);
+
+            Assert.True(headers.Contains("myheader"), "Store doesn't have the header after adding a value to it.");
+            Assert.Equal(2, headers.GetValues("myheader").Count());
+
+            Assert.Equal(headerValue1.ToString(), headers.First().Value.ElementAt(0));
+            Assert.Equal(headerValue2.ToString(), headers.First().Value.ElementAt(1));
+        }
+
+        [Fact]
+        public void AddParsedValue_UseDifferentAddMethods_AllValuesAddedCorrectly()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            headers.AddParsedValue(knownHeader, parsedPrefix + "3");
+
+            // Adding a parsed value, will trigger all raw values to be parsed.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(3, headers.GetValues(knownHeader).Count());
+            Assert.Equal(parsedPrefix + "1", headers.First().Value.ElementAt(0));
+            Assert.Equal(parsedPrefix + "2", headers.First().Value.ElementAt(1));
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(2));
+        }
+
+        [Fact]
+        public void AddParsedValue_FirstAddInvalidNewlineCharsValueThenCallAddParsedValue_ParsedValueAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Add header value with invalid newline chars.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            headers.AddParsedValue(knownHeader, parsedPrefix + "1");
+
+            Assert.True(headers.Contains(knownHeader), "Store should have an entry for 'knownHeader'.");
+            Assert.Equal(1, headers.GetValues(knownHeader).Count());
+            Assert.Equal(parsedPrefix + "1", headers.GetValues(knownHeader).First());
+        }
+
+        [Fact]
+        public void AddParsedValue_FirstAddInvalidNewlineCharsValueThenAddValidValueThenCallAddParsedValue_ParsedValueAdded()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // Add header value with invalid newline chars.
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue + "\r\ninvalid");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "0");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            headers.AddParsedValue(knownHeader, parsedPrefix + "1");
+
+            Assert.True(headers.Contains(knownHeader), "Store should have an entry for 'knownHeader'.");
+            Assert.Equal(2, headers.GetValues(knownHeader).Count());
+            Assert.Equal(parsedPrefix + "0", headers.GetValues(knownHeader).ElementAt(0));
+            Assert.Equal(parsedPrefix + "1", headers.GetValues(knownHeader).ElementAt(1));
+        }
+
+        [Fact]
+        public void SetParsedValue_AddSingleValueToNonExistingHeader_HeaderGetsCreatedAndValueAdded()
+        {
+            Uri headerValue = new Uri("http://example.org/");
+
+            CustomTypeHeaders headers = new CustomTypeHeaders("myheader", new CustomTypeHeaderParser());
+            headers.SetParsedValue("myheader", headerValue);
+
+            Assert.True(headers.Contains("myheader"), "Store doesn't have the header after adding a value to it.");
+
+            Assert.Equal(headerValue.ToString(), headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void SetParsedValue_SetTwoValuesToNonExistingHeader_HeaderGetsCreatedAndLastValueAdded()
+        {
+            Uri headerValue1 = new Uri("http://example.org/1/");
+            Uri headerValue2 = new Uri("http://example.org/2/");
+
+            CustomTypeHeaders headers = new CustomTypeHeaders("myheader", new CustomTypeHeaderParser());
+            headers.SetParsedValue("myheader", headerValue1);
+
+            // The following line will remove the previously added values and replace them with the provided value.
+            headers.SetParsedValue("myheader", headerValue2);
+
+            Assert.True(headers.Contains("myheader"), "Store doesn't have the header after adding a value to it.");
+            Assert.Equal(1, headers.GetValues("myheader").Count());
+
+            // The second value replaces the first value.
+            Assert.Equal(headerValue2.ToString(), headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void SetParsedValue_SetValueAfterAddingMultipleValues_SetValueReplacesOtherValues()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+
+            headers.SetParsedValue(knownHeader, parsedPrefix + "3");
+
+            // Adding a parsed value, will trigger all raw values to be parsed.
+            Assert.Equal(2, headers.Parser.TryParseValueCallCount);
+
+            Assert.Equal(1, headers.GetValues(knownHeader).Count());
+            Assert.Equal(parsedPrefix + "3", headers.First().Value.ElementAt(0));
+        }
+
+        [Fact]
+        public void ContainsParsedValue_ContainsParsedValueFromUninitializedHeaderStore_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            Assert.False(headers.ContainsParsedValue(customHeader, "custom1"));
+        }
+
+        [Fact]
+        public void ContainsParsedValue_ContainsParsedValueForNonExistingHeader_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.False(headers.ContainsParsedValue(customHeader, "custom1"));
+
+            // ContainsParsedValue() must not trigger raw value parsing for headers other than the requested one.
+            // In this case we expect ContainsParsedValue(customeHeader) not to trigger raw value parsing for
+            // 'knownHeader'.
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void ContainsParsedValue_ContainsParsedValueForNonExistingHeaderValue_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.AddParsedValue(knownHeader, "value1");
+            headers.AddParsedValue(knownHeader, "value2");
+
+            // After adding two values to header 'knownHeader' we ask for a non-existing value.
+            Assert.False(headers.ContainsParsedValue(knownHeader, "doesntexist"));
+        }
+
+        [Fact]
+        public void ContainsParsedValue_ContainsParsedValueForExistingHeaderButNonAvailableValue_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix);
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.False(headers.ContainsParsedValue(knownHeader, "custom1"));
+
+            // ContainsParsedValue() must trigger raw value parsing for the header it was asked for.
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void ContainsParsedValue_ContainsParsedValueForExistingHeaderWithAvailableValue_ReturnsTrue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "1");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "2");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "3");
+            headers.TryAddWithoutValidation(knownHeader, rawPrefix + "4");
+
+            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+
+            Assert.True(headers.ContainsParsedValue(knownHeader, parsedPrefix + "3"));
+
+            // ContainsParsedValue() must trigger raw value parsing for the header it was asked for.
+            Assert.Equal(4, headers.Parser.TryParseValueCallCount);
+        }
+
+        [Fact]
+        public void ContainsParsedValue_AddOneValueToKnownHeaderAndCompareWithValueThatDiffersInCase_CustomComparerUsedForComparison()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.AddParsedValue(knownHeader, "value");
+
+            // Our custom comparer (MockComparer) does case-insensitive value comparison. Verify that our custom
+            // comparer is used to compare the header value.
+            Assert.True(headers.ContainsParsedValue(knownHeader, "VALUE"));
+            Assert.Equal(1, headers.Parser.MockComparer.EqualsCount);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation(knownHeader, invalidHeaderValue);
+            Assert.False(headers.ContainsParsedValue(knownHeader, invalidHeaderValue));
+        }
+
+        [Fact]
+        public void ContainsParsedValue_AddTwoValuesToKnownHeaderAndCompareWithValueThatDiffersInCase_CustomComparerUsedForComparison()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.AddParsedValue(knownHeader, "differentvalue");
+            headers.AddParsedValue(knownHeader, "value");
+
+            // Our custom comparer (MockComparer) does case-insensitive value comparison. Verify that our custom
+            // comparer is used to compare the header value.
+            // Note that since we added 2 values a different code path than in the previous test is used. In this
+            // case we have stored the values as List<string> internally.
+            Assert.True(headers.ContainsParsedValue(knownHeader, "VALUE"));
+            Assert.Equal(2, headers.Parser.MockComparer.EqualsCount);
+        }
+
+        [Fact]
+        public void ContainsParsedValue_ParserWithNoEqualityComparer_CaseSensitiveComparison()
+        {
+            CustomTypeHeaders headers = new CustomTypeHeaders("noComparerHeader", new NoComparerHeaderParser());
+            headers.AddParsedValue("noComparerHeader", "lowercasevalue");
+
+            // Since we don't provide a comparer, the default string.Equals() is called which is case-sensitive. So
+            // the following call should return false.
+            Assert.False(headers.ContainsParsedValue("noComparerHeader", "LOWERCASEVALUE"));
+
+            // Now we try to use the correct casing. This should return true.
+            Assert.True(headers.ContainsParsedValue("noComparerHeader", "lowercasevalue"));
+        }
+
+        [Fact]
+        public void ContainsParsedValue_CallFromEmptyHeaderStore_ReturnsFalse()
+        {
+            MockHeaders headers = new MockHeaders();
+
+            // This will create a header entry with no value.
+            headers.Add(knownHeader, string.Empty);
+
+            Assert.False(headers.Contains(knownHeader), "Expected known header to be in the store.");
+
+            // This will just return fals and not touch the header.
+            Assert.False(headers.ContainsParsedValue(knownHeader, "x"),
+                "Expected 'ContainsParsedValue' to return false.");
+        }
+
+        [Fact]
+        public void AddHeaders_SourceAndDestinationStoreHaveMultipleHeaders_OnlyHeadersNotInDestinationAreCopiedFromSource()
+        {
+            Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+            parserStore.Add("known1", new MockHeaderParser());
+            parserStore.Add("known2", new MockHeaderParser());
+            parserStore.Add("known3", new MockHeaderParser());
+            parserStore.Add("known4", new CustomTypeHeaderParser());
+
+            // Add header values to the source store.
+            MockHeaders source = new MockHeaders(parserStore);
+            source.Add("custom1", "source10");
+            source.Add("custom1", "source11");
+
+            source.TryAddWithoutValidation("custom2", "source2");
+
+            source.Add("known1", rawPrefix + "3");
+            source.TryAddWithoutValidation("known1", rawPrefix + "4");
+
+            source.TryAddWithoutValidation("known2", rawPrefix + "5");
+            source.TryAddWithoutValidation("known2", invalidHeaderValue);
+            source.TryAddWithoutValidation("known2", rawPrefix + "7");
+
+            // this header value gets removed when it gets parsed.
+            source.TryAddWithoutValidation("known3", (string)null);
+            source.Add("known3", string.Empty);
+
+            DateTimeOffset known4Value1 = new DateTimeOffset(2010, 6, 15, 18, 31, 34, TimeSpan.Zero);
+            DateTimeOffset known4Value2 = new DateTimeOffset(2010, 4, 8, 11, 21, 04, TimeSpan.Zero);
+            source.AddParsedValue("known4", known4Value1);
+            source.AddParsedValue("known4", known4Value2);
+
+            source.Add("custom5", "source5");
+            source.TryAddWithoutValidation("custom6", (string)null);
+
+            // This header value gets added even though it doesn't have values. But since this is a custom header we
+            // assume it supports empty values.
+            source.TryAddWithoutValidation("custom7", (string)null);
+            source.Add("custom7", string.Empty);
+
+            // Add header values to the destination store.
+            MockHeaders destination = new MockHeaders(parserStore);
+            destination.Add("custom2", "destination1");
+            destination.Add("known1", rawPrefix + "9");
+
+            // Now add all headers that are in source but not destination to destination.
+            destination.AddHeaders(source);
+
+            Assert.Equal(8, destination.Count());
+
+            Assert.Equal(2, destination.GetValues("custom1").Count());
+            Assert.Equal("source10", destination.GetValues("custom1").ElementAt(0));
+            Assert.Equal("source11", destination.GetValues("custom1").ElementAt(1));
+
+            // This value was set in destination. The header in source was ignored.
+            Assert.Equal(1, destination.GetValues("custom2").Count());
+            Assert.Equal("destination1", destination.GetValues("custom2").First());
+
+            // This value was set in destination. The header in source was ignored.
+            Assert.Equal(1, destination.GetValues("known1").Count());
+            Assert.Equal(parsedPrefix + "9", destination.GetValues("known1").First());
+
+            // The header in source gets first parsed and then copied to destination. Note that here we have one
+            // invalid value.
+            Assert.Equal(3, destination.GetValues("known2").Count());
+            Assert.Equal(parsedPrefix + "5", destination.GetValues("known2").ElementAt(0));
+            Assert.Equal(parsedPrefix + "7", destination.GetValues("known2").ElementAt(1));
+            Assert.Equal(invalidHeaderValue, destination.GetValues("known2").ElementAt(2));
+
+            // Header 'known3' should not be copied, since it doesn't contain any values.
+            Assert.False(destination.Contains("known3"), "'known3' header value count.");
+
+            Assert.Equal(2, destination.GetValues("known4").Count());
+            Assert.Equal(known4Value1.ToString(), destination.GetValues("known4").ElementAt(0));
+            Assert.Equal(known4Value2.ToString(), destination.GetValues("known4").ElementAt(1));
+
+            Assert.Equal("source5", destination.GetValues("custom5").First());
+
+            Assert.Equal(string.Empty, destination.GetValues("custom6").First());
+
+            // Unlike 'known3', 'custom7' was added even though it only had empty values. The reason is that 'custom7'
+            // is a custom header so we just add whatever value we get passed in.
+            Assert.Equal(2, destination.GetValues("custom7").Count());
+            Assert.Equal("", destination.GetValues("custom7").ElementAt(0));
+            Assert.Equal("", destination.GetValues("custom7").ElementAt(1));
+        }
+
+        [Fact]
+        public void AddHeaders_SourceHasEmptyHeaderStore_DestinationRemainsUnchanged()
+        {
+            Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+            parserStore.Add("known1", new MockHeaderParser());
+
+            MockHeaders source = new MockHeaders(parserStore);
+
+            MockHeaders destination = new MockHeaders(parserStore);
+            destination.Add("known1", rawPrefix);
+
+            destination.AddHeaders(source);
+
+            Assert.Equal(1, destination.Count());
+        }
+
+        [Fact]
+        public void AddHeaders_DestinationHasEmptyHeaderStore_DestinationHeaderStoreGetsCreatedAndValuesAdded()
+        {
+            Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+            parserStore.Add("known1", new MockHeaderParser());
+
+            MockHeaders source = new MockHeaders(parserStore);
+            source.Add("known1", rawPrefix);
+
+            MockHeaders destination = new MockHeaders(parserStore);
+
+            destination.AddHeaders(source);
+
+            Assert.Equal(1, destination.Count());
+        }
+
+        [Fact]
+        public void AddHeaders_SourceHasInvalidHeaderValues_InvalidHeadersRemovedFromSourceAndNotCopiedToDestination()
+        {
+            Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+            parserStore.Add("known", new MockHeaderParser());
+
+            MockHeaders source = new MockHeaders(parserStore);
+            source.TryAddWithoutValidation("known", invalidHeaderValue + "\r\ninvalid");
+            source.TryAddWithoutValidation("custom", "invalid\r\nvalue");
+
+            MockHeaders destination = new MockHeaders(parserStore);
+            destination.AddHeaders(source);
+
+            Assert.Equal(0, source.Count());
+            Assert.False(source.Contains("known"), "source contains 'known' header.");
+            Assert.False(source.Contains("custom"), "source contains 'custom' header.");
+            Assert.Equal(0, destination.Count());
+            Assert.False(destination.Contains("known"), "destination contains 'known' header.");
+            Assert.False(destination.Contains("custom"), "destination contains 'custom' header.");
+        }
+
+        #region Helper methods
+
+        private class MockHeaders : HttpHeaders
+        {
+            private MockHeaderParser parser;
+
+            public MockHeaderParser Parser
+            {
+                get { return parser; }
+            }
+
+            public MockHeaders(MockHeaderParser parser)
+                : base()
+            {
+                Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+                this.parser = parser;
+                parserStore.Add(knownHeader, this.parser);
+                SetConfiguration(parserStore, new HashSet<string>());
+            }
+
+            public MockHeaders()
+                : this(new MockHeaderParser())
+            {
+            }
+
+            public MockHeaders(Dictionary<string, HttpHeaderParser> parserStore)
+            {
+                SetConfiguration(parserStore, new HashSet<string>());
+            }
+        }
+
+        private class MockHeaderParser : HttpHeaderParser
+        {
+            public int TryParseValueCallCount { get; set; }
+            public int EmptyValueCount { get; private set; }
+            public MockComparer MockComparer { get; private set; }
+
+            public MockHeaderParser()
+                : this(true)
+            {
+            }
+
+            public MockHeaderParser(bool supportsMultipleValues)
+                : base(supportsMultipleValues)
+            {
+                this.MockComparer = new MockComparer();
+            }
+
+            public MockHeaderParser(string separator)
+                : base(true, separator)
+            {
+                this.MockComparer = new MockComparer();
+            }
+
+            #region IHeaderParser Members
+
+            public override IEqualityComparer Comparer
+            {
+                get { return MockComparer; }
+            }
+
+            public override bool TryParseValue(string value, object storeValue, ref int index, out object parsedValue)
+            {
+                TryParseValueCallCount++;
+                return TryParseValueCore(value, ref index, out parsedValue);
+            }
+
+            private bool TryParseValueCore(string value, ref int index, out object parsedValue)
+            {
+                parsedValue = null;
+
+                if (value == null)
+                {
+                    parsedValue = null;
+                    return true;
+                }
+
+                if (value == string.Empty)
+                {
+                    EmptyValueCount++;
+                    parsedValue = null;
+                    return true;
+                }
+
+                int separatorIndex = value.IndexOf(',', index);
+
+                // Just fail if we don't support multiple values and the value is actually a list of values.
+                if ((!SupportsMultipleValues) && (separatorIndex >= 0))
+                {
+                    return false;
+                }
+
+                if (separatorIndex == -1)
+                {
+                    // If the raw string just contains one value, then use the whole string.
+                    separatorIndex = value.Length;
+                }
+
+                string tempValue = value.Substring(index, separatorIndex - index);
+
+                if (tempValue.StartsWith(rawPrefix, StringComparison.Ordinal))
+                {
+                    index = Math.Min(separatorIndex + 1, value.Length);
+
+                    // We "parse" the value by replacing 'rawPrefix' strings with 'parsedPrefix' string.
+                    parsedValue = parsedPrefix + tempValue.Substring(rawPrefix.Length,
+                        tempValue.Length - rawPrefix.Length);
+                }
+                else if (tempValue.StartsWith(invalidHeaderValue, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                else
+                {
+                    Assert.True(false, string.Format("Unknown mock value: {0}", tempValue));
+                }
+
+                return true;
+            }
+            #endregion
+        }
+
+        private class MockComparer : IEqualityComparer
+        {
+            public int GetHashCodeCount { get; private set; }
+            public int EqualsCount { get; private set; }
+
+            #region IEqualityComparer Members
+
+            public new bool Equals(object x, object y)
+            {
+                Assert.NotNull(x);
+                Assert.NotNull(y);
+
+                EqualsCount++;
+
+                string xs = x as string;
+                string ys = y as string;
+
+                if ((xs != null) && (ys != null))
+                {
+                    return string.Compare(xs, ys, StringComparison.OrdinalIgnoreCase) == 0;
+                }
+
+                return x.Equals(y);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                GetHashCodeCount++;
+                return obj.GetHashCode();
+            }
+            #endregion
+        }
+
+        private class CustomTypeHeaders : HttpHeaders
+        {
+            public CustomTypeHeaders()
+            {
+            }
+
+            public CustomTypeHeaders(string headerName, HttpHeaderParser parser)
+            {
+                Dictionary<string, HttpHeaderParser> parserStore = new Dictionary<string, HttpHeaderParser>();
+                parserStore.Add(headerName, parser);
+                SetConfiguration(parserStore, new HashSet<string>());
+            }
+        }
+
+        private class CustomTypeHeaderParser : HttpHeaderParser
+        {
+            private static CustomTypeComparer comparer = new CustomTypeComparer();
+
+            public override IEqualityComparer Comparer
+            {
+                get { return comparer; }
+            }
+
+            public CustomTypeHeaderParser()
+                : base(true)
+            {
+            }
+
+            public override bool TryParseValue(string value, object storeValue, ref int index, out object parsedValue)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class CustomTypeComparer : IEqualityComparer
+        {
+            #region IEqualityComparer Members
+
+            public new bool Equals(object x, object y)
+            {
+                Assert.NotNull(x);
+                Assert.NotNull(y);
+                return x.Equals(y);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                Assert.NotNull(obj);
+                return obj.GetHashCode();
+            }
+            #endregion
+        }
+
+        private class NoComparerHeaderParser : HttpHeaderParser
+        {
+            public NoComparerHeaderParser()
+                : base(true)
+            {
+            }
+
+            public override bool TryParseValue(string value, object storeValue, ref int index, out object parsedValue)
+            {
+                throw new NotImplementedException();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpRequestHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpRequestHeadersTest.cs
@@ -1,0 +1,1574 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Net.Mail;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpRequestHeadersTest
+    {
+        private HttpRequestHeaders headers;
+
+        public HttpRequestHeadersTest()
+        {
+            headers = new HttpRequestHeaders();
+        }
+
+        #region Request headers
+
+        [Fact]
+        public void Accept_AddInvalidValueUsingUnusualCasing_ParserRetrievedUsingCaseInsensitiveComparison()
+        {
+            // Use uppercase header name to make sure the parser gets retrieved using case-insensitive comparison.
+            Assert.Throws<FormatException>(() => { headers.Add("AcCePt", "this is invalid"); });
+        }
+
+        [Fact]
+        public void Accept_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            MediaTypeWithQualityHeaderValue value1 = new MediaTypeWithQualityHeaderValue("text/plain");
+            value1.CharSet = "utf-8";
+            value1.Quality = 0.5;
+            value1.Parameters.Add(new NameValueHeaderValue("custom", "value"));
+            MediaTypeWithQualityHeaderValue value2 = new MediaTypeWithQualityHeaderValue("text/plain");
+            value2.CharSet = "iso-8859-1";
+            value2.Quality = 0.3868;
+
+            Assert.Equal(0, headers.Accept.Count);
+
+            headers.Accept.Add(value1);
+            headers.Accept.Add(value2);
+
+            Assert.Equal(2, headers.Accept.Count);
+            Assert.Equal(value1, headers.Accept.ElementAt(0));
+            Assert.Equal(value2, headers.Accept.ElementAt(1));
+
+            headers.Accept.Clear();
+            Assert.Equal(0, headers.Accept.Count);
+        }
+
+        [Fact]
+        public void Accept_ReadEmptyProperty_EmptyCollection()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+
+            Assert.Equal(0, request.Headers.Accept.Count);
+            // Copy to another list
+            List<MediaTypeWithQualityHeaderValue> accepts = request.Headers.Accept.ToList();
+            Assert.Equal(0, accepts.Count);
+            accepts = new List<MediaTypeWithQualityHeaderValue>(request.Headers.Accept);
+            Assert.Equal(0, accepts.Count);
+        }
+
+        [Fact]
+        public void Accept_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Accept",
+                ",, , ,,text/plain; charset=iso-8859-1; q=1.0,\r\n */xml; charset=utf-8; q=0.5,,,");
+
+            MediaTypeWithQualityHeaderValue value1 = new MediaTypeWithQualityHeaderValue("text/plain");
+            value1.CharSet = "iso-8859-1";
+            value1.Quality = 1.0;
+
+            MediaTypeWithQualityHeaderValue value2 = new MediaTypeWithQualityHeaderValue("*/xml");
+            value2.CharSet = "utf-8";
+            value2.Quality = 0.5;
+
+            Assert.Equal(value1, headers.Accept.ElementAt(0));
+            Assert.Equal(value2, headers.Accept.ElementAt(1));
+        }
+
+        [Fact]
+        public void Accept_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            // Add a valid media-type with an invalid quality value
+            headers.TryAddWithoutValidation("Accept", "text/plain; q=a"); // invalid quality
+            Assert.NotNull(headers.Accept.First());
+            Assert.Null(headers.Accept.First().Quality);
+            Assert.Equal("text/plain; q=a", headers.Accept.First().ToString());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Accept", "text/plain application/xml"); // no separator
+
+            Assert.Equal(0, headers.Accept.Count);
+            Assert.Equal(1, headers.GetValues("Accept").Count());
+            Assert.Equal("text/plain application/xml", headers.GetValues("Accept").First());
+        }
+
+        [Fact]
+        public void AcceptCharset_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.AcceptCharset.Count);
+
+            headers.AcceptCharset.Add(new StringWithQualityHeaderValue("iso-8859-5"));
+            headers.AcceptCharset.Add(new StringWithQualityHeaderValue("unicode-1-1", 0.8));
+
+            Assert.Equal(2, headers.AcceptCharset.Count);
+            Assert.Equal(new StringWithQualityHeaderValue("iso-8859-5"), headers.AcceptCharset.ElementAt(0));
+            Assert.Equal(new StringWithQualityHeaderValue("unicode-1-1", 0.8), headers.AcceptCharset.ElementAt(1));
+
+            headers.AcceptCharset.Clear();
+            Assert.Equal(0, headers.AcceptCharset.Count);
+        }
+
+        [Fact]
+        public void AcceptCharset_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Accept-Charset", ", ,,iso-8859-5 , \r\n utf-8 ; q=0.300 ,,,");
+
+            Assert.Equal(new StringWithQualityHeaderValue("iso-8859-5"),
+                headers.AcceptCharset.ElementAt(0));
+            Assert.Equal(new StringWithQualityHeaderValue("utf-8", 0.3),
+                headers.AcceptCharset.ElementAt(1));
+        }
+
+        [Fact]
+        public void AcceptCharset_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Accept-Charset", "iso-8859-5 utf-8"); // no separator
+            Assert.Equal(0, headers.AcceptCharset.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Charset").Count());
+            Assert.Equal("iso-8859-5 utf-8", headers.GetValues("Accept-Charset").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Accept-Charset", "utf-8; q=1; q=0.3");
+            Assert.Equal(0, headers.AcceptCharset.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Charset").Count());
+            Assert.Equal("utf-8; q=1; q=0.3", headers.GetValues("Accept-Charset").First());
+        }
+
+        [Fact]
+        public void AcceptCharset_AddMultipleValuesAndGetValueString_AllValuesAddedUsingTheCorrectDelimiter()
+        {
+            headers.TryAddWithoutValidation("Accept-Charset", "invalid value");
+            headers.Add("Accept-Charset", "utf-8");
+            headers.AcceptCharset.Add(new StringWithQualityHeaderValue("iso-8859-5", 0.5));
+
+            foreach (var header in headers.GetHeaderStrings())
+            {
+                Assert.Equal("Accept-Charset", header.Key);
+                Assert.Equal("utf-8, iso-8859-5; q=0.5, invalid value", header.Value);
+            }
+        }
+
+        [Fact]
+        public void AcceptEncoding_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.AcceptEncoding.Count);
+
+            headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("compress", 0.9));
+            headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+            Assert.Equal(2, headers.AcceptEncoding.Count);
+            Assert.Equal(new StringWithQualityHeaderValue("compress", 0.9), headers.AcceptEncoding.ElementAt(0));
+            Assert.Equal(new StringWithQualityHeaderValue("gzip"), headers.AcceptEncoding.ElementAt(1));
+
+            headers.AcceptEncoding.Clear();
+            Assert.Equal(0, headers.AcceptEncoding.Count);
+        }
+
+        [Fact]
+        public void AcceptEncoding_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Accept-Encoding", ", gzip; q=1.0, identity; q=0.5, *;q=0, ");
+
+            Assert.Equal(new StringWithQualityHeaderValue("gzip", 1),
+                headers.AcceptEncoding.ElementAt(0));
+            Assert.Equal(new StringWithQualityHeaderValue("identity", 0.5),
+                headers.AcceptEncoding.ElementAt(1));
+            Assert.Equal(new StringWithQualityHeaderValue("*", 0),
+                headers.AcceptEncoding.ElementAt(2));
+
+            headers.AcceptEncoding.Clear();
+            headers.TryAddWithoutValidation("Accept-Encoding", "");
+            Assert.Equal(0, headers.AcceptEncoding.Count);
+            Assert.False(headers.Contains("Accept-Encoding"));
+        }
+
+        [Fact]
+        public void AcceptEncoding_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Accept-Encoding", "gzip deflate"); // no separator
+            Assert.Equal(0, headers.AcceptEncoding.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Encoding").Count());
+            Assert.Equal("gzip deflate", headers.GetValues("Accept-Encoding").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Accept-Encoding", "compress; q=1; gzip");
+            Assert.Equal(0, headers.AcceptEncoding.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Encoding").Count());
+            Assert.Equal("compress; q=1; gzip", headers.GetValues("Accept-Encoding").First());
+        }
+
+        [Fact]
+        public void AcceptLanguage_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.AcceptLanguage.Count);
+
+            headers.AcceptLanguage.Add(new StringWithQualityHeaderValue("da"));
+            headers.AcceptLanguage.Add(new StringWithQualityHeaderValue("en-GB", 0.8));
+            headers.AcceptLanguage.Add(new StringWithQualityHeaderValue("en", 0.7));
+
+            Assert.Equal(3, headers.AcceptLanguage.Count);
+            Assert.Equal(new StringWithQualityHeaderValue("da"), headers.AcceptLanguage.ElementAt(0));
+            Assert.Equal(new StringWithQualityHeaderValue("en-GB", 0.8), headers.AcceptLanguage.ElementAt(1));
+            Assert.Equal(new StringWithQualityHeaderValue("en", 0.7), headers.AcceptLanguage.ElementAt(2));
+
+            headers.AcceptLanguage.Clear();
+            Assert.Equal(0, headers.AcceptLanguage.Count);
+        }
+
+        [Fact]
+        public void AcceptLanguage_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Accept-Language", " , de-DE;q=0.9,de-AT;q=0.5,*;q=0.010 , ");
+
+            Assert.Equal(new StringWithQualityHeaderValue("de-DE", 0.9),
+                headers.AcceptLanguage.ElementAt(0));
+            Assert.Equal(new StringWithQualityHeaderValue("de-AT", 0.5),
+                headers.AcceptLanguage.ElementAt(1));
+            Assert.Equal(new StringWithQualityHeaderValue("*", 0.01),
+                headers.AcceptLanguage.ElementAt(2));
+
+            headers.AcceptLanguage.Clear();
+            headers.TryAddWithoutValidation("Accept-Language", "");
+            Assert.Equal(0, headers.AcceptLanguage.Count);
+            Assert.False(headers.Contains("Accept-Language"));
+        }
+
+        [Fact]
+        public void AcceptLanguage_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Accept-Language", "de -DE"); // no separator
+            Assert.Equal(0, headers.AcceptLanguage.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Language").Count());
+            Assert.Equal("de -DE", headers.GetValues("Accept-Language").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Accept-Language", "en; q=0.4,[");
+            Assert.Equal(0, headers.AcceptLanguage.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Language").Count());
+            Assert.Equal("en; q=0.4,[", headers.GetValues("Accept-Language").First());
+        }
+
+        [Fact]
+        public void Expect_Add100Continue_Success()
+        {
+            // use non-default casing to make sure we do case-insensitive comparison.
+            headers.Expect.Add(new NameValueWithParametersHeaderValue("100-CONTINUE"));
+            Assert.True(headers.ExpectContinue == true);
+            Assert.Equal(1, headers.Expect.Count);
+        }
+
+        [Fact]
+        public void Expect_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Expect.Count);
+            Assert.Null(headers.ExpectContinue);
+
+            headers.Expect.Add(new NameValueWithParametersHeaderValue("custom1"));
+            headers.Expect.Add(new NameValueWithParametersHeaderValue("custom2"));
+            headers.ExpectContinue = true;
+
+            // Connection collection has 2 values plus '100-Continue'
+            Assert.Equal(3, headers.Expect.Count);
+            Assert.Equal(3, headers.GetValues("Expect").Count());
+            Assert.True(headers.ExpectContinue == true, "ExpectContinue == true");
+            Assert.Equal(new NameValueWithParametersHeaderValue("custom1"), headers.Expect.ElementAt(0));
+            Assert.Equal(new NameValueWithParametersHeaderValue("custom2"), headers.Expect.ElementAt(1));
+
+            // Remove '100-continue' value from store. But leave other 'Expect' values.
+            headers.ExpectContinue = false;
+            Assert.True(headers.ExpectContinue == false, "ExpectContinue == false");
+            Assert.Equal(2, headers.Expect.Count);
+            Assert.Equal(new NameValueWithParametersHeaderValue("custom1"), headers.Expect.ElementAt(0));
+            Assert.Equal(new NameValueWithParametersHeaderValue("custom2"), headers.Expect.ElementAt(1));
+
+            headers.ExpectContinue = true;
+            headers.Expect.Clear();
+            Assert.True(headers.ExpectContinue == false, "ExpectContinue should be modified by Expect.Clear().");
+            Assert.Equal(0, headers.Expect.Count);
+            IEnumerable<string> dummyArray;
+            Assert.False(headers.TryGetValues("Expect", out dummyArray), "Expect header count after Expect.Clear().");
+
+            // Remove '100-continue' value from store. Since there are no other 'Expect' values, remove whole header.
+            headers.ExpectContinue = false;
+            Assert.True(headers.ExpectContinue == false, "ExpectContinue == false");
+            Assert.Equal(0, headers.Expect.Count);
+            Assert.False(headers.Contains("Expect"));
+
+            headers.ExpectContinue = null;
+            Assert.Null(headers.ExpectContinue);
+        }
+
+        [Fact]
+        public void Expect_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Expect",
+                ", , 100-continue, name1 = value1, name2; param2=paramValue2, name3=value3; param3 ,");
+
+            // Connection collection has 3 values plus '100-continue'
+            Assert.Equal(4, headers.Expect.Count);
+            Assert.Equal(4, headers.GetValues("Expect").Count());
+            Assert.True(headers.ExpectContinue == true, "ExpectContinue expected to be true.");
+
+            Assert.Equal(new NameValueWithParametersHeaderValue("100-continue"),
+                headers.Expect.ElementAt(0));
+
+            Assert.Equal(new NameValueWithParametersHeaderValue("name1", "value1"),
+                headers.Expect.ElementAt(1));
+
+            NameValueWithParametersHeaderValue expected2 = new NameValueWithParametersHeaderValue("name2");
+            expected2.Parameters.Add(new NameValueHeaderValue("param2", "paramValue2"));
+            Assert.Equal(expected2, headers.Expect.ElementAt(2));
+
+            NameValueWithParametersHeaderValue expected3 = new NameValueWithParametersHeaderValue("name3", "value3");
+            expected3.Parameters.Add(new NameValueHeaderValue("param3"));
+            Assert.Equal(expected3, headers.Expect.ElementAt(3));
+
+            headers.Expect.Clear();
+            Assert.Null(headers.ExpectContinue);
+            Assert.Equal(0, headers.Expect.Count);
+            IEnumerable<string> dummyArray;
+            Assert.False(headers.TryGetValues("Expect", out dummyArray), "Expect header count after Expect.Clear().");
+        }
+
+        [Fact]
+        public void Expect_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Expect", "100-continue other"); // no separator
+
+            Assert.Equal(0, headers.Expect.Count);
+            Assert.Equal(1, headers.GetValues("Expect").Count());
+            Assert.Equal("100-continue other", headers.GetValues("Expect").First());
+        }
+
+        [Fact]
+        public void Host_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.Host);
+
+            headers.Host = "host";
+            Assert.Equal("host", headers.Host);
+
+            headers.Host = null;
+            Assert.Null(headers.Host);
+            Assert.False(headers.Contains("Host"),
+                "Header store should not contain a header 'Host' after setting it to null.");
+
+            Assert.Throws<FormatException>(() => { headers.Host = "invalid host"; });
+        }
+
+        [Fact]
+        public void Host_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Host", "host:80");
+
+            Assert.Equal("host:80", headers.Host);
+        }
+
+        [Fact]
+        public void IfMatch_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.IfMatch.Count);
+
+            headers.IfMatch.Add(new EntityTagHeaderValue("\"custom1\""));
+            headers.IfMatch.Add(new EntityTagHeaderValue("\"custom2\"", true));
+
+            Assert.Equal(2, headers.IfMatch.Count);
+            Assert.Equal(2, headers.GetValues("If-Match").Count());
+            Assert.Equal(new EntityTagHeaderValue("\"custom1\""), headers.IfMatch.ElementAt(0));
+            Assert.Equal(new EntityTagHeaderValue("\"custom2\"", true), headers.IfMatch.ElementAt(1));
+
+            headers.IfMatch.Clear();
+            Assert.Equal(0, headers.IfMatch.Count);
+            Assert.False(headers.Contains("If-Match"), "Header store should not contain 'If-Match'");
+        }
+
+        [Fact]
+        public void IfMatch_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("If-Match", ", , W/\"tag1\", \"tag2\", W/\"tag3\" ,");
+
+            Assert.Equal(3, headers.IfMatch.Count);
+            Assert.Equal(3, headers.GetValues("If-Match").Count());
+
+            Assert.Equal(new EntityTagHeaderValue("\"tag1\"", true), headers.IfMatch.ElementAt(0));
+            Assert.Equal(new EntityTagHeaderValue("\"tag2\"", false), headers.IfMatch.ElementAt(1));
+            Assert.Equal(new EntityTagHeaderValue("\"tag3\"", true), headers.IfMatch.ElementAt(2));
+
+            headers.IfMatch.Clear();
+            headers.Add("If-Match", "*");
+            Assert.Equal(1, headers.IfMatch.Count);
+            Assert.Same(EntityTagHeaderValue.Any, headers.IfMatch.ElementAt(0));
+        }
+
+        [Fact]
+        public void IfMatch_UseAddMethodWithInvalidInput_PropertyNotUpdated()
+        {
+            headers.TryAddWithoutValidation("If-Match", "W/\"tag1\" \"tag2\""); // no separator
+            Assert.Equal(0, headers.IfMatch.Count);
+            Assert.Equal(1, headers.GetValues("If-Match").Count());
+        }
+
+        [Fact]
+        public void IfNoneMatch_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.IfNoneMatch.Count);
+
+            headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"custom1\""));
+            headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"custom2\"", true));
+
+            Assert.Equal(2, headers.IfNoneMatch.Count);
+            Assert.Equal(2, headers.GetValues("If-None-Match").Count());
+            Assert.Equal(new EntityTagHeaderValue("\"custom1\""), headers.IfNoneMatch.ElementAt(0));
+            Assert.Equal(new EntityTagHeaderValue("\"custom2\"", true), headers.IfNoneMatch.ElementAt(1));
+
+            headers.IfNoneMatch.Clear();
+            Assert.Equal(0, headers.IfNoneMatch.Count);
+            Assert.False(headers.Contains("If-None-Match"), "Header store should not contain 'If-None-Match'");
+        }
+
+        [Fact]
+        public void IfNoneMatch_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("If-None-Match", "W/\"tag1\", \"tag2\", W/\"tag3\"");
+
+            Assert.Equal(3, headers.IfNoneMatch.Count);
+            Assert.Equal(3, headers.GetValues("If-None-Match").Count());
+
+            Assert.Equal(new EntityTagHeaderValue("\"tag1\"", true), headers.IfNoneMatch.ElementAt(0));
+            Assert.Equal(new EntityTagHeaderValue("\"tag2\"", false), headers.IfNoneMatch.ElementAt(1));
+            Assert.Equal(new EntityTagHeaderValue("\"tag3\"", true), headers.IfNoneMatch.ElementAt(2));
+
+            headers.IfNoneMatch.Clear();
+            headers.Add("If-None-Match", "*");
+            Assert.Equal(1, headers.IfNoneMatch.Count);
+            Assert.Same(EntityTagHeaderValue.Any, headers.IfNoneMatch.ElementAt(0));
+        }
+
+        [Fact]
+        public void TE_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            TransferCodingWithQualityHeaderValue value1 = new TransferCodingWithQualityHeaderValue("custom");
+            value1.Quality = 0.5;
+            value1.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            TransferCodingWithQualityHeaderValue value2 = new TransferCodingWithQualityHeaderValue("custom");
+            value2.Quality = 0.3868;
+
+            Assert.Equal(0, headers.TE.Count);
+
+            headers.TE.Add(value1);
+            headers.TE.Add(value2);
+
+            Assert.Equal(2, headers.TE.Count);
+            Assert.Equal(value1, headers.TE.ElementAt(0));
+            Assert.Equal(value2, headers.TE.ElementAt(1));
+
+            headers.TE.Clear();
+            Assert.Equal(0, headers.TE.Count);
+        }
+
+        [Fact]
+        public void TE_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("TE",
+                ",custom1; param1=value1; q=1.0,,\r\n custom2; param2=value2; q=0.5  ,");
+
+            TransferCodingWithQualityHeaderValue value1 = new TransferCodingWithQualityHeaderValue("custom1");
+            value1.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            value1.Quality = 1.0;
+
+            TransferCodingWithQualityHeaderValue value2 = new TransferCodingWithQualityHeaderValue("custom2");
+            value2.Parameters.Add(new NameValueHeaderValue("param2", "value2"));
+            value2.Quality = 0.5;
+
+            Assert.Equal(value1, headers.TE.ElementAt(0));
+            Assert.Equal(value2, headers.TE.ElementAt(1));
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("TE", "");
+            Assert.False(headers.Contains("TE"), "'TE' header should not be added if it just has empty values.");
+        }
+
+        [Fact]
+        public void Range_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.Range);
+            RangeHeaderValue value = new RangeHeaderValue(1, 2);
+
+            headers.Range = value;
+            Assert.Equal(value, headers.Range);
+
+            headers.Range = null;
+            Assert.Null(headers.Range);
+        }
+
+        [Fact]
+        public void Range_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Range", "custom= , ,1-2, -4 , ");
+
+            RangeHeaderValue value = new RangeHeaderValue();
+            value.Unit = "custom";
+            value.Ranges.Add(new RangeItemHeaderValue(1, 2));
+            value.Ranges.Add(new RangeItemHeaderValue(null, 4));
+
+            Assert.Equal(value, headers.Range);
+        }
+
+        [Fact]
+        public void Authorization_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.Authorization);
+
+            headers.Authorization = new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+            Assert.Equal(new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="), headers.Authorization);
+
+            headers.Authorization = null;
+            Assert.Null(headers.Authorization);
+            Assert.False(headers.Contains("Authorization"),
+                "Header store should not contain a header 'Authorization' after setting it to null.");
+        }
+
+        [Fact]
+        public void Authorization_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Authorization", "NTLM blob");
+
+            Assert.Equal(new AuthenticationHeaderValue("NTLM", "blob"), headers.Authorization);
+        }
+
+        [Fact]
+        public void ProxyAuthorization_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.ProxyAuthorization);
+
+            headers.ProxyAuthorization = new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+            Assert.Equal(new AuthenticationHeaderValue("Basic", "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+                headers.ProxyAuthorization);
+
+            headers.ProxyAuthorization = null;
+            Assert.Null(headers.ProxyAuthorization);
+            Assert.False(headers.Contains("ProxyAuthorization"),
+                "Header store should not contain a header 'ProxyAuthorization' after setting it to null.");
+        }
+
+        [Fact]
+        public void ProxyAuthorization_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Proxy-Authorization", "NTLM blob");
+
+            Assert.Equal(new AuthenticationHeaderValue("NTLM", "blob"), headers.ProxyAuthorization);
+        }
+
+        [Fact]
+        public void UserAgent_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.UserAgent.Count);
+
+            headers.UserAgent.Add(new ProductInfoHeaderValue("(custom1)"));
+            headers.UserAgent.Add(new ProductInfoHeaderValue("custom2", "1.1"));
+
+            Assert.Equal(2, headers.UserAgent.Count);
+            Assert.Equal(2, headers.GetValues("User-Agent").Count());
+            Assert.Equal(new ProductInfoHeaderValue("(custom1)"), headers.UserAgent.ElementAt(0));
+            Assert.Equal(new ProductInfoHeaderValue("custom2", "1.1"), headers.UserAgent.ElementAt(1));
+
+            headers.UserAgent.Clear();
+            Assert.Equal(0, headers.UserAgent.Count);
+            Assert.False(headers.Contains("User-Agent"), "User-Agent header should be removed after calling Clear().");
+
+            headers.UserAgent.Add(new ProductInfoHeaderValue("(comment)"));
+            headers.UserAgent.Remove(new ProductInfoHeaderValue("(comment)"));
+            Assert.Equal(0, headers.UserAgent.Count);
+            Assert.False(headers.Contains("User-Agent"), "User-Agent header should be removed after removing last value.");
+        }
+
+        [Fact]
+        public void UserAgent_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("User-Agent", "Opera/9.80 (Windows NT 6.1; U; en) Presto/2.6.30 Version/10.63");
+
+            Assert.Equal(4, headers.UserAgent.Count);
+            Assert.Equal(4, headers.GetValues("User-Agent").Count());
+
+            Assert.Equal(new ProductInfoHeaderValue("Opera", "9.80"), headers.UserAgent.ElementAt(0));
+            Assert.Equal(new ProductInfoHeaderValue("(Windows NT 6.1; U; en)"), headers.UserAgent.ElementAt(1));
+            Assert.Equal(new ProductInfoHeaderValue("Presto", "2.6.30"), headers.UserAgent.ElementAt(2));
+            Assert.Equal(new ProductInfoHeaderValue("Version", "10.63"), headers.UserAgent.ElementAt(3));
+
+            headers.UserAgent.Clear();
+            Assert.Equal(0, headers.UserAgent.Count);
+            Assert.False(headers.Contains("User-Agent"), "User-Agent header should be removed after calling Clear().");
+        }
+
+        [Fact]
+        public void UserAgent_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("User-Agent", "custom\u4F1A");
+            Assert.Null(headers.GetParsedValues("User-Agent"));
+            Assert.Equal(1, headers.GetValues("User-Agent").Count());
+            Assert.Equal("custom\u4F1A", headers.GetValues("User-Agent").First());
+
+            headers.Clear();
+            // Note that "User-Agent" uses whitespaces as separators, so the following is an invalid value
+            headers.TryAddWithoutValidation("User-Agent", "custom1, custom2");
+            Assert.Null(headers.GetParsedValues("User-Agent"));
+            Assert.Equal(1, headers.GetValues("User-Agent").Count());
+            Assert.Equal("custom1, custom2", headers.GetValues("User-Agent").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("User-Agent", "custom1, ");
+            Assert.Null(headers.GetParsedValues("User-Agent"));
+            Assert.Equal(1, headers.GetValues("User-Agent").Count());
+            Assert.Equal("custom1, ", headers.GetValues("User-Agent").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("User-Agent", ",custom1");
+            Assert.Null(headers.GetParsedValues("User-Agent"));
+            Assert.Equal(1, headers.GetValues("User-Agent").Count());
+            Assert.Equal(",custom1", headers.GetValues("User-Agent").First());
+        }
+
+        [Fact]
+        public void UserAgent_AddMultipleValuesAndGetValueString_AllValuesAddedUsingTheCorrectDelimiter()
+        {
+            headers.TryAddWithoutValidation("User-Agent", "custom\u4F1A");
+            headers.Add("User-Agent", "custom2/1.1");
+            headers.UserAgent.Add(new ProductInfoHeaderValue("(comment)"));
+
+            foreach (var header in headers.GetHeaderStrings())
+            {
+                Assert.Equal("User-Agent", header.Key);
+                Assert.Equal("custom2/1.1 (comment) custom\u4F1A", header.Value);
+            }
+        }
+
+        [Fact]
+        public void IfRange_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.IfRange);
+
+            headers.IfRange = new RangeConditionHeaderValue("\"x\"");
+
+            Assert.Equal(1, headers.GetValues("If-Range").Count());
+            Assert.Equal(new RangeConditionHeaderValue("\"x\""), headers.IfRange);
+
+            headers.IfRange = null;
+            Assert.Null(headers.IfRange);
+            Assert.False(headers.Contains("If-Range"), "If-Range header should be removed after calling Clear().");
+        }
+
+        [Fact]
+        public void IfRange_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("If-Range", " W/\"tag\" ");
+
+            Assert.Equal(new RangeConditionHeaderValue(new EntityTagHeaderValue("\"tag\"", true)),
+                headers.IfRange);
+            Assert.Equal(1, headers.GetValues("If-Range").Count());
+
+            headers.IfRange = null;
+            Assert.Null(headers.IfRange);
+            Assert.False(headers.Contains("If-Range"), "If-Range header should be removed after calling Clear().");
+        }
+
+        [Fact]
+        public void IfRange_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("If-Range", "\"tag\"\u4F1A");
+            Assert.Null(headers.GetParsedValues("If-Range"));
+            Assert.Equal(1, headers.GetValues("If-Range").Count());
+            Assert.Equal("\"tag\"\u4F1A", headers.GetValues("If-Range").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("If-Range", " \"tag\", ");
+            Assert.Null(headers.GetParsedValues("If-Range"));
+            Assert.Equal(1, headers.GetValues("If-Range").Count());
+            Assert.Equal(" \"tag\", ", headers.GetValues("If-Range").First());
+        }
+
+        [Fact]
+        public void From_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.From);
+
+            headers.From = "info@example.com";
+            Assert.Equal("info@example.com", headers.From);
+
+            headers.From = null;
+            Assert.Null(headers.From);
+            Assert.False(headers.Contains("From"),
+                "Header store should not contain a header 'From' after setting it to null.");
+
+            Assert.Throws<FormatException>(() => { headers.From = " "; });
+            Assert.Throws<FormatException>(() => { headers.From = "invalid email address"; });
+        }
+
+        [Fact]
+        public void From_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("From", "  \"My Name\"   info@example.com  ");
+            Assert.Equal("\"My Name\"   info@example.com  ", headers.From);
+
+            // The following encoded string represents the character sequence "\u4F1A\u5458\u670D\u52A1".
+            headers.Clear();
+            headers.TryAddWithoutValidation("From", "=?utf-8?Q?=E4=BC=9A=E5=91=98=E6=9C=8D=E5=8A=A1?= <info@example.com>");
+            Assert.Equal("=?utf-8?Q?=E4=BC=9A=E5=91=98=E6=9C=8D=E5=8A=A1?= <info@example.com>", headers.From);
+        }
+
+        [Fact]
+        public void From_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("From", " info@example.com ,");
+            Assert.Null(headers.GetParsedValues("From"));
+            Assert.Equal(1, headers.GetValues("From").Count());
+            Assert.Equal(" info@example.com ,", headers.GetValues("From").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("From", "info@");
+            Assert.Null(headers.GetParsedValues("From"));
+            Assert.Equal(1, headers.GetValues("From").Count());
+            Assert.Equal("info@", headers.GetValues("From").First());
+        }
+
+        [Fact]
+        public void IfModifiedSince_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.IfModifiedSince);
+
+            DateTimeOffset expected = DateTimeOffset.Now;
+            headers.IfModifiedSince = expected;
+            Assert.Equal(expected, headers.IfModifiedSince);
+
+            headers.IfModifiedSince = null;
+            Assert.Null(headers.IfModifiedSince);
+            Assert.False(headers.Contains("If-Modified-Since"),
+                "Header store should not contain a header 'IfModifiedSince' after setting it to null.");
+        }
+
+        [Fact]
+        public void IfModifiedSince_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("If-Modified-Since", "  Sun, 06 Nov 1994 08:49:37 GMT  ");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.IfModifiedSince);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("If-Modified-Since", "Sun, 06 Nov 1994 08:49:37 GMT");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.IfModifiedSince);
+        }
+
+        [Fact]
+        public void IfModifiedSince_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("If-Modified-Since", " Sun, 06 Nov 1994 08:49:37 GMT ,");
+            Assert.Null(headers.GetParsedValues("If-Modified-Since"));
+            Assert.Equal(1, headers.GetValues("If-Modified-Since").Count());
+            Assert.Equal(" Sun, 06 Nov 1994 08:49:37 GMT ,", headers.GetValues("If-Modified-Since").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("If-Modified-Since", " Sun, 06 Nov ");
+            Assert.Null(headers.GetParsedValues("If-Modified-Since"));
+            Assert.Equal(1, headers.GetValues("If-Modified-Since").Count());
+            Assert.Equal(" Sun, 06 Nov ", headers.GetValues("If-Modified-Since").First());
+        }
+
+        [Fact]
+        public void IfUnmodifiedSince_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.IfUnmodifiedSince);
+
+            DateTimeOffset expected = DateTimeOffset.Now;
+            headers.IfUnmodifiedSince = expected;
+            Assert.Equal(expected, headers.IfUnmodifiedSince);
+
+            headers.IfUnmodifiedSince = null;
+            Assert.Null(headers.IfUnmodifiedSince);
+            Assert.False(headers.Contains("If-Unmodified-Since"),
+                "Header store should not contain a header 'IfUnmodifiedSince' after setting it to null.");
+        }
+
+        [Fact]
+        public void IfUnmodifiedSince_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("If-Unmodified-Since", "  Sun, 06 Nov 1994 08:49:37 GMT  ");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.IfUnmodifiedSince);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("If-Unmodified-Since", "Sun, 06 Nov 1994 08:49:37 GMT");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.IfUnmodifiedSince);
+        }
+
+        [Fact]
+        public void IfUnmodifiedSince_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("If-Unmodified-Since", " Sun, 06 Nov 1994 08:49:37 GMT ,");
+            Assert.Null(headers.GetParsedValues("If-Unmodified-Since"));
+            Assert.Equal(1, headers.GetValues("If-Unmodified-Since").Count());
+            Assert.Equal(" Sun, 06 Nov 1994 08:49:37 GMT ,", headers.GetValues("If-Unmodified-Since").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("If-Unmodified-Since", " Sun, 06 Nov ");
+            Assert.Null(headers.GetParsedValues("If-Unmodified-Since"));
+            Assert.Equal(1, headers.GetValues("If-Unmodified-Since").Count());
+            Assert.Equal(" Sun, 06 Nov ", headers.GetValues("If-Unmodified-Since").First());
+        }
+
+        [Fact]
+        public void Referrer_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.Referrer);
+
+            Uri expected = new Uri("http://example.com/path/");
+            headers.Referrer = expected;
+            Assert.Equal(expected, headers.Referrer);
+
+            headers.Referrer = null;
+            Assert.Null(headers.Referrer);
+            Assert.False(headers.Contains("Referer"),
+                "Header store should not contain a header 'Referrer' after setting it to null.");
+        }
+
+        [Fact]
+        public void Referrer_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Referer", "  http://www.example.com/path/?q=v  ");
+            Assert.Equal(new Uri("http://www.example.com/path/?q=v"), headers.Referrer);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Referer", "/relative/uri/");
+            Assert.Equal(new Uri("/relative/uri/", UriKind.Relative), headers.Referrer);
+        }
+
+        [Fact]
+        public void Referrer_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Referer", " http://example.com http://other");
+            Assert.Null(headers.GetParsedValues("Referer"));
+            Assert.Equal(1, headers.GetValues("Referer").Count());
+            Assert.Equal(" http://example.com http://other", headers.GetValues("Referer").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Referer", "http://host /other");
+            Assert.Null(headers.GetParsedValues("Referer"));
+            Assert.Equal(1, headers.GetValues("Referer").Count());
+            Assert.Equal("http://host /other", headers.GetValues("Referer").First());
+        }
+
+        [Fact]
+        public void MaxForwards_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.MaxForwards);
+
+            headers.MaxForwards = 15;
+            Assert.Equal(15, headers.MaxForwards);
+
+            headers.MaxForwards = null;
+            Assert.Null(headers.MaxForwards);
+            Assert.False(headers.Contains("Max-Forwards"),
+                "Header store should not contain a header 'MaxForwards' after setting it to null.");
+
+            // Make sure the header gets serialized correctly
+            headers.MaxForwards = 12345;
+            Assert.Equal("12345", headers.GetValues("Max-Forwards").First());
+        }
+
+        [Fact]
+        public void MaxForwards_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Max-Forwards", "  00123  ");
+            Assert.Equal(123, headers.MaxForwards);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Max-Forwards", "0");
+            Assert.Equal(0, headers.MaxForwards);
+        }
+
+        [Fact]
+        public void MaxForwards_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Max-Forwards", "15,");
+            Assert.Null(headers.GetParsedValues("Max-Forwards"));
+            Assert.Equal(1, headers.GetValues("Max-Forwards").Count());
+            Assert.Equal("15,", headers.GetValues("Max-Forwards").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Max-Forwards", "1.0");
+            Assert.Null(headers.GetParsedValues("Max-Forwards"));
+            Assert.Equal(1, headers.GetValues("Max-Forwards").Count());
+            Assert.Equal("1.0", headers.GetValues("Max-Forwards").First());
+        }
+
+        [Fact]
+        public void AddHeaders_SpecialHeaderValuesOnSourceNotOnDestination_Copied()
+        {
+            // Positive
+            HttpRequestHeaders source = new HttpRequestHeaders();
+            source.ExpectContinue = true;
+            source.TransferEncodingChunked = true;
+            source.ConnectionClose = true;
+
+            HttpRequestHeaders destination = new HttpRequestHeaders();
+            Assert.Null(destination.ExpectContinue);
+            Assert.Null(destination.TransferEncodingChunked);
+            Assert.Null(destination.ConnectionClose);
+
+            destination.AddHeaders(source);
+            Assert.NotNull(destination.ExpectContinue);
+            Assert.NotNull(destination.TransferEncodingChunked);
+            Assert.NotNull(destination.ConnectionClose);
+            Assert.True(destination.ExpectContinue.Value);
+            Assert.True(destination.TransferEncodingChunked.Value);
+            Assert.True(destination.ConnectionClose.Value);
+
+            // Negitive
+            source = new HttpRequestHeaders();
+            source.ExpectContinue = false;
+            source.TransferEncodingChunked = false;
+            source.ConnectionClose = false;
+
+            destination = new HttpRequestHeaders();
+            Assert.Null(destination.ExpectContinue);
+            Assert.Null(destination.TransferEncodingChunked);
+            Assert.Null(destination.ConnectionClose);
+
+            destination.AddHeaders(source);
+            Assert.NotNull(destination.ExpectContinue);
+            Assert.NotNull(destination.TransferEncodingChunked);
+            Assert.NotNull(destination.ConnectionClose);
+            Assert.False(destination.ExpectContinue.Value);
+            Assert.False(destination.TransferEncodingChunked.Value);
+            Assert.False(destination.ConnectionClose.Value);
+        }
+
+        [Fact]
+        public void AddHeaders_SpecialHeaderValuesOnDestinationNotOnSource_NotCopied()
+        {
+            // Positive
+            HttpRequestHeaders destination = new HttpRequestHeaders();
+            destination.ExpectContinue = true;
+            destination.TransferEncodingChunked = true;
+            destination.ConnectionClose = true;
+            Assert.NotNull(destination.ExpectContinue);
+            Assert.NotNull(destination.TransferEncodingChunked);
+            Assert.NotNull(destination.ConnectionClose);
+            Assert.True(destination.ExpectContinue.Value);
+            Assert.True(destination.TransferEncodingChunked.Value);
+            Assert.True(destination.ConnectionClose.Value);
+
+            HttpRequestHeaders source = new HttpRequestHeaders();
+            Assert.Null(source.ExpectContinue);
+            Assert.Null(source.TransferEncodingChunked);
+            Assert.Null(source.ConnectionClose);
+
+            destination.AddHeaders(source);
+            Assert.Null(source.ExpectContinue);
+            Assert.Null(source.TransferEncodingChunked);
+            Assert.Null(source.ConnectionClose);
+            Assert.NotNull(destination.ExpectContinue);
+            Assert.NotNull(destination.TransferEncodingChunked);
+            Assert.NotNull(destination.ConnectionClose);
+            Assert.True(destination.ExpectContinue.Value);
+            Assert.True(destination.TransferEncodingChunked.Value);
+            Assert.True(destination.ConnectionClose.Value);
+
+            // Negitive
+            destination = new HttpRequestHeaders();
+            destination.ExpectContinue = false;
+            destination.TransferEncodingChunked = false;
+            destination.ConnectionClose = false;
+            Assert.NotNull(destination.ExpectContinue);
+            Assert.NotNull(destination.TransferEncodingChunked);
+            Assert.NotNull(destination.ConnectionClose);
+            Assert.False(destination.ExpectContinue.Value);
+            Assert.False(destination.TransferEncodingChunked.Value);
+            Assert.False(destination.ConnectionClose.Value);
+
+            source = new HttpRequestHeaders();
+            Assert.Null(source.ExpectContinue);
+            Assert.Null(source.TransferEncodingChunked);
+            Assert.Null(source.ConnectionClose);
+
+            destination.AddHeaders(source);
+            Assert.Null(source.ExpectContinue);
+            Assert.Null(source.TransferEncodingChunked);
+            Assert.Null(source.ConnectionClose);
+            Assert.NotNull(destination.ExpectContinue);
+            Assert.NotNull(destination.TransferEncodingChunked);
+            Assert.NotNull(destination.ConnectionClose);
+            Assert.False(destination.ExpectContinue.Value);
+            Assert.False(destination.TransferEncodingChunked.Value);
+            Assert.False(destination.ConnectionClose.Value);
+        }
+
+        #endregion
+
+        #region General headers
+
+        [Fact]
+        public void Connection_AddClose_Success()
+        {
+            headers.Connection.Add("CLOSE"); // use non-default casing to make sure we do case-insensitive comparison.
+            Assert.True(headers.ConnectionClose == true);
+            Assert.Equal(1, headers.Connection.Count);
+        }
+
+        [Fact]
+        public void Connection_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Connection.Count);
+            Assert.Null(headers.ConnectionClose);
+
+            headers.Connection.Add("custom1");
+            headers.Connection.Add("custom2");
+            headers.ConnectionClose = true;
+
+            // Connection collection has 2 values plus 'close'
+            Assert.Equal(3, headers.Connection.Count);
+            Assert.Equal(3, headers.GetValues("Connection").Count());
+            Assert.True(headers.ConnectionClose == true, "ConnectionClose");
+
+            Assert.Equal("custom1", headers.Connection.ElementAt(0));
+            Assert.Equal("custom2", headers.Connection.ElementAt(1));
+
+            // Remove 'close' value from store. But leave other 'Connection' values.
+            headers.ConnectionClose = false;
+            Assert.True(headers.ConnectionClose == false, "ConnectionClose == false");
+            Assert.Equal(2, headers.Connection.Count);
+            Assert.Equal("custom1", headers.Connection.ElementAt(0));
+            Assert.Equal("custom2", headers.Connection.ElementAt(1));
+
+            headers.ConnectionClose = true;
+            headers.Connection.Clear();
+            Assert.True(headers.ConnectionClose == false,
+                "ConnectionClose should be modified by Connection.Clear().");
+            Assert.Equal(0, headers.Connection.Count);
+            IEnumerable<string> dummyArray;
+            Assert.False(headers.TryGetValues("Connection", out dummyArray),
+                "Connection header count after Connection.Clear().");
+
+            // Remove 'close' value from store. Since there are no other 'Connection' values, remove whole header.
+            headers.ConnectionClose = false;
+            Assert.True(headers.ConnectionClose == false, "ConnectionClose == false");
+            Assert.Equal(0, headers.Connection.Count);
+            Assert.False(headers.Contains("Connection"));
+
+            headers.ConnectionClose = null;
+            Assert.Null(headers.ConnectionClose);
+        }
+
+        [Fact]
+        public void Connection_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Connection", "custom1, close, custom2, custom3");
+
+            // Connection collection has 3 values plus 'close'
+            Assert.Equal(4, headers.Connection.Count);
+            Assert.Equal(4, headers.GetValues("Connection").Count());
+            Assert.True(headers.ConnectionClose == true);
+
+            Assert.Equal("custom1", headers.Connection.ElementAt(0));
+            Assert.Equal("close", headers.Connection.ElementAt(1));
+            Assert.Equal("custom2", headers.Connection.ElementAt(2));
+            Assert.Equal("custom3", headers.Connection.ElementAt(3));
+
+            headers.Connection.Clear();
+            Assert.Null(headers.ConnectionClose);
+            Assert.Equal(0, headers.Connection.Count);
+            IEnumerable<string> dummyArray;
+            Assert.False(headers.TryGetValues("Connection", out dummyArray),
+                "Connection header count after Connection.Clear().");
+        }
+
+        [Fact]
+        public void Connection_AddInvalidValue_Throw()
+        {
+            Assert.Throws<FormatException>(() => { headers.Connection.Add("this is invalid"); });
+        }
+
+        [Fact]
+        public void TransferEncoding_AddChunked_Success()
+        {
+            // use non-default casing to make sure we do case-insensitive comparison.
+            headers.TransferEncoding.Add(new TransferCodingHeaderValue("CHUNKED"));
+            Assert.True(headers.TransferEncodingChunked == true);
+            Assert.Equal(1, headers.TransferEncoding.Count);
+        }
+
+        [Fact]
+        public void TransferEncoding_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.Null(headers.TransferEncodingChunked);
+
+            headers.TransferEncoding.Add(new TransferCodingHeaderValue("custom1"));
+            headers.TransferEncoding.Add(new TransferCodingHeaderValue("custom2"));
+            headers.TransferEncodingChunked = true;
+
+            // Connection collection has 2 values plus 'chunked'
+            Assert.Equal(3, headers.TransferEncoding.Count);
+            Assert.Equal(3, headers.GetValues("Transfer-Encoding").Count());
+            Assert.Equal(true, headers.TransferEncodingChunked);
+            Assert.Equal(new TransferCodingHeaderValue("custom1"), headers.TransferEncoding.ElementAt(0));
+            Assert.Equal(new TransferCodingHeaderValue("custom2"), headers.TransferEncoding.ElementAt(1));
+
+            // Remove 'chunked' value from store. But leave other 'Transfer-Encoding' values. Note that according to
+            // the RFC this is not valid, since 'chunked' must always be present. However this check is done
+            // in the transport handler since the user can add invalid header values anyways.
+            headers.TransferEncodingChunked = false;
+            Assert.True(headers.TransferEncodingChunked == false, "TransferEncodingChunked == false");
+            Assert.Equal(2, headers.TransferEncoding.Count);
+            Assert.Equal(new TransferCodingHeaderValue("custom1"), headers.TransferEncoding.ElementAt(0));
+            Assert.Equal(new TransferCodingHeaderValue("custom2"), headers.TransferEncoding.ElementAt(1));
+
+            headers.TransferEncodingChunked = true;
+            headers.TransferEncoding.Clear();
+            Assert.True(headers.TransferEncodingChunked == false,
+                "TransferEncodingChunked should be modified by TransferEncoding.Clear().");
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.False(headers.Contains("Transfer-Encoding"));
+
+            // Remove 'chunked' value from store. Since there are no other 'Transfer-Encoding' values, remove whole
+            // header.
+            headers.TransferEncodingChunked = false;
+            Assert.True(headers.TransferEncodingChunked == false, "TransferEncodingChunked == false");
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.False(headers.Contains("Transfer-Encoding"));
+
+            headers.TransferEncodingChunked = null;
+            Assert.Null(headers.TransferEncodingChunked);
+        }
+
+        [Fact]
+        public void TransferEncoding_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Transfer-Encoding", " , custom1, , custom2, custom3, chunked    ,");
+
+            // Connection collection has 3 values plus 'chunked'
+            Assert.Equal(4, headers.TransferEncoding.Count);
+            Assert.Equal(4, headers.GetValues("Transfer-Encoding").Count());
+            Assert.True(headers.TransferEncodingChunked == true, "TransferEncodingChunked expected to be true.");
+
+            Assert.Equal(new TransferCodingHeaderValue("custom1"), headers.TransferEncoding.ElementAt(0));
+            Assert.Equal(new TransferCodingHeaderValue("custom2"), headers.TransferEncoding.ElementAt(1));
+            Assert.Equal(new TransferCodingHeaderValue("custom3"), headers.TransferEncoding.ElementAt(2));
+
+            headers.TransferEncoding.Clear();
+            Assert.Null(headers.TransferEncodingChunked);
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.False(headers.Contains("Transfer-Encoding"),
+                "Transfer-Encoding header after TransferEncoding.Clear().");
+        }
+
+        [Fact]
+        public void TransferEncoding_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Transfer-Encoding", "custom\u4F1A");
+            Assert.Null(headers.GetParsedValues("Transfer-Encoding"));
+            Assert.Equal(1, headers.GetValues("Transfer-Encoding").Count());
+            Assert.Equal("custom\u4F1A", headers.GetValues("Transfer-Encoding").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Transfer-Encoding", "custom1 custom2");
+            Assert.Null(headers.GetParsedValues("Transfer-Encoding"));
+            Assert.Equal(1, headers.GetValues("Transfer-Encoding").Count());
+            Assert.Equal("custom1 custom2", headers.GetValues("Transfer-Encoding").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Transfer-Encoding", "");
+            Assert.False(headers.Contains("Transfer-Encoding"), "'Transfer-Encoding' header should not be added if it just has empty values.");
+        }
+
+        [Fact]
+        public void Upgrade_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Upgrade.Count);
+
+            headers.Upgrade.Add(new ProductHeaderValue("custom1"));
+            headers.Upgrade.Add(new ProductHeaderValue("custom2", "1.1"));
+
+            Assert.Equal(2, headers.Upgrade.Count);
+            Assert.Equal(2, headers.GetValues("Upgrade").Count());
+            Assert.Equal(new ProductHeaderValue("custom1"), headers.Upgrade.ElementAt(0));
+            Assert.Equal(new ProductHeaderValue("custom2", "1.1"), headers.Upgrade.ElementAt(1));
+
+            headers.Upgrade.Clear();
+            Assert.Equal(0, headers.Upgrade.Count);
+            Assert.False(headers.Contains("Upgrade"), "Upgrade header should be removed after calling Clear().");
+        }
+
+        [Fact]
+        public void Upgrade_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Upgrade", " , custom1 / 1.0, , custom2, custom3/2.0,");
+
+            Assert.Equal(3, headers.Upgrade.Count);
+            Assert.Equal(3, headers.GetValues("Upgrade").Count());
+
+            Assert.Equal(new ProductHeaderValue("custom1", "1.0"), headers.Upgrade.ElementAt(0));
+            Assert.Equal(new ProductHeaderValue("custom2"), headers.Upgrade.ElementAt(1));
+            Assert.Equal(new ProductHeaderValue("custom3", "2.0"), headers.Upgrade.ElementAt(2));
+
+            headers.Upgrade.Clear();
+            Assert.Equal(0, headers.Upgrade.Count);
+            Assert.False(headers.Contains("Upgrade"), "Upgrade header should be removed after calling Clear().");
+        }
+
+        [Fact]
+        public void Upgrade_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Upgrade", "custom\u4F1A");
+            Assert.Null(headers.GetParsedValues("Upgrade"));
+            Assert.Equal(1, headers.GetValues("Upgrade").Count());
+            Assert.Equal("custom\u4F1A", headers.GetValues("Upgrade").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Upgrade", "custom1 custom2");
+            Assert.Null(headers.GetParsedValues("Upgrade"));
+            Assert.Equal(1, headers.GetValues("Upgrade").Count());
+            Assert.Equal("custom1 custom2", headers.GetValues("Upgrade").First());
+        }
+
+        [Fact]
+        public void Date_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.Date);
+
+            DateTimeOffset expected = DateTimeOffset.Now;
+            headers.Date = expected;
+            Assert.Equal(expected, headers.Date);
+
+            headers.Date = null;
+            Assert.Null(headers.Date);
+            Assert.False(headers.Contains("Date"),
+                "Header store should not contain a header 'Date' after setting it to null.");
+
+            // Make sure the header gets serialized correctly
+            headers.Date = (new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero));
+            Assert.Equal("Sun, 06 Nov 1994 08:49:37 GMT", headers.GetValues("Date").First());
+        }
+
+        [Fact]
+        public void Date_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Date", "  Sun, 06 Nov 1994 08:49:37 GMT  ");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.Date);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Date", "Sun, 06 Nov 1994 08:49:37 GMT");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.Date);
+        }
+
+        [Fact]
+        public void Date_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Date", " Sun, 06 Nov 1994 08:49:37 GMT ,");
+            Assert.Null(headers.GetParsedValues("Date"));
+            Assert.Equal(1, headers.GetValues("Date").Count());
+            Assert.Equal(" Sun, 06 Nov 1994 08:49:37 GMT ,", headers.GetValues("Date").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Date", " Sun, 06 Nov ");
+            Assert.Null(headers.GetParsedValues("Date"));
+            Assert.Equal(1, headers.GetValues("Date").Count());
+            Assert.Equal(" Sun, 06 Nov ", headers.GetValues("Date").First());
+        }
+
+        [Fact]
+        public void Via_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Via.Count);
+
+            headers.Via.Add(new ViaHeaderValue("x11", "host"));
+            headers.Via.Add(new ViaHeaderValue("1.1", "example.com:8080", "HTTP", "(comment)"));
+
+            Assert.Equal(2, headers.Via.Count);
+            Assert.Equal(new ViaHeaderValue("x11", "host"), headers.Via.ElementAt(0));
+            Assert.Equal(new ViaHeaderValue("1.1", "example.com:8080", "HTTP", "(comment)"),
+                headers.Via.ElementAt(1));
+
+            headers.Via.Clear();
+            Assert.Equal(0, headers.Via.Count);
+        }
+
+        [Fact]
+        public void Via_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Via", ", 1.1 host, WS/1.0 [::1],X/11 192.168.0.1 (c(comment)) ");
+
+            Assert.Equal(new ViaHeaderValue("1.1", "host"), headers.Via.ElementAt(0));
+            Assert.Equal(new ViaHeaderValue("1.0", "[::1]", "WS"), headers.Via.ElementAt(1));
+            Assert.Equal(new ViaHeaderValue("11", "192.168.0.1", "X", "(c(comment))"), headers.Via.ElementAt(2));
+
+            headers.Via.Clear();
+            headers.TryAddWithoutValidation("Via", "");
+            Assert.Equal(0, headers.Via.Count);
+            Assert.False(headers.Contains("Via"));
+        }
+
+        [Fact]
+        public void Via_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Via", "1.1 host1 1.1 host2"); // no separator
+            Assert.Equal(0, headers.Via.Count);
+            Assert.Equal(1, headers.GetValues("Via").Count());
+            Assert.Equal("1.1 host1 1.1 host2", headers.GetValues("Via").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Via", "X/11 host/1");
+            Assert.Equal(0, headers.Via.Count);
+            Assert.Equal(1, headers.GetValues("Via").Count());
+            Assert.Equal("X/11 host/1", headers.GetValues("Via").First());
+        }
+
+        [Fact]
+        public void Warning_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Warning.Count);
+
+            headers.Warning.Add(new WarningHeaderValue(199, "microsoft.com", "\"Miscellaneous warning\""));
+            headers.Warning.Add(new WarningHeaderValue(113, "example.com", "\"Heuristic expiration\""));
+
+            Assert.Equal(2, headers.Warning.Count);
+            Assert.Equal(new WarningHeaderValue(199, "microsoft.com", "\"Miscellaneous warning\""),
+                headers.Warning.ElementAt(0));
+            Assert.Equal(new WarningHeaderValue(113, "example.com", "\"Heuristic expiration\""),
+                headers.Warning.ElementAt(1));
+
+            headers.Warning.Clear();
+            Assert.Equal(0, headers.Warning.Count);
+        }
+
+        [Fact]
+        public void Warning_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Warning",
+                "112 example.com \"Disconnected operation\", 111 example.org \"Revalidation failed\"");
+
+            Assert.Equal(new WarningHeaderValue(112, "example.com", "\"Disconnected operation\""),
+                headers.Warning.ElementAt(0));
+            Assert.Equal(new WarningHeaderValue(111, "example.org", "\"Revalidation failed\""),
+                headers.Warning.ElementAt(1));
+
+            headers.Warning.Clear();
+            headers.TryAddWithoutValidation("Warning", "");
+            Assert.Equal(0, headers.Warning.Count);
+            Assert.False(headers.Contains("Warning"));
+        }
+
+        [Fact]
+        public void Warning_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Warning", "123 host1 \"\" 456 host2 \"\""); // no separator
+            Assert.Equal(0, headers.Warning.Count);
+            Assert.Equal(1, headers.GetValues("Warning").Count());
+            Assert.Equal("123 host1 \"\" 456 host2 \"\"", headers.GetValues("Warning").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Warning", "123 host1\"text\"");
+            Assert.Equal(0, headers.Warning.Count);
+            Assert.Equal(1, headers.GetValues("Warning").Count());
+            Assert.Equal("123 host1\"text\"", headers.GetValues("Warning").First());
+        }
+
+        [Fact]
+        public void CacheControl_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Null(headers.CacheControl);
+
+            CacheControlHeaderValue value = new CacheControlHeaderValue();
+            value.NoCache = true;
+            value.NoCacheHeaders.Add("token1");
+            value.NoCacheHeaders.Add("token2");
+            value.MustRevalidate = true;
+            value.SharedMaxAge = new TimeSpan(1, 2, 3);
+            headers.CacheControl = value;
+            Assert.Equal(value, headers.CacheControl);
+
+            headers.CacheControl = null;
+            Assert.Null(headers.CacheControl);
+            Assert.False(headers.Contains("Cache-Control"),
+                "Header store should not contain a header 'Cache-Control' after setting it to null.");
+        }
+
+        [Fact]
+        public void CacheControl_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Cache-Control", "no-cache=\"token1, token2\", must-revalidate, max-age=3");
+            headers.Add("Cache-Control", "");
+            headers.Add("Cache-Control", "public, s-maxage=15");
+            headers.TryAddWithoutValidation("Cache-Control", "");
+
+            CacheControlHeaderValue value = new CacheControlHeaderValue();
+            value.NoCache = true;
+            value.NoCacheHeaders.Add("token1");
+            value.NoCacheHeaders.Add("token2");
+            value.MustRevalidate = true;
+            value.MaxAge = new TimeSpan(0, 0, 3);
+            value.Public = true;
+            value.SharedMaxAge = new TimeSpan(0, 0, 15);
+            Assert.Equal(value, headers.CacheControl);
+        }
+
+        [Fact]
+        public void Trailer_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Trailer.Count);
+
+            headers.Trailer.Add("custom1");
+            headers.Trailer.Add("custom2");
+
+            Assert.Equal(2, headers.Trailer.Count);
+            Assert.Equal(2, headers.GetValues("Trailer").Count());
+
+            Assert.Equal("custom1", headers.Trailer.ElementAt(0));
+            Assert.Equal("custom2", headers.Trailer.ElementAt(1));
+
+            headers.Trailer.Clear();
+            Assert.Equal(0, headers.Trailer.Count);
+            Assert.False(headers.Contains("Trailer"),
+                "There should be no Trailer header after calling Clear().");
+        }
+
+        [Fact]
+        public void Trailer_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Trailer", ",custom1, custom2, custom3,");
+
+            Assert.Equal(3, headers.Trailer.Count);
+            Assert.Equal(3, headers.GetValues("Trailer").Count());
+
+            Assert.Equal("custom1", headers.Trailer.ElementAt(0));
+            Assert.Equal("custom2", headers.Trailer.ElementAt(1));
+            Assert.Equal("custom3", headers.Trailer.ElementAt(2));
+
+            headers.Trailer.Clear();
+            Assert.Equal(0, headers.Trailer.Count);
+            Assert.False(headers.Contains("Trailer"),
+                "There should be no Trailer header after calling Clear().");
+        }
+
+        [Fact]
+        public void Trailer_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Trailer", "custom1 custom2"); // no separator
+
+            Assert.Equal(0, headers.Trailer.Count);
+            Assert.Equal(1, headers.GetValues("Trailer").Count());
+            Assert.Equal("custom1 custom2", headers.GetValues("Trailer").First());
+        }
+
+        [Fact]
+        public void Pragma_ReadAndWriteProperty_ValueMatchesPriorSetValue()
+        {
+            Assert.Equal(0, headers.Pragma.Count);
+
+            headers.Pragma.Add(new NameValueHeaderValue("custom1", "value1"));
+            headers.Pragma.Add(new NameValueHeaderValue("custom2"));
+
+            Assert.Equal(2, headers.Pragma.Count);
+            Assert.Equal(2, headers.GetValues("Pragma").Count());
+
+            Assert.Equal(new NameValueHeaderValue("custom1", "value1"), headers.Pragma.ElementAt(0));
+            Assert.Equal(new NameValueHeaderValue("custom2"), headers.Pragma.ElementAt(1));
+
+            headers.Pragma.Clear();
+            Assert.Equal(0, headers.Pragma.Count);
+            Assert.False(headers.Contains("Pragma"),
+                "There should be no Pragma header after calling Clear().");
+        }
+
+        [Fact]
+        public void Pragma_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Pragma", ",custom1=value1, custom2, custom3=value3,");
+
+            Assert.Equal(3, headers.Pragma.Count);
+            Assert.Equal(3, headers.GetValues("Pragma").Count());
+
+            Assert.Equal(new NameValueHeaderValue("custom1", "value1"), headers.Pragma.ElementAt(0));
+            Assert.Equal(new NameValueHeaderValue("custom2"), headers.Pragma.ElementAt(1));
+            Assert.Equal(new NameValueHeaderValue("custom3", "value3"), headers.Pragma.ElementAt(2));
+
+            headers.Pragma.Clear();
+            Assert.Equal(0, headers.Pragma.Count);
+            Assert.False(headers.Contains("Pragma"),
+                "There should be no Pragma header after calling Clear().");
+        }
+
+        [Fact]
+        public void Pragma_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Pragma", "custom1, custom2=");
+
+            Assert.Equal(0, headers.Pragma.Count());
+            Assert.Equal(1, headers.GetValues("Pragma").Count());
+            Assert.Equal("custom1, custom2=", headers.GetValues("Pragma").First());
+        }
+
+        #endregion
+
+        [Fact]
+        public void ToString_SeveralRequestHeaders_Success()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+            string expected = string.Empty;
+
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/xml"));
+            expected += HttpKnownHeaderNames.Accept + ": application/xml, */xml\r\n";
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic");
+            expected += HttpKnownHeaderNames.Authorization + ": Basic\r\n";
+
+            request.Headers.ExpectContinue = true;
+            expected += HttpKnownHeaderNames.Expect + ": 100-continue\r\n";
+
+            request.Headers.TransferEncodingChunked = true;
+            expected += HttpKnownHeaderNames.TransferEncoding + ": chunked\r\n";
+
+            Assert.Equal(expected, request.Headers.ToString());
+        }
+
+        [Fact]
+        public void CustomHeaders_ResponseHeadersAsCustomHeaders_Success()
+        {
+            // Header names reserved for response headers are permitted as custom request headers.
+            headers.Add("Accept-Ranges", "v");
+            headers.TryAddWithoutValidation("age", "v");
+            headers.Add("ETag", "v");
+            headers.Add("Location", "v");
+            headers.Add("Proxy-Authenticate", "v");
+            headers.Add("Retry-After", "v");
+            headers.Add("Server", "v");
+            headers.Add("Vary", "v");
+            headers.Add("WWW-Authenticate", "v");
+        }
+
+        [Fact]
+        public void InvalidHeaders_AddContentHeaders_Throw()
+        {
+            // Try adding content headers. Use different casing to make sure case-insensitive comparison
+            // is used.
+
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Allow", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Encoding", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Language", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("content-length", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Location", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-MD5", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Range", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("CONTENT-TYPE", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Expires", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Last-Modified", "v"); });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpResponseHeadersTest.cs
@@ -1,0 +1,655 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpResponseHeadersTest
+    {
+        private HttpResponseHeaders headers;
+
+        public HttpResponseHeadersTest()
+        {
+            headers = new HttpResponseHeaders();
+        }
+
+        #region Response headers
+        [Fact]
+        public void Location_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Null(headers.Location);
+
+            Uri expected = new Uri("http://example.com/path/");
+            headers.Location = expected;
+            Assert.Equal(expected, headers.Location);
+
+            headers.Location = null;
+            Assert.Null(headers.Location);
+            Assert.False(headers.Contains("Location"),
+                "Header store should not contain a header 'Location' after setting it to null.");
+        }
+
+        [Fact]
+        public void Location_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            // just verify header names are compared using case-insensitive comparison.
+            headers.TryAddWithoutValidation("LoCaTiOn", "  http://www.example.com/path/?q=v  ");
+            Assert.Equal(new Uri("http://www.example.com/path/?q=v"), headers.Location);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Location", "http://host");
+            Assert.Equal(new Uri("http://host"), headers.Location);
+
+            // This violates the RFCs, the Location header should be absolute.  However,
+            // IIS and HttpListener do not enforce this requirement.
+            headers.Clear();
+            headers.Add("LoCaTiOn", "/relative/");
+            Assert.Equal<Uri>(new Uri("/relative/", UriKind.Relative), headers.Location);
+        }
+
+        [Fact]
+        public void Location_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Location", " http://example.com http://other");
+            Assert.Null(headers.GetParsedValues("Location"));
+            Assert.Equal(1, headers.GetValues("Location").Count());
+            Assert.Equal(" http://example.com http://other", headers.GetValues("Location").First());
+        }
+
+        [Fact]
+        public void Location_RequiresEncoding_Encoded()
+        {
+            // Absolute
+            headers.Location = new Uri("http://www.example\u30AF.com/%25path\u30AF/?q=v\u30AF");
+            IEnumerable<string> values = headers.GetValues("Location");
+            string[] strings = values.ToArray<string>();
+            Assert.Equal(1, strings.Length);
+            Assert.Equal("http://www.example\u30AF.com/%25path%E3%82%AF/?q=v%E3%82%AF", strings[0]);
+
+            headers.Clear();
+
+            // Relative
+            headers.Location = new Uri("%25path\u30AF/?q=v\u30AF", UriKind.Relative);
+            values = headers.GetValues("Location");
+            strings = values.ToArray<string>();
+            Assert.Equal(1, strings.Length);
+            Assert.Equal("%25path%E3%82%AF/?q=v%E3%82%AF", strings[0]);
+        }
+
+        [Fact]
+        public void ETag_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Null(headers.ETag);
+
+            EntityTagHeaderValue etag = new EntityTagHeaderValue("\"tag\"", true);
+            headers.ETag = etag;
+            Assert.Same(etag, headers.ETag);
+
+            headers.ETag = null;
+            Assert.Null(headers.ETag);
+            Assert.False(headers.Contains("ETag"),
+                "Header store should not contain a header 'ETag' after setting it to null.");
+        }
+
+        [Fact]
+        public void ETag_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("ETag", "W/\"tag\"");
+            Assert.Equal(new EntityTagHeaderValue("\"tag\"", true), headers.ETag);
+        }
+
+        [Fact]
+        public void ETag_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("ETag", ",\"tag\""); // leading separator
+            Assert.Null(headers.ETag);
+            Assert.Equal(1, headers.GetValues("ETag").Count());
+            Assert.Equal(",\"tag\"", headers.GetValues("ETag").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("ETag", "\"tag\","); // trailing separator
+            Assert.Null(headers.ETag);
+            Assert.Equal(1, headers.GetValues("ETag").Count());
+            Assert.Equal("\"tag\",", headers.GetValues("ETag").First());
+        }
+
+        [Fact]
+        public void AcceptRanges_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.AcceptRanges.Count);
+
+            headers.AcceptRanges.Add("custom1");
+            headers.AcceptRanges.Add("custom2");
+
+            Assert.Equal(2, headers.AcceptRanges.Count);
+            Assert.Equal(2, headers.GetValues("Accept-Ranges").Count());
+
+            Assert.Equal("custom1", headers.AcceptRanges.ElementAt(0));
+            Assert.Equal("custom2", headers.AcceptRanges.ElementAt(1));
+
+            headers.AcceptRanges.Clear();
+            Assert.Equal(0, headers.AcceptRanges.Count);
+            Assert.False(headers.Contains("Accept-Ranges"),
+                "There should be no Accept-Ranges header after calling Clear().");
+        }
+
+        [Fact]
+        public void AcceptRanges_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Accept-Ranges", ",custom1, custom2, custom3,");
+
+            Assert.Equal(3, headers.AcceptRanges.Count);
+            Assert.Equal(3, headers.GetValues("Accept-Ranges").Count());
+
+            Assert.Equal("custom1", headers.AcceptRanges.ElementAt(0));
+            Assert.Equal("custom2", headers.AcceptRanges.ElementAt(1));
+            Assert.Equal("custom3", headers.AcceptRanges.ElementAt(2));
+
+            headers.AcceptRanges.Clear();
+            Assert.Equal(0, headers.AcceptRanges.Count);
+            Assert.False(headers.Contains("Accept-Ranges"),
+                "There should be no Accept-Ranges header after calling Clear().");
+        }
+
+        [Fact]
+        public void AcceptRanges_AddInvalidValue_Throw()
+        {
+            Assert.Throws<FormatException>(() => { headers.AcceptRanges.Add("this is invalid"); });
+        }
+
+        [Fact]
+        public void AcceptRanges_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Accept-Ranges", "custom1 custom2"); // no separator
+
+            Assert.Equal(0, headers.AcceptRanges.Count);
+            Assert.Equal(1, headers.GetValues("Accept-Ranges").Count());
+            Assert.Equal("custom1 custom2", headers.GetValues("Accept-Ranges").First());
+        }
+
+        [Fact]
+        public void WwwAuthenticate_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.WwwAuthenticate.Count);
+
+            headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("NTLM"));
+            headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\""));
+
+            Assert.Equal(2, headers.WwwAuthenticate.Count);
+            Assert.Equal(2, headers.GetValues("WWW-Authenticate").Count());
+
+            Assert.Equal(new AuthenticationHeaderValue("NTLM"),
+                headers.WwwAuthenticate.ElementAt(0));
+            Assert.Equal(new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\""),
+                headers.WwwAuthenticate.ElementAt(1));
+
+            headers.WwwAuthenticate.Clear();
+            Assert.Equal(0, headers.WwwAuthenticate.Count);
+            Assert.False(headers.Contains("WWW-Authenticate"),
+                "There should be no WWW-Authenticate header after calling Clear().");
+        }
+
+        [Fact]
+        public void WwwAuthenticate_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.Add("WWW-Authenticate", "Negotiate");
+            headers.TryAddWithoutValidation("WWW-Authenticate", "Basic realm=\"contoso.com\", Digest a=b, c=d, NTLM");
+            headers.TryAddWithoutValidation("WWW-Authenticate", "Kerberos");
+
+            Assert.Equal(5, headers.WwwAuthenticate.Count);
+            Assert.Equal(5, headers.GetValues("WWW-Authenticate").Count());
+
+            Assert.Equal(new AuthenticationHeaderValue("Negotiate"),
+                headers.WwwAuthenticate.ElementAt(0));
+            Assert.Equal(new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\""),
+                headers.WwwAuthenticate.ElementAt(1));
+            Assert.Equal(new AuthenticationHeaderValue("Digest", "a=b, c=d"),
+                headers.WwwAuthenticate.ElementAt(2));
+            Assert.Equal(new AuthenticationHeaderValue("NTLM"),
+                headers.WwwAuthenticate.ElementAt(3));
+            Assert.Equal(new AuthenticationHeaderValue("Kerberos"),
+                headers.WwwAuthenticate.ElementAt(4));
+
+            headers.WwwAuthenticate.Clear();
+            Assert.Equal(0, headers.WwwAuthenticate.Count);
+            Assert.False(headers.Contains("WWW-Authenticate"),
+                "There should be no WWW-Authenticate header after calling Clear().");
+        }
+
+        [Fact]
+        public void ProxyAuthenticate_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.ProxyAuthenticate.Count);
+
+            headers.ProxyAuthenticate.Add(new AuthenticationHeaderValue("NTLM"));
+            headers.ProxyAuthenticate.Add(new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\""));
+
+            Assert.Equal(2, headers.ProxyAuthenticate.Count);
+            Assert.Equal(2, headers.GetValues("Proxy-Authenticate").Count());
+
+            Assert.Equal(new AuthenticationHeaderValue("NTLM"),
+                headers.ProxyAuthenticate.ElementAt(0));
+            Assert.Equal(new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\""),
+                headers.ProxyAuthenticate.ElementAt(1));
+
+            headers.ProxyAuthenticate.Clear();
+            Assert.Equal(0, headers.ProxyAuthenticate.Count);
+            Assert.False(headers.Contains("Proxy-Authenticate"),
+                "There should be no Proxy-Authenticate header after calling Clear().");
+        }
+
+        [Fact]
+        public void ProxyAuthenticate_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.Add("Proxy-Authenticate", "Negotiate");
+            headers.TryAddWithoutValidation("Proxy-Authenticate", "Basic realm=\"contoso.com\"");
+            headers.TryAddWithoutValidation("Proxy-Authenticate", "NTLM");
+
+            Assert.Equal(3, headers.ProxyAuthenticate.Count);
+            Assert.Equal(3, headers.GetValues("Proxy-Authenticate").Count());
+
+            Assert.Equal(new AuthenticationHeaderValue("Negotiate"),
+                headers.ProxyAuthenticate.ElementAt(0));
+            Assert.Equal(new AuthenticationHeaderValue("Basic", "realm=\"contoso.com\""),
+                headers.ProxyAuthenticate.ElementAt(1));
+            Assert.Equal(new AuthenticationHeaderValue("NTLM"),
+                headers.ProxyAuthenticate.ElementAt(2));
+
+            headers.ProxyAuthenticate.Clear();
+            Assert.Equal(0, headers.ProxyAuthenticate.Count);
+            Assert.False(headers.Contains("Proxy-Authenticate"),
+                "There should be no Proxy-Authenticate header after calling Clear().");
+        }
+
+        [Fact]
+        public void Server_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Server.Count);
+
+            headers.Server.Add(new ProductInfoHeaderValue("(custom1)"));
+            headers.Server.Add(new ProductInfoHeaderValue("custom2", "1.1"));
+
+            Assert.Equal(2, headers.Server.Count);
+            Assert.Equal(2, headers.GetValues("Server").Count());
+            Assert.Equal(new ProductInfoHeaderValue("(custom1)"), headers.Server.ElementAt(0));
+            Assert.Equal(new ProductInfoHeaderValue("custom2", "1.1"), headers.Server.ElementAt(1));
+
+            headers.Server.Clear();
+            Assert.Equal(0, headers.Server.Count);
+            Assert.False(headers.Contains("Server"), "Server header should be removed after calling Clear().");
+
+            headers.Server.Add(new ProductInfoHeaderValue("(comment)"));
+            headers.Server.Remove(new ProductInfoHeaderValue("(comment)"));
+            Assert.Equal(0, headers.Server.Count);
+            Assert.False(headers.Contains("Server"), "Server header should be removed after removing last value.");
+        }
+
+        [Fact]
+        public void Server_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Server", "CERN/3.0 libwww/2.17 (mycomment)");
+
+            Assert.Equal(3, headers.Server.Count);
+            Assert.Equal(3, headers.GetValues("Server").Count());
+
+            Assert.Equal(new ProductInfoHeaderValue("CERN", "3.0"), headers.Server.ElementAt(0));
+            Assert.Equal(new ProductInfoHeaderValue("libwww", "2.17"), headers.Server.ElementAt(1));
+            Assert.Equal(new ProductInfoHeaderValue("(mycomment)"), headers.Server.ElementAt(2));
+
+            headers.Server.Clear();
+            Assert.Equal(0, headers.Server.Count);
+            Assert.False(headers.Contains("Server"), "Server header should be removed after calling Clear().");
+        }
+
+        [Fact]
+        public void Server_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Server", "custom会");
+            Assert.Null(headers.GetParsedValues("Server"));
+            Assert.Equal(1, headers.GetValues("Server").Count());
+            Assert.Equal("custom会", headers.GetValues("Server").First());
+
+            headers.Clear();
+            // Note that "Server" uses whitespaces as separators, so the following is an invalid value
+            headers.TryAddWithoutValidation("Server", "custom1, custom2");
+            Assert.Null(headers.GetParsedValues("Server"));
+            Assert.Equal(1, headers.GetValues("Server").Count());
+            Assert.Equal("custom1, custom2", headers.GetValues("Server").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Server", "custom1, ");
+            Assert.Null(headers.GetParsedValues("Server"));
+            Assert.Equal(1, headers.GetValues("Server").Count());
+            Assert.Equal("custom1, ", headers.GetValues("Server").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Server", ",custom1");
+            Assert.Null(headers.GetParsedValues("Server"));
+            Assert.Equal(1, headers.GetValues("Server").Count());
+            Assert.Equal(",custom1", headers.GetValues("Server").First());
+        }
+
+        [Fact]
+        public void RetryAfter_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Null(headers.RetryAfter);
+
+            RetryConditionHeaderValue retry = new RetryConditionHeaderValue(new TimeSpan(0, 1, 10));
+            headers.RetryAfter = retry;
+            Assert.Same(retry, headers.RetryAfter);
+
+            headers.RetryAfter = null;
+            Assert.Null(headers.RetryAfter);
+            Assert.False(headers.Contains("RetryAfter"),
+                "Header store should not contain a header 'ETag' after setting it to null.");
+        }
+
+        [Fact]
+        public void RetryAfter_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Retry-After", " 2100000 ");
+            Assert.Equal(new RetryConditionHeaderValue(new TimeSpan(0, 0, 2100000)), headers.RetryAfter);
+        }
+
+        [Fact]
+        public void RetryAfter_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Retry-After", "123,"); // trailing separator
+            Assert.Null(headers.RetryAfter);
+            Assert.Equal(1, headers.GetValues("Retry-After").Count());
+            Assert.Equal("123,", headers.GetValues("Retry-After").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Retry-After", ",Sun, 06 Nov 1994 08:49:37 GMT"); // leading separator
+            Assert.Null(headers.RetryAfter);
+            Assert.Equal(1, headers.GetValues("Retry-After").Count());
+            Assert.Equal(",Sun, 06 Nov 1994 08:49:37 GMT", headers.GetValues("Retry-After").First());
+        }
+
+        [Fact]
+        public void Vary_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Vary.Count);
+
+            headers.Vary.Add("custom1");
+            headers.Vary.Add("custom2");
+
+            Assert.Equal(2, headers.Vary.Count);
+            Assert.Equal(2, headers.GetValues("Vary").Count());
+
+            Assert.Equal("custom1", headers.Vary.ElementAt(0));
+            Assert.Equal("custom2", headers.Vary.ElementAt(1));
+
+            headers.Vary.Clear();
+            Assert.Equal(0, headers.Vary.Count);
+            Assert.False(headers.Contains("Vary"),
+                "There should be no Vary header after calling Clear().");
+        }
+
+        [Fact]
+        public void Vary_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Vary", ",custom1, custom2, custom3,");
+
+            Assert.Equal(3, headers.Vary.Count);
+            Assert.Equal(3, headers.GetValues("Vary").Count());
+
+            Assert.Equal("custom1", headers.Vary.ElementAt(0));
+            Assert.Equal("custom2", headers.Vary.ElementAt(1));
+            Assert.Equal("custom3", headers.Vary.ElementAt(2));
+
+            headers.Vary.Clear();
+            Assert.Equal(0, headers.Vary.Count);
+            Assert.False(headers.Contains("Vary"),
+                "There should be no Vary header after calling Clear().");
+        }
+
+        [Fact]
+        public void Vary_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Vary", "custom1 custom2"); // no separator
+
+            Assert.Equal(0, headers.Vary.Count);
+            Assert.Equal(1, headers.GetValues("Vary").Count());
+            Assert.Equal("custom1 custom2", headers.GetValues("Vary").First());
+        }
+
+        [Fact]
+        public void Age_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Null(headers.Age);
+
+            TimeSpan expected = new TimeSpan(0, 1, 2);
+            headers.Age = expected;
+            Assert.Equal(expected, headers.Age);
+
+            headers.Age = null;
+            Assert.Null(headers.Age);
+            Assert.False(headers.Contains("Age"),
+                "Header store should not contain a header 'Age' after setting it to null.");
+
+            // Make sure the header gets serialized correctly
+            headers.Age = new TimeSpan(0, 1, 2);
+            Assert.Equal("62", headers.GetValues("Age").First());
+        }
+
+        [Fact]
+        public void Age_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
+        {
+            headers.TryAddWithoutValidation("Age", "  15  ");
+            Assert.Equal(new TimeSpan(0, 0, 15), headers.Age);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Age", "0");
+            Assert.Equal(new TimeSpan(0, 0, 0), headers.Age);
+        }
+
+        [Fact]
+        public void Age_UseAddMethodWithInvalidValue_InvalidValueRecognized()
+        {
+            headers.TryAddWithoutValidation("Age", "10,");
+            Assert.Null(headers.GetParsedValues("Age"));
+            Assert.Equal(1, headers.GetValues("Age").Count());
+            Assert.Equal("10,", headers.GetValues("Age").First());
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Age", "1.1");
+            Assert.Null(headers.GetParsedValues("Age"));
+            Assert.Equal(1, headers.GetValues("Age").Count());
+            Assert.Equal("1.1", headers.GetValues("Age").First());
+        }
+
+        #endregion
+
+        // General headers are tested in more detail in HttpRequestHeadersTest. This file only makes sure
+        // HttpResponseHeaders correctly forwards calls to HttpGeneralHeaders.
+        #region General headers
+
+        [Fact]
+        public void Connection_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Connection.Count);
+            Assert.Null(headers.ConnectionClose);
+
+            headers.Connection.Add("custom1");
+            headers.ConnectionClose = true;
+
+            // Connection collection has 1 values plus 'close'
+            Assert.Equal(2, headers.Connection.Count);
+            Assert.Equal(2, headers.GetValues("Connection").Count());
+            Assert.True(headers.ConnectionClose == true, "ConnectionClose");
+
+            headers.TryAddWithoutValidation("Connection", "custom2");
+            Assert.Equal(3, headers.Connection.Count);
+            Assert.Equal(3, headers.GetValues("Connection").Count());
+        }
+
+        [Fact]
+        public void TransferEncoding_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.TransferEncoding.Count);
+            Assert.Null(headers.TransferEncodingChunked);
+
+            headers.TransferEncoding.Add(new TransferCodingHeaderValue("custom1"));
+            headers.TransferEncodingChunked = true;
+
+            // Connection collection has 1 value plus 'chunked'
+            Assert.Equal(2, headers.TransferEncoding.Count);
+            Assert.Equal(2, headers.GetValues("Transfer-Encoding").Count());
+            Assert.Equal(true, headers.TransferEncodingChunked);
+
+            // Note that 'chunked' is already in the collection, we add 'chunked' again here. Therefore the total 
+            // number of headers is 4 (2x customm, 2x 'chunked').
+            headers.TryAddWithoutValidation("Transfer-Encoding", " , custom2, chunked ,");
+            Assert.Equal(4, headers.TransferEncoding.Count);
+            Assert.Equal(4, headers.GetValues("Transfer-Encoding").Count());
+        }
+
+        [Fact]
+        public void Upgrade_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Upgrade.Count);
+
+            headers.Upgrade.Add(new ProductHeaderValue("custom1"));
+
+            Assert.Equal(1, headers.Upgrade.Count);
+            Assert.Equal(1, headers.GetValues("Upgrade").Count());
+
+            headers.TryAddWithoutValidation("Upgrade", " , custom1 / 1.0, ");
+            Assert.Equal(2, headers.Upgrade.Count);
+            Assert.Equal(2, headers.GetValues("Upgrade").Count());
+        }
+
+        [Fact]
+        public void Date_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Null(headers.Date);
+
+            DateTimeOffset expected = DateTimeOffset.Now;
+            headers.Date = expected;
+            Assert.Equal(expected, headers.Date);
+
+            headers.Clear();
+            headers.TryAddWithoutValidation("Date", "  Sun, 06 Nov 1994 08:49:37 GMT  ");
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), headers.Date);
+        }
+
+        [Fact]
+        public void Via_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Via.Count);
+
+            headers.Via.Add(new ViaHeaderValue("x11", "host"));
+
+            Assert.Equal(1, headers.Via.Count);
+
+            headers.TryAddWithoutValidation("Via", ", 1.1 host2");
+            Assert.Equal(2, headers.Via.Count);
+        }
+
+        [Fact]
+        public void Warning_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Warning.Count);
+
+            headers.Warning.Add(new WarningHeaderValue(199, "microsoft.com", "\"Miscellaneous warning\""));
+
+            Assert.Equal(1, headers.Warning.Count);
+
+            headers.TryAddWithoutValidation("Warning", "112 example.com \"Disconnected operation\"");
+            Assert.Equal(2, headers.Warning.Count);
+        }
+
+        [Fact]
+        public void CacheControl_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Null(headers.CacheControl);
+
+            CacheControlHeaderValue value = new CacheControlHeaderValue();
+            value.NoCache = true;
+            headers.CacheControl = value;
+            Assert.Equal(value, headers.CacheControl);
+
+            headers.TryAddWithoutValidation("Cache-Control", "must-revalidate");
+            value = new CacheControlHeaderValue();
+            value.NoCache = true;
+            value.MustRevalidate = true;
+            Assert.Equal(value, headers.CacheControl);
+        }
+
+        [Fact]
+        public void Trailer_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Trailer.Count);
+
+            headers.Trailer.Add("custom1");
+
+            Assert.Equal(1, headers.Trailer.Count);
+
+            headers.TryAddWithoutValidation("Trailer", ",custom2, ,");
+            Assert.Equal(2, headers.Trailer.Count);
+        }
+
+        [Fact]
+        public void Pragma_ReadAndWriteProperty_CallsForwardedToHttpGeneralHeaders()
+        {
+            Assert.Equal(0, headers.Pragma.Count);
+
+            headers.Pragma.Add(new NameValueHeaderValue("custom1", "value1"));
+
+            Assert.Equal(1, headers.Pragma.Count);
+
+            headers.TryAddWithoutValidation("Pragma", "custom2");
+            Assert.Equal(2, headers.Pragma.Count);
+        }
+
+        #endregion
+
+        [Fact]
+        public void CustomHeaders_RequestHeadersAsCustomHeaders_Success()
+        {
+            // Header names reserved for request headers are permitted as custom response headers.
+            headers.Add("Accept", "v");
+            headers.Add("Accept-Charset", "v");
+            headers.Add("Accept-Encoding", "v");
+            headers.Add("Accept-Language", "v");
+            headers.Add("Authorization", "v");
+            headers.Add("Expect", "v");
+            headers.Add("From", "v");
+            headers.Add("Host", "v");
+            headers.Add("If-Match", "v");
+            headers.Add("If-Modified-Since", "v");
+            headers.Add("If-None-Match", "v");
+            headers.Add("If-Range", "v");
+            headers.Add("If-Unmodified-Since", "v");
+            headers.Add("Max-Forwards", "v");
+            headers.Add("Proxy-Authorization", "v");
+            headers.Add("Range", "v");
+            headers.Add("Referer", "v");
+            headers.Add("TE", "v");
+            headers.Add("User-Agent", "v");
+        }
+
+        [Fact]
+        public void InvalidHeaders_AddContentHeaders_Throw()
+        {
+            // Try adding content headers. Use different casing to make sure case-insensitive comparison
+            // is used.
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Allow", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Encoding", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Language", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("content-length", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Location", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-MD5", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Content-Range", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("CONTENT-TYPE", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Expires", "v"); });
+            Assert.Throws<InvalidOperationException>(() => { headers.Add("Last-Modified", "v"); });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/Int32NumberHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/Int32NumberHeaderParserTest.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class Int32NumberHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+            Assert.False(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_ValidValue_ReturnsLongValue()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+            int index = 2;
+            Assert.Equal((int)15, parser.ParseValue("  15", null, ref index));
+            Assert.Equal(4, index);
+
+            index = 0;
+            Assert.Equal((int)15, parser.ParseValue("  15", null, ref index));
+            Assert.Equal(4, index);
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throw()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue("a", null, ref index); });
+        }
+
+        [Fact]
+        public void Parse_NullValue_Throw()
+        {
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue(null, null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("1234567890", 0, 1234567890, 10);
+            CheckValidParsedValue("0", 0, 0, 1);
+            CheckValidParsedValue("000015", 0, 15, 6);
+            CheckValidParsedValue(" 123 \t\r\n ", 0, 123, 9);
+            CheckValidParsedValue("a 5 \r\n ", 1, 5, 7);
+            CheckValidParsedValue(" 987", 0, 987, 4);
+            CheckValidParsedValue("987 ", 0, 987, 4);
+            CheckValidParsedValue("a456", 1, 456, 4);
+            CheckValidParsedValue("a456 ", 1, 456, 5);
+            CheckValidParsedValue("2147483647", 0, int.MaxValue, 10);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("", 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("a", 0);
+            CheckInvalidParsedValue(".123", 0);
+            CheckInvalidParsedValue(".", 0);
+            CheckInvalidParsedValue("12a", 0);
+            CheckInvalidParsedValue("a12b", 1);
+            CheckInvalidParsedValue("123 1", 0);
+            CheckInvalidParsedValue("123.1", 0);
+            CheckInvalidParsedValue(" 123 1", 0);
+            CheckInvalidParsedValue("a 123 1", 1);
+            CheckInvalidParsedValue("a 123 1 ", 1);
+            CheckInvalidParsedValue("-123.1", 0);
+            CheckInvalidParsedValue("-123", 0);
+            CheckInvalidParsedValue("123456789012345678901234567890", 0); // value >> Int32.MaxValue
+            CheckInvalidParsedValue("2147483648", 0); // value = Int32.MaxValue + 1
+        }
+
+        [Fact]
+        public void ToString_UseDifferentValues_MatchExpectation()
+        {
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+
+            Assert.Equal("1234567890", parser.ToString(1234567890));
+            Assert.Equal("0", parser.ToString(0));
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, int expectedResult, int expectedIndex)
+        {
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+            object result = 0;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedIndex, startIndex);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            Int32NumberHeaderParser parser = Int32NumberHeaderParser.Parser;
+            object result = 0;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/Int64NumberHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/Int64NumberHeaderParserTest.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+namespace System.Net.Http.Unit.Tests
+{
+    public class Int64NumberHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+            Assert.False(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_ValidValue_ReturnsLongValue()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+            int index = 2;
+            Assert.Equal((long)15, parser.ParseValue("  15", null, ref index));
+            Assert.Equal(4, index);
+
+            index = 0;
+            Assert.Equal((long)15, parser.ParseValue("  15", null, ref index));
+            Assert.Equal(4, index);
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throw()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue("a", null, ref index); });
+        }
+
+        [Fact]
+        public void Parse_NullValue_Throw()
+        {
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue(null, null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("123456789012345", 0, 123456789012345, 15);
+            CheckValidParsedValue("0", 0, 0, 1);
+            CheckValidParsedValue("000015", 0, 15, 6);
+            CheckValidParsedValue(" 123 \t\r\n ", 0, 123, 9);
+            CheckValidParsedValue("a 5 \r\n ", 1, 5, 7);
+            CheckValidParsedValue(" 987", 0, 987, 4);
+            CheckValidParsedValue("987 ", 0, 987, 4);
+            CheckValidParsedValue("a456", 1, 456, 4);
+            CheckValidParsedValue("a456 ", 1, 456, 5);
+            CheckValidParsedValue("9223372036854775807", 0, long.MaxValue, 19);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("", 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("a", 0);
+            CheckInvalidParsedValue(".123", 0);
+            CheckInvalidParsedValue(".", 0);
+            CheckInvalidParsedValue("12a", 0);
+            CheckInvalidParsedValue("a12b", 1);
+            CheckInvalidParsedValue("123 1", 0);
+            CheckInvalidParsedValue("123.1", 0);
+            CheckInvalidParsedValue(" 123 1", 0);
+            CheckInvalidParsedValue("a 123 1", 1);
+            CheckInvalidParsedValue("a 123 1 ", 1);
+            CheckInvalidParsedValue("-123.1", 0);
+            CheckInvalidParsedValue("-123", 0);
+            CheckInvalidParsedValue("123456789012345678901234567890", 0); // value >> Int64.MaxValue
+            CheckInvalidParsedValue("9223372036854775808", 0); // value = Int64.MaxValue + 1
+        }
+
+        [Fact]
+        public void ToString_UseDifferentValues_MatchExpectation()
+        {
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+
+            Assert.Equal("123456789012345", parser.ToString((long)123456789012345));
+            Assert.Equal("0", parser.ToString((long)0));
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, long expectedResult, int expectedIndex)
+        {
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+            object result = 0;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedIndex, startIndex);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            Int64NumberHeaderParser parser = Int64NumberHeaderParser.Parser;
+            object result = 0;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/MediaTypeHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/MediaTypeHeaderParserTest.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class MediaTypeHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            MediaTypeHeaderParser parser = MediaTypeHeaderParser.SingleValueParser;
+            Assert.False(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+
+            parser = MediaTypeHeaderParser.MultipleValuesParser;
+            Assert.True(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_ValidValue_ReturnsMediaTypeHeaderValue()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            MediaTypeHeaderParser parser = MediaTypeHeaderParser.SingleValueParser;
+            int index = 2;
+
+            MediaTypeHeaderValue expected = new MediaTypeHeaderValue("text/plain");
+            expected.CharSet = "utf-8";
+            Assert.True(expected.Equals(parser.ParseValue("   text / plain ; charset = utf-8 ", null, ref index)));
+            Assert.Equal(34, index);
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throw()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            MediaTypeHeaderParser parser = MediaTypeHeaderParser.SingleValueParser;
+            int index = 0;
+            
+            // only one value allowed.
+            Assert.Throws<FormatException>(() => { parser.ParseValue("text/plain; charset=utf-8, next/mediatype", null, ref index); });
+        }
+
+        [Fact]
+        public void Parse_NullValue_Throw()
+        {
+            MediaTypeHeaderParser parser = MediaTypeHeaderParser.SingleValueParser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue(null, null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStringsForMediaType_ParsedCorrectly()
+        {
+            MediaTypeHeaderValue expected = new MediaTypeHeaderValue("text/plain");
+            CheckValidParsedValue("\r\n text/plain  ", 0, expected, 15, false);
+            CheckValidParsedValue("text/plain", 0, expected, 10, false);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // media-type parser.
+            expected.CharSet = "utf-8";
+            CheckValidParsedValue("\r\n text   /  plain ;  charset =   utf-8 ", 0, expected, 40, false);
+            CheckValidParsedValue("  text/plain;charset=utf-8", 2, expected, 26, false);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStringsForMediaTypeWithQuality_ParsedCorrectly()
+        {
+            MediaTypeWithQualityHeaderValue expected = new MediaTypeWithQualityHeaderValue("text/plain");
+            CheckValidParsedValue("\r\n text/plain  ", 0, expected, 15, true);
+            CheckValidParsedValue("text/plain", 0, expected, 10, true);
+            CheckValidParsedValue("\r\n text/plain  , next/mediatype", 0, expected, 17, true);
+            CheckValidParsedValue("text/plain, next/mediatype", 0, expected, 12, true);
+            CheckValidParsedValue("  ", 0, null, 2, true);
+            CheckValidParsedValue("", 0, null, 0, true);
+            CheckValidParsedValue(null, 0, null, 0, true);
+            CheckValidParsedValue("  ,,", 0, null, 4, true);
+
+            // Note that even if the whole string is invalid, the first media-type value is valid. When the parser
+            // gets called again using the result-index (13), then it fails: I.e. we have 1 valid media-type and an
+            // invalid one.
+            CheckValidParsedValue("text/plain , invalid", 0, expected, 13, true);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // media-type parser.
+            expected.CharSet = "utf-8";
+            CheckValidParsedValue("\r\n text   /  plain ;  charset =   utf-8 ", 0, expected, 40, true);
+            CheckValidParsedValue("  text/plain;charset=utf-8", 2, expected, 26, true);
+            CheckValidParsedValue("\r\n text   /  plain ;  charset =   utf-8  , next/mediatype", 0, expected, 43, true);
+            CheckValidParsedValue("  text/plain;charset=utf-8, next/mediatype", 2, expected, 28, true);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("", 0, false);
+            CheckInvalidParsedValue("  ", 0, false);
+            CheckInvalidParsedValue(null, 0, false);
+            CheckInvalidParsedValue("text/plain会", 0, true);
+            CheckInvalidParsedValue("text/plain会", 0, false);
+            CheckInvalidParsedValue("text/plain ,", 0, false);
+            CheckInvalidParsedValue("text/plain,", 0, false);
+            CheckInvalidParsedValue("text/plain; charset=utf-8 ,", 0, false);
+            CheckInvalidParsedValue("text/plain; charset=utf-8,", 0, false);
+            CheckInvalidParsedValue("textplain", 0, true);
+            CheckInvalidParsedValue("textplain", 0, false);
+            CheckInvalidParsedValue("text/", 0, true);
+            CheckInvalidParsedValue("text/", 0, false);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, MediaTypeHeaderValue expectedResult,
+            int expectedIndex, bool supportsMultipleValues)
+        {
+            MediaTypeHeaderParser parser = null;
+            if (supportsMultipleValues)
+            {
+                parser = MediaTypeHeaderParser.MultipleValuesParser;
+            }
+            else
+            {
+                parser = MediaTypeHeaderParser.SingleValueParser;
+            }
+
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}', Index: {1}", input, startIndex));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex, bool supportsMultipleValues)
+        {
+            MediaTypeHeaderParser parser = null;
+            if (supportsMultipleValues)
+            {
+                parser = MediaTypeHeaderParser.MultipleValuesParser;
+            }
+            else
+            {
+                parser = MediaTypeHeaderParser.SingleValueParser;
+            }
+
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}', Index: {1}", input, startIndex));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/MediaTypeHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/MediaTypeHeaderValueTest.cs
@@ -1,0 +1,392 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class MediaTypeHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_MediaTypeNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { new MediaTypeHeaderValue(null); });
+        }
+
+        [Fact]
+        public void Ctor_MediaTypeEmpty_Throw()
+        {
+            // null and empty should be treated the same. So we also throw for empty strings.
+            Assert.Throws<ArgumentException>(() => { new MediaTypeHeaderValue(string.Empty); });
+        }
+
+        [Fact]
+        public void Ctor_MediaTypeInvalidFormat_ThrowFormatException()
+        {
+            // When adding values using strongly typed objects, no leading/trailing LWS (whitespaces) are allowed.
+            AssertFormatException(" text/plain ");
+            AssertFormatException("text / plain");
+            AssertFormatException("text/ plain");
+            AssertFormatException("text /plain");
+            AssertFormatException("text/plain ");
+            AssertFormatException(" text/plain");
+            AssertFormatException("te xt/plain");
+            AssertFormatException("te=xt/plain");
+            AssertFormatException("teäxt/plain");
+            AssertFormatException("text/pläin");
+            AssertFormatException("text");
+            AssertFormatException("\"text/plain\"");
+            AssertFormatException("text/plain; charset=utf-8; ");
+            AssertFormatException("text/plain;");
+            AssertFormatException("text/plain;charset=utf-8"); // ctor takes only media-type name, no parameters
+        }
+
+        [Fact]
+        public void Ctor_MediaTypeValidFormat_SuccessfullyCreated()
+        {
+            MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("text/plain");
+            Assert.Equal("text/plain", mediaType.MediaType);
+            Assert.Equal(0, mediaType.Parameters.Count);
+            Assert.Null(mediaType.CharSet);
+        }
+
+        [Fact]
+        public void Parameters_AddNull_Throw()
+        {
+            MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("text/plain");
+            
+            Assert.Throws<ArgumentNullException>(() => { mediaType.Parameters.Add(null); });
+        }
+
+        [Fact]
+        public void MediaType_SetAndGetMediaType_MatchExpectations()
+        {
+            MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("text/plain");
+            Assert.Equal("text/plain", mediaType.MediaType);
+
+            mediaType.MediaType = "application/xml";
+            Assert.Equal("application/xml", mediaType.MediaType);
+        }
+
+        [Fact]
+        public void CharSet_SetCharSetAndValidateObject_ParametersEntryForCharSetAdded()
+        {
+            MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("text/plain");
+            mediaType.CharSet = "mycharset";
+            Assert.Equal("mycharset", mediaType.CharSet);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("charset", mediaType.Parameters.First().Name);
+
+            mediaType.CharSet = null;
+            Assert.Null(mediaType.CharSet);
+            Assert.Equal(0, mediaType.Parameters.Count);
+            mediaType.CharSet = null; // It's OK to set it again to null; no exception.
+        }
+
+        [Fact]
+        public void CharSet_AddCharSetParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("text/plain");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue charset = new NameValueHeaderValue("CHARSET", "old_charset");
+            mediaType.Parameters.Add(charset);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("CHARSET", mediaType.Parameters.First().Name);
+
+            mediaType.CharSet = "new_charset";
+            Assert.Equal("new_charset", mediaType.CharSet);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("CHARSET", mediaType.Parameters.First().Name);
+
+            mediaType.Parameters.Remove(charset);
+            Assert.Null(mediaType.CharSet);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentMediaTypes_AllSerializedCorrectly()
+        {
+            MediaTypeHeaderValue mediaType = new MediaTypeHeaderValue("text/plain");
+            Assert.Equal("text/plain", mediaType.ToString());
+
+            mediaType.CharSet = "utf-8";
+            Assert.Equal("text/plain; charset=utf-8", mediaType.ToString());
+
+            mediaType.Parameters.Add(new NameValueHeaderValue("custom", "\"custom value\""));
+            Assert.Equal("text/plain; charset=utf-8; custom=\"custom value\"", mediaType.ToString());
+
+            mediaType.CharSet = null;
+            Assert.Equal("text/plain; custom=\"custom value\"", mediaType.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseMediaTypeWithAndWithoutParameters_SameOrDifferentHashCodes()
+        {
+            MediaTypeHeaderValue mediaType1 = new MediaTypeHeaderValue("text/plain");
+            MediaTypeHeaderValue mediaType2 = new MediaTypeHeaderValue("text/plain");
+            mediaType2.CharSet = "utf-8";
+            MediaTypeHeaderValue mediaType3 = new MediaTypeHeaderValue("text/plain");
+            mediaType3.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            MediaTypeHeaderValue mediaType4 = new MediaTypeHeaderValue("TEXT/plain");
+            MediaTypeHeaderValue mediaType5 = new MediaTypeHeaderValue("TEXT/plain");
+            mediaType5.Parameters.Add(new NameValueHeaderValue("CHARSET", "UTF-8"));
+
+            Assert.NotEqual(mediaType1.GetHashCode(), mediaType2.GetHashCode());
+            Assert.NotEqual(mediaType1.GetHashCode(), mediaType3.GetHashCode());
+            Assert.NotEqual(mediaType2.GetHashCode(), mediaType3.GetHashCode());
+            Assert.Equal(mediaType1.GetHashCode(), mediaType4.GetHashCode());
+            Assert.Equal(mediaType2.GetHashCode(), mediaType5.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseMediaTypeWithAndWithoutParameters_EqualOrNotEqualNoExceptions()
+        {
+            MediaTypeHeaderValue mediaType1 = new MediaTypeHeaderValue("text/plain");
+            MediaTypeHeaderValue mediaType2 = new MediaTypeHeaderValue("text/plain");
+            mediaType2.CharSet = "utf-8";
+            MediaTypeHeaderValue mediaType3 = new MediaTypeHeaderValue("text/plain");
+            mediaType3.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            MediaTypeHeaderValue mediaType4 = new MediaTypeHeaderValue("TEXT/plain");
+            MediaTypeHeaderValue mediaType5 = new MediaTypeHeaderValue("TEXT/plain");
+            mediaType5.Parameters.Add(new NameValueHeaderValue("CHARSET", "UTF-8"));
+            MediaTypeHeaderValue mediaType6 = new MediaTypeHeaderValue("TEXT/plain");
+            mediaType6.Parameters.Add(new NameValueHeaderValue("CHARSET", "UTF-8"));
+            mediaType6.Parameters.Add(new NameValueHeaderValue("custom", "value"));
+            MediaTypeHeaderValue mediaType7 = new MediaTypeHeaderValue("text/other");
+
+            Assert.False(mediaType1.Equals(mediaType2), "No params vs. charset.");
+            Assert.False(mediaType2.Equals(mediaType1), "charset vs. no params.");
+            Assert.False(mediaType1.Equals(null), "No params vs. <null>.");
+            Assert.False(mediaType1.Equals(mediaType3), "No params vs. custom param.");
+            Assert.False(mediaType2.Equals(mediaType3), "charset vs. custom param.");
+            Assert.True(mediaType1.Equals(mediaType4), "Different casing.");
+            Assert.True(mediaType2.Equals(mediaType5), "Different casing in charset.");
+            Assert.False(mediaType5.Equals(mediaType6), "charset vs. custom param.");
+            Assert.False(mediaType1.Equals(mediaType7), "text/plain vs. text/other.");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            MediaTypeHeaderValue source = new MediaTypeHeaderValue("application/xml");
+            MediaTypeHeaderValue clone = (MediaTypeHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.MediaType, clone.MediaType);
+            Assert.Equal(0, clone.Parameters.Count);
+
+            source.CharSet = "utf-8";
+            clone = (MediaTypeHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.MediaType, clone.MediaType);
+            Assert.Equal("utf-8", clone.CharSet);
+            Assert.Equal(1, clone.Parameters.Count);
+
+            source.Parameters.Add(new NameValueHeaderValue("custom", "customValue"));
+            clone = (MediaTypeHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.MediaType, clone.MediaType);
+            Assert.Equal("utf-8", clone.CharSet);
+            Assert.Equal(2, clone.Parameters.Count);
+            Assert.Equal("custom", clone.Parameters.ElementAt(1).Name);
+            Assert.Equal("customValue", clone.Parameters.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void GetMediaTypeLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            MediaTypeHeaderValue result = null;
+
+            Assert.Equal(11, MediaTypeHeaderValue.GetMediaTypeLength("text/plain , other/charset", 0,
+                DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal(0, result.Parameters.Count);
+
+            Assert.Equal(10, MediaTypeHeaderValue.GetMediaTypeLength("text/plain", 0, DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal(0, result.Parameters.Count);
+
+            Assert.Equal(30, MediaTypeHeaderValue.GetMediaTypeLength("text/plain; charset=iso-8859-1", 0,
+                DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal("iso-8859-1", result.CharSet);
+            Assert.Equal(1, result.Parameters.Count);
+
+            Assert.Equal(38, MediaTypeHeaderValue.GetMediaTypeLength(" text/plain; custom=value;charset=utf-8",
+                1, DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal("utf-8", result.CharSet);
+            Assert.Equal(2, result.Parameters.Count);
+
+            Assert.Equal(18, MediaTypeHeaderValue.GetMediaTypeLength(" text/plain; custom, next/mediatype",
+                1, DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Null(result.CharSet);
+            Assert.Equal(1, result.Parameters.Count);
+            Assert.Equal("custom", result.Parameters.ElementAt(0).Name);
+            Assert.Null(result.Parameters.ElementAt(0).Value);
+
+            Assert.Equal(48, MediaTypeHeaderValue.GetMediaTypeLength(
+                "text / plain ; custom =\r\n \"x\" ; charset = utf-8 , next/mediatype", 0, DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal("utf-8", result.CharSet);
+            Assert.Equal(2, result.Parameters.Count);
+            Assert.Equal("custom", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("\"x\"", result.Parameters.ElementAt(0).Value);
+            Assert.Equal("charset", result.Parameters.ElementAt(1).Name);
+            Assert.Equal("utf-8", result.Parameters.ElementAt(1).Value);
+
+            Assert.Equal(35, MediaTypeHeaderValue.GetMediaTypeLength(
+                "text/plain;custom=\"x\";charset=utf-8,next/mediatype", 0, DummyCreator, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal("utf-8", result.CharSet);
+            Assert.Equal(2, result.Parameters.Count);
+            Assert.Equal("custom", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("\"x\"", result.Parameters.ElementAt(0).Value);
+            Assert.Equal("charset", result.Parameters.ElementAt(1).Name);
+            Assert.Equal("utf-8", result.Parameters.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void GetMediaTypeLength_UseCustomCreator_CustomCreatorUsedToCreateMediaTypeInstance()
+        {
+            MediaTypeHeaderValue result = null;
+
+            // Path: media-type only
+            Assert.Equal(10, MediaTypeHeaderValue.GetMediaTypeLength("text/plain", 0,
+                () => { return new MediaTypeWithQualityHeaderValue(); }, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal(0, result.Parameters.Count);
+            Assert.IsType<MediaTypeWithQualityHeaderValue>(result);
+
+            // Path: media-type and parameters
+            Assert.Equal(25, MediaTypeHeaderValue.GetMediaTypeLength("text/plain; charset=utf-8", 0,
+                () => { return new MediaTypeWithQualityHeaderValue(); }, out result));
+            Assert.Equal("text/plain", result.MediaType);
+            Assert.Equal(1, result.Parameters.Count);
+            Assert.Equal("utf-8", result.CharSet);
+            Assert.IsType<MediaTypeWithQualityHeaderValue>(result);
+        }
+
+        [Fact]
+        public void GetMediaTypeLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            MediaTypeHeaderValue result = null;
+
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength(" text/plain", 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength("text/plain;", 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength("text/plain;name=", 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength("text/plain;name=value;", 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength("text/plain;", 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength(null, 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, MediaTypeHeaderValue.GetMediaTypeLength(string.Empty, 0, DummyCreator, out result));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            MediaTypeHeaderValue expected = new MediaTypeHeaderValue("text/plain");
+            CheckValidParse("\r\n text/plain  ", expected);
+            CheckValidParse("text/plain", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // media-type parser.
+            expected.CharSet = "utf-8";
+            CheckValidParse("\r\n text   /  plain ;  charset =   utf-8 ", expected);
+            CheckValidParse("  text/plain;charset=utf-8", expected);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("");
+            CheckInvalidParse("  ");
+            CheckInvalidParse(null);
+            CheckInvalidParse("text/plain\u4F1A");
+            CheckInvalidParse("text/plain ,");
+            CheckInvalidParse("text/plain,");
+            CheckInvalidParse("text/plain; charset=utf-8 ,");
+            CheckInvalidParse("text/plain; charset=utf-8,");
+            CheckInvalidParse("textplain");
+            CheckInvalidParse("text/");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            MediaTypeHeaderValue expected = new MediaTypeHeaderValue("text/plain");
+            CheckValidTryParse("\r\n text/plain  ", expected);
+            CheckValidTryParse("text/plain", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // media-type parser.
+            expected.CharSet = "utf-8";
+            CheckValidTryParse("\r\n text   /  plain ;  charset =   utf-8 ", expected);
+            CheckValidTryParse("  text/plain;charset=utf-8", expected);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("");
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse("text/plain\u4F1A");
+            CheckInvalidTryParse("text/plain ,");
+            CheckInvalidTryParse("text/plain,");
+            CheckInvalidTryParse("text/plain; charset=utf-8 ,");
+            CheckInvalidTryParse("text/plain; charset=utf-8,");
+            CheckInvalidTryParse("textplain");
+            CheckInvalidTryParse("text/");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, MediaTypeHeaderValue expectedResult)
+        {
+            MediaTypeHeaderValue result = MediaTypeHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { MediaTypeHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, MediaTypeHeaderValue expectedResult)
+        {
+            MediaTypeHeaderValue result = null;
+            Assert.True(MediaTypeHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            MediaTypeHeaderValue result = null;
+            Assert.False(MediaTypeHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void AssertFormatException(string mediaType)
+        {
+            Assert.Throws<FormatException>(() => { new MediaTypeHeaderValue(mediaType); });
+        }
+
+        private static MediaTypeHeaderValue DummyCreator()
+        {
+            return new MediaTypeHeaderValue();
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/MediaTypeWithQualityHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/MediaTypeWithQualityHeaderValueTest.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class MediaTypeWithQualityHeaderValueTest
+    {
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            // This test just verifies that MediaTypeWithQualityHeaderValue calls the correct base implementation.
+            MediaTypeWithQualityHeaderValue source = new MediaTypeWithQualityHeaderValue("application/xml");
+            MediaTypeWithQualityHeaderValue clone = (MediaTypeWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.MediaType, clone.MediaType);
+            Assert.Equal(0, clone.Parameters.Count);
+
+            source.CharSet = "utf-8";
+            source.Quality = 0.1;
+            clone = (MediaTypeWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.MediaType, clone.MediaType);
+            Assert.Equal("utf-8", clone.CharSet);
+            Assert.Equal(0.1, clone.Quality);
+            Assert.Equal(2, clone.Parameters.Count);
+
+            source.Parameters.Add(new NameValueHeaderValue("custom", "customValue"));
+            clone = (MediaTypeWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.MediaType, clone.MediaType);
+            Assert.Equal("utf-8", clone.CharSet);
+            Assert.Equal(0.1, clone.Quality);
+            Assert.Equal(3, clone.Parameters.Count);
+            Assert.Equal("custom", clone.Parameters.ElementAt(2).Name);
+            Assert.Equal("customValue", clone.Parameters.ElementAt(2).Value);
+        }
+
+        [Fact]
+        public void Ctor_AddNameAndQuality_QualityParameterAdded()
+        {
+            MediaTypeWithQualityHeaderValue mediaType = new MediaTypeWithQualityHeaderValue("application/xml", 0.08);
+            Assert.Equal(0.08, mediaType.Quality);
+            Assert.Equal("application/xml", mediaType.MediaType);
+            Assert.Equal(1, mediaType.Parameters.Count);
+        }
+
+        [Fact]
+        public void Quality_SetCharSetAndValidateObject_ParametersEntryForCharSetAdded()
+        {
+            MediaTypeWithQualityHeaderValue mediaType = new MediaTypeWithQualityHeaderValue("text/plain");
+            mediaType.Quality = 0.563156454;
+            Assert.Equal(0.563, mediaType.Quality);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("q", mediaType.Parameters.First().Name);
+            Assert.Equal("0.563", mediaType.Parameters.First().Value);
+
+            mediaType.Quality = null;
+            Assert.Null(mediaType.Quality);
+            Assert.Equal(0, mediaType.Parameters.Count);
+            mediaType.Quality = null; // It's OK to set it again to null; no exception.
+        }
+
+        [Fact]
+        public void Quality_AddQualityParameterThenUseProperty_ParametersEntryIsOverwritten()
+        {
+            MediaTypeWithQualityHeaderValue mediaType = new MediaTypeWithQualityHeaderValue("text/plain");
+
+            NameValueHeaderValue quality = new NameValueHeaderValue("q", "0.132");
+            mediaType.Parameters.Add(quality);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("q", mediaType.Parameters.First().Name);
+            Assert.Equal(0.132, mediaType.Quality);
+
+            mediaType.Quality = 0.9;
+            Assert.Equal(0.9, mediaType.Quality);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("q", mediaType.Parameters.First().Name);
+
+            mediaType.Parameters.Remove(quality);
+            Assert.Null(mediaType.Quality);
+        }
+
+        [Fact]
+        public void Quality_AddQualityParameterUpperCase_CaseInsensitiveComparison()
+        {
+            MediaTypeWithQualityHeaderValue mediaType = new MediaTypeWithQualityHeaderValue("text/plain");
+
+            NameValueHeaderValue quality = new NameValueHeaderValue("Q", "0.132");
+            mediaType.Parameters.Add(quality);
+            Assert.Equal(1, mediaType.Parameters.Count);
+            Assert.Equal("Q", mediaType.Parameters.First().Name);
+            Assert.Equal(0.132, mediaType.Quality);
+        }
+
+        [Fact]
+        public void Quality_LessThanZero_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                MediaTypeWithQualityHeaderValue mediaType = new MediaTypeWithQualityHeaderValue("application/xml", -0.01); });
+        }
+
+        [Fact]
+        public void Quality_GreaterThanOne_Throw()
+        {
+            MediaTypeWithQualityHeaderValue mediaType = new MediaTypeWithQualityHeaderValue("application/xml");
+            
+            Assert.Throws<ArgumentOutOfRangeException>(() => { mediaType.Quality = 1.01; });
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            MediaTypeWithQualityHeaderValue expected = new MediaTypeWithQualityHeaderValue("text/plain");
+            CheckValidParse("\r\n text/plain  ", expected);
+            CheckValidParse("text/plain", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // media-type parser.
+            expected.CharSet = "utf-8";
+            CheckValidParse("\r\n text   /  plain ;  charset =   utf-8 ", expected);
+            CheckValidParse("  text/plain;charset=utf-8", expected);
+
+            MediaTypeWithQualityHeaderValue value1 = new MediaTypeWithQualityHeaderValue("text/plain");
+            value1.CharSet = "iso-8859-1";
+            value1.Quality = 1.0;
+
+            CheckValidParse("text/plain; charset=iso-8859-1; q=1.0", value1);
+
+            MediaTypeWithQualityHeaderValue value2 = new MediaTypeWithQualityHeaderValue("*/xml");
+            value2.CharSet = "utf-8";
+            value2.Quality = 0.5;
+
+            CheckValidParse("\r\n */xml; charset=utf-8; q=0.5", value2);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("");
+            CheckInvalidParse("  ");
+            CheckInvalidParse(null);
+            CheckInvalidParse("text/plain会");
+            CheckInvalidParse("text/plain ,");
+            CheckInvalidParse("text/plain,");
+            CheckInvalidParse("text/plain; charset=utf-8 ,");
+            CheckInvalidParse("text/plain; charset=utf-8,");
+            CheckInvalidParse("textplain");
+            CheckInvalidParse("text/");
+            CheckInvalidParse(",, , ,,text/plain; charset=iso-8859-1; q=1.0,\r\n */xml; charset=utf-8; q=0.5,,,");
+            CheckInvalidParse("text/plain; charset=iso-8859-1; q=1.0, */xml; charset=utf-8; q=0.5");
+            CheckInvalidParse(" , */xml; charset=utf-8; q=0.5 ");
+            CheckInvalidParse("text/plain; charset=iso-8859-1; q=1.0 , ");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            MediaTypeWithQualityHeaderValue expected = new MediaTypeWithQualityHeaderValue("text/plain");
+            CheckValidTryParse("\r\n text/plain  ", expected);
+            CheckValidTryParse("text/plain", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // media-type parser.
+            expected.CharSet = "utf-8";
+            CheckValidTryParse("\r\n text   /  plain ;  charset =   utf-8 ", expected);
+            CheckValidTryParse("  text/plain;charset=utf-8", expected);
+
+            MediaTypeWithQualityHeaderValue value1 = new MediaTypeWithQualityHeaderValue("text/plain");
+            value1.CharSet = "iso-8859-1";
+            value1.Quality = 1.0;
+
+            CheckValidTryParse("text/plain; charset=iso-8859-1; q=1.0", value1);
+
+            MediaTypeWithQualityHeaderValue value2 = new MediaTypeWithQualityHeaderValue("*/xml");
+            value2.CharSet = "utf-8";
+            value2.Quality = 0.5;
+
+            CheckValidTryParse("\r\n */xml; charset=utf-8; q=0.5", value2);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("");
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse("text/plain会");
+            CheckInvalidTryParse("text/plain ,");
+            CheckInvalidTryParse("text/plain,");
+            CheckInvalidTryParse("text/plain; charset=utf-8 ,");
+            CheckInvalidTryParse("text/plain; charset=utf-8,");
+            CheckInvalidTryParse("textplain");
+            CheckInvalidTryParse("text/");
+            CheckInvalidTryParse(",, , ,,text/plain; charset=iso-8859-1; q=1.0,\r\n */xml; charset=utf-8; q=0.5,,,");
+            CheckInvalidTryParse("text/plain; charset=iso-8859-1; q=1.0, */xml; charset=utf-8; q=0.5");
+            CheckInvalidTryParse(" , */xml; charset=utf-8; q=0.5 ");
+            CheckInvalidTryParse("text/plain; charset=iso-8859-1; q=1.0 , ");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, MediaTypeWithQualityHeaderValue expectedResult)
+        {
+            MediaTypeWithQualityHeaderValue result = MediaTypeWithQualityHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { MediaTypeWithQualityHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, MediaTypeWithQualityHeaderValue expectedResult)
+        {
+            MediaTypeWithQualityHeaderValue result = null;
+            Assert.True(MediaTypeWithQualityHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            MediaTypeWithQualityHeaderValue result = null;
+            Assert.False(MediaTypeWithQualityHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class NameValueHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_NameNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { NameValueHeaderValue nameValue = new NameValueHeaderValue(null); });
+        }
+
+        [Fact]
+        public void Ctor_NameEmpty_Throw()
+        {
+            // null and empty should be treated the same. So we also throw for empty strings.
+            Assert.Throws<ArgumentException>(() => { NameValueHeaderValue nameValue = new NameValueHeaderValue(string.Empty); });
+        }
+
+        [Fact]
+        public void Ctor_NameInvalidFormat_ThrowFormatException()
+        {
+            // When adding values using strongly typed objects, no leading/trailing LWS (whitespaces) are allowed.
+            AssertFormatException(" text ", null);
+            AssertFormatException("text ", null);
+            AssertFormatException(" text", null);
+            AssertFormatException("te xt", null);
+            AssertFormatException("te=xt", null); // The ctor takes a name which must not contain '='.
+            AssertFormatException("teäxt", null);
+        }
+
+        [Fact]
+        public void Ctor_NameValidFormat_SuccessfullyCreated()
+        {
+            NameValueHeaderValue nameValue = new NameValueHeaderValue("text", null);
+            Assert.Equal("text", nameValue.Name);
+        }
+
+        [Fact]
+        public void Ctor_ValueInvalidFormat_ThrowFormatException()
+        {
+            // When adding values using strongly typed objects, no leading/trailing LWS (whitespaces) are allowed.
+            AssertFormatException("text", " token ");
+            AssertFormatException("text", "token ");
+            AssertFormatException("text", " token");
+            AssertFormatException("text", "token string");
+            AssertFormatException("text", "\"quoted string with \" quotes\"");
+            AssertFormatException("text", "\"quoted string with \"two\" quotes\"");
+        }
+
+        [Fact]
+        public void Ctor_ValueValidFormat_SuccessfullyCreated()
+        {
+            CheckValue(null);
+            CheckValue(string.Empty);
+            CheckValue("token_string");
+            CheckValue("\"quoted string\"");
+            CheckValue("\"quoted string with quoted \\\" quote-pair\"");
+        }
+
+        [Fact]
+        public void Value_CallSetterWithInvalidValues_Throw()
+        {
+            // Just verify that the setter calls the same validation the ctor invokes.
+            Assert.Throws<FormatException>(() => { var x = new NameValueHeaderValue("name"); x.Value = " x "; });
+            Assert.Throws<FormatException>(() => { var x = new NameValueHeaderValue("name"); x.Value = "x y"; });
+        }
+
+        [Fact]
+        public void ToString_UseNoValueAndTokenAndQuotedStringValues_SerializedCorrectly()
+        {
+            NameValueHeaderValue nameValue = new NameValueHeaderValue("text", "token");
+            Assert.Equal("text=token", nameValue.ToString());
+
+            nameValue.Value = "\"quoted string\"";
+            Assert.Equal("text=\"quoted string\"", nameValue.ToString());
+
+            nameValue.Value = null;
+            Assert.Equal("text", nameValue.ToString());
+
+            nameValue.Value = string.Empty;
+            Assert.Equal("text", nameValue.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_ValuesUseDifferentValues_HashDiffersAccordingToRfc()
+        {
+            NameValueHeaderValue nameValue1 = new NameValueHeaderValue("text");
+            NameValueHeaderValue nameValue2 = new NameValueHeaderValue("text");
+
+            nameValue1.Value = null;
+            nameValue2.Value = null;
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = "token";
+            nameValue2.Value = null;
+            Assert.NotEqual(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = "token";
+            nameValue2.Value = string.Empty;
+            Assert.NotEqual(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = null;
+            nameValue2.Value = string.Empty;
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = "token";
+            nameValue2.Value = "TOKEN";
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = "token";
+            nameValue2.Value = "token";
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = "\"quoted string\"";
+            nameValue2.Value = "\"QUOTED STRING\"";
+            Assert.NotEqual(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Value = "\"quoted string\"";
+            nameValue2.Value = "\"quoted string\"";
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_NameUseDifferentCasing_HashDiffersAccordingToRfc()
+        {
+            NameValueHeaderValue nameValue1 = new NameValueHeaderValue("text");
+            NameValueHeaderValue nameValue2 = new NameValueHeaderValue("TEXT");
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_ValuesUseDifferentValues_ValuesAreEqualOrDifferentAccordingToRfc()
+        {
+            NameValueHeaderValue nameValue1 = new NameValueHeaderValue("text");
+            NameValueHeaderValue nameValue2 = new NameValueHeaderValue("text");
+
+            nameValue1.Value = null;
+            nameValue2.Value = null;
+            Assert.True(nameValue1.Equals(nameValue2), "<null> vs. <null>.");
+
+            nameValue1.Value = "token";
+            nameValue2.Value = null;
+            Assert.False(nameValue1.Equals(nameValue2), "token vs. <null>.");
+
+            nameValue1.Value = null;
+            nameValue2.Value = "token";
+            Assert.False(nameValue1.Equals(nameValue2), "<null> vs. token.");
+
+            nameValue1.Value = string.Empty;
+            nameValue2.Value = "token";
+            Assert.False(nameValue1.Equals(nameValue2), "string.Empty vs. token.");
+
+            nameValue1.Value = null;
+            nameValue2.Value = string.Empty;
+            Assert.True(nameValue1.Equals(nameValue2), "<null> vs. string.Empty.");
+
+            nameValue1.Value = "token";
+            nameValue2.Value = "TOKEN";
+            Assert.True(nameValue1.Equals(nameValue2), "token vs. TOKEN.");
+
+            nameValue1.Value = "token";
+            nameValue2.Value = "token";
+            Assert.True(nameValue1.Equals(nameValue2), "token vs. token.");
+
+            nameValue1.Value = "\"quoted string\"";
+            nameValue2.Value = "\"QUOTED STRING\"";
+            Assert.False(nameValue1.Equals(nameValue2), "\"quoted string\" vs. \"QUOTED STRING\".");
+
+            nameValue1.Value = "\"quoted string\"";
+            nameValue2.Value = "\"quoted string\"";
+            Assert.True(nameValue1.Equals(nameValue2), "\"quoted string\" vs. \"quoted string\".");
+
+            Assert.False(nameValue1.Equals(null), "\"quoted string\" vs. <null>.");
+        }
+
+        [Fact]
+        public void Equals_NameUseDifferentCasing_ConsideredEqual()
+        {
+            NameValueHeaderValue nameValue1 = new NameValueHeaderValue("text");
+            NameValueHeaderValue nameValue2 = new NameValueHeaderValue("TEXT");
+            Assert.True(nameValue1.Equals(nameValue2), "text vs. TEXT.");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            NameValueHeaderValue source = new NameValueHeaderValue("name", "value");
+            NameValueHeaderValue clone = (NameValueHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Name, clone.Name);
+            Assert.Equal(source.Value, clone.Value);
+        }
+
+        [Fact]
+        public void GetNameValueLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            NameValueHeaderValue result = null;
+
+            Assert.Equal(10, NameValueHeaderValue.GetNameValueLength("name=value", 0, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+
+            Assert.Equal(10, NameValueHeaderValue.GetNameValueLength(" name=value", 1, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+
+            Assert.Equal(4, NameValueHeaderValue.GetNameValueLength(" name", 1, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Null(result.Value);
+
+            Assert.Equal(17, NameValueHeaderValue.GetNameValueLength("name=\"quoted str\"", 0, DummyCreator,
+                out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("\"quoted str\"", result.Value);
+
+            Assert.Equal(17, NameValueHeaderValue.GetNameValueLength(" name=\"quoted str\"", 1, DummyCreator,
+                out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("\"quoted str\"", result.Value);
+
+            Assert.Equal(12, NameValueHeaderValue.GetNameValueLength("name\t =va1ue\"", 0, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("va1ue", result.Value);
+
+            Assert.Equal(12, NameValueHeaderValue.GetNameValueLength(" name= va*ue ", 1, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("va*ue", result.Value);
+
+            Assert.Equal(6, NameValueHeaderValue.GetNameValueLength(" name  ", 1, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Null(result.Value);
+
+            Assert.Equal(12, NameValueHeaderValue.GetNameValueLength(" name= va*ue ,", 1, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("va*ue", result.Value);
+
+            Assert.Equal(9, NameValueHeaderValue.GetNameValueLength(" name = va:ue", 1, DummyCreator, out result));
+            Assert.Equal("name", result.Name);
+            Assert.Equal("va", result.Value);
+        }
+
+        [Fact]
+        public void GetNameValueLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            NameValueHeaderValue result = null;
+
+            Assert.Equal(0, NameValueHeaderValue.GetNameValueLength(" name=value", 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, NameValueHeaderValue.GetNameValueLength(" name=", 1, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, NameValueHeaderValue.GetNameValueLength(" ,", 1, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, NameValueHeaderValue.GetNameValueLength("name=value", 10, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, NameValueHeaderValue.GetNameValueLength("", 0, DummyCreator, out result));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse("  name = value    ", new NameValueHeaderValue("name", "value"));
+            CheckValidParse(" name", new NameValueHeaderValue("name"));
+            CheckValidParse(" name=\"value\"", new NameValueHeaderValue("name", "\"value\""));
+            CheckValidParse("name=value", new NameValueHeaderValue("name", "value"));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("name[value");
+            CheckInvalidParse("name=value=");
+            CheckInvalidParse("name=\u4F1A");
+            CheckInvalidParse("name==value");
+            CheckInvalidParse("=value");
+            CheckInvalidParse("name value");
+            CheckInvalidParse("name=,value");
+            CheckInvalidParse("\u4F1A");
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+            CheckInvalidParse(" , , name = value  ,  ");
+            CheckInvalidParse(" name,");
+            CheckInvalidParse(" ,name=\"value\"");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse("  name = value    ", new NameValueHeaderValue("name", "value"));
+            CheckValidTryParse(" name", new NameValueHeaderValue("name"));
+            CheckValidTryParse(" name=\"value\"", new NameValueHeaderValue("name", "\"value\""));
+            CheckValidTryParse("name=value", new NameValueHeaderValue("name", "value"));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("name[value");
+            CheckInvalidTryParse("name=value=");
+            CheckInvalidTryParse("name=\u4F1A");
+            CheckInvalidTryParse("name==value");
+            CheckInvalidTryParse("=value");
+            CheckInvalidTryParse("name value");
+            CheckInvalidTryParse("name=,value");
+            CheckInvalidTryParse("\u4F1A");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+            CheckInvalidTryParse(" , , name = value  ,  ");
+            CheckInvalidTryParse(" name,");
+            CheckInvalidTryParse(" ,name=\"value\"");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, NameValueHeaderValue expectedResult)
+        {
+            NameValueHeaderValue result = NameValueHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { NameValueHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, NameValueHeaderValue expectedResult)
+        {
+            NameValueHeaderValue result = null;
+            Assert.True(NameValueHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            NameValueHeaderValue result = null;
+            Assert.False(NameValueHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CheckValue(string value)
+        {
+            NameValueHeaderValue nameValue = new NameValueHeaderValue("text", value);
+            Assert.Equal(value, nameValue.Value);
+        }
+
+        private static void AssertFormatException(string name, string value)
+        {
+            Assert.Throws<FormatException>(() => { new NameValueHeaderValue(name, value); });
+        }
+
+        private static NameValueHeaderValue DummyCreator()
+        {
+            return new NameValueHeaderValue();
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/NameValueWithParametersHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/NameValueWithParametersHeaderValueTest.cs
@@ -1,0 +1,292 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class NameValueWithParametersHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_NameNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { NameValueWithParametersHeaderValue nameValue = new NameValueWithParametersHeaderValue(null); });
+        }
+
+        [Fact]
+        public void Ctor_NameEmpty_Throw()
+        {
+            // null and empty should be treated the same. So we also throw for empty strings.
+            Assert.Throws<ArgumentException>(() => { NameValueWithParametersHeaderValue nameValue = new NameValueWithParametersHeaderValue(string.Empty); });
+        }
+
+        [Fact]
+        public void Ctor_CallBaseCtor_Success()
+        {
+            // Just make sure the base ctor gets called correctly. Validation of input parameters is done in the base
+            // class.
+            NameValueWithParametersHeaderValue nameValue = new NameValueWithParametersHeaderValue("name");
+            Assert.Equal("name", nameValue.Name);
+            Assert.Null(nameValue.Value);
+
+            nameValue = new NameValueWithParametersHeaderValue("name", "value");
+            Assert.Equal("name", nameValue.Name);
+            Assert.Equal("value", nameValue.Value);
+        }
+
+        [Fact]
+        public void Parameters_AddNull_Throw()
+        {
+            NameValueWithParametersHeaderValue nameValue = new NameValueWithParametersHeaderValue("name");
+            
+            Assert.Throws<ArgumentNullException>(() => { nameValue.Parameters.Add(null); });
+        }
+
+        [Fact]
+        public void ToString_WithAndWithoutParameters_SerializedCorrectly()
+        {
+            NameValueWithParametersHeaderValue nameValue = new NameValueWithParametersHeaderValue("text", "token");
+            Assert.Equal("text=token", nameValue.ToString());
+
+            nameValue.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            nameValue.Parameters.Add(new NameValueHeaderValue("param2", "value2"));
+            Assert.Equal("text=token; param1=value1; param2=value2", nameValue.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_ValuesUseDifferentValues_HashDiffersAccordingToRfc()
+        {
+            NameValueWithParametersHeaderValue nameValue1 = new NameValueWithParametersHeaderValue("text");
+            NameValueWithParametersHeaderValue nameValue2 = new NameValueWithParametersHeaderValue("text");
+
+            // NameValueWithParametersHeaderValue just calls methods of the base class. Just verify Parameters is used.
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue1.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            nameValue2.Value = null;
+            Assert.NotEqual(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+
+            nameValue2.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            Assert.Equal(nameValue1.GetHashCode(), nameValue2.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_ValuesUseDifferentValues_ValuesAreEqualOrDifferentAccordingToRfc()
+        {
+            NameValueWithParametersHeaderValue nameValue1 = new NameValueWithParametersHeaderValue("text", "value");
+            NameValueWithParametersHeaderValue nameValue2 = new NameValueWithParametersHeaderValue("text", "value");
+            NameValueHeaderValue nameValue3 = new NameValueHeaderValue("text", "value");
+
+            // NameValueWithParametersHeaderValue just calls methods of the base class. Just verify Parameters is used.
+            Assert.True(nameValue1.Equals(nameValue2), "No parameters.");
+            Assert.False(nameValue1.Equals(null), "Compare to null.");
+            Assert.False(nameValue1.Equals(nameValue3), "Compare to base class instance.");
+
+            nameValue1.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            Assert.False(nameValue1.Equals(nameValue2), "none vs. 1 parameter.");
+
+            nameValue2.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            Assert.True(nameValue1.Equals(nameValue2), "1 parameter vs. 1 parameter.");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            NameValueWithParametersHeaderValue source = new NameValueWithParametersHeaderValue("name", "value");
+            source.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            NameValueWithParametersHeaderValue clone = (NameValueWithParametersHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Name, clone.Name);
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(1, clone.Parameters.Count);
+            Assert.Equal("param1", clone.Parameters.First().Name);
+            Assert.Equal("value1", clone.Parameters.First().Value);
+        }
+
+        [Fact]
+        public void GetNameValueLength_DifferentScenariosWithNoParameters_AllReturnNonZero()
+        {
+            NameValueWithParametersHeaderValue result = null;
+
+            CallGetNameValueWithParametersLength("name=value", 0, 10, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+
+            CallGetNameValueWithParametersLength(" name=value", 1, 10, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+
+            CallGetNameValueWithParametersLength(" name", 1, 4, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Null(result.Value);
+
+            CallGetNameValueWithParametersLength("name=\"quoted str\"", 0, 17, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("\"quoted str\"", result.Value);
+
+            CallGetNameValueWithParametersLength(" name=\"quoted str\"", 1, 17, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("\"quoted str\"", result.Value);
+
+            CallGetNameValueWithParametersLength("name\t =va1ue\"", 0, 12, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("va1ue", result.Value);
+
+            CallGetNameValueWithParametersLength(" name  ", 1, 6, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Null(result.Value);
+        }
+
+        [Fact]
+        public void GetNameValueLength_DifferentScenariosWithParameters_AllReturnNonZero()
+        {
+            NameValueWithParametersHeaderValue result = null;
+
+            CallGetNameValueWithParametersLength(" name = value ; param1 = value1 ,", 1, 31, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+            Assert.Equal(1, result.Parameters.Count);
+            Assert.Equal("param1", result.Parameters.First().Name);
+            Assert.Equal("value1", result.Parameters.First().Value);
+
+            CallGetNameValueWithParametersLength(" name=value;param1=value1;param2=value2,next", 1, 38, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+            Assert.Equal(2, result.Parameters.Count);
+            Assert.Equal("param1", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("value1", result.Parameters.ElementAt(0).Value);
+            Assert.Equal("param2", result.Parameters.ElementAt(1).Name);
+            Assert.Equal("value2", result.Parameters.ElementAt(1).Value);
+
+            CallGetNameValueWithParametersLength(" name= value ;   param1 , next", 1, 23, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Equal("value", result.Value);
+            Assert.Equal(1, result.Parameters.Count);
+            Assert.Equal("param1", result.Parameters.First().Name);
+            Assert.Null(result.Parameters.First().Value);
+
+            CallGetNameValueWithParametersLength(" name ;   param1 , next", 1, 16, out result);
+            Assert.Equal("name", result.Name);
+            Assert.Null(result.Value);
+            Assert.Equal(1, result.Parameters.Count);
+            Assert.Equal("param1", result.Parameters.First().Name);
+            Assert.Null(result.Parameters.First().Value);
+        }
+
+        [Fact]
+        public void GetNameValueLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetNameValueWithParametersLength(" name=value", 0);
+            CheckInvalidGetNameValueWithParametersLength(" name=", 1);
+            CheckInvalidGetNameValueWithParametersLength(" name=value; param;", 1);
+            CheckInvalidGetNameValueWithParametersLength(" name;", 1);
+            CheckInvalidGetNameValueWithParametersLength(" ,name", 1);
+            CheckInvalidGetNameValueWithParametersLength("name=value", 10);
+            CheckInvalidGetNameValueWithParametersLength("", 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            NameValueWithParametersHeaderValue expected = new NameValueWithParametersHeaderValue("custom");
+            CheckValidParse("\r\n custom  ", expected);
+            CheckValidParse("custom", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidParse("\r\n custom ;  name =   value ", expected);
+            CheckValidParse("  custom;name=value", expected);
+            CheckValidParse("  custom ; name=value", expected);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("custom会");
+            CheckInvalidParse("custom; name=value;");
+            CheckInvalidParse("custom; name1=value1; name2=value2;");
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            NameValueWithParametersHeaderValue expected = new NameValueWithParametersHeaderValue("custom");
+            CheckValidTryParse("\r\n custom  ", expected);
+            CheckValidTryParse("custom", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidTryParse("\r\n custom ;  name =   value ", expected);
+            CheckValidTryParse("  custom;name=value", expected);
+            CheckValidTryParse("  custom ; name=value", expected);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("custom会");
+            CheckInvalidTryParse("custom; name=value;");
+            CheckInvalidTryParse("custom; name1=value1; name2=value2;");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, NameValueWithParametersHeaderValue expectedResult)
+        {
+            NameValueWithParametersHeaderValue result = NameValueWithParametersHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { NameValueWithParametersHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, NameValueWithParametersHeaderValue expectedResult)
+        {
+            NameValueWithParametersHeaderValue result = null;
+            Assert.True(NameValueWithParametersHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            NameValueWithParametersHeaderValue result = null;
+            Assert.False(NameValueWithParametersHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetNameValueWithParametersLength(string input, int startIndex, int expectedLength,
+            out NameValueWithParametersHeaderValue result)
+        {
+            object temp = null;
+            Assert.Equal(expectedLength, NameValueWithParametersHeaderValue.GetNameValueWithParametersLength(input,
+                startIndex, out temp));
+            result = temp as NameValueWithParametersHeaderValue;
+        }
+
+        private static void CheckInvalidGetNameValueWithParametersLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, NameValueWithParametersHeaderValue.GetNameValueWithParametersLength(input, startIndex,
+                out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ObjectCollectionTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ObjectCollectionTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ObjectCollectionTest
+    {
+        [Fact]
+        public void Ctor_ExecuteBothOverloads_MatchExpectation()
+        {
+            // Use default validator
+            ObjectCollection<string> c = new ObjectCollection<string>();
+
+            c.Add("value1");
+            c.Insert(0, "value2");
+
+            Assert.Throws<ArgumentNullException>(() => { c.Add(null); });
+            Assert.Throws<ArgumentNullException>(() => { c[0] = null; });
+
+            Assert.Equal(2, c.Count);
+            Assert.Equal("value2", c[0]);
+            Assert.Equal("value1", c[1]);
+
+            // Use custom validator
+            c = new ObjectCollection<string>(item =>
+            {
+                if (item == null)
+                {
+                    throw new InvalidOperationException("custom");
+                }
+            });
+
+            c.Add("value1");
+            c[0] = "value2";
+
+            Assert.Throws<InvalidOperationException>(() => { c.Add(null); });
+            Assert.Throws<InvalidOperationException>(() => { c[0] = null; });
+
+            Assert.Equal(1, c.Count);
+            Assert.Equal("value2", c[0]);
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ProductHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ProductHeaderValueTest.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ProductHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_SetValidHeaderValues_InstanceCreatedCorrectly()
+        {
+            ProductHeaderValue product = new ProductHeaderValue("HTTP", "2.0");
+            Assert.Equal("HTTP", product.Name);
+            Assert.Equal("2.0", product.Version);
+
+            product = new ProductHeaderValue("HTTP");
+            Assert.Equal("HTTP", product.Name);
+            Assert.Null(product.Version);
+
+            product = new ProductHeaderValue("HTTP", ""); // null and string.Empty are equivalent
+            Assert.Equal("HTTP", product.Name);
+            Assert.Null(product.Version);
+        }
+
+        [Fact]
+        public void Ctor_UseInvalidValues_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { new ProductHeaderValue(null); });
+            Assert.Throws<ArgumentException>(() => { new ProductHeaderValue(string.Empty); });
+            Assert.Throws<FormatException>(() => { new ProductHeaderValue(" x"); });
+            Assert.Throws<FormatException>(() => { new ProductHeaderValue("x "); });
+            Assert.Throws<FormatException>(() => { new ProductHeaderValue("x y"); });
+
+            Assert.Throws<FormatException>(() => { new ProductHeaderValue("x", " y"); });
+            Assert.Throws<FormatException>(() => { new ProductHeaderValue("x", "y "); });
+            Assert.Throws<FormatException>(() => { new ProductHeaderValue("x", "y z"); });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRanges_AllSerializedCorrectly()
+        {
+            ProductHeaderValue product = new ProductHeaderValue("IRC", "6.9");
+            Assert.Equal("IRC/6.9", product.ToString());
+
+            product = new ProductHeaderValue("product");
+            Assert.Equal("product", product.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRanges_SameOrDifferentHashCodes()
+        {
+            ProductHeaderValue product1 = new ProductHeaderValue("custom", "1.0");
+            ProductHeaderValue product2 = new ProductHeaderValue("custom");
+            ProductHeaderValue product3 = new ProductHeaderValue("CUSTOM", "1.0");
+            ProductHeaderValue product4 = new ProductHeaderValue("RTA", "x11");
+            ProductHeaderValue product5 = new ProductHeaderValue("rta", "X11");
+
+            Assert.NotEqual(product1.GetHashCode(), product2.GetHashCode());
+            Assert.Equal(product1.GetHashCode(), product3.GetHashCode());
+            Assert.NotEqual(product1.GetHashCode(), product4.GetHashCode());
+            Assert.Equal(product4.GetHashCode(), product5.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            ProductHeaderValue product1 = new ProductHeaderValue("custom", "1.0");
+            ProductHeaderValue product2 = new ProductHeaderValue("custom");
+            ProductHeaderValue product3 = new ProductHeaderValue("CUSTOM", "1.0");
+            ProductHeaderValue product4 = new ProductHeaderValue("RTA", "x11");
+            ProductHeaderValue product5 = new ProductHeaderValue("rta", "X11");
+
+            Assert.False(product1.Equals(null), "custom/1.0 vs. <null>");
+            Assert.False(product1.Equals(product2), "custom/1.0 vs. custom");
+            Assert.False(product2.Equals(product1), "custom/1.0 vs. custom");
+            Assert.True(product1.Equals(product3), "custom/1.0 vs. CUSTOM/1.0");
+            Assert.False(product1.Equals(product4), "custom/1.0 vs. rta/X11");
+            Assert.True(product4.Equals(product5), "RTA/x11 vs. rta/X11");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            ProductHeaderValue source = new ProductHeaderValue("SHTTP", "1.3");
+            ProductHeaderValue clone = (ProductHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source.Name, clone.Name);
+            Assert.Equal(source.Version, clone.Version);
+
+            source = new ProductHeaderValue("SHTTP", null);
+            clone = (ProductHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source.Name, clone.Name);
+            Assert.Null(clone.Version);
+        }
+
+        [Fact]
+        public void GetProductLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            ProductHeaderValue result = null;
+
+            CallGetProductLength(" custom", 1, 6, out result);
+            Assert.Equal("custom", result.Name);
+            Assert.Null(result.Version);
+
+            CallGetProductLength(" custom, ", 1, 6, out result);
+            Assert.Equal("custom", result.Name);
+            Assert.Null(result.Version);
+
+            CallGetProductLength(" custom / 5.6 ", 1, 13, out result);
+            Assert.Equal("custom", result.Name);
+            Assert.Equal("5.6", result.Version);
+
+            CallGetProductLength("RTA / x58 ,", 0, 10, out result);
+            Assert.Equal("RTA", result.Name);
+            Assert.Equal("x58", result.Version);
+
+            CallGetProductLength("RTA / x58", 0, 9, out result);
+            Assert.Equal("RTA", result.Name);
+            Assert.Equal("x58", result.Version);
+
+            CallGetProductLength("RTA / x58 XXX", 0, 10, out result);
+            Assert.Equal("RTA", result.Name);
+            Assert.Equal("x58", result.Version);
+        }
+
+        [Fact]
+        public void GetProductLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetProductLength(" custom", 0); // no leading whitespaces allowed
+            CheckInvalidGetProductLength("custom/", 0);
+            CheckInvalidGetProductLength("custom/[", 0);
+            CheckInvalidGetProductLength("=", 0);
+
+            CheckInvalidGetProductLength("", 0);
+            CheckInvalidGetProductLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse(" y/1 ", new ProductHeaderValue("y", "1"));
+            CheckValidParse(" custom / 1.0 ", new ProductHeaderValue("custom", "1.0"));
+            CheckValidParse("custom / 1.0 ", new ProductHeaderValue("custom", "1.0"));
+            CheckValidParse("custom / 1.0", new ProductHeaderValue("custom", "1.0"));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("product/version="); // only delimiter ',' allowed after last product
+            CheckInvalidParse("product otherproduct");
+            CheckInvalidParse("product[");
+            CheckInvalidParse("=");
+
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse(" y/1 ", new ProductHeaderValue("y", "1"));
+            CheckValidTryParse(" custom / 1.0 ", new ProductHeaderValue("custom", "1.0"));
+            CheckValidTryParse("custom / 1.0 ", new ProductHeaderValue("custom", "1.0"));
+            CheckValidTryParse("custom / 1.0", new ProductHeaderValue("custom", "1.0"));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("product/version="); // only delimiter ',' allowed after last product
+            CheckInvalidTryParse("product otherproduct");
+            CheckInvalidTryParse("product[");
+            CheckInvalidTryParse("=");
+
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, ProductHeaderValue expectedResult)
+        {
+            ProductHeaderValue result = ProductHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { ProductHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, ProductHeaderValue expectedResult)
+        {
+            ProductHeaderValue result = null;
+            Assert.True(ProductHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            ProductHeaderValue result = null;
+            Assert.False(ProductHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetProductLength(string input, int startIndex, int expectedLength,
+            out ProductHeaderValue result)
+        {
+            Assert.Equal(expectedLength, ProductHeaderValue.GetProductLength(input, startIndex, out result));
+        }
+
+        private static void CheckInvalidGetProductLength(string input, int startIndex)
+        {
+            ProductHeaderValue result = null;
+            Assert.Equal(0, ProductHeaderValue.GetProductLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ProductInfoHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ProductInfoHeaderParserTest.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ProductInfoHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            ProductInfoHeaderParser parser = ProductInfoHeaderParser.SingleValueParser;
+            Assert.False(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+
+            parser = ProductInfoHeaderParser.MultipleValueParser;
+            Assert.True(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("X product ", 1, new ProductInfoHeaderValue("product", null), 10);
+
+            // Note that the following is considered valid, since we have a valid product and after the ',' delimiter
+            // we have non-whitespace characters. It's the callers responsibility to consider the whole string invalid.
+            CheckValidParsedValue("p/1.0 =", 0, new ProductInfoHeaderValue("p", "1.0"), 6);
+
+            CheckValidParsedValue(" (comment)   p", 0, new ProductInfoHeaderValue("(comment)"), 13);
+
+            CheckValidParsedValue(" Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) ", 0,
+                new ProductInfoHeaderValue("Mozilla", "5.0"), 13);
+            CheckValidParsedValue(" Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) ", 13,
+                new ProductInfoHeaderValue("(compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)"), 13 + 59);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("p/1.0,", 0);
+            CheckInvalidParsedValue("p/1.0\r\n", 0); // for \r\n to be a valid whitespace, it must be followed by space/tab
+            CheckInvalidParsedValue("p/1.0(comment)", 0);
+            CheckInvalidParsedValue("(comment)[", 0);
+
+            // "User-Agent" and "Server" don't allow empty values (unlike most other headers supporting lists of values)
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+            CheckInvalidParsedValue("  ", 0);
+            CheckInvalidParsedValue("\t", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, ProductInfoHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            ProductInfoHeaderParser parser = ProductInfoHeaderParser.MultipleValueParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false. Input: '{0}'", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            ProductInfoHeaderParser parser = ProductInfoHeaderParser.MultipleValueParser;
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}'", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ProductInfoHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ProductInfoHeaderValueTest.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ProductInfoHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_ProductOverload_MatchExpectation()
+        {
+            ProductInfoHeaderValue productInfo = new ProductInfoHeaderValue(new ProductHeaderValue("product"));
+            Assert.Equal(new ProductHeaderValue("product"), productInfo.Product);
+            Assert.Null(productInfo.Comment);
+
+            ProductHeaderValue input = null;
+            Assert.Throws<ArgumentNullException>(() => { new ProductInfoHeaderValue(input); });
+        }
+
+        [Fact]
+        public void Ctor_ProductStringOverload_MatchExpectation()
+        {
+            ProductInfoHeaderValue productInfo = new ProductInfoHeaderValue("product", "1.0");
+            Assert.Equal(new ProductHeaderValue("product", "1.0"), productInfo.Product);
+            Assert.Null(productInfo.Comment);
+        }
+
+        [Fact]
+        public void Ctor_CommentOverload_MatchExpectation()
+        {
+            ProductInfoHeaderValue productInfo = new ProductInfoHeaderValue("(this is a comment)");
+            Assert.Null(productInfo.Product);
+            Assert.Equal("(this is a comment)", productInfo.Comment);
+
+            Assert.Throws<ArgumentException>(() => { new ProductInfoHeaderValue((string)null); });
+            Assert.Throws<FormatException>(() => { new ProductInfoHeaderValue("invalid comment"); });
+            Assert.Throws<FormatException>(() => { new ProductInfoHeaderValue(" (leading space)"); });
+            Assert.Throws<FormatException>(() => { new ProductInfoHeaderValue("(trailing space) "); });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentProductInfos_AllSerializedCorrectly()
+        {
+            ProductInfoHeaderValue productInfo = new ProductInfoHeaderValue("product", "1.0");
+            Assert.Equal("product/1.0", productInfo.ToString());
+
+            productInfo = new ProductInfoHeaderValue("(comment)");
+            Assert.Equal("(comment)", productInfo.ToString());
+        }
+
+        [Fact]
+        public void ToString_Aggregate_AllSerializedCorrectly()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+            string input = string.Empty;
+
+            ProductInfoHeaderValue productInfo = new ProductInfoHeaderValue("product", "1.0");
+            Assert.Equal("product/1.0", productInfo.ToString());
+
+            input += productInfo.ToString();
+            request.Headers.UserAgent.Add(productInfo);
+
+            productInfo = new ProductInfoHeaderValue("(comment)");
+            Assert.Equal("(comment)", productInfo.ToString());
+
+            input += " " + productInfo.ToString(); // Space delineated
+            request.Headers.UserAgent.Add(productInfo);
+
+            Assert.Equal(input, request.Headers.UserAgent.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentProductInfos_SameOrDifferentHashCodes()
+        {
+            ProductInfoHeaderValue productInfo1 = new ProductInfoHeaderValue("product", "1.0");
+            ProductInfoHeaderValue productInfo2 = new ProductInfoHeaderValue(new ProductHeaderValue("product", "1.0"));
+            ProductInfoHeaderValue productInfo3 = new ProductInfoHeaderValue("(comment)");
+            ProductInfoHeaderValue productInfo4 = new ProductInfoHeaderValue("(COMMENT)");
+
+            Assert.Equal(productInfo1.GetHashCode(), productInfo2.GetHashCode());
+            Assert.NotEqual(productInfo1.GetHashCode(), productInfo3.GetHashCode());
+            Assert.NotEqual(productInfo3.GetHashCode(), productInfo4.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            ProductInfoHeaderValue productInfo1 = new ProductInfoHeaderValue("product", "1.0");
+            ProductInfoHeaderValue productInfo2 = new ProductInfoHeaderValue(new ProductHeaderValue("product", "1.0"));
+            ProductInfoHeaderValue productInfo3 = new ProductInfoHeaderValue("(comment)");
+            ProductInfoHeaderValue productInfo4 = new ProductInfoHeaderValue("(COMMENT)");
+
+            Assert.False(productInfo1.Equals(null), "product/1.0 vs. <null>");
+            Assert.True(productInfo1.Equals(productInfo2), "product/1.0 vs. product/1.0");
+            Assert.False(productInfo1.Equals(productInfo3), "product/1.0 vs. (comment)");
+            Assert.False(productInfo3.Equals(productInfo4), "(comment) vs. (COMMENT)");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            ProductInfoHeaderValue source = new ProductInfoHeaderValue("product", "1.0");
+            ProductInfoHeaderValue clone = (ProductInfoHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source.Product, clone.Product);
+            Assert.Null(clone.Comment);
+
+            source = new ProductInfoHeaderValue("(comment)");
+            clone = (ProductInfoHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Null(clone.Product);
+            Assert.Equal(source.Comment, clone.Comment);
+        }
+
+        [Fact]
+        public void GetProductInfoLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            ProductInfoHeaderValue result = null;
+
+            CallGetProductInfoLength(" product / 1.0 ", 1, 14, out result);
+            Assert.Equal(new ProductHeaderValue("product", "1.0"), result.Product);
+            Assert.Null(result.Comment);
+
+            CallGetProductInfoLength("p/1.0", 0, 5, out result);
+            Assert.Equal(new ProductHeaderValue("p", "1.0"), result.Product);
+            Assert.Null(result.Comment);
+
+            CallGetProductInfoLength(" (this is a comment)  , ", 1, 21, out result);
+            Assert.Null(result.Product);
+            Assert.Equal("(this is a comment)", result.Comment);
+
+            CallGetProductInfoLength("(c)", 0, 3, out result);
+            Assert.Null(result.Product);
+            Assert.Equal("(c)", result.Comment);
+
+            CallGetProductInfoLength("(comment/1.0)[", 0, 13, out result);
+            Assert.Null(result.Product);
+            Assert.Equal("(comment/1.0)", result.Comment);
+        }
+
+        [Fact]
+        public void GetRangeLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetProductInfoLength(" p/1.0", 0); // no leading whitespaces allowed
+            CheckInvalidGetProductInfoLength(" (c)", 0); // no leading whitespaces allowed
+            CheckInvalidGetProductInfoLength("(invalid", 0);
+            CheckInvalidGetProductInfoLength("product/", 0);
+            CheckInvalidGetProductInfoLength("product/(1.0)", 0);
+
+            CheckInvalidGetProductInfoLength("", 0);
+            CheckInvalidGetProductInfoLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse("product", new ProductInfoHeaderValue("product", null));
+            CheckValidParse(" product ", new ProductInfoHeaderValue("product", null));
+
+            CheckValidParse(" (comment)   ", new ProductInfoHeaderValue("(comment)"));
+
+            CheckValidParse(" Mozilla/5.0 ", new ProductInfoHeaderValue("Mozilla", "5.0"));
+            CheckValidParse(" (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) ",
+                new ProductInfoHeaderValue("(compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)"));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("p/1.0,");
+            CheckInvalidParse("p/1.0\r\n"); // for \r\n to be a valid whitespace, it must be followed by space/tab
+            CheckInvalidParse("p/1.0(comment)");
+            CheckInvalidParse("(comment)[");
+
+            CheckInvalidParse(" Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) ");
+            CheckInvalidParse("p/1.0 =");
+
+            // "User-Agent" and "Server" don't allow empty values (unlike most other headers supporting lists of values)
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("\t");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse("product", new ProductInfoHeaderValue("product", null));
+            CheckValidTryParse(" product ", new ProductInfoHeaderValue("product", null));
+
+            CheckValidTryParse(" (comment)   ", new ProductInfoHeaderValue("(comment)"));
+
+            CheckValidTryParse(" Mozilla/5.0 ", new ProductInfoHeaderValue("Mozilla", "5.0"));
+            CheckValidTryParse(" (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) ",
+                new ProductInfoHeaderValue("(compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)"));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("p/1.0,");
+            CheckInvalidTryParse("p/1.0\r\n"); // for \r\n to be a valid whitespace, it must be followed by space/tab
+            CheckInvalidTryParse("p/1.0(comment)");
+            CheckInvalidTryParse("(comment)[");
+
+            CheckInvalidTryParse(" Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) ");
+            CheckInvalidTryParse("p/1.0 =");
+
+            // "User-Agent" and "Server" don't allow empty values (unlike most other headers supporting lists of values)
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("\t");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, ProductInfoHeaderValue expectedResult)
+        {
+            ProductInfoHeaderValue result = ProductInfoHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { ProductInfoHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, ProductInfoHeaderValue expectedResult)
+        {
+            ProductInfoHeaderValue result = null;
+            Assert.True(ProductInfoHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            ProductInfoHeaderValue result = null;
+            Assert.False(ProductInfoHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetProductInfoLength(string input, int startIndex, int expectedLength,
+            out ProductInfoHeaderValue result)
+        {
+            Assert.Equal(expectedLength, ProductInfoHeaderValue.GetProductInfoLength(input, startIndex, out result));
+        }
+
+        private static void CheckInvalidGetProductInfoLength(string input, int startIndex)
+        {
+            ProductInfoHeaderValue result = null;
+            Assert.Equal(0, ProductInfoHeaderValue.GetProductInfoLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/RangeConditionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/RangeConditionHeaderValueTest.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RangeConditionHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_EntityTagOverload_MatchExpectation()
+        {
+            RangeConditionHeaderValue rangeCondition = new RangeConditionHeaderValue(new EntityTagHeaderValue("\"x\""));
+            Assert.Equal(new EntityTagHeaderValue("\"x\""), rangeCondition.EntityTag);
+            Assert.Null(rangeCondition.Date);
+
+            EntityTagHeaderValue input = null;
+            Assert.Throws<ArgumentNullException>(() => { new RangeConditionHeaderValue(input); });
+        }
+
+        [Fact]
+        public void Ctor_EntityTagStringOverload_MatchExpectation()
+        {
+            RangeConditionHeaderValue rangeCondition = new RangeConditionHeaderValue("\"y\"");
+            Assert.Equal(new EntityTagHeaderValue("\"y\""), rangeCondition.EntityTag);
+            Assert.Null(rangeCondition.Date);
+
+            Assert.Throws<ArgumentException>(() => { new RangeConditionHeaderValue((string)null); });
+        }
+
+        [Fact]
+        public void Ctor_DateOverload_MatchExpectation()
+        {
+            RangeConditionHeaderValue rangeCondition = new RangeConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            Assert.Null(rangeCondition.EntityTag);
+            Assert.Equal(new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero), rangeCondition.Date);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentrangeConditions_AllSerializedCorrectly()
+        {
+            RangeConditionHeaderValue rangeCondition = new RangeConditionHeaderValue(new EntityTagHeaderValue("\"x\""));
+            Assert.Equal("\"x\"", rangeCondition.ToString());
+
+            rangeCondition = new RangeConditionHeaderValue(new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            Assert.Equal("Thu, 15 Jul 2010 12:33:57 GMT", rangeCondition.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentrangeConditions_SameOrDifferentHashCodes()
+        {
+            RangeConditionHeaderValue rangeCondition1 = new RangeConditionHeaderValue("\"x\"");
+            RangeConditionHeaderValue rangeCondition2 = new RangeConditionHeaderValue(new EntityTagHeaderValue("\"x\""));
+            RangeConditionHeaderValue rangeCondition3 = new RangeConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RangeConditionHeaderValue rangeCondition4 = new RangeConditionHeaderValue(
+                new DateTimeOffset(2008, 8, 16, 13, 44, 10, TimeSpan.Zero));
+            RangeConditionHeaderValue rangeCondition5 = new RangeConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RangeConditionHeaderValue rangeCondition6 = new RangeConditionHeaderValue(
+                new EntityTagHeaderValue("\"x\"", true));
+
+            Assert.Equal(rangeCondition1.GetHashCode(), rangeCondition2.GetHashCode());
+            Assert.NotEqual(rangeCondition1.GetHashCode(), rangeCondition3.GetHashCode());
+            Assert.NotEqual(rangeCondition3.GetHashCode(), rangeCondition4.GetHashCode());
+            Assert.Equal(rangeCondition3.GetHashCode(), rangeCondition5.GetHashCode());
+            Assert.NotEqual(rangeCondition1.GetHashCode(), rangeCondition6.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            RangeConditionHeaderValue rangeCondition1 = new RangeConditionHeaderValue("\"x\"");
+            RangeConditionHeaderValue rangeCondition2 = new RangeConditionHeaderValue(new EntityTagHeaderValue("\"x\""));
+            RangeConditionHeaderValue rangeCondition3 = new RangeConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RangeConditionHeaderValue rangeCondition4 = new RangeConditionHeaderValue(
+                new DateTimeOffset(2008, 8, 16, 13, 44, 10, TimeSpan.Zero));
+            RangeConditionHeaderValue rangeCondition5 = new RangeConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RangeConditionHeaderValue rangeCondition6 = new RangeConditionHeaderValue(
+                new EntityTagHeaderValue("\"x\"", true));
+
+            Assert.False(rangeCondition1.Equals(null), "\"x\" vs. <null>");
+            Assert.True(rangeCondition1.Equals(rangeCondition2), "\"x\" vs. \"x\"");
+            Assert.False(rangeCondition1.Equals(rangeCondition3), "\"x\" vs. date");
+            Assert.False(rangeCondition3.Equals(rangeCondition1), "date vs. \"x\"");
+            Assert.False(rangeCondition3.Equals(rangeCondition4), "date vs. different date");
+            Assert.True(rangeCondition3.Equals(rangeCondition5), "date vs. date");
+            Assert.False(rangeCondition1.Equals(rangeCondition6), "\"x\" vs. W/\"x\"");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            RangeConditionHeaderValue source = new RangeConditionHeaderValue(new EntityTagHeaderValue("\"x\""));
+            RangeConditionHeaderValue clone = (RangeConditionHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source.EntityTag, clone.EntityTag);
+            Assert.Null(clone.Date);
+
+            source = new RangeConditionHeaderValue(new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            clone = (RangeConditionHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Null(clone.EntityTag);
+            Assert.Equal(source.Date, clone.Date);
+        }
+
+        [Fact]
+        public void GetRangeConditionLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            RangeConditionHeaderValue result = null;
+
+            CallGetRangeConditionLength(" W/ \"tag\" ", 1, 9, out result);
+            Assert.Equal(new EntityTagHeaderValue("\"tag\"", true), result.EntityTag);
+            Assert.Null(result.Date);
+
+            CallGetRangeConditionLength(" w/\"tag\"", 1, 7, out result);
+            Assert.Equal(new EntityTagHeaderValue("\"tag\"", true), result.EntityTag);
+            Assert.Null(result.Date);
+
+            CallGetRangeConditionLength("\"tag\"", 0, 5, out result);
+            Assert.Equal(new EntityTagHeaderValue("\"tag\""), result.EntityTag);
+            Assert.Null(result.Date);
+
+            CallGetRangeConditionLength("Wed, 09 Nov 1994 08:49:37 GMT", 0, 29, out result);
+            Assert.Null(result.EntityTag);
+            Assert.Equal(new DateTimeOffset(1994, 11, 9, 8, 49, 37, TimeSpan.Zero), result.Date);
+
+            CallGetRangeConditionLength("Sun, 06 Nov 1994 08:49:37 GMT", 0, 29, out result);
+            Assert.Null(result.EntityTag);
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), result.Date);
+        }
+
+        [Fact]
+        public void GetRangeConditionLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetRangeConditionLength(" \"x\"", 0); // no leading whitespaces allowed
+            CheckInvalidGetRangeConditionLength(" Wed 09 Nov 1994 08:49:37 GMT", 0);
+            CheckInvalidGetRangeConditionLength("\"x", 0);
+            CheckInvalidGetRangeConditionLength("Wed, 09 Nov", 0);
+            CheckInvalidGetRangeConditionLength("W/Wed 09 Nov 1994 08:49:37 GMT", 0);
+            CheckInvalidGetRangeConditionLength("\"x\",", 0);
+            CheckInvalidGetRangeConditionLength("Wed 09 Nov 1994 08:49:37 GMT,", 0);
+
+            CheckInvalidGetRangeConditionLength("", 0);
+            CheckInvalidGetRangeConditionLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse("  \"x\" ", new RangeConditionHeaderValue("\"x\""));
+            CheckValidParse("  Sun, 06 Nov 1994 08:49:37 GMT ",
+                new RangeConditionHeaderValue(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero)));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("\"x\" ,"); // no delimiter allowed
+            CheckInvalidParse("Sun, 06 Nov 1994 08:49:37 GMT ,"); // no delimiter allowed
+            CheckInvalidParse("\"x\" Sun, 06 Nov 1994 08:49:37 GMT");
+            CheckInvalidParse("Sun, 06 Nov 1994 08:49:37 GMT \"x\"");
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse("  \"x\" ", new RangeConditionHeaderValue("\"x\""));
+            CheckValidTryParse("  Sun, 06 Nov 1994 08:49:37 GMT ",
+                new RangeConditionHeaderValue(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero)));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("\"x\" ,"); // no delimiter allowed
+            CheckInvalidTryParse("Sun, 06 Nov 1994 08:49:37 GMT ,"); // no delimiter allowed
+            CheckInvalidTryParse("\"x\" Sun, 06 Nov 1994 08:49:37 GMT");
+            CheckInvalidTryParse("Sun, 06 Nov 1994 08:49:37 GMT \"x\"");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, RangeConditionHeaderValue expectedResult)
+        {
+            RangeConditionHeaderValue result = RangeConditionHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { RangeConditionHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, RangeConditionHeaderValue expectedResult)
+        {
+            RangeConditionHeaderValue result = null;
+            Assert.True(RangeConditionHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            RangeConditionHeaderValue result = null;
+            Assert.False(RangeConditionHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetRangeConditionLength(string input, int startIndex, int expectedLength,
+            out RangeConditionHeaderValue result)
+        {
+            object temp = null;
+            Assert.Equal(expectedLength, RangeConditionHeaderValue.GetRangeConditionLength(input, startIndex,
+                out temp));
+            result = temp as RangeConditionHeaderValue;
+        }
+
+        private static void CheckInvalidGetRangeConditionLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, RangeConditionHeaderValue.GetRangeConditionLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/RangeHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/RangeHeaderValueTest.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RangeHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_InvalidRange_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new RangeHeaderValue(5, 2); });
+        }
+
+        [Fact]
+        public void Unit_GetAndSetValidAndInvalidValues_MatchExpectation()
+        {
+            RangeHeaderValue range = new RangeHeaderValue();
+            range.Unit = "myunit";
+            Assert.Equal("myunit", range.Unit);
+
+            Assert.Throws<ArgumentException>(() => { range.Unit = null; });
+            Assert.Throws<ArgumentException>(() => { range.Unit = ""; });
+            Assert.Throws<FormatException>(() => { range.Unit = " x"; });
+            Assert.Throws<FormatException>(() => { range.Unit = "x "; });
+            Assert.Throws<FormatException>(() => { range.Unit = "x y"; });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRanges_AllSerializedCorrectly()
+        {
+            RangeHeaderValue range = new RangeHeaderValue();
+            range.Unit = "myunit";
+            range.Ranges.Add(new RangeItemHeaderValue(1, 3));
+            Assert.Equal("myunit=1-3", range.ToString());
+
+            range.Ranges.Add(new RangeItemHeaderValue(5, null));
+            range.Ranges.Add(new RangeItemHeaderValue(null, 17));
+            Assert.Equal("myunit=1-3, 5-, -17", range.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRanges_SameOrDifferentHashCodes()
+        {
+            RangeHeaderValue range1 = new RangeHeaderValue(1, 2);
+            RangeHeaderValue range2 = new RangeHeaderValue(1, 2);
+            range2.Unit = "BYTES";
+            RangeHeaderValue range3 = new RangeHeaderValue(1, null);
+            RangeHeaderValue range4 = new RangeHeaderValue(null, 2);
+            RangeHeaderValue range5 = new RangeHeaderValue();
+            range5.Ranges.Add(new RangeItemHeaderValue(1, 2));
+            range5.Ranges.Add(new RangeItemHeaderValue(3, 4));
+            RangeHeaderValue range6 = new RangeHeaderValue();
+            range6.Ranges.Add(new RangeItemHeaderValue(3, 4)); // reverse order of range5
+            range6.Ranges.Add(new RangeItemHeaderValue(1, 2));
+
+            Assert.Equal(range1.GetHashCode(), range2.GetHashCode());
+            Assert.NotEqual(range1.GetHashCode(), range3.GetHashCode());
+            Assert.NotEqual(range1.GetHashCode(), range4.GetHashCode());
+            Assert.NotEqual(range1.GetHashCode(), range5.GetHashCode());
+            Assert.Equal(range5.GetHashCode(), range6.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            RangeHeaderValue range1 = new RangeHeaderValue(1, 2);
+            RangeHeaderValue range2 = new RangeHeaderValue(1, 2);
+            range2.Unit = "BYTES";
+            RangeHeaderValue range3 = new RangeHeaderValue(1, null);
+            RangeHeaderValue range4 = new RangeHeaderValue(null, 2);
+            RangeHeaderValue range5 = new RangeHeaderValue();
+            range5.Ranges.Add(new RangeItemHeaderValue(1, 2));
+            range5.Ranges.Add(new RangeItemHeaderValue(3, 4));
+            RangeHeaderValue range6 = new RangeHeaderValue();
+            range6.Ranges.Add(new RangeItemHeaderValue(3, 4)); // reverse order of range5
+            range6.Ranges.Add(new RangeItemHeaderValue(1, 2));
+            RangeHeaderValue range7 = new RangeHeaderValue(1, 2);
+            range7.Unit = "other";
+
+            Assert.False(range1.Equals(null), "bytes=1-2 vs. <null>");
+            Assert.True(range1.Equals(range2), "bytes=1-2 vs. BYTES=1-2");
+            Assert.False(range1.Equals(range3), "bytes=1-2 vs. bytes=1-");
+            Assert.False(range1.Equals(range4), "bytes=1-2 vs. bytes=-2");
+            Assert.False(range1.Equals(range5), "bytes=1-2 vs. bytes=1-2,3-4");
+            Assert.True(range5.Equals(range6), "bytes=1-2,3-4 vs. bytes=3-4,1-2");
+            Assert.False(range1.Equals(range7), "bytes=1-2 vs. other=1-2");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            RangeHeaderValue source = new RangeHeaderValue(1, 2);
+            RangeHeaderValue clone = (RangeHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(1, source.Ranges.Count);
+            Assert.Equal(source.Unit, clone.Unit);
+            Assert.Equal(source.Ranges.Count, clone.Ranges.Count);
+            Assert.Equal(source.Ranges.ElementAt(0), clone.Ranges.ElementAt(0));
+
+            source.Unit = "custom";
+            source.Ranges.Add(new RangeItemHeaderValue(3, null));
+            source.Ranges.Add(new RangeItemHeaderValue(null, 4));
+            clone = (RangeHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(3, source.Ranges.Count);
+            Assert.Equal(source.Unit, clone.Unit);
+            Assert.Equal(source.Ranges.Count, clone.Ranges.Count);
+            Assert.Equal(source.Ranges.ElementAt(0), clone.Ranges.ElementAt(0));
+            Assert.Equal(source.Ranges.ElementAt(1), clone.Ranges.ElementAt(1));
+            Assert.Equal(source.Ranges.ElementAt(2), clone.Ranges.ElementAt(2));
+        }
+
+        [Fact]
+        public void GetRangeLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            RangeHeaderValue result = null;
+
+            CallGetRangeLength(" custom = 1 - 2", 1, 14, out result);
+            Assert.Equal("custom", result.Unit);
+            Assert.Equal(1, result.Ranges.Count);
+            Assert.Equal(new RangeItemHeaderValue(1, 2), result.Ranges.First());
+
+            CallGetRangeLength("bytes =1-2,,3-, , ,-4,,", 0, 23, out result);
+            Assert.Equal("bytes", result.Unit);
+            Assert.Equal(3, result.Ranges.Count);
+            Assert.Equal(new RangeItemHeaderValue(1, 2), result.Ranges.ElementAt(0));
+            Assert.Equal(new RangeItemHeaderValue(3, null), result.Ranges.ElementAt(1));
+            Assert.Equal(new RangeItemHeaderValue(null, 4), result.Ranges.ElementAt(2));
+        }
+
+        [Fact]
+        public void GetRangeLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetRangeLength(" bytes=1-2", 0); // no leading whitespaces allowed
+            CheckInvalidGetRangeLength("bytes=1", 0);
+            CheckInvalidGetRangeLength("bytes=", 0);
+            CheckInvalidGetRangeLength("bytes", 0);
+            CheckInvalidGetRangeLength("bytes 1-2", 0);
+            CheckInvalidGetRangeLength("bytes=1-2.5", 0);
+            CheckInvalidGetRangeLength("bytes= ,,, , ,,", 0);
+
+            CheckInvalidGetRangeLength("", 0);
+            CheckInvalidGetRangeLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse(" bytes=1-2 ", new RangeHeaderValue(1, 2));
+
+            RangeHeaderValue expected = new RangeHeaderValue();
+            expected.Unit = "custom";
+            expected.Ranges.Add(new RangeItemHeaderValue(null, 5));
+            expected.Ranges.Add(new RangeItemHeaderValue(1, 4));
+            CheckValidParse("custom = -  5 , 1 - 4 ,,", expected);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("bytes=1-2x"); // only delimiter ',' allowed after last range
+            CheckInvalidParse("x bytes=1-2");
+            CheckInvalidParse("bytes=1-2.4");
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse(" bytes=1-2 ", new RangeHeaderValue(1, 2));
+
+            RangeHeaderValue expected = new RangeHeaderValue();
+            expected.Unit = "custom";
+            expected.Ranges.Add(new RangeItemHeaderValue(null, 5));
+            expected.Ranges.Add(new RangeItemHeaderValue(1, 4));
+            CheckValidTryParse("custom = -  5 , 1 - 4 ,,", expected);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("bytes=1-2x"); // only delimiter ',' allowed after last range
+            CheckInvalidTryParse("x bytes=1-2");
+            CheckInvalidTryParse("bytes=1-2.4");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, RangeHeaderValue expectedResult)
+        {
+            RangeHeaderValue result = RangeHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { RangeHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, RangeHeaderValue expectedResult)
+        {
+            RangeHeaderValue result = null;
+            Assert.True(RangeHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            RangeHeaderValue result = null;
+            Assert.False(RangeHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetRangeLength(string input, int startIndex, int expectedLength,
+            out RangeHeaderValue result)
+        {
+            object temp = null;
+            Assert.Equal(expectedLength, RangeHeaderValue.GetRangeLength(input, startIndex, out temp));
+            result = temp as RangeHeaderValue;
+        }
+
+        private static void CheckInvalidGetRangeLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, RangeHeaderValue.GetRangeLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/RangeItemHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/RangeItemHeaderValueTest.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RangeItemHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_BothValuesNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { new RangeItemHeaderValue(null, null); });
+        }
+
+        [Fact]
+        public void Ctor_FromValueNegative_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new RangeItemHeaderValue(-1, null); });
+        }
+
+        [Fact]
+        public void Ctor_FromGreaterThanToValue_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new RangeItemHeaderValue(2, 1); });
+        }
+
+        [Fact]
+        public void Ctor_ToValueNegative_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new RangeItemHeaderValue(null, -1); });
+        }
+
+        [Fact]
+        public void Ctor_ValidFormat_SuccessfullyCreated()
+        {
+            RangeItemHeaderValue rangeItem = new RangeItemHeaderValue(1, 2);
+            Assert.Equal(1, rangeItem.From);
+            Assert.Equal(2, rangeItem.To);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRangeItems_AllSerializedCorrectly()
+        {
+            // Make sure ToString() doesn't add any separators.
+            RangeItemHeaderValue rangeItem = new RangeItemHeaderValue(1000000000, 2000000000);
+            Assert.Equal("1000000000-2000000000", rangeItem.ToString());
+
+            rangeItem = new RangeItemHeaderValue(5, null);
+            Assert.Equal("5-", rangeItem.ToString());
+
+            rangeItem = new RangeItemHeaderValue(null, 10);
+            Assert.Equal("-10", rangeItem.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRangeItems_SameOrDifferentHashCodes()
+        {
+            RangeItemHeaderValue rangeItem1 = new RangeItemHeaderValue(1, 2);
+            RangeItemHeaderValue rangeItem2 = new RangeItemHeaderValue(1, null);
+            RangeItemHeaderValue rangeItem3 = new RangeItemHeaderValue(null, 2);
+            RangeItemHeaderValue rangeItem4 = new RangeItemHeaderValue(2, 2);
+            RangeItemHeaderValue rangeItem5 = new RangeItemHeaderValue(1, 2);
+
+            Assert.NotEqual(rangeItem1.GetHashCode(), rangeItem2.GetHashCode());
+            Assert.NotEqual(rangeItem1.GetHashCode(), rangeItem3.GetHashCode());
+            Assert.NotEqual(rangeItem1.GetHashCode(), rangeItem4.GetHashCode());
+            Assert.Equal(rangeItem1.GetHashCode(), rangeItem5.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            RangeItemHeaderValue rangeItem1 = new RangeItemHeaderValue(1, 2);
+            RangeItemHeaderValue rangeItem2 = new RangeItemHeaderValue(1, null);
+            RangeItemHeaderValue rangeItem3 = new RangeItemHeaderValue(null, 2);
+            RangeItemHeaderValue rangeItem4 = new RangeItemHeaderValue(2, 2);
+            RangeItemHeaderValue rangeItem5 = new RangeItemHeaderValue(1, 2);
+
+            Assert.False(rangeItem1.Equals(rangeItem2), "1-2 vs. 1-.");
+            Assert.False(rangeItem2.Equals(rangeItem1), "1- vs. 1-2.");
+            Assert.False(rangeItem1.Equals(null), "1-2 vs. null.");
+            Assert.False(rangeItem1.Equals(rangeItem3), "1-2 vs. -2.");
+            Assert.False(rangeItem3.Equals(rangeItem1), "-2 vs. 1-2.");
+            Assert.False(rangeItem1.Equals(rangeItem4), "1-2 vs. 2-2.");
+            Assert.True(rangeItem1.Equals(rangeItem5), "1-2 vs. 1-2.");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            RangeItemHeaderValue source = new RangeItemHeaderValue(1, 2);
+            RangeItemHeaderValue clone = (RangeItemHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.From, clone.From);
+            Assert.Equal(source.To, clone.To);
+
+            source = new RangeItemHeaderValue(1, null);
+            clone = (RangeItemHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.From, clone.From);
+            Assert.Equal(source.To, clone.To);
+
+            source = new RangeItemHeaderValue(null, 2);
+            clone = (RangeItemHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.From, clone.From);
+            Assert.Equal(source.To, clone.To);
+        }
+
+        [Fact]
+        public void GetRangeItemLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            CheckValidGetRangeItemLength("1-2", 0, 3, 1, 2);
+            CheckValidGetRangeItemLength("0-0", 0, 3, 0, 0);
+            CheckValidGetRangeItemLength(" 1-", 1, 2, 1, null);
+            CheckValidGetRangeItemLength(" -2", 1, 2, null, 2);
+
+            // Note that the parser will only parse '1-' as a valid range and ignore '-2'. It is the callers 
+            // responsibility to determine if this is indeed a valid range
+            CheckValidGetRangeItemLength(" 1--2", 1, 2, 1, null);
+
+            CheckValidGetRangeItemLength(" 684684 - 123456789012345 !", 1, 25, 684684, 123456789012345);
+
+            // The separator doesn't matter. It only parses until the first non-whitespace
+            CheckValidGetRangeItemLength(" 1 - 2 ,", 1, 6, 1, 2);
+        }
+
+        [Fact]
+        public void GetRangeItemLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetRangeItemLength(" 1-2", 0); // no leading spaces.
+            CheckInvalidGetRangeItemLength("2-1", 0);
+            CheckInvalidGetRangeItemLength("-", 0);
+            CheckInvalidGetRangeItemLength("1", 0);
+            CheckInvalidGetRangeItemLength(null, 0);
+            CheckInvalidGetRangeItemLength(string.Empty, 0);
+            CheckInvalidGetRangeItemLength("12345678901234567890123-", 0); // >>Int64.MaxValue
+            CheckInvalidGetRangeItemLength("-12345678901234567890123", 0); // >>Int64.MaxValue
+            CheckInvalidGetRangeItemLength("9999999999999999999-", 0); // 19-digit numbers outside the Int64 range.
+            CheckInvalidGetRangeItemLength("-9999999999999999999", 0); // 19-digit numbers outside the Int64 range.
+        }
+
+        [Fact]
+        public void GetRangeItemListLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            CheckValidGetRangeItemListLength("x,,1-2, 3 -  , , -6 , ,,", 1, 23,
+                new Tuple<long?, long?>(1, 2), new Tuple<long?, long?>(3, null), new Tuple<long?, long?>(null, 6));
+            CheckValidGetRangeItemListLength("1-2,", 0, 4, new Tuple<long?, long?>(1, 2));
+            CheckValidGetRangeItemListLength("1-", 0, 2, new Tuple<long?, long?>(1, null));
+        }
+
+        [Fact]
+        public void GetRangeItemListLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetRangeItemListLength(null, 0);
+            CheckInvalidGetRangeItemListLength(string.Empty, 0);
+            CheckInvalidGetRangeItemListLength("1-2", 3);
+            CheckInvalidGetRangeItemListLength(",,", 0);
+            CheckInvalidGetRangeItemListLength("1", 0);
+            CheckInvalidGetRangeItemListLength("1-2,3", 0);
+            CheckInvalidGetRangeItemListLength("1--2", 0);
+            CheckInvalidGetRangeItemListLength("1,-2", 0);
+            CheckInvalidGetRangeItemListLength("-", 0);
+            CheckInvalidGetRangeItemListLength("--", 0);
+        }
+
+        #region Helper methods
+
+        private static void AssertFormatException(string tag)
+        {
+            Assert.Throws<FormatException>(() => { new EntityTagHeaderValue(tag); });
+        }
+
+        private static void CheckValidGetRangeItemLength(string input, int startIndex, int expectedLength,
+            long? expectedFrom, long? expectedTo)
+        {
+            RangeItemHeaderValue result = null;
+            Assert.Equal(expectedLength, RangeItemHeaderValue.GetRangeItemLength(input, startIndex, out result));
+            Assert.Equal(expectedFrom, result.From);
+            Assert.Equal(expectedTo, result.To);
+        }
+
+        private static void CheckInvalidGetRangeItemLength(string input, int startIndex)
+        {
+            RangeItemHeaderValue result = null;
+            Assert.Equal(0, RangeItemHeaderValue.GetRangeItemLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+
+        private static void CheckValidGetRangeItemListLength(string input, int startIndex, int expectedLength,
+            params Tuple<long?, long?>[] expectedRanges)
+        {
+            List<RangeItemHeaderValue> ranges = new List<RangeItemHeaderValue>();
+            Assert.Equal(expectedLength, RangeItemHeaderValue.GetRangeItemListLength(input, startIndex, ranges));
+
+            Assert.Equal<int>(expectedRanges.Length, ranges.Count);
+
+            for (int i = 0; i < expectedRanges.Length; i++)
+            {
+                Assert.Equal(expectedRanges[i].Item1, ranges[i].From);
+                Assert.Equal(expectedRanges[i].Item2, ranges[i].To);
+            }
+        }
+
+        private static void CheckInvalidGetRangeItemListLength(string input, int startIndex)
+        {
+            List<RangeItemHeaderValue> ranges = new List<RangeItemHeaderValue>();
+            Assert.Equal(0, RangeItemHeaderValue.GetRangeItemListLength(input, startIndex, ranges));
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/RetryConditionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/RetryConditionHeaderValueTest.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class RetryConditionHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_EntityTagOverload_MatchExpectation()
+        {
+            RetryConditionHeaderValue retryCondition = new RetryConditionHeaderValue(new TimeSpan(0, 0, 3));
+            Assert.Equal(new TimeSpan(0, 0, 3), retryCondition.Delta);
+            Assert.Null(retryCondition.Date);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new RetryConditionHeaderValue(new TimeSpan(1234567, 0, 0)); });
+        }
+
+        [Fact]
+        public void Ctor_DateOverload_MatchExpectation()
+        {
+            RetryConditionHeaderValue retryCondition = new RetryConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            Assert.Null(retryCondition.Delta);
+            Assert.Equal(new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero), retryCondition.Date);
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRetryConditions_AllSerializedCorrectly()
+        {
+            RetryConditionHeaderValue retryCondition = new RetryConditionHeaderValue(new TimeSpan(0, 0, 50000000));
+            Assert.Equal("50000000", retryCondition.ToString());
+
+            retryCondition = new RetryConditionHeaderValue(new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            Assert.Equal("Thu, 15 Jul 2010 12:33:57 GMT", retryCondition.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRetryConditions_SameOrDifferentHashCodes()
+        {
+            RetryConditionHeaderValue retryCondition1 = new RetryConditionHeaderValue(new TimeSpan(0, 0, 1000000));
+            RetryConditionHeaderValue retryCondition2 = new RetryConditionHeaderValue(new TimeSpan(0, 0, 1000000));
+            RetryConditionHeaderValue retryCondition3 = new RetryConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RetryConditionHeaderValue retryCondition4 = new RetryConditionHeaderValue(
+                new DateTimeOffset(2008, 8, 16, 13, 44, 10, TimeSpan.Zero));
+            RetryConditionHeaderValue retryCondition5 = new RetryConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RetryConditionHeaderValue retryCondition6 = new RetryConditionHeaderValue(new TimeSpan(0, 0, 2000000));
+
+            Assert.Equal(retryCondition1.GetHashCode(), retryCondition2.GetHashCode());
+            Assert.NotEqual(retryCondition1.GetHashCode(), retryCondition3.GetHashCode());
+            Assert.NotEqual(retryCondition3.GetHashCode(), retryCondition4.GetHashCode());
+            Assert.Equal(retryCondition3.GetHashCode(), retryCondition5.GetHashCode());
+            Assert.NotEqual(retryCondition1.GetHashCode(), retryCondition6.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRetrys_EqualOrNotEqualNoExceptions()
+        {
+            RetryConditionHeaderValue retryCondition1 = new RetryConditionHeaderValue(new TimeSpan(0, 0, 1000000));
+            RetryConditionHeaderValue retryCondition2 = new RetryConditionHeaderValue(new TimeSpan(0, 0, 1000000));
+            RetryConditionHeaderValue retryCondition3 = new RetryConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RetryConditionHeaderValue retryCondition4 = new RetryConditionHeaderValue(
+                new DateTimeOffset(2008, 8, 16, 13, 44, 10, TimeSpan.Zero));
+            RetryConditionHeaderValue retryCondition5 = new RetryConditionHeaderValue(
+                new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            RetryConditionHeaderValue retryCondition6 = new RetryConditionHeaderValue(new TimeSpan(0, 0, 2000000));
+
+            Assert.False(retryCondition1.Equals(null), "delta vs. <null>");
+            Assert.True(retryCondition1.Equals(retryCondition2), "delta vs. delta");
+            Assert.False(retryCondition1.Equals(retryCondition3), "delta vs. date");
+            Assert.False(retryCondition3.Equals(retryCondition1), "date vs. delta");
+            Assert.False(retryCondition3.Equals(retryCondition4), "date vs. different date");
+            Assert.True(retryCondition3.Equals(retryCondition5), "date vs. date");
+            Assert.False(retryCondition1.Equals(retryCondition6), "delta vs. different delta");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            RetryConditionHeaderValue source = new RetryConditionHeaderValue(new TimeSpan(0, 0, 123456789));
+            RetryConditionHeaderValue clone = (RetryConditionHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Equal(source.Delta, clone.Delta);
+            Assert.Null(clone.Date);
+
+            source = new RetryConditionHeaderValue(new DateTimeOffset(2010, 7, 15, 12, 33, 57, TimeSpan.Zero));
+            clone = (RetryConditionHeaderValue)((ICloneable)source).Clone();
+
+            Assert.Null(clone.Delta);
+            Assert.Equal(source.Date, clone.Date);
+        }
+
+        [Fact]
+        public void GetRetryConditionLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            RetryConditionHeaderValue result = null;
+
+            CallGetRetryConditionLength(" 1234567890 ", 1, 11, out result);
+            Assert.Equal(new TimeSpan(0, 0, 1234567890), result.Delta);
+            Assert.Null(result.Date);
+
+            CallGetRetryConditionLength("1", 0, 1, out result);
+            Assert.Equal(new TimeSpan(0, 0, 1), result.Delta);
+            Assert.Null(result.Date);
+
+            CallGetRetryConditionLength("001", 0, 3, out result);
+            Assert.Equal(new TimeSpan(0, 0, 1), result.Delta);
+            Assert.Null(result.Date);
+
+            CallGetRetryConditionLength("Wed, 09 Nov 1994 08:49:37 GMT", 0, 29, out result);
+            Assert.Null(result.Delta);
+            Assert.Equal(new DateTimeOffset(1994, 11, 9, 8, 49, 37, TimeSpan.Zero), result.Date);
+
+            CallGetRetryConditionLength("Sun, 06 Nov 1994 08:49:37 GMT     ", 0, 34, out result);
+            Assert.Null(result.Delta);
+            Assert.Equal(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero), result.Date);
+        }
+
+        [Fact]
+        public void GetRetryConditionLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetRetryConditionLength(" 1", 0); // no leading whitespaces allowed
+            CheckInvalidGetRetryConditionLength(" Wed 09 Nov 1994 08:49:37 GMT", 0);
+            CheckInvalidGetRetryConditionLength("-5", 0);
+
+            // Even though the first char is a valid 'delta', GetRetryConditionLength() expects the whole string to be
+            // a valid 'delta'.
+            CheckInvalidGetRetryConditionLength("1.5", 0);
+            CheckInvalidGetRetryConditionLength("5123,", 0);
+
+            CheckInvalidGetRetryConditionLength("123456789012345678901234567890", 0); // >>Int32.MaxValue
+            CheckInvalidGetRetryConditionLength("9999999999", 0); // >Int32.MaxValue but same amount of digits
+
+            CheckInvalidGetRetryConditionLength("Wed, 09 Nov", 0);
+            CheckInvalidGetRetryConditionLength("W/Wed 09 Nov 1994 08:49:37 GMT", 0);
+            CheckInvalidGetRetryConditionLength("Wed 09 Nov 1994 08:49:37 GMT,", 0);
+
+            CheckInvalidGetRetryConditionLength("", 0);
+            CheckInvalidGetRetryConditionLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse("  123456789 ", new RetryConditionHeaderValue(new TimeSpan(0, 0, 123456789)));
+            CheckValidParse("  Sun, 06 Nov 1994 08:49:37 GMT ",
+                new RetryConditionHeaderValue(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero)));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("123 ,"); // no delimiter allowed
+            CheckInvalidParse("Sun, 06 Nov 1994 08:49:37 GMT ,"); // no delimiter allowed
+            CheckInvalidParse("123 Sun, 06 Nov 1994 08:49:37 GMT");
+            CheckInvalidParse("Sun, 06 Nov 1994 08:49:37 GMT \"x\"");
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse("  123456789 ", new RetryConditionHeaderValue(new TimeSpan(0, 0, 123456789)));
+            CheckValidTryParse("  Sun, 06 Nov 1994 08:49:37 GMT ",
+                new RetryConditionHeaderValue(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero)));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("123 ,"); // no delimiter allowed
+            CheckInvalidTryParse("Sun, 06 Nov 1994 08:49:37 GMT ,"); // no delimiter allowed
+            CheckInvalidTryParse("123 Sun, 06 Nov 1994 08:49:37 GMT");
+            CheckInvalidTryParse("Sun, 06 Nov 1994 08:49:37 GMT \"x\"");
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, RetryConditionHeaderValue expectedResult)
+        {
+            RetryConditionHeaderValue result = RetryConditionHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { RetryConditionHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, RetryConditionHeaderValue expectedResult)
+        {
+            RetryConditionHeaderValue result = null;
+            Assert.True(RetryConditionHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            RetryConditionHeaderValue result = null;
+            Assert.False(RetryConditionHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetRetryConditionLength(string input, int startIndex, int expectedLength,
+            out RetryConditionHeaderValue result)
+        {
+            object temp = null;
+            Assert.Equal(expectedLength, RetryConditionHeaderValue.GetRetryConditionLength(input, startIndex,
+                out temp));
+            result = temp as RetryConditionHeaderValue;
+        }
+
+        private static void CheckInvalidGetRetryConditionLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, RetryConditionHeaderValue.GetRetryConditionLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/StringWithQualityHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/StringWithQualityHeaderValueTest.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class StringWithQualityHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_StringOnlyOverload_MatchExpectation()
+        {
+            StringWithQualityHeaderValue value = new StringWithQualityHeaderValue("token");
+            Assert.Equal("token", value.Value);
+            Assert.Null(value.Quality);
+
+            Assert.Throws<ArgumentException>(() => { new StringWithQualityHeaderValue(null); });
+            Assert.Throws<ArgumentException>(() => { new StringWithQualityHeaderValue(""); });
+            Assert.Throws<FormatException>(() => { new StringWithQualityHeaderValue("in valid"); });
+        }
+
+        [Fact]
+        public void Ctor_StringWithQualityOverload_MatchExpectation()
+        {
+            StringWithQualityHeaderValue value = new StringWithQualityHeaderValue("token", 0.5);
+            Assert.Equal("token", value.Value);
+            Assert.Equal(0.5, value.Quality);
+
+            Assert.Throws<ArgumentException>(() => { new StringWithQualityHeaderValue(null, 0.1); });
+            Assert.Throws<ArgumentException>(() => { new StringWithQualityHeaderValue("", 0.1); });
+            Assert.Throws<FormatException>(() => { new StringWithQualityHeaderValue("in valid", 0.1); });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new StringWithQualityHeaderValue("t", 1.1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new StringWithQualityHeaderValue("t", -0.1); });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentValues_AllSerializedCorrectly()
+        {
+            StringWithQualityHeaderValue value = new StringWithQualityHeaderValue("token");
+            Assert.Equal("token", value.ToString());
+
+            value = new StringWithQualityHeaderValue("token", 0.1);
+            Assert.Equal("token; q=0.1", value.ToString());
+
+            value = new StringWithQualityHeaderValue("token", 0);
+            Assert.Equal("token; q=0.0", value.ToString());
+
+            value = new StringWithQualityHeaderValue("token", 1);
+            Assert.Equal("token; q=1.0", value.ToString());
+
+            // Note that the quality value gets rounded
+            value = new StringWithQualityHeaderValue("token", 0.56789);
+            Assert.Equal("token; q=0.568", value.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentValues_SameOrDifferentHashCodes()
+        {
+            StringWithQualityHeaderValue value1 = new StringWithQualityHeaderValue("t", 0.123);
+            StringWithQualityHeaderValue value2 = new StringWithQualityHeaderValue("t", 0.123);
+            StringWithQualityHeaderValue value3 = new StringWithQualityHeaderValue("T", 0.123);
+            StringWithQualityHeaderValue value4 = new StringWithQualityHeaderValue("t");
+            StringWithQualityHeaderValue value5 = new StringWithQualityHeaderValue("x", 0.123);
+            StringWithQualityHeaderValue value6 = new StringWithQualityHeaderValue("t", 0.5);
+            StringWithQualityHeaderValue value7 = new StringWithQualityHeaderValue("t", 0.1234);
+            StringWithQualityHeaderValue value8 = new StringWithQualityHeaderValue("T");
+            StringWithQualityHeaderValue value9 = new StringWithQualityHeaderValue("x");
+
+            Assert.Equal(value1.GetHashCode(), value2.GetHashCode());
+            Assert.Equal(value1.GetHashCode(), value3.GetHashCode());
+            Assert.NotEqual(value1.GetHashCode(), value4.GetHashCode());
+            Assert.NotEqual(value1.GetHashCode(), value5.GetHashCode());
+            Assert.NotEqual(value1.GetHashCode(), value6.GetHashCode());
+            Assert.NotEqual(value1.GetHashCode(), value7.GetHashCode());
+            Assert.Equal(value4.GetHashCode(), value8.GetHashCode());
+            Assert.NotEqual(value4.GetHashCode(), value9.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            StringWithQualityHeaderValue value1 = new StringWithQualityHeaderValue("t", 0.123);
+            StringWithQualityHeaderValue value2 = new StringWithQualityHeaderValue("t", 0.123);
+            StringWithQualityHeaderValue value3 = new StringWithQualityHeaderValue("T", 0.123);
+            StringWithQualityHeaderValue value4 = new StringWithQualityHeaderValue("t");
+            StringWithQualityHeaderValue value5 = new StringWithQualityHeaderValue("x", 0.123);
+            StringWithQualityHeaderValue value6 = new StringWithQualityHeaderValue("t", 0.5);
+            StringWithQualityHeaderValue value7 = new StringWithQualityHeaderValue("t", 0.1234);
+            StringWithQualityHeaderValue value8 = new StringWithQualityHeaderValue("T");
+            StringWithQualityHeaderValue value9 = new StringWithQualityHeaderValue("x");
+
+            Assert.False(value1.Equals(null), "t; q=0.123 vs. <null>");
+            Assert.True(value1.Equals(value2), "t; q=0.123 vs. t; q=0.123");
+            Assert.True(value1.Equals(value3), "t; q=0.123 vs. T; q=0.123");
+            Assert.False(value1.Equals(value4), "t; q=0.123 vs. t");
+            Assert.False(value4.Equals(value1), "t vs. t; q=0.123");
+            Assert.False(value1.Equals(value5), "t; q=0.123 vs. x; q=0.123");
+            Assert.False(value1.Equals(value6), "t; q=0.123 vs. t; q=0.5");
+            Assert.False(value1.Equals(value7), "t; q=0.123 vs. t; q=0.1234");
+            Assert.True(value4.Equals(value8), "t vs. T");
+            Assert.False(value4.Equals(value9), "t vs. T");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            StringWithQualityHeaderValue source = new StringWithQualityHeaderValue("token", 0.123);
+            StringWithQualityHeaderValue clone = (StringWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(source.Quality, clone.Quality);
+
+            source = new StringWithQualityHeaderValue("token");
+            clone = (StringWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Null(source.Quality);
+        }
+
+        [Fact]
+        public void GetStringWithQualityLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            StringWithQualityHeaderValue result = null;
+
+            CallGetStringWithQualityLength(" token ; q = 0.123 ,", 1, 18, out result);
+            Assert.Equal("token", result.Value);
+            Assert.Equal(0.123, result.Quality);
+
+            CallGetStringWithQualityLength("token;q=1 , x", 0, 10, out result);
+            Assert.Equal("token", result.Value);
+            Assert.Equal(1, result.Quality);
+
+            CallGetStringWithQualityLength("*", 0, 1, out result);
+            Assert.Equal("*", result.Value);
+            Assert.Null(result.Quality);
+
+            CallGetStringWithQualityLength("t;q=0.", 0, 6, out result);
+            Assert.Equal("t", result.Value);
+            Assert.Equal(0, result.Quality);
+
+            CallGetStringWithQualityLength("t;q=1.,", 0, 6, out result);
+            Assert.Equal("t", result.Value);
+            Assert.Equal(1, result.Quality);
+
+            CallGetStringWithQualityLength("t ;  q  =   0X", 0, 13, out result);
+            Assert.Equal("t", result.Value);
+            Assert.Equal(0, result.Quality);
+
+            CallGetStringWithQualityLength("t ;  q  =   0,", 0, 13, out result);
+            Assert.Equal("t", result.Value);
+            Assert.Equal(0, result.Quality);
+        }
+
+        [Fact]
+        public void GetStringWithQualityLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetStringWithQualityLength(" t", 0); // no leading whitespaces allowed
+            CheckInvalidGetStringWithQualityLength("t;q=", 0);
+            CheckInvalidGetStringWithQualityLength("t;q=-1", 0);
+            CheckInvalidGetStringWithQualityLength("t;q=1.00001", 0);
+            CheckInvalidGetStringWithQualityLength("t;q", 0);
+            CheckInvalidGetStringWithQualityLength("t;", 0);
+            CheckInvalidGetStringWithQualityLength("t;;q=1", 0);
+            CheckInvalidGetStringWithQualityLength("t;q=a", 0);
+            CheckInvalidGetStringWithQualityLength("t;qa", 0);
+            CheckInvalidGetStringWithQualityLength("t;q1", 0);
+
+            CheckInvalidGetStringWithQualityLength("", 0);
+            CheckInvalidGetStringWithQualityLength(null, 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse("text", new StringWithQualityHeaderValue("text"));
+            CheckValidParse("text;q=0.5", new StringWithQualityHeaderValue("text", 0.5));
+            CheckValidParse("text ; q = 0.5", new StringWithQualityHeaderValue("text", 0.5));
+            CheckValidParse("\r\n text ; q = 0.5 ", new StringWithQualityHeaderValue("text", 0.5));
+            CheckValidParse("  text  ", new StringWithQualityHeaderValue("text"));
+            CheckValidParse(" \r\n text \r\n ; \r\n q = 0.123", new StringWithQualityHeaderValue("text", 0.123));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("text,");
+            CheckInvalidParse("\r\n text ; q = 0.5, next_text  ");
+            CheckInvalidParse("  text,next_text  ");
+            CheckInvalidParse(" ,, text, , ,next");
+            CheckInvalidParse(" ,, text, , ,");
+            CheckInvalidParse(", \r\n text \r\n ; \r\n q = 0.123");
+            CheckInvalidParse("teäxt");
+            CheckInvalidParse("text会");
+            CheckInvalidParse("会");
+            CheckInvalidParse("t;q=会");
+            CheckInvalidParse("t;q=");
+            CheckInvalidParse("t;q");
+            CheckInvalidParse("t;会=1");
+            CheckInvalidParse("t;q会=1");
+            CheckInvalidParse("t y");
+            CheckInvalidParse("t;q=1 y");
+
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse("text", new StringWithQualityHeaderValue("text"));
+            CheckValidTryParse("text;q=0.5", new StringWithQualityHeaderValue("text", 0.5));
+            CheckValidTryParse("text ; q = 0.5", new StringWithQualityHeaderValue("text", 0.5));
+            CheckValidTryParse("\r\n text ; q = 0.5 ", new StringWithQualityHeaderValue("text", 0.5));
+            CheckValidTryParse("  text  ", new StringWithQualityHeaderValue("text"));
+            CheckValidTryParse(" \r\n text \r\n ; \r\n q = 0.123", new StringWithQualityHeaderValue("text", 0.123));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("text,");
+            CheckInvalidTryParse("\r\n text ; q = 0.5, next_text  ");
+            CheckInvalidTryParse("  text,next_text  ");
+            CheckInvalidTryParse(" ,, text, , ,next");
+            CheckInvalidTryParse(" ,, text, , ,");
+            CheckInvalidTryParse(", \r\n text \r\n ; \r\n q = 0.123");
+            CheckInvalidTryParse("teäxt");
+            CheckInvalidTryParse("text会");
+            CheckInvalidTryParse("会");
+            CheckInvalidTryParse("t;q=会");
+            CheckInvalidTryParse("t;q=");
+            CheckInvalidTryParse("t;q");
+            CheckInvalidTryParse("t;会=1");
+            CheckInvalidTryParse("t;q会=1");
+            CheckInvalidTryParse("t y");
+            CheckInvalidTryParse("t;q=1 y");
+
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, StringWithQualityHeaderValue expectedResult)
+        {
+            StringWithQualityHeaderValue result = StringWithQualityHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { StringWithQualityHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, StringWithQualityHeaderValue expectedResult)
+        {
+            StringWithQualityHeaderValue result = null;
+            Assert.True(StringWithQualityHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            StringWithQualityHeaderValue result = null;
+            Assert.False(StringWithQualityHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CallGetStringWithQualityLength(string input, int startIndex, int expectedLength,
+            out StringWithQualityHeaderValue result)
+        {
+            object temp = null;
+            Assert.Equal(expectedLength, StringWithQualityHeaderValue.GetStringWithQualityLength(input,
+                startIndex, out temp));
+            result = temp as StringWithQualityHeaderValue;
+        }
+
+        private static void CheckInvalidGetStringWithQualityLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, StringWithQualityHeaderValue.GetStringWithQualityLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/TimeSpanHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/TimeSpanHeaderParserTest.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class TimeSpanHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+            Assert.False(parser.SupportsMultipleValues, "SupportsMultipleValues");
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_ValidValue_ReturnsLongValue()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+            int index = 2;
+            Assert.Equal(new TimeSpan(0, 0, 15), parser.ParseValue("  15", null, ref index));
+            Assert.Equal(4, index);
+
+            index = 0;
+            Assert.Equal(new TimeSpan(0, 0, 30), parser.ParseValue("  030", null, ref index));
+            Assert.Equal(5, index);
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throw()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue("a", null, ref index); });
+        }
+
+        [Fact]
+        public void Parse_NullValue_Throw()
+        {
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue(null, null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParsedValue("1234567890", 0, new TimeSpan(0, 0, 1234567890), 10);
+            CheckValidParsedValue("0", 0, new TimeSpan(0, 0, 0), 1);
+            CheckValidParsedValue("000015", 0, new TimeSpan(0, 0, 15), 6);
+            CheckValidParsedValue(" 123 \t\r\n ", 0, new TimeSpan(0, 0, 123), 9);
+            CheckValidParsedValue("a 5 \r\n ", 1, new TimeSpan(0, 0, 5), 7);
+            CheckValidParsedValue(" 987", 0, new TimeSpan(0, 0, 987), 4);
+            CheckValidParsedValue("987 ", 0, new TimeSpan(0, 0, 987), 4);
+            CheckValidParsedValue("a456", 1, new TimeSpan(0, 0, 456), 4);
+            CheckValidParsedValue("a456 ", 1, new TimeSpan(0, 0, 456), 5);
+            CheckValidParsedValue("2147483647", 0, new TimeSpan(0, 0, int.MaxValue), 10);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("", 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("a", 0);
+            CheckInvalidParsedValue(".123", 0);
+            CheckInvalidParsedValue(".", 0);
+            CheckInvalidParsedValue("12a", 0);
+            CheckInvalidParsedValue("a12b", 1);
+            CheckInvalidParsedValue("123 1", 0);
+            CheckInvalidParsedValue("123.1", 0);
+            CheckInvalidParsedValue(" 123 1", 0);
+            CheckInvalidParsedValue("a 123 1", 1);
+            CheckInvalidParsedValue("a 123 1 ", 1);
+            CheckInvalidParsedValue("-123.1", 0);
+            CheckInvalidParsedValue("-123", 0);
+            CheckInvalidParsedValue("123456789012345678901234567890", 0); // value >> Int32.MaxValue
+            CheckInvalidParsedValue("2147483648", 0); // value = Int32.MaxValue + 1
+        }
+
+        [Fact]
+        public void ToString_UseDifferentValues_MatchExpectation()
+        {
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+
+            Assert.Equal("123", parser.ToString(new TimeSpan(0, 2, 3)));
+            Assert.Equal("0", parser.ToString(new TimeSpan(0, 0, 0)));
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, TimeSpan expectedResult, int expectedIndex)
+        {
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+            object result = 0;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedIndex, startIndex);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            TimeSpanHeaderParser parser = TimeSpanHeaderParser.Parser;
+            object result = 0;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result), 
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/TransferCodingHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/TransferCodingHeaderParserTest.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class TransferCodingHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            TransferCodingHeaderParser parser = TransferCodingHeaderParser.MultipleValueParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = TransferCodingHeaderParser.SingleValueParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = TransferCodingHeaderParser.MultipleValueWithQualityParser;
+            Assert.True(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+
+            parser = TransferCodingHeaderParser.SingleValueWithQualityParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void Parse_ValidValue_ReturnsTransferCodingHeaderValue()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            TransferCodingHeaderParser parser = TransferCodingHeaderParser.MultipleValueParser;
+            int index = 2;
+
+            TransferCodingHeaderValue expected = new TransferCodingHeaderValue("custom");
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            Assert.True(expected.Equals(parser.ParseValue("   custom ; name = value ", null, ref index)));
+            Assert.Equal(25, index);
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throw()
+        {
+            // This test verifies that Parse() correctly calls TryParse().
+            TransferCodingHeaderParser parser = TransferCodingHeaderParser.MultipleValueParser;
+            int index = 0;
+            
+            Assert.Throws<FormatException>(() => { parser.ParseValue("custom;=value", null, ref index); });
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            TransferCodingHeaderValue expected = new TransferCodingHeaderValue("custom");
+            CheckValidParsedValue("\r\n custom  ", 0, expected, 11);
+            CheckValidParsedValue("custom", 0, expected, 6);
+            CheckValidParsedValue(",,custom", 0, expected, 8);
+            CheckValidParsedValue(" , , custom", 0, expected, 11);
+            CheckValidParsedValue("\r\n custom  , chunked", 0, expected, 13);
+            CheckValidParsedValue("\r\n custom  , , , chunked", 0, expected, 17);
+
+            CheckValidParsedValue(null, 0, null, 0);
+            CheckValidParsedValue(string.Empty, 0, null, 0);
+            CheckValidParsedValue("  ", 0, null, 2);
+            CheckValidParsedValue("  ,,", 0, null, 4);
+
+            // Note that even if the whole string is invalid, the first transfer-coding value is valid. When the parser
+            // gets called again using the result-index (9), then it fails: I.e. we have 1 valid transfer-coding
+            // and an invalid one.
+            CheckValidParsedValue("custom , 会", 0, expected, 9);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidParsedValue("\r\n custom ;  name =   value ", 0, expected, 28);
+            CheckValidParsedValue("\r\n , , custom ;  name =   value ", 0, expected, 32);
+            CheckValidParsedValue("  custom;name=value", 2, expected, 19);
+            CheckValidParsedValue("  custom ; name=value", 2, expected, 21);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("custom; name=value;", 0);
+            CheckInvalidParsedValue("custom; name1=value1; name2=value2;", 0);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int index, TransferCodingHeaderValue expectedResult,
+            int expectedIndex)
+        {
+            TransferCodingHeaderParser parser = TransferCodingHeaderParser.MultipleValueParser;
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref index, out result),
+                string.Format("TryParse returned false. Input: '{0}', Index: {1}", input, index));
+            Assert.Equal(expectedIndex, index);
+            Assert.Equal(result, expectedResult);
+        }
+
+        private void CheckInvalidParsedValue(string source, int index)
+        {
+            TransferCodingHeaderParser parser = TransferCodingHeaderParser.MultipleValueParser;
+            object result = null;
+            int newIndex = index;
+            Assert.False(parser.TryParseValue(source, null, ref newIndex, out result),
+                string.Format("TryParse returned true. Input: '{0}', Index: {1}", source, index));
+            Assert.Equal(null, result);
+            Assert.Equal(index, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/TransferCodingHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/TransferCodingHeaderValueTest.cs
@@ -1,0 +1,329 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class TransferCodingHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_ValueNull_Throw()
+        {
+            Assert.Throws<ArgumentException>(() => { new TransferCodingHeaderValue(null); });
+        }
+
+        [Fact]
+        public void Ctor_ValueEmpty_Throw()
+        {
+            // null and empty should be treated the same. So we also throw for empty strings.
+            Assert.Throws<ArgumentException>(() => { new TransferCodingHeaderValue(string.Empty); });
+        }
+
+        [Fact]
+        public void Ctor_TransferCodingInvalidFormat_ThrowFormatException()
+        {
+            // When adding values using strongly typed objects, no leading/trailing LWS (whitespaces) are allowed.
+            AssertFormatException(" custom ");
+            AssertFormatException("custom;");
+            AssertFormatException("chänked");
+            AssertFormatException("\"chunked\"");
+            AssertFormatException("custom; name=value");
+        }
+
+        [Fact]
+        public void Ctor_TransferCodingValidFormat_SuccessfullyCreated()
+        {
+            TransferCodingHeaderValue transferCoding = new TransferCodingHeaderValue("custom");
+            Assert.Equal("custom", transferCoding.Value);
+            Assert.Equal(0, transferCoding.Parameters.Count);
+        }
+
+        [Fact]
+        public void Parameters_AddNull_Throw()
+        {
+            TransferCodingHeaderValue transferCoding = new TransferCodingHeaderValue("custom");
+            
+            Assert.Throws<ArgumentNullException>(() => { transferCoding.Parameters.Add(null); });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentTransferCodings_AllSerializedCorrectly()
+        {
+            TransferCodingHeaderValue transferCoding = new TransferCodingHeaderValue("custom");
+            Assert.Equal("custom", transferCoding.ToString());
+
+            transferCoding.Parameters.Add(new NameValueHeaderValue("paramName", "\"param value\""));
+            Assert.Equal("custom; paramName=\"param value\"", transferCoding.ToString());
+
+            transferCoding.Parameters.Add(new NameValueHeaderValue("paramName2", "\"param value2\""));
+            Assert.Equal("custom; paramName=\"param value\"; paramName2=\"param value2\"",
+                transferCoding.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseTransferCodingWithAndWithoutParameters_SameOrDifferentHashCodes()
+        {
+            TransferCodingHeaderValue transferCoding1 = new TransferCodingHeaderValue("custom");
+            TransferCodingHeaderValue transferCoding2 = new TransferCodingHeaderValue("CUSTOM");
+            TransferCodingHeaderValue transferCoding3 = new TransferCodingHeaderValue("custom");
+            transferCoding3.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            TransferCodingHeaderValue transferCoding4 = new TransferCodingHeaderValue("custom");
+            transferCoding4.Parameters.Add(new NameValueHeaderValue("NAME", "VALUE"));
+            TransferCodingHeaderValue transferCoding5 = new TransferCodingHeaderValue("custom");
+            transferCoding5.Parameters.Add(new NameValueHeaderValue("name", "\"value\""));
+            TransferCodingHeaderValue transferCoding6 = new TransferCodingHeaderValue("custom");
+            transferCoding6.Parameters.Add(new NameValueHeaderValue("name", "\"VALUE\""));
+            TransferCodingHeaderValue transferCoding7 = new TransferCodingHeaderValue("custom");
+            transferCoding7.Parameters.Add(new NameValueHeaderValue("name", "\"VALUE\""));
+            transferCoding7.Parameters.Clear();
+
+            Assert.Equal(transferCoding1.GetHashCode(), transferCoding2.GetHashCode());
+            Assert.NotEqual(transferCoding1.GetHashCode(), transferCoding3.GetHashCode());
+            Assert.Equal(transferCoding3.GetHashCode(), transferCoding4.GetHashCode());
+            Assert.NotEqual(transferCoding5.GetHashCode(), transferCoding6.GetHashCode());
+            Assert.Equal(transferCoding1.GetHashCode(), transferCoding7.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseTransferCodingWithAndWithoutParameters_EqualOrNotEqualNoExceptions()
+        {
+            TransferCodingHeaderValue transferCoding1 = new TransferCodingHeaderValue("custom");
+            TransferCodingHeaderValue transferCoding2 = new TransferCodingHeaderValue("CUSTOM");
+            TransferCodingHeaderValue transferCoding3 = new TransferCodingHeaderValue("custom");
+            transferCoding3.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            TransferCodingHeaderValue transferCoding4 = new TransferCodingHeaderValue("custom");
+            transferCoding4.Parameters.Add(new NameValueHeaderValue("NAME", "VALUE"));
+            TransferCodingHeaderValue transferCoding5 = new TransferCodingHeaderValue("custom");
+            transferCoding5.Parameters.Add(new NameValueHeaderValue("name", "\"value\""));
+            TransferCodingHeaderValue transferCoding6 = new TransferCodingHeaderValue("custom");
+            transferCoding6.Parameters.Add(new NameValueHeaderValue("name", "\"VALUE\""));
+            TransferCodingHeaderValue transferCoding7 = new TransferCodingHeaderValue("custom");
+            transferCoding7.Parameters.Add(new NameValueHeaderValue("name", "\"VALUE\""));
+            transferCoding7.Parameters.Clear();
+
+            Assert.False(transferCoding1.Equals(null), "Compare to <null>.");
+            Assert.True(transferCoding1.Equals(transferCoding2), "Different casing.");
+            Assert.False(transferCoding1.Equals(transferCoding3), "No params vs. custom param.");
+            Assert.True(transferCoding3.Equals(transferCoding4), "Params have different casing.");
+            Assert.False(transferCoding5.Equals(transferCoding6),
+                "Param value are quoted strings with different casing.");
+            Assert.True(transferCoding1.Equals(transferCoding7), "no vs. empty parameters collection.");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            TransferCodingHeaderValue source = new TransferCodingHeaderValue("custom");
+            TransferCodingHeaderValue clone = (TransferCodingHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(0, clone.Parameters.Count);
+
+            source.Parameters.Add(new NameValueHeaderValue("custom", "customValue"));
+            clone = (TransferCodingHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(1, clone.Parameters.Count);
+            Assert.Equal("custom", clone.Parameters.ElementAt(0).Name);
+            Assert.Equal("customValue", clone.Parameters.ElementAt(0).Value);
+        }
+
+        [Fact]
+        public void GetTransferCodingLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            TransferCodingHeaderValue result = null;
+
+            Assert.Equal(7, TransferCodingHeaderValue.GetTransferCodingLength("chunked", 0,
+                DummyCreator, out result));
+            Assert.Equal("chunked", result.Value);
+            Assert.Equal(0, result.Parameters.Count);
+
+            Assert.Equal(5, TransferCodingHeaderValue.GetTransferCodingLength("gzip , chunked", 0,
+                DummyCreator, out result));
+            Assert.Equal("gzip", result.Value);
+            Assert.Equal(0, result.Parameters.Count);
+
+            Assert.Equal(18, TransferCodingHeaderValue.GetTransferCodingLength("custom; name=value", 0,
+                DummyCreator, out result));
+            Assert.Equal("custom", result.Value);
+            Assert.Equal(1, result.Parameters.Count);
+            Assert.Equal("name", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("value", result.Parameters.ElementAt(0).Value);
+
+            // Note that TransferCodingHeaderValue recognizes the first transfer-coding as valid, even though it is
+            // followed by an invalid character. The parser will call GetTransferCodingLength() starting at the invalid
+            // character which will result in GetTransferCodingLength() returning 0 (see next test).
+            Assert.Equal(26, TransferCodingHeaderValue.GetTransferCodingLength(
+                " custom;name1=value1;name2 ,  \u4F1A", 1, DummyCreator, out result));
+            Assert.Equal("custom", result.Value);
+            Assert.Equal(2, result.Parameters.Count);
+            Assert.Equal("name1", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("value1", result.Parameters.ElementAt(0).Value);
+            Assert.Equal("name2", result.Parameters.ElementAt(1).Name);
+            Assert.Null(result.Parameters.ElementAt(1).Value);
+
+            // There will be no exception for invalid characters. GetTransferCodingLength() will just return a length
+            // of 0. The caller needs to validate if that's OK or not.
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength("\u4F1A", 0, DummyCreator, out result));
+
+            Assert.Equal(45, TransferCodingHeaderValue.GetTransferCodingLength(
+                "  custom ; name1 =\r\n \"value1\" ; name2 = value2 , next", 2, DummyCreator, out result));
+            Assert.Equal("custom", result.Value);
+            Assert.Equal(2, result.Parameters.Count);
+            Assert.Equal("name1", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("\"value1\"", result.Parameters.ElementAt(0).Value);
+            Assert.Equal("name2", result.Parameters.ElementAt(1).Name);
+            Assert.Equal("value2", result.Parameters.ElementAt(1).Value);
+
+            Assert.Equal(32, TransferCodingHeaderValue.GetTransferCodingLength(
+                " custom;name1=value1;name2=value2,next", 1, DummyCreator, out result));
+            Assert.Equal("custom", result.Value);
+            Assert.Equal(2, result.Parameters.Count);
+            Assert.Equal("name1", result.Parameters.ElementAt(0).Name);
+            Assert.Equal("value1", result.Parameters.ElementAt(0).Value);
+            Assert.Equal("name2", result.Parameters.ElementAt(1).Name);
+            Assert.Equal("value2", result.Parameters.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void GetTransferCodingLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            TransferCodingHeaderValue result = null;
+
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength(" custom", 0, DummyCreator,
+                out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength("custom;", 0, DummyCreator,
+                out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength("custom;name=", 0, DummyCreator,
+                out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength("custom;name=value;", 0,
+                DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength("custom;name=,value;", 0,
+                DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength("custom;", 0, DummyCreator,
+                out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength(null, 0, DummyCreator, out result));
+            Assert.Null(result);
+            Assert.Equal(0, TransferCodingHeaderValue.GetTransferCodingLength(string.Empty, 0, DummyCreator,
+                out result));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            TransferCodingHeaderValue expected = new TransferCodingHeaderValue("custom");
+            CheckValidParse("\r\n custom  ", expected);
+            CheckValidParse("custom", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidParse("\r\n custom ;  name =   value ", expected);
+            CheckValidParse("  custom;name=value", expected);
+            CheckValidParse("  custom ; name=value", expected);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("custom; name=value;");
+            CheckInvalidParse("custom; name1=value1; name2=value2;");
+            CheckInvalidParse(",,custom");
+            CheckInvalidParse(" , , custom");
+            CheckInvalidParse("\r\n custom  , chunked");
+            CheckInvalidParse("\r\n custom  , , , chunked");
+            CheckInvalidParse("custom , \u4F1A");
+            CheckInvalidParse("\r\n , , custom ;  name =   value ");
+
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            TransferCodingHeaderValue expected = new TransferCodingHeaderValue("custom");
+            CheckValidTryParse("\r\n custom  ", expected);
+            CheckValidTryParse("custom", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidTryParse("\r\n custom ;  name =   value ", expected);
+            CheckValidTryParse("  custom;name=value", expected);
+            CheckValidTryParse("  custom ; name=value", expected);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("custom; name=value;");
+            CheckInvalidTryParse("custom; name1=value1; name2=value2;");
+            CheckInvalidTryParse(",,custom");
+            CheckInvalidTryParse(" , , custom");
+            CheckInvalidTryParse("\r\n custom  , chunked");
+            CheckInvalidTryParse("\r\n custom  , , , chunked");
+            CheckInvalidTryParse("custom , \u4F1A");
+            CheckInvalidTryParse("\r\n , , custom ;  name =   value ");
+
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, TransferCodingHeaderValue expectedResult)
+        {
+            TransferCodingHeaderValue result = TransferCodingHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { TransferCodingHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, TransferCodingHeaderValue expectedResult)
+        {
+            TransferCodingHeaderValue result = null;
+            Assert.True(TransferCodingHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            TransferCodingHeaderValue result = null;
+            Assert.False(TransferCodingHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void AssertFormatException(string transferCoding)
+        {
+            Assert.Throws<FormatException>(() => { new TransferCodingHeaderValue(transferCoding); });
+        }
+
+        private static TransferCodingHeaderValue DummyCreator()
+        {
+            return new TransferCodingHeaderValue();
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/TransferCodingWithQualityHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/TransferCodingWithQualityHeaderValueTest.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class TransferCodingWithQualityHeaderValueTest
+    {
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            // This test just verifies that TransferCodingWithQualityHeaderValue calls the correct base implementation.
+            TransferCodingWithQualityHeaderValue source = new TransferCodingWithQualityHeaderValue("custom");
+            TransferCodingWithQualityHeaderValue clone = (TransferCodingWithQualityHeaderValue)
+                ((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(0, clone.Parameters.Count);
+
+            source.Quality = 0.1;
+            clone = (TransferCodingWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(0.1, clone.Quality);
+            Assert.Equal(1, clone.Parameters.Count);
+
+            source.Parameters.Add(new NameValueHeaderValue("custom", "customValue"));
+            clone = (TransferCodingWithQualityHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Value, clone.Value);
+            Assert.Equal(0.1, clone.Quality);
+            Assert.Equal(2, clone.Parameters.Count);
+            Assert.Equal("custom", clone.Parameters.ElementAt(1).Name);
+            Assert.Equal("customValue", clone.Parameters.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void Ctor_AddValueAndQuality_QualityParameterAdded()
+        {
+            TransferCodingWithQualityHeaderValue mediaType = new TransferCodingWithQualityHeaderValue("custom", 0.08);
+            Assert.Equal(0.08, mediaType.Quality);
+            Assert.Equal("custom", mediaType.Value);
+            Assert.Equal(1, mediaType.Parameters.Count);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            TransferCodingWithQualityHeaderValue expected = new TransferCodingWithQualityHeaderValue("custom");
+            CheckValidParse("\r\n custom  ", expected);
+            CheckValidParse("custom", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidParse("\r\n custom ;  name =   value ", expected);
+            CheckValidParse("  custom;name=value", expected);
+            CheckValidParse("  custom ; name=value", expected);
+
+
+            TransferCodingWithQualityHeaderValue value1 = new TransferCodingWithQualityHeaderValue("custom1");
+            value1.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            value1.Quality = 1.0;
+
+            CheckValidParse("custom1 ; param1 =value1 ; q= 1.0 ", value1);
+
+            TransferCodingWithQualityHeaderValue value2 = new TransferCodingWithQualityHeaderValue("custom2");
+            value2.Parameters.Add(new NameValueHeaderValue("param2", "value2"));
+            value2.Quality = 0.5;
+
+            CheckValidParse("\r\n custom2; param2= value2; q =0.5  ", value2);
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("custom; name=value;");
+            CheckInvalidParse("custom; name1=value1; name2=value2;");
+            CheckInvalidParse(",,custom");
+            CheckInvalidParse(" , , custom");
+            CheckInvalidParse("\r\n custom  , chunked");
+            CheckInvalidParse("\r\n custom  , , , chunked");
+            CheckInvalidParse("custom , \u4F1A");
+            CheckInvalidParse("\r\n , , custom ;  name =   value ");
+
+            CheckInvalidParse(",custom1; param1=value1; q=1.0,,\r\n custom2; param2=value2; q=0.5  ,");
+            CheckInvalidParse("custom1; param1=value1; q=1.0,");
+            CheckInvalidParse(",\r\n custom2; param2=value2; q=0.5");
+
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            TransferCodingWithQualityHeaderValue expected = new TransferCodingWithQualityHeaderValue("custom");
+            CheckValidTryParse("\r\n custom  ", expected);
+            CheckValidTryParse("custom", expected);
+
+            // We don't have to test all possible input strings, since most of the pieces are handled by other parsers.
+            // The purpose of this test is to verify that these other parsers are combined correctly to build a 
+            // transfer-coding parser.
+            expected.Parameters.Add(new NameValueHeaderValue("name", "value"));
+            CheckValidTryParse("\r\n custom ;  name =   value ", expected);
+            CheckValidTryParse("  custom;name=value", expected);
+            CheckValidTryParse("  custom ; name=value", expected);
+
+
+            TransferCodingWithQualityHeaderValue value1 = new TransferCodingWithQualityHeaderValue("custom1");
+            value1.Parameters.Add(new NameValueHeaderValue("param1", "value1"));
+            value1.Quality = 1.0;
+
+            CheckValidTryParse("custom1 ; param1 =value1 ; q= 1.0 ", value1);
+
+            TransferCodingWithQualityHeaderValue value2 = new TransferCodingWithQualityHeaderValue("custom2");
+            value2.Parameters.Add(new NameValueHeaderValue("param2", "value2"));
+            value2.Quality = 0.5;
+
+            CheckValidTryParse("\r\n custom2; param2= value2; q =0.5  ", value2);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("custom; name=value;");
+            CheckInvalidTryParse("custom; name1=value1; name2=value2;");
+            CheckInvalidTryParse(",,custom");
+            CheckInvalidTryParse(" , , custom");
+            CheckInvalidTryParse("\r\n custom  , chunked");
+            CheckInvalidTryParse("\r\n custom  , , , chunked");
+            CheckInvalidTryParse("custom , \u4F1A");
+            CheckInvalidTryParse("\r\n , , custom ;  name =   value ");
+
+            CheckInvalidTryParse(",custom1; param1=value1; q=1.0,,\r\n custom2; param2=value2; q=0.5  ,");
+            CheckInvalidTryParse("custom1; param1=value1; q=1.0,");
+            CheckInvalidTryParse(",\r\n custom2; param2=value2; q=0.5");
+
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, TransferCodingWithQualityHeaderValue expectedResult)
+        {
+            TransferCodingWithQualityHeaderValue result = TransferCodingWithQualityHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { TransferCodingWithQualityHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, TransferCodingWithQualityHeaderValue expectedResult)
+        {
+            TransferCodingWithQualityHeaderValue result = null;
+            Assert.True(TransferCodingWithQualityHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            TransferCodingWithQualityHeaderValue result = null;
+            Assert.False(TransferCodingWithQualityHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/UriHeaderParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/UriHeaderParserTest.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class UriHeaderParserTest
+    {
+        [Fact]
+        public void Properties_ReadValues_MatchExpectation()
+        {
+            UriHeaderParser parser = UriHeaderParser.RelativeOrAbsoluteUriParser;
+            Assert.False(parser.SupportsMultipleValues);
+            Assert.Null(parser.Comparer);
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            // We don't need to validate all possible Uri values, since we use Uri.TryParse().
+            // Just make sure the parser calls Uri.TryParse() correctly.
+            CheckValidParsedValue("/this/is/a/rel/uri", 0, new Uri("/this/is/a/rel/uri", UriKind.Relative), 18);
+            CheckValidParsedValue("!!  http://example.com/path,/ ", 2, new Uri("http://example.com/path,/"), 30);
+
+            // Note that Uri.TryParse(.., UriKind.Relative) doesn't remove whitespaces
+            CheckValidParsedValue("!!  /path/x,/  ", 2, new Uri("  /path/x,/  ", UriKind.Relative), 15);
+            CheckValidParsedValue("  http://example.com/path/?query=value   ", 2, new Uri("http://example.com/path/?query=value"), 41);
+            CheckValidParsedValue("  http://example.com/path/?query=value \r\n  ", 2, new Uri("http://example.com/path/?query=value"), 43);
+            CheckValidParsedValue("http://idn-iis1.\u65E5\u672C\u56FD.microsoft.com/", 0, new Uri("http://idn-iis1.\u65E5\u672C\u56FD.microsoft.com/"), 34);
+            CheckValidParsedValue("http://idn-iis1.\u00E6\u0097\u00A5\u00E6\u009C\u00AC\u00E5\u009B\u00BD.microsoft.com/", 0, new Uri("http://idn-iis1.\u65E5\u672C\u56FD.microsoft.com/"), 40);
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidParsedValue("http://example.com,", 0);
+
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(null, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+            CheckInvalidParsedValue(string.Empty, 0);
+            CheckInvalidParsedValue("  ", 2);
+            CheckInvalidParsedValue("  ", 2);
+        }
+
+        #region Helper methods
+
+        private void CheckValidParsedValue(string input, int startIndex, Uri expectedResult, int expectedIndex)
+        {
+            UriHeaderParser parser = UriHeaderParser.RelativeOrAbsoluteUriParser;
+
+            object result = null;
+            Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
+                string.Format("TryParse returned false: {0}", input));
+            Assert.Equal(expectedIndex, startIndex);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParsedValue(string input, int startIndex)
+        {
+            UriHeaderParser parser = UriHeaderParser.RelativeOrAbsoluteUriParser;
+
+            object result = null;
+            int newIndex = startIndex;
+            Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),
+                string.Format("TryParse returned true: {0}", input));
+            Assert.Equal(null, result);
+            Assert.Equal(startIndex, newIndex);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/ViaHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ViaHeaderValueTest.cs
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class ViaHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_ProtocolVersionAndReceivedByOnlyOverload_CallForwardedToOtherCtor()
+        {
+            ViaHeaderValue via = new ViaHeaderValue("1.1", ".token");
+            Assert.Equal("1.1", via.ProtocolVersion);
+            Assert.Equal(".token", via.ReceivedBy);
+            Assert.Null(via.ProtocolName);
+            Assert.Null(via.Comment);
+
+            via = new ViaHeaderValue("x11", "[::1]:1818");
+            Assert.Equal("x11", via.ProtocolVersion);
+            Assert.Equal("[::1]:1818", via.ReceivedBy);
+
+            Assert.Throws<ArgumentException>(() => { new ViaHeaderValue(null, "host"); });
+            Assert.Throws<ArgumentException>(() => { new ViaHeaderValue("", "host"); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("x y", "h"); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("x ", "h"); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue(" x", "h"); });
+            Assert.Throws<ArgumentException>(() => { new ViaHeaderValue("1.1", null); });
+            Assert.Throws<ArgumentException>(() => { new ViaHeaderValue("1.1", ""); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "x y"); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "x "); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", " x"); });
+        }
+
+        [Fact]
+        public void Ctor_ProtocolVersionReceivedByAndProtocolNameOnlyOverload_CallForwardedToOtherCtor()
+        {
+            ViaHeaderValue via = new ViaHeaderValue("1.1", "host", "HTTP");
+            Assert.Equal("1.1", via.ProtocolVersion);
+            Assert.Equal("host", via.ReceivedBy);
+            Assert.Equal("HTTP", via.ProtocolName);
+            Assert.Null(via.Comment);
+
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "h", "x y"); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "h", "x "); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "h", " x"); });
+        }
+
+        [Fact]
+        public void Ctor_AllParams_AllFieldsInitializedCorrectly()
+        {
+            ViaHeaderValue via = new ViaHeaderValue("1.1", "host", "HTTP", "(comment)");
+            Assert.Equal("1.1", via.ProtocolVersion);
+            Assert.Equal("host", via.ReceivedBy);
+            Assert.Equal("HTTP", via.ProtocolName);
+            Assert.Equal("(comment)", via.Comment);
+
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "h", "p", "(x"); });
+            Assert.Throws<FormatException>(() => { new ViaHeaderValue("v", "h", "p", "x)"); });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRanges_AllSerializedCorrectly()
+        {
+            ViaHeaderValue via = new ViaHeaderValue("1.1", "host:80");
+            Assert.Equal("1.1 host:80", via.ToString());
+
+            via = new ViaHeaderValue("1.1", "[::1]", "HTTP");
+            Assert.Equal("HTTP/1.1 [::1]", via.ToString());
+
+            via = new ViaHeaderValue("1.0", "www.example.com", "WS", "(comment)");
+            Assert.Equal("WS/1.0 www.example.com (comment)", via.ToString());
+
+            via = new ViaHeaderValue("1.0", "www.example.com:80", null, "(comment)");
+            Assert.Equal("1.0 www.example.com:80 (comment)", via.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRanges_SameOrDifferentHashCodes()
+        {
+            ViaHeaderValue via1 = new ViaHeaderValue("x11", "host");
+            ViaHeaderValue via2 = new ViaHeaderValue("x11", "HOST");
+            ViaHeaderValue via3 = new ViaHeaderValue("X11", "host");
+            ViaHeaderValue via4 = new ViaHeaderValue("x11", "host", "HTTP");
+            ViaHeaderValue via5 = new ViaHeaderValue("x11", "host", "http");
+            ViaHeaderValue via6 = new ViaHeaderValue("x11", "host", null, "(comment)");
+            ViaHeaderValue via7 = new ViaHeaderValue("x11", "host", "HTTP", "(comment)");
+            ViaHeaderValue via8 = new ViaHeaderValue("x11", "host", "HTTP", "(COMMENT)");
+            ViaHeaderValue via9 = new ViaHeaderValue("x12", "host");
+            ViaHeaderValue via10 = new ViaHeaderValue("x11", "host2");
+            ViaHeaderValue via11 = new ViaHeaderValue("x11", "host", "WS");
+            ViaHeaderValue via12 = new ViaHeaderValue("x11", "host", string.Empty, string.Empty);
+
+            Assert.Equal(via1.GetHashCode(), via2.GetHashCode());
+            Assert.Equal(via1.GetHashCode(), via3.GetHashCode());
+            Assert.NotEqual(via1.GetHashCode(), via4.GetHashCode());
+            Assert.NotEqual(via1.GetHashCode(), via6.GetHashCode());
+            Assert.NotEqual(via1.GetHashCode(), via7.GetHashCode());
+            Assert.NotEqual(via1.GetHashCode(), via9.GetHashCode());
+            Assert.NotEqual(via1.GetHashCode(), via10.GetHashCode());
+            Assert.NotEqual(via4.GetHashCode(), via11.GetHashCode());
+            Assert.Equal(via4.GetHashCode(), via5.GetHashCode());
+            Assert.NotEqual(via4.GetHashCode(), via6.GetHashCode());
+            Assert.NotEqual(via6.GetHashCode(), via7.GetHashCode());
+            Assert.NotEqual(via7.GetHashCode(), via8.GetHashCode());
+            Assert.Equal(via1.GetHashCode(), via12.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            ViaHeaderValue via1 = new ViaHeaderValue("x11", "host");
+            ViaHeaderValue via2 = new ViaHeaderValue("x11", "HOST");
+            ViaHeaderValue via3 = new ViaHeaderValue("X11", "host");
+            ViaHeaderValue via4 = new ViaHeaderValue("x11", "host", "HTTP");
+            ViaHeaderValue via5 = new ViaHeaderValue("x11", "host", "http");
+            ViaHeaderValue via6 = new ViaHeaderValue("x11", "host", null, "(comment)");
+            ViaHeaderValue via7 = new ViaHeaderValue("x11", "host", "HTTP", "(comment)");
+            ViaHeaderValue via8 = new ViaHeaderValue("x11", "host", "HTTP", "(COMMENT)");
+            ViaHeaderValue via9 = new ViaHeaderValue("x12", "host");
+            ViaHeaderValue via10 = new ViaHeaderValue("x11", "host2");
+            ViaHeaderValue via11 = new ViaHeaderValue("x11", "host", "WS");
+            ViaHeaderValue via12 = new ViaHeaderValue("x11", "host", string.Empty, string.Empty);
+
+            Assert.False(via1.Equals(null), "x11 host vs. <null>");
+            Assert.True(via1.Equals(via2), "x11 host vs. x11 HOST");
+            Assert.True(via1.Equals(via3), "x11 host vs. X11 host");
+            Assert.False(via1.Equals(via4), "x11 host vs. HTTP/x11 host");
+            Assert.False(via4.Equals(via1), "HTTP/x11 host vs. x11 host");
+            Assert.False(via1.Equals(via6), "x11 host vs. HTTP/x11 (comment)");
+            Assert.False(via6.Equals(via1), "HTTP/x11 (comment) vs. x11 host");
+            Assert.False(via1.Equals(via7), "x11 host vs. HTTP/x11 host (comment)");
+            Assert.False(via7.Equals(via1), "HTTP/x11 host (comment) vs. x11 host");
+            Assert.False(via1.Equals(via9), "x11 host vs. x12 host");
+            Assert.False(via1.Equals(via10), "x11 host vs. x11 host2");
+            Assert.False(via4.Equals(via11), "HTTP/x11 host vs. WS/x11 host");
+            Assert.True(via4.Equals(via5), "HTTP/x11 host vs. http/x11 host");
+            Assert.False(via4.Equals(via6), "HTTP/x11 host vs. x11 host (comment)");
+            Assert.False(via6.Equals(via4), "x11 host (comment) vs. HTTP/x11 host");
+            Assert.False(via6.Equals(via7), "x11 host (comment) vs. HTTP/x11 host (comment)");
+            Assert.False(via7.Equals(via6), "HTTP/x11 host (comment) vs. x11 host (comment)");
+            Assert.False(via7.Equals(via8), "HTTP/x11 host (comment) vs. HTTP/x11 host (COMMENT)");
+            Assert.True(via1.Equals(via12), "x11 host vs. x11 host <empty> <empty>");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            ViaHeaderValue source = new ViaHeaderValue("1.1", "host");
+            ViaHeaderValue clone = (ViaHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.ProtocolVersion, clone.ProtocolVersion);
+            Assert.Equal(source.ReceivedBy, clone.ReceivedBy);
+            Assert.Equal(source.ProtocolName, clone.ProtocolName);
+            Assert.Equal(source.Comment, clone.Comment);
+
+            source = new ViaHeaderValue("1.1", "host", "HTTP");
+            clone = (ViaHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.ProtocolVersion, clone.ProtocolVersion);
+            Assert.Equal(source.ReceivedBy, clone.ReceivedBy);
+            Assert.Equal(source.ProtocolName, clone.ProtocolName);
+            Assert.Equal(source.Comment, clone.Comment);
+
+            source = new ViaHeaderValue("1.1", "host", "HTTP", "(comment)");
+            clone = (ViaHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.ProtocolVersion, clone.ProtocolVersion);
+            Assert.Equal(source.ReceivedBy, clone.ReceivedBy);
+            Assert.Equal(source.ProtocolName, clone.ProtocolName);
+            Assert.Equal(source.Comment, clone.Comment);
+        }
+
+        [Fact]
+        public void GetViaLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            CheckGetViaLength(" HTTP  /  1.1   .host \t (comment)  ", 1, 34,
+                new ViaHeaderValue("1.1", ".host", "HTTP", "(comment)"));
+            CheckGetViaLength("x11x [FE18:AB64::156]:80 (comment,) other", 0, 36,
+                new ViaHeaderValue("x11x", "[FE18:AB64::156]:80", null, "(comment,)"));
+
+            // The parser reads until it reaches an invalid/unexpected character. If until then it was able to create
+            // a valid ViaHeaderValue, it will return the length of the parsed string. Therefore a string like 
+            // "1.1 host," is considered valid (until ','), whereas "1.1 host (invalid" is considered invalid, since
+            // the comment is in an invalid format.
+            CheckGetViaLength("WS/version example.com,next", 0, 22, new ViaHeaderValue("version", "example.com", "WS"));
+
+            // Note that since 'HTTP1.1' is a valid token, it is considered to be the protocol version.
+            CheckGetViaLength("HTTP1.1 host", 0, 12, new ViaHeaderValue("HTTP1.1", "host"));
+
+            CheckGetViaLength(" v h", 1, 3, new ViaHeaderValue("v", "h"));
+            CheckGetViaLength(" p/v h", 1, 5, new ViaHeaderValue("v", "h", "p"));
+            CheckGetViaLength(" p/v h (c)", 1, 9, new ViaHeaderValue("v", "h", "p", "(c)"));
+            CheckGetViaLength(" v h,,", 1, 3, new ViaHeaderValue("v", "h"));
+            CheckGetViaLength(" p/v h,,", 1, 5, new ViaHeaderValue("v", "h", "p"));
+            CheckGetViaLength(" p/v h (c),,", 1, 9, new ViaHeaderValue("v", "h", "p", "(c)"));
+            CheckGetViaLength(" v h ", 1, 4, new ViaHeaderValue("v", "h"));
+            CheckGetViaLength(" p/v h ", 1, 6, new ViaHeaderValue("v", "h", "p"));
+            CheckGetViaLength(" p/v h (c) ", 1, 10, new ViaHeaderValue("v", "h", "p", "(c)"));
+
+            CheckGetViaLength(null, 0, 0, null);
+            CheckGetViaLength(string.Empty, 0, 0, null);
+            CheckGetViaLength("  ", 0, 0, null);
+        }
+
+        [Fact]
+        public void GetViaLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidGetViaLength(" 1.1 host", 0); // no leading whitespaces allowed
+            CheckInvalidGetViaLength("1=host", 0);
+            CheckInvalidGetViaLength("1.1 host (invalid_comment", 0);
+            CheckInvalidGetViaLength("=", 0);
+            CheckInvalidGetViaLength("HTTP=1.1 host", 0);
+            CheckInvalidGetViaLength("HTTP=/1.1 host", 0);
+            CheckInvalidGetViaLength("HTTP/1.1[ host", 0);
+            CheckInvalidGetViaLength("HTTP/ = host", 0);
+            CheckInvalidGetViaLength("HTTP/务 host", 0);
+            CheckInvalidGetViaLength("HTTP/  ", 0);
+            CheckInvalidGetViaLength("HTTP  ", 0);
+            CheckInvalidGetViaLength("HTTP/1.1 /  ", 0);
+            CheckInvalidGetViaLength("1.1 ", 0);
+            CheckInvalidGetViaLength("  ", 0);
+            CheckInvalidGetViaLength("WS/version example.com[", 0);
+            CheckInvalidGetViaLength("HTTP/test[::1]", 0);
+            CheckInvalidGetViaLength("HTTP/test [::1]:80(comment)", 0);
+            CheckInvalidGetViaLength("1.1 http://example.com", 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse(" 1.1   host ", new ViaHeaderValue("1.1", "host"));
+            CheckValidParse(" HTTP  /  x11   192.168.0.1\r\n (comment) ",
+                new ViaHeaderValue("x11", "192.168.0.1", "HTTP", "(comment)"));
+            CheckValidParse(" HTTP/1.1 [::1]", new ViaHeaderValue("1.1", "[::1]", "HTTP"));
+            CheckValidParse("1.1 host", new ViaHeaderValue("1.1", "host"));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("HTTP/1.1 host (comment)invalid");
+            CheckInvalidParse("HTTP/1.1 host (comment)=");
+            CheckInvalidParse("HTTP/1.1 host (comment) invalid");
+            CheckInvalidParse("HTTP/1.1 host (comment) =");
+            CheckInvalidParse("HTTP/1.1 host invalid");
+            CheckInvalidParse("HTTP/1.1 host =");
+            CheckInvalidParse("1.1 host invalid");
+            CheckInvalidParse("1.1 host =");
+            CheckInvalidParse("会");
+            CheckInvalidParse("HTTP/test [::1]:80\r(comment)");
+            CheckInvalidParse("HTTP/test [::1]:80\n(comment)");
+
+            CheckInvalidParse("X , , 1.1   host, ,next");
+            CheckInvalidParse("X HTTP  /  x11   192.168.0.1\r\n (comment) , ,next");
+            CheckInvalidParse(" ,HTTP/1.1 [::1]");
+
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse(" 1.1   host ", new ViaHeaderValue("1.1", "host"));
+            CheckValidTryParse(" HTTP  /  x11   192.168.0.1\r\n (comment) ",
+                new ViaHeaderValue("x11", "192.168.0.1", "HTTP", "(comment)"));
+            CheckValidTryParse(" HTTP/1.1 [::1]", new ViaHeaderValue("1.1", "[::1]", "HTTP"));
+            CheckValidTryParse("1.1 host", new ViaHeaderValue("1.1", "host"));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("HTTP/1.1 host (comment)invalid");
+            CheckInvalidTryParse("HTTP/1.1 host (comment)=");
+            CheckInvalidTryParse("HTTP/1.1 host (comment) invalid");
+            CheckInvalidTryParse("HTTP/1.1 host (comment) =");
+            CheckInvalidTryParse("HTTP/1.1 host invalid");
+            CheckInvalidTryParse("HTTP/1.1 host =");
+            CheckInvalidTryParse("1.1 host invalid");
+            CheckInvalidTryParse("1.1 host =");
+            CheckInvalidTryParse("会");
+            CheckInvalidTryParse("HTTP/test [::1]:80\r(comment)");
+            CheckInvalidTryParse("HTTP/test [::1]:80\n(comment)");
+
+            CheckInvalidTryParse("X , , 1.1   host, ,next");
+            CheckInvalidTryParse("X HTTP  /  x11   192.168.0.1\r\n (comment) , ,next");
+            CheckInvalidTryParse(" ,HTTP/1.1 [::1]");
+
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, ViaHeaderValue expectedResult)
+        {
+            ViaHeaderValue result = ViaHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { ViaHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, ViaHeaderValue expectedResult)
+        {
+            ViaHeaderValue result = null;
+            Assert.True(ViaHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            ViaHeaderValue result = null;
+            Assert.False(ViaHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CheckGetViaLength(string input, int startIndex, int expectedLength,
+            ViaHeaderValue expectedResult)
+        {
+            object result = null;
+            Assert.Equal(expectedLength, ViaHeaderValue.GetViaLength(input, startIndex, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private static void CheckInvalidGetViaLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, ViaHeaderValue.GetViaLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/Headers/WarningHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/WarningHeaderValueTest.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class WarningHeaderValueTest
+    {
+        [Fact]
+        public void Ctor_3ParamsOverload_AllFieldsInitializedCorrectly()
+        {
+            WarningHeaderValue warning = new WarningHeaderValue(111, ".host", "\"Revalidation failed\"");
+            Assert.Equal(111, warning.Code);
+            Assert.Equal(".host", warning.Agent);
+            Assert.Equal("\"Revalidation failed\"", warning.Text);
+            Assert.Null(warning.Date);
+
+            warning = new WarningHeaderValue(112, "[::1]", "\"Disconnected operation\"");
+            Assert.Equal(112, warning.Code);
+            Assert.Equal("[::1]", warning.Agent);
+            Assert.Equal("\"Disconnected operation\"", warning.Text);
+            Assert.Null(warning.Date);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new WarningHeaderValue(-1, "host", "\"\""); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new WarningHeaderValue(1000, "host", "\"\""); });
+
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, null, "\"\""); });
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, "", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "x y", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "x ", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, " x", "\"\""); });
+
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, null, "\"\""); });
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, "", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "h", "x"); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "h", "\"x"); });
+        }
+
+        [Fact]
+        public void Ctor_4ParamsOverload_AllFieldsInitializedCorrectly()
+        {
+            WarningHeaderValue warning = new WarningHeaderValue(111, "host", "\"Revalidation failed\"",
+                new DateTimeOffset(2010, 7, 19, 17, 9, 15, TimeSpan.Zero));
+            Assert.Equal(111, warning.Code);
+            Assert.Equal("host", warning.Agent);
+            Assert.Equal("\"Revalidation failed\"", warning.Text);
+            Assert.Equal(new DateTimeOffset(2010, 7, 19, 17, 9, 15, TimeSpan.Zero), warning.Date);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new WarningHeaderValue(-1, "host", "\"\""); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new WarningHeaderValue(1000, "host", "\"\""); });
+
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, null, "\"\""); });
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, "", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "[::1]:80(x)", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "host::80", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "192.168.0.1=", "\"\""); });
+
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, null, "\"\""); });
+            Assert.Throws<ArgumentException>(() => { new WarningHeaderValue(100, "", "\"\""); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "h", "(x)"); });
+            Assert.Throws<FormatException>(() => { new WarningHeaderValue(100, "h", "\"x\"y"); });
+        }
+
+        [Fact]
+        public void ToString_UseDifferentRanges_AllSerializedCorrectly()
+        {
+            WarningHeaderValue warning = new WarningHeaderValue(113, "host:80", "\"Heuristic expiration\"");
+            Assert.Equal("113 host:80 \"Heuristic expiration\"", warning.ToString());
+
+            warning = new WarningHeaderValue(199, "[::1]", "\"Miscellaneous warning\"",
+                new DateTimeOffset(2010, 7, 19, 18, 31, 27, TimeSpan.Zero));
+            Assert.Equal("199 [::1] \"Miscellaneous warning\" \"Mon, 19 Jul 2010 18:31:27 GMT\"", warning.ToString());
+        }
+
+        [Fact]
+        public void GetHashCode_UseSameAndDifferentRanges_SameOrDifferentHashCodes()
+        {
+            WarningHeaderValue warning1 = new WarningHeaderValue(214, "host", "\"Transformation applied\"");
+            WarningHeaderValue warning2 = new WarningHeaderValue(214, "HOST", "\"Transformation applied\"");
+            WarningHeaderValue warning3 = new WarningHeaderValue(215, "host", "\"Transformation applied\"");
+            WarningHeaderValue warning4 = new WarningHeaderValue(214, "other", "\"Transformation applied\"");
+            WarningHeaderValue warning5 = new WarningHeaderValue(214, "host", "\"TRANSFORMATION APPLIED\"");
+            WarningHeaderValue warning6 = new WarningHeaderValue(214, "host", "\"Transformation applied\"",
+                new DateTimeOffset(2010, 7, 19, 18, 31, 27, TimeSpan.Zero));
+            WarningHeaderValue warning7 = new WarningHeaderValue(214, "host", "\"Transformation applied\"",
+                new DateTimeOffset(2011, 7, 19, 18, 31, 27, TimeSpan.Zero));
+            WarningHeaderValue warning8 = new WarningHeaderValue(214, "host", "\"Transformation applied\"",
+                new DateTimeOffset(2010, 7, 19, 18, 31, 27, TimeSpan.Zero));
+
+            Assert.Equal(warning1.GetHashCode(), warning2.GetHashCode());
+            Assert.NotEqual(warning1.GetHashCode(), warning3.GetHashCode());
+            Assert.NotEqual(warning1.GetHashCode(), warning4.GetHashCode());
+            Assert.NotEqual(warning1.GetHashCode(), warning6.GetHashCode());
+            Assert.NotEqual(warning1.GetHashCode(), warning7.GetHashCode());
+            Assert.NotEqual(warning6.GetHashCode(), warning7.GetHashCode());
+            Assert.Equal(warning6.GetHashCode(), warning8.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_UseSameAndDifferentRanges_EqualOrNotEqualNoExceptions()
+        {
+            WarningHeaderValue warning1 = new WarningHeaderValue(214, "host", "\"Transformation applied\"");
+            WarningHeaderValue warning2 = new WarningHeaderValue(214, "HOST", "\"Transformation applied\"");
+            WarningHeaderValue warning3 = new WarningHeaderValue(215, "host", "\"Transformation applied\"");
+            WarningHeaderValue warning4 = new WarningHeaderValue(214, "other", "\"Transformation applied\"");
+            WarningHeaderValue warning5 = new WarningHeaderValue(214, "host", "\"TRANSFORMATION APPLIED\"");
+            WarningHeaderValue warning6 = new WarningHeaderValue(214, "host", "\"Transformation applied\"",
+                new DateTimeOffset(2010, 7, 19, 18, 31, 27, TimeSpan.Zero));
+            WarningHeaderValue warning7 = new WarningHeaderValue(214, "host", "\"Transformation applied\"",
+                new DateTimeOffset(2011, 7, 19, 18, 31, 27, TimeSpan.Zero));
+            WarningHeaderValue warning8 = new WarningHeaderValue(214, "host", "\"Transformation applied\"",
+                new DateTimeOffset(2010, 7, 19, 18, 31, 27, TimeSpan.Zero));
+
+            Assert.False(warning1.Equals(null), "214 host \"t.a.\" vs. <null>");
+            Assert.True(warning1.Equals(warning2), "214 host \"t.a.\" vs. 214 HOST \"t.a.\"");
+            Assert.False(warning1.Equals(warning3), "214 host \"t.a.\" vs. 215 host \"t.a.\"");
+            Assert.False(warning1.Equals(warning4), "214 host \"t.a.\" vs. 214 other \"t.a.\"");
+            Assert.False(warning1.Equals(warning6), "214 host \"t.a.\" vs. 214 host \"T.A.\"");
+            Assert.False(warning1.Equals(warning7), "214 host \"t.a.\" vs. 214 host \"t.a.\" \"D\"");
+            Assert.False(warning7.Equals(warning1), "214 host \"t.a.\" \"D\" vs. 214 host \"t.a.\"");
+            Assert.False(warning6.Equals(warning7), "214 host \"t.a.\" \"D\" vs. 214 host \"t.a.\" \"other D\"");
+            Assert.True(warning6.Equals(warning8), "214 host \"t.a.\" \"D\" vs. 214 host \"t.a.\" \"D\"");
+        }
+
+        [Fact]
+        public void Clone_Call_CloneFieldsMatchSourceFields()
+        {
+            WarningHeaderValue source = new WarningHeaderValue(299, "host", "\"Miscellaneous persistent warning\"");
+            WarningHeaderValue clone = (WarningHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Code, clone.Code);
+            Assert.Equal(source.Agent, clone.Agent);
+            Assert.Equal(source.Text, clone.Text);
+            Assert.Equal(source.Date, clone.Date);
+
+            source = new WarningHeaderValue(110, "host", "\"Response is stale\"",
+                new DateTimeOffset(2010, 7, 31, 15, 37, 05, TimeSpan.Zero));
+            clone = (WarningHeaderValue)((ICloneable)source).Clone();
+            Assert.Equal(source.Code, clone.Code);
+            Assert.Equal(source.Agent, clone.Agent);
+            Assert.Equal(source.Text, clone.Text);
+            Assert.Equal(source.Date, clone.Date);
+        }
+
+        [Fact]
+        public void GetWarningLength_DifferentValidScenarios_AllReturnNonZero()
+        {
+            CheckGetWarningLength(" 199 .host \r\n \"Miscellaneous warning\"  ", 1, 38,
+                new WarningHeaderValue(199, ".host", "\"Miscellaneous warning\""));
+            CheckGetWarningLength("987 [FE18:AB64::156]:80 \"\" \"Tue, 20 Jul 2010 01:02:03 GMT\"", 0, 58,
+                new WarningHeaderValue(987, "[FE18:AB64::156]:80", "\"\"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
+
+            // The parser reads until it reaches an invalid/unexpected character. If until then it was able to create
+            // a valid WarningHeaderValue, it will return the length of the parsed string. Therefore a string like 
+            // the following is considered valid (until '[')
+            CheckGetWarningLength("1 h \"t\"[", 0, 7, new WarningHeaderValue(1, "h", "\"t\""));
+            CheckGetWarningLength("1 h \"t\" \"Tue, 20 Jul 2010 01:02:03 GMT\"[", 0, 39,
+                new WarningHeaderValue(1, "h", "\"t\"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
+
+            CheckGetWarningLength(null, 0, 0, null);
+            CheckGetWarningLength(string.Empty, 0, 0, null);
+            CheckGetWarningLength("  ", 0, 0, null);
+        }
+
+        [Fact]
+        public void GetWarningLength_DifferentInvalidScenarios_AllReturnZero()
+        {
+            CheckInvalidWarningViaLength(" 123 host", 0); // no leading whitespaces allowed
+
+            // No delimiter between two values
+            CheckInvalidWarningViaLength("123host \"t\"", 0);
+            CheckInvalidWarningViaLength("123 host\"t\"", 0);
+            CheckInvalidWarningViaLength("123 host \"t\"\"Tue, 20 Jul 2010 01:02:03 GMT\"", 0);
+            CheckInvalidWarningViaLength("123 http://host \"t\"", 0);
+
+            CheckInvalidWarningViaLength("1=host \"t\"", 0);
+            CheckInvalidWarningViaLength("1.1 host \"invalid_quoted_string", 0);
+            CheckInvalidWarningViaLength("=", 0);
+            CheckInvalidWarningViaLength("121 host=\"t\"", 0);
+            CheckInvalidWarningViaLength("121 host= \"t\"", 0);
+            CheckInvalidWarningViaLength("121 host =\"t\"", 0);
+            CheckInvalidWarningViaLength("121 host = \"t\"", 0);
+            CheckInvalidWarningViaLength("121 host =", 0);
+            CheckInvalidWarningViaLength("121 = \"t\"", 0);
+            CheckInvalidWarningViaLength("123", 0);
+            CheckInvalidWarningViaLength("123 host", 0);
+            CheckInvalidWarningViaLength("  ", 0);
+            CheckInvalidWarningViaLength("123 example.com[ \"t\"", 0);
+            CheckInvalidWarningViaLength("123 / \"t\"", 0);
+            CheckInvalidWarningViaLength("123 host::80 \"t\"", 0);
+            CheckInvalidWarningViaLength("123 host/\"t\"", 0);
+            CheckInvalidWarningViaLength("123 host \"t\" \"Tue, 20 Jul 2010 01:02:03 GMT", 0);
+            CheckInvalidWarningViaLength("123 host \"t\" \"Tue, 200 Jul 2010 01:02:03 GMT\"", 0);
+            CheckInvalidWarningViaLength("123 host \"t\" \"\"", 0);
+        }
+
+        [Fact]
+        public void Parse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidParse(" 123   host \"text\"", new WarningHeaderValue(123, "host", "\"text\""));
+            CheckValidParse(" 50  192.168.0.1  \"text  \"  \"Tue, 20 Jul 2010 01:02:03 GMT\" ",
+                new WarningHeaderValue(50, "192.168.0.1", "\"text  \"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
+            CheckValidParse(" 123 h \"t\"", new WarningHeaderValue(123, "h", "\"t\""));
+            CheckValidParse("1 h \"t\"", new WarningHeaderValue(1, "h", "\"t\""));
+            CheckValidParse("1 h \"t\" \"Tue, 20 Jul 2010 01:02:03 GMT\"",
+                new WarningHeaderValue(1, "h", "\"t\"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
+            CheckValidParse("1 \u4F1A \"t\" ", new WarningHeaderValue(1, "\u4F1A", "\"t\""));
+        }
+
+        [Fact]
+        public void Parse_SetOfInvalidValueStrings_Throws()
+        {
+            CheckInvalidParse("1.1 host \"text\"");
+            CheckInvalidParse("11 host text");
+            CheckInvalidParse("11 host \"text\" Tue, 20 Jul 2010 01:02:03 GMT");
+            CheckInvalidParse("11 host \"text\" 123 next \"text\"");
+            CheckInvalidParse("\u4F1A");
+            CheckInvalidParse("123 \u4F1A");
+            CheckInvalidParse("111 [::1]:80\r(comment) \"text\"");
+            CheckInvalidParse("111 [::1]:80\n(comment) \"text\"");
+
+            CheckInvalidParse("X , , 123   host \"text\", ,next");
+            CheckInvalidParse("X 50  192.168.0.1  \"text  \"  \"Tue, 20 Jul 2010 01:02:03 GMT\" , ,next");
+            CheckInvalidParse(" ,123 h \"t\",");
+            CheckInvalidParse("1 \u4F1A \"t\" ,,");
+
+            CheckInvalidParse(null);
+            CheckInvalidParse(string.Empty);
+            CheckInvalidParse("  ");
+            CheckInvalidParse("  ,,");
+        }
+
+        [Fact]
+        public void TryParse_SetOfValidValueStrings_ParsedCorrectly()
+        {
+            CheckValidTryParse(" 123   host \"text\"", new WarningHeaderValue(123, "host", "\"text\""));
+            CheckValidTryParse(" 50  192.168.0.1  \"text  \"  \"Tue, 20 Jul 2010 01:02:03 GMT\" ",
+                new WarningHeaderValue(50, "192.168.0.1", "\"text  \"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
+            CheckValidTryParse(" 123 h \"t\"", new WarningHeaderValue(123, "h", "\"t\""));
+            CheckValidTryParse("1 h \"t\"", new WarningHeaderValue(1, "h", "\"t\""));
+            CheckValidTryParse("1 h \"t\" \"Tue, 20 Jul 2010 01:02:03 GMT\"",
+                new WarningHeaderValue(1, "h", "\"t\"",
+                    new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
+            CheckValidTryParse("1 \u4F1A \"t\" ", new WarningHeaderValue(1, "\u4F1A", "\"t\""));
+        }
+
+        [Fact]
+        public void TryParse_SetOfInvalidValueStrings_ReturnsFalse()
+        {
+            CheckInvalidTryParse("1.1 host \"text\"");
+            CheckInvalidTryParse("11 host text");
+            CheckInvalidTryParse("11 host \"text\" Tue, 20 Jul 2010 01:02:03 GMT");
+            CheckInvalidTryParse("11 host \"text\" 123 next \"text\"");
+            CheckInvalidTryParse("\u4F1A");
+            CheckInvalidTryParse("123 \u4F1A");
+            CheckInvalidTryParse("111 [::1]:80\r(comment) \"text\"");
+            CheckInvalidTryParse("111 [::1]:80\n(comment) \"text\"");
+
+            CheckInvalidTryParse("X , , 123   host \"text\", ,next");
+            CheckInvalidTryParse("X 50  192.168.0.1  \"text  \"  \"Tue, 20 Jul 2010 01:02:03 GMT\" , ,next");
+            CheckInvalidTryParse(" ,123 h \"t\",");
+            CheckInvalidTryParse("1 \u4F1A \"t\" ,,");
+
+            CheckInvalidTryParse(null);
+            CheckInvalidTryParse(string.Empty);
+            CheckInvalidTryParse("  ");
+            CheckInvalidTryParse("  ,,");
+        }
+
+        #region Helper methods
+
+        private void CheckValidParse(string input, WarningHeaderValue expectedResult)
+        {
+            WarningHeaderValue result = WarningHeaderValue.Parse(input);
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidParse(string input)
+        {
+            Assert.Throws<FormatException>(() => { WarningHeaderValue.Parse(input); });
+        }
+
+        private void CheckValidTryParse(string input, WarningHeaderValue expectedResult)
+        {
+            WarningHeaderValue result = null;
+            Assert.True(WarningHeaderValue.TryParse(input, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private void CheckInvalidTryParse(string input)
+        {
+            WarningHeaderValue result = null;
+            Assert.False(WarningHeaderValue.TryParse(input, out result));
+            Assert.Null(result);
+        }
+
+        private static void CheckGetWarningLength(string input, int startIndex, int expectedLength,
+            WarningHeaderValue expectedResult)
+        {
+            object result = null;
+            Assert.Equal(expectedLength, WarningHeaderValue.GetWarningLength(input, startIndex, out result));
+            Assert.Equal(expectedResult, result);
+        }
+
+        private static void CheckInvalidWarningViaLength(string input, int startIndex)
+        {
+            object result = null;
+            Assert.Equal(0, WarningHeaderValue.GetWarningLength(input, startIndex, out result));
+            Assert.Null(result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpContentTest.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Reflection;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpContentTest
+    {
+        [Fact]
+        public void Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed()
+        {
+            MockContent content = new MockContent();
+            content.LoadIntoBufferAsync().Wait();
+
+            Type type = typeof(HttpContent);
+            TypeInfo typeInfo = type.GetTypeInfo();
+            FieldInfo bufferedContentField = typeof(HttpContent).GetField("_bufferedContent",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(bufferedContentField);
+
+            MemoryStream bufferedContentStream = bufferedContentField.GetValue(content) as MemoryStream;
+            Assert.NotNull(bufferedContentStream);
+
+            content.Dispose();
+
+            // The following line will throw an ObjectDisposedException if the buffered-stream was correctly disposed.
+            Assert.Throws<ObjectDisposedException>(() => { string str = bufferedContentStream.Length.ToString(); });
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
@@ -1,0 +1,424 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests
+{
+    public class HttpRuleParserTest
+    {
+        private const string ValidTokenChars = "!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz^_`|~";
+
+        [Fact]
+        public void IsTokenChar_IterateArrayWithAllValidTokenChars_AllCharsConsideredValid()
+        {
+            for (int i = 0; i < ValidTokenChars.Length; i++)
+            {
+                // TODO: This test should be a [Theory]
+                Assert.True(HttpRuleParser.IsTokenChar(ValidTokenChars[i]));
+            }
+        }
+
+        [Fact]
+        public void IsTokenChar_IterateArrayWithAllInvalidTokenChars_AllCharsConsideredInvalid()
+        {
+            // All octets not in 'validTokenChars' must be considered invalid characters.
+            for (int i = 0; i < 256; i++)
+            {
+                if (ValidTokenChars.IndexOf((char)i) == -1)
+                {
+                    // TODO: This test should be a [Theory]
+                    Assert.False(HttpRuleParser.IsTokenChar((char)i));
+                }
+            }
+        }
+
+        [Fact]
+        public void GetTokenLength_SetOfValidTokens_AllConsideredValid()
+        {
+            AssertGetTokenLength("token", 0, 5);
+            AssertGetTokenLength(" token ", 1, 5);
+            AssertGetTokenLength(" token token", 1, 5);
+            AssertGetTokenLength("x, y", 0, 1);
+            AssertGetTokenLength("x,y", 0, 1);
+            AssertGetTokenLength(":x:y", 1, 1);
+            AssertGetTokenLength("(comment)token(comment)", 9, 5);
+        }
+
+        [Fact]
+        public void GetTokenLength_SetOfInvalidTokens_TokenLengthIsZero()
+        {
+            AssertGetTokenLength(" token", 0, 0);
+            AssertGetTokenLength("\token", 0, 0);
+            AssertGetTokenLength("token token ", 5, 0);
+            AssertGetTokenLength(" ", 0, 0);
+        }
+
+        [Fact]
+        public void GetHostLength_SetOfValidHostStrings_MatchExpectation()
+        {
+            // Allow token or URI host:
+            AssertGetHostLength("", 0, 0, true, null);
+            AssertGetHostLength("  ", 2, 0, true, null);
+            AssertGetHostLength("host", 0, 4, true, "host");
+            AssertGetHostLength("host:80", 0, 7, true, "host:80");
+            AssertGetHostLength("host:80 ", 0, 7, true, "host:80");
+            AssertGetHostLength("host:80,nexthost", 0, 7, true, "host:80");
+            AssertGetHostLength("host.com:80,nexthost", 0, 11, true, "host.com:80");
+            AssertGetHostLength(".token ,nexthost", 0, 6, true, ".token");
+            AssertGetHostLength(".token nexthost", 0, 6, true, ".token");
+            AssertGetHostLength(".token", 0, 6, true, ".token");
+            AssertGetHostLength("[::1]:80", 0, 8, true, "[::1]:80");
+            AssertGetHostLength("[::1],host", 0, 5, true, "[::1]");
+            AssertGetHostLength("192.168.0.1,", 0, 11, true, "192.168.0.1");
+            AssertGetHostLength("192.168.0.1:8080 ", 0, 16, true, "192.168.0.1:8080");
+
+            // Allow URI host only (no token):
+            AssertGetHostLength("", 0, 0, false, null);
+            AssertGetHostLength("  ", 2, 0, false, null);
+            AssertGetHostLength("host", 0, 4, false, "host");
+            AssertGetHostLength("host:80", 0, 7, false, "host:80");
+            AssertGetHostLength("host:80 ", 0, 7, false, "host:80");
+            AssertGetHostLength("host:80,nexthost", 0, 7, false, "host:80");
+            AssertGetHostLength("host.com:80,nexthost", 0, 11, false, "host.com:80");
+            AssertGetHostLength("[::1]:80", 0, 8, false, "[::1]:80");
+            AssertGetHostLength("[::1],host", 0, 5, false, "[::1]");
+            AssertGetHostLength("192.168.0.1,", 0, 11, false, "192.168.0.1");
+            AssertGetHostLength("192.168.0.1:8080 ", 0, 16, false, "192.168.0.1:8080");
+        }
+
+        [Fact]
+        public void GetHostLength_SetOfInvalidHostStrings_MatchExpectation()
+        {
+            // Allow token or URI host:
+            AssertGetHostLength("host:80invalid", 0, 0, true, null);
+            AssertGetHostLength("host:80:nexthost", 0, 0, true, null);
+            AssertGetHostLength("  ", 0, 0, true, null);
+            AssertGetHostLength("token@:80", 0, 0, true, null);
+            AssertGetHostLength("token@host:80", 0, 0, true, null);
+            AssertGetHostLength("token@host", 0, 0, true, null);
+            AssertGetHostLength("token@", 0, 0, true, null);
+            AssertGetHostLength("token<", 0, 0, true, null);
+            AssertGetHostLength("192.168.0.1:8080!", 0, 0, true, null);
+            AssertGetHostLength(".token/", 0, 0, true, null);
+            AssertGetHostLength("host:80/", 0, 0, true, null);
+            AssertGetHostLength("host:80/path", 0, 0, true, null);
+            AssertGetHostLength("@host:80", 0, 0, true, null);
+            AssertGetHostLength("u:p@host:80", 0, 0, true, null);
+
+            // Allow URI host only (no token):
+            AssertGetHostLength("host:80invalid", 0, 0, false, null);
+            AssertGetHostLength("host:80:nexthost", 0, 0, false, null);
+            AssertGetHostLength("  ", 0, 0, false, null);
+            AssertGetHostLength("token@:80", 0, 0, false, null);
+            AssertGetHostLength("token@host:80", 0, 0, false, null);
+            AssertGetHostLength("token@host", 0, 0, false, null);
+            AssertGetHostLength("token@", 0, 0, false, null);
+            AssertGetHostLength("token<", 0, 0, false, null);
+            AssertGetHostLength("192.168.0.1:8080!", 0, 0, false, null);
+            AssertGetHostLength(".token/", 0, 0, false, null);
+            AssertGetHostLength("host:80/", 0, 0, false, null);
+            AssertGetHostLength("host:80/path", 0, 0, false, null);
+            AssertGetHostLength("@host:80", 0, 0, false, null);
+            AssertGetHostLength("u:p@host:80", 0, 0, false, null);
+            AssertGetHostLength(".token", 0, 0, false, null);
+            AssertGetHostLength("to~ken", 0, 0, false, null);
+        }
+
+        [Fact]
+        public void GetQuotedPairLength_SetOfValidQuotedPairs_AllConsideredValid()
+        {
+            AssertGetQuotedPairLength("\\x", 0, 2, HttpParseResult.Parsed);
+            AssertGetQuotedPairLength(" \\x ", 1, 2, HttpParseResult.Parsed);
+            AssertGetQuotedPairLength("\\x ", 0, 2, HttpParseResult.Parsed);
+            AssertGetQuotedPairLength("\\\t", 0, 2, HttpParseResult.Parsed);
+        }
+
+        [Fact]
+        public void GetQuotedPairLength_SetOfInvalidQuotedPairs_AllConsideredInvalid()
+        {
+            // only ASCII chars allowed in quoted-pair
+            AssertGetQuotedPairLength("\\ü", 0, 0, HttpParseResult.InvalidFormat);
+
+            // a quoted-pair needs 1 char after '\'
+            AssertGetQuotedPairLength("\\", 0, 0, HttpParseResult.InvalidFormat);
+        }
+
+        [Fact]
+        public void GetQuotedPairLength_SetOfNonQuotedPairs_NothingParsed()
+        {
+            AssertGetQuotedPairLength("token\\x", 0, 0, HttpParseResult.NotParsed);
+        }
+
+        [Fact]
+        public void GetQuotedStringLength_SetOfValidQuotedStrings_AllConsideredValid()
+        {
+            AssertGetQuotedStringLength("\"x\"", 0, 3, HttpParseResult.Parsed);
+            AssertGetQuotedStringLength("token \"quoted string\" token", 6, 15, HttpParseResult.Parsed);
+            AssertGetQuotedStringLength("\"\\x\"", 0, 4, HttpParseResult.Parsed); // "\x"
+            AssertGetQuotedStringLength("\"\\\"\"", 0, 4, HttpParseResult.Parsed); // "\""
+            AssertGetQuotedStringLength("\"before \\\" after\"", 0, 17, HttpParseResult.Parsed); // "before \" after"
+            AssertGetQuotedStringLength("\"\\ü\"", 0, 4, HttpParseResult.Parsed); // "\ü"
+            AssertGetQuotedStringLength("\"a\\ü\\\"b\"", 0, 8, HttpParseResult.Parsed); // "a\ü\"b"
+            AssertGetQuotedStringLength("\"\\\"", 0, 3, HttpParseResult.Parsed); // "\"
+            AssertGetQuotedStringLength("\"\\\"\"", 0, 4, HttpParseResult.Parsed); // "\""
+            AssertGetQuotedStringLength(" \"\\\"", 1, 3, HttpParseResult.Parsed); // "\"
+            AssertGetQuotedStringLength(" \"\\\"\"", 1, 4, HttpParseResult.Parsed); // "\""
+            AssertGetQuotedStringLength("\"a \\\" b\"", 0, 8, HttpParseResult.Parsed); // "a \" b"
+            AssertGetQuotedStringLength("\"s\\x\"", 0, 5, HttpParseResult.Parsed); // "s\x"
+            AssertGetQuotedStringLength("\"\\xx\"", 0, 5, HttpParseResult.Parsed); // "\xx"
+            AssertGetQuotedStringLength("\"(x)\"", 0, 5, HttpParseResult.Parsed); // "(x)"
+            AssertGetQuotedStringLength(" \" (x) \" ", 1, 7, HttpParseResult.Parsed); // " (x) "
+            AssertGetQuotedStringLength("\"text\r\n new line\"", 0, 17, HttpParseResult.Parsed); // "text<crlf> new line"
+            AssertGetQuotedStringLength("\"a\\ü\\\"b\\\"c\\\"\\\"d\\\"\"", 0, 18, HttpParseResult.Parsed); // "a\ü\"b\"c\"\"d\""
+            AssertGetQuotedStringLength("\"\\\" \"", 0, 5, HttpParseResult.Parsed); // "\" "
+        }
+
+        [Fact]
+        public void GetQuotedStringLength_SetOfInvalidQuotedStrings_AllConsideredInvalid()
+        {
+            AssertGetQuotedStringLength("\"x", 0, 0, HttpParseResult.InvalidFormat); // "x
+            AssertGetQuotedStringLength(" \"x ", 1, 0, HttpParseResult.InvalidFormat); // ' "x '
+        }
+
+        [Fact]
+        public void GetQuotedStringLength_SetOfNonQuotedStrings_NothingParsed()
+        {
+            AssertGetQuotedStringLength("a\"x", 0, 0, HttpParseResult.NotParsed); // a"x"
+            AssertGetQuotedStringLength("(\"x", 0, 0, HttpParseResult.NotParsed); // ("x"
+            AssertGetQuotedStringLength("\\\"x", 0, 0, HttpParseResult.NotParsed); // \"x"
+        }
+
+        [Fact]
+        public void GetCommentLength_SetOfValidComments_AllConsideredValid()
+        {
+            AssertGetCommentLength("()", 0, 2, HttpParseResult.Parsed);
+            AssertGetCommentLength("(x)", 0, 3, HttpParseResult.Parsed);
+            AssertGetCommentLength("token (comment) token", 6, 9, HttpParseResult.Parsed);
+            AssertGetCommentLength("(\\x)", 0, 4, HttpParseResult.Parsed); // (\x)
+            AssertGetCommentLength("(\\))", 0, 4, HttpParseResult.Parsed); // (\))
+            AssertGetCommentLength("(\\()", 0, 4, HttpParseResult.Parsed); // (\()
+            AssertGetCommentLength("(\\ü)", 0, 4, HttpParseResult.Parsed); // (\ü)
+            AssertGetCommentLength("(\\)", 0, 3, HttpParseResult.Parsed); // (\)
+            AssertGetCommentLength("(s\\x)", 0, 5, HttpParseResult.Parsed); // (s\x)
+            AssertGetCommentLength("(\\xx)", 0, 5, HttpParseResult.Parsed); // (\xx)
+            AssertGetCommentLength("(\"x\")", 0, 5, HttpParseResult.Parsed); // ("x")
+            AssertGetCommentLength(" ( \"x\" ) ", 1, 7, HttpParseResult.Parsed); // ( "x" )
+            AssertGetCommentLength("(text\r\n new line)", 0, 17, HttpParseResult.Parsed); // (text<crlf> new line)
+            AssertGetCommentLength("(\\) )", 0, 5, HttpParseResult.Parsed); // (\))
+            AssertGetCommentLength("(\\( )", 0, 5, HttpParseResult.Parsed); // (\()
+
+            // Nested comments
+            AssertGetCommentLength("((x))", 0, 5, HttpParseResult.Parsed);
+            AssertGetCommentLength("( (x) )", 0, 7, HttpParseResult.Parsed);
+            AssertGetCommentLength("( (\\(x) )", 0, 9, HttpParseResult.Parsed);
+            AssertGetCommentLength("( (\\)x) )", 0, 9, HttpParseResult.Parsed);
+            AssertGetCommentLength("(\\) (\\(x) )", 0, 11, HttpParseResult.Parsed);
+            AssertGetCommentLength("((((((x))))))", 0, 13, HttpParseResult.Parsed);
+            AssertGetCommentLength("((x) (x) ((x)x) ((((x)x)x)x(x(x))))", 0, 35, HttpParseResult.Parsed);
+            AssertGetCommentLength("((x) (\\(x\\())", 0, 13, HttpParseResult.Parsed); // ((x) (\(x\()))
+            AssertGetCommentLength("((\\)))", 0, 6, HttpParseResult.Parsed); // ((\))) -> quoted-pair )
+            AssertGetCommentLength("((\\())", 0, 6, HttpParseResult.Parsed); // ((\()) -> quoted-pair (
+            AssertGetCommentLength("((x)))", 0, 5, HttpParseResult.Parsed); // final ) ignored
+        }
+
+        [Fact]
+        public void GetCommentLength_SetOfInvalidQuotedStrings_AllConsideredInvalid()
+        {
+            AssertGetCommentLength("(x", 0, 0, HttpParseResult.InvalidFormat);
+            AssertGetCommentLength(" (x ", 1, 0, HttpParseResult.InvalidFormat);
+            AssertGetCommentLength("((x) ", 0, 0, HttpParseResult.InvalidFormat);
+            AssertGetCommentLength("((x ", 0, 0, HttpParseResult.InvalidFormat);
+            AssertGetCommentLength("(x(x ", 0, 0, HttpParseResult.InvalidFormat);
+            AssertGetCommentLength("(x(((((((((x ", 0, 0, HttpParseResult.InvalidFormat);
+
+            // To prevent attacker from sending comments resulting in stack overflow exceptions, we limit the depth
+            // of nested comments. I.e. the following comment is considered invalid since it is considered a 
+            // "malicious" comment.
+            AssertGetCommentLength("((((((((((x))))))))))", 0, 0, HttpParseResult.InvalidFormat);
+        }
+
+        [Fact]
+        public void GetCommentLength_SetOfNonQuotedStrings_NothingParsed()
+        {
+            AssertGetCommentLength("a(x", 0, 0, HttpParseResult.NotParsed); // a"x"
+            AssertGetCommentLength("\"(x", 0, 0, HttpParseResult.NotParsed); // ("x"
+            AssertGetCommentLength("\\(x", 0, 0, HttpParseResult.NotParsed); // \"x"
+        }
+
+        [Fact]
+        public void DateToString_UseRfcSampleTimestamp_FormattedAccordingToRfc1123()
+        {
+            // We don't need extensive tests, since we let DateTimeOffset do the formatting. This test is just
+            // to validate that we use the correct parameters when calling into DateTimeOffset.ToString().
+            DateTimeOffset dateTime = new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero);
+            Assert.Equal("Sun, 06 Nov 1994 08:49:37 GMT", HttpRuleParser.DateToString(dateTime));
+        }
+
+        [Fact]
+        public void TryStringToDate_UseOfValidDateTimeStringsInDifferentFormats_ParsedCorrectly()
+        {
+            // We don't need extensive tests, since we let DateTimeOffset do the parsing. This test is just
+            // to validate that we use the correct parameters when calling into DateTimeOffset.ToString().
+
+            // RFC1123 date/time value
+            DateTimeOffset expected = new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero);
+            DateTimeOffset result = DateTimeOffset.MinValue;
+            Assert.True(HttpRuleParser.TryStringToDate("Sun, 06 Nov 1994 08:49:37 GMT", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("Sun, 06 Nov 1994 08:49:37", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("6 Nov 1994 8:49:37 GMT", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("6 Nov 1994 8:49:37", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("Sun, 06 Nov 94 08:49:37", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("6 Nov 94 8:49:37", out result));
+            Assert.Equal(expected, result);
+
+            // RFC850 date/time value
+            Assert.True(HttpRuleParser.TryStringToDate("Sunday, 06-Nov-94 08:49:37 GMT", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("Sunday, 6-Nov-94 8:49:37", out result));
+            Assert.Equal(expected, result);
+
+            // ANSI C's asctime() format
+            Assert.True(HttpRuleParser.TryStringToDate("Sun Nov  06 08:49:37 1994", out result));
+            Assert.Equal(expected, result);
+            Assert.True(HttpRuleParser.TryStringToDate("Sun Nov  6 8:49:37 1994", out result));
+            Assert.Equal(expected, result);
+
+            // RFC5322 date/time
+            expected = new DateTimeOffset(1997, 11, 8, 9, 55, 6, new TimeSpan(-6, 0, 0));
+            Assert.True(HttpRuleParser.TryStringToDate("Sat, 08 Nov 1997 09:55:06 -0600", out result));
+            Assert.Equal(expected, result);
+            expected = new DateTimeOffset(1997, 11, 8, 9, 55, 6, TimeSpan.Zero);
+            Assert.True(HttpRuleParser.TryStringToDate("8 Nov 1997 9:55:6", out result));
+            Assert.Equal(expected, result);
+            expected = new DateTimeOffset(1997, 11, 8, 9, 55, 6, new TimeSpan(2, 0, 0));
+            Assert.True(HttpRuleParser.TryStringToDate("Sat, 8 Nov 1997 9:55:6 +0200", out result));
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void TryStringToDate_UseInvalidDateTimeString_Throw()
+        {
+            DateTimeOffset result = DateTimeOffset.MinValue;
+            Assert.False(HttpRuleParser.TryStringToDate("Sun, 06 Nov 1994 08:49:37 GMT invalid", out result));
+            Assert.False(HttpRuleParser.TryStringToDate("Sun, 06 Nov 1994 08:49:37 GMT,", out result));
+            Assert.False(HttpRuleParser.TryStringToDate(",Sun, 06 Nov 1994 08:49:37 GMT", out result));
+        }
+
+        [Fact]
+        public void GetWhitespaceLength_SetOfValidWhitespaces_ParsedCorrectly()
+        {
+            Assert.Equal(1, HttpRuleParser.GetWhitespaceLength(" ", 0));
+            Assert.Equal(0, HttpRuleParser.GetWhitespaceLength("a b", 0));
+            Assert.Equal(1, HttpRuleParser.GetWhitespaceLength("a b", 1));
+            Assert.Equal(1, HttpRuleParser.GetWhitespaceLength("a\tb", 1));
+            Assert.Equal(1, HttpRuleParser.GetWhitespaceLength("a\t", 1));
+            Assert.Equal(3, HttpRuleParser.GetWhitespaceLength("a\t  ", 1));
+            Assert.Equal(2, HttpRuleParser.GetWhitespaceLength("\t b", 0));
+
+            // Newlines
+            Assert.Equal(3, HttpRuleParser.GetWhitespaceLength("a\r\n b", 1));
+            Assert.Equal(3, HttpRuleParser.GetWhitespaceLength("\r\n ", 0));
+            Assert.Equal(3, HttpRuleParser.GetWhitespaceLength("\r\n\t", 0));
+            Assert.Equal(13, HttpRuleParser.GetWhitespaceLength("  \r\n\t\t  \r\n   ", 0));
+            Assert.Equal(1, HttpRuleParser.GetWhitespaceLength(" \r\n", 0)); // first char considered valid whitespace
+            Assert.Equal(1, HttpRuleParser.GetWhitespaceLength(" \r\n\r\n ", 0));
+            Assert.Equal(3, HttpRuleParser.GetWhitespaceLength(" \r\n\r\n ", 3));
+        }
+
+        [Fact]
+        public void GetWhitespaceLength_SetOfInvalidWhitespaces_ReturnsZero()
+        {
+            // Newlines: SP/HT required after #13#10
+            Assert.Equal(0, HttpRuleParser.GetWhitespaceLength("\r\n", 0));
+            Assert.Equal(0, HttpRuleParser.GetWhitespaceLength(" \r\n\r\n", 1));
+            Assert.Equal(0, HttpRuleParser.GetWhitespaceLength("a\r\nb", 1));
+        }
+
+        [Fact]
+        public void GetNumberLength_SetOfValidNumbers_ParsedCorrectly()
+        {
+            Assert.Equal(3, HttpRuleParser.GetNumberLength("123", 0, false));
+            Assert.Equal(4, HttpRuleParser.GetNumberLength("123.", 0, true));
+            Assert.Equal(7, HttpRuleParser.GetNumberLength("123.456", 0, true));
+            Assert.Equal(1, HttpRuleParser.GetNumberLength("1a", 0, false));
+            Assert.Equal(2, HttpRuleParser.GetNumberLength("1.a", 0, true));
+            Assert.Equal(2, HttpRuleParser.GetNumberLength("1..", 0, true));
+            Assert.Equal(3, HttpRuleParser.GetNumberLength("1.2.", 0, true));
+            Assert.Equal(1, HttpRuleParser.GetNumberLength("1.2.", 0, false));
+            Assert.Equal(5, HttpRuleParser.GetNumberLength("123456", 1, false));
+            Assert.Equal(1, HttpRuleParser.GetNumberLength("1.5", 0, false)); // parse until '.'
+            Assert.Equal(1, HttpRuleParser.GetNumberLength("1 2 3", 2, true));
+
+            // GetNumberLength doesn't have any size restrictions. The caller needs to decide whether a value is
+            // outside the valid range or not.
+            Assert.Equal(30, HttpRuleParser.GetNumberLength("123456789012345678901234567890", 0, false));
+            Assert.Equal(61, HttpRuleParser.GetNumberLength(
+                "123456789012345678901234567890.123456789012345678901234567890", 0, true));
+        }
+
+        [Fact]
+        public void GetNumberLength_SetOfInvalidNumbers_ReturnsZero()
+        {
+            Assert.Equal(0, HttpRuleParser.GetNumberLength(".456", 0, true));
+            Assert.Equal(0, HttpRuleParser.GetNumberLength("-1", 0, true));
+            Assert.Equal(0, HttpRuleParser.GetNumberLength("a", 0, true));
+        }
+
+        #region Helper methods
+
+        private static void AssertGetTokenLength(string input, int startIndex, int expectedLength)
+        {
+            Assert.Equal(expectedLength, HttpRuleParser.GetTokenLength(input, startIndex));
+        }
+
+        private static void AssertGetQuotedPairLength(string input, int startIndex, int expectedLength,
+            HttpParseResult expectedResult)
+        {
+            int length = 0;
+            HttpParseResult result = HttpRuleParser.GetQuotedPairLength(input, startIndex, out length);
+
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedLength, length);
+        }
+
+        private static void AssertGetQuotedStringLength(string input, int startIndex, int expectedLength,
+            HttpParseResult expectedResult)
+        {
+            int length = 0;
+            HttpParseResult result = HttpRuleParser.GetQuotedStringLength(input, startIndex, out length);
+
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedLength, length);
+        }
+
+        private static void AssertGetCommentLength(string input, int startIndex, int expectedLength,
+            HttpParseResult expectedResult)
+        {
+            int length = 0;
+            HttpParseResult result = HttpRuleParser.GetCommentLength(input, startIndex, out length);
+
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedLength, length);
+        }
+
+        private static void AssertGetHostLength(string input, int startIndex, int expectedLength, bool allowToken,
+            string expectedResult)
+        {
+            string result = null;
+            Assert.Equal(expectedLength, HttpRuleParser.GetHostLength(input, startIndex, allowToken, out result));
+            Assert.Equal(expectedResult, result);
+        }
+        #endregion
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/MockContent.cs
+++ b/src/System.Net.Http/tests/UnitTests/MockContent.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Unit.Tests
+{
+    [Flags]
+    public enum MockOptions
+    {
+        None = 0x0,
+        ThrowInSerializeMethods = 0x1,
+        ReturnNullInCopyToAsync = 0x2,
+        UseWriteByteInCopyTo = 0x4,
+        DontOverrideCreateContentReadStream = 0x8,
+        CanCalculateLength = 0x10,
+        ThrowInTryComputeLength = 0x20,
+        ThrowInAsyncSerializeMethods = 0x40
+    }
+
+    public class MockException : Exception
+    {
+        public MockException() { }
+        public MockException(string message) : base(message) { }
+        public MockException(string message, Exception inner) : base(message, inner) { }
+    }
+
+    public class MockContent : HttpContent
+    {
+        private byte[] _mockData;
+        private MockOptions _options;
+        private Exception _customException;
+
+        public int TryComputeLengthCount { get; private set; }
+        public int SerializeToStreamAsyncCount { get; private set; }
+        public int CreateContentReadStreamCount { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public byte[] MockData
+        {
+            get { return _mockData; }
+        }
+
+        public MockContent()
+            : this((byte[])null, MockOptions.None)
+        {
+        }
+
+        public MockContent(byte[] mockData)
+            : this(mockData, MockOptions.None)
+        {
+        }
+
+        public MockContent(MockOptions options)
+            : this((byte[])null, options)
+        {
+        }
+
+        public MockContent(Exception customException, MockOptions options)
+            : this((byte[])null, options)
+        {
+            _customException = customException;
+        }
+
+        public MockContent(byte[] mockData, MockOptions options)
+        {
+            _options = options;
+
+            if (mockData == null)
+            {
+                _mockData = Encoding.UTF8.GetBytes("data");
+            }
+            else
+            {
+                _mockData = mockData;
+            }
+        }
+
+        public byte[] GetMockData()
+        {
+            return _mockData;
+        }
+
+        protected internal override bool TryComputeLength(out long length)
+        {
+            TryComputeLengthCount++;
+
+            if ((_options & MockOptions.ThrowInTryComputeLength) != 0)
+            {
+                throw new MockException();
+            }
+
+            if ((_options & MockOptions.CanCalculateLength) != 0)
+            {
+                length = _mockData.Length;
+                return true;
+            }
+            else
+            {
+                length = 0;
+                return false;
+            }
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            SerializeToStreamAsyncCount++;
+
+            if ((_options & MockOptions.ReturnNullInCopyToAsync) != 0)
+            {
+                return null;
+            }
+
+            if ((_options & MockOptions.ThrowInAsyncSerializeMethods) != 0)
+            {
+                throw _customException;
+            }
+
+            return Task.Run(() =>
+            {
+                CheckThrow();
+                return stream.WriteAsync(_mockData, 0, _mockData.Length);
+            });
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+        {
+            CreateContentReadStreamCount++;
+
+            if ((_options & MockOptions.DontOverrideCreateContentReadStream) != 0)
+            {
+                return base.CreateContentReadStreamAsync();
+            }
+            else
+            {
+                return Task.FromResult<Stream>(new MockMemoryStream(_mockData, 0, _mockData.Length, false));
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
+
+        private void CheckThrow()
+        {
+            if ((_options & MockOptions.ThrowInSerializeMethods) != 0)
+            {
+                throw _customException;
+            }
+        }
+    }
+
+    public class MockMemoryStream : MemoryStream
+    {
+        public int DisposeCount { get; private set; }
+
+        public MockMemoryStream(byte[] buffer, int index, int count, bool writable)
+            : base(buffer, index, count, writable)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5F9C3C9F-652E-461E-B2D6-85D264F5A733}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Net.Http.Unit.Tests</RootNamespace>
+    <AssemblyName>System.Net.Http.Unit.Tests</AssemblyName>
+    <StringResourcesPath>..\..\src\Resources\Strings.resx</StringResourcesPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\Common\src\System\NotImplemented.cs">
+      <Link>ProductionCode\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\HttpKnownHeaderNames.cs">
+      <Link>ProductionCode\HttpKnownHeaderNames.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\HttpStatusDescription.cs">
+      <Link>ProductionCode\HttpStatusDescription.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\HttpVersion.cs">
+      <Link>ProductionCode\HttpVersion.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\ICloneable.cs">
+      <Link>ProductionCode\ICloneable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\MailAddress.cs">
+      <Link>ProductionCode\MailAddress.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\DomainLiteralReader.cs">
+      <Link>ProductionCode\DomainLiteralReader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\DotAtomReader.cs">
+      <Link>ProductionCode\DotAtomReader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\MailAddressParser.cs">
+      <Link>ProductionCode\MailAddressParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\MailBnfHelper.cs">
+      <Link>ProductionCode\MailBnfHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\QuotedPairReader.cs">
+      <Link>ProductionCode\QuotedPairReader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\QuotedStringFormatReader.cs">
+      <Link>ProductionCode\QuotedStringFormatReader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Mail\WhitespaceReader.cs">
+      <Link>ProductionCode\WhitespaceReader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\Logging.cs">
+      <Link>ProductionCode\Logging.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Internal\UriHelper.cs">
+      <Link>ProductionCode\UriHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Shims\Uri.cs">
+      <Link>ProductionCode\Uri.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\ByteArrayContent.cs">
+      <Link>ProductionCode\ByteArrayContent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\ClientCertificateOption.cs">
+      <Link>ProductionCode\ClientCertificateOption.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\DelegatingHandler.cs">
+      <Link>ProductionCode\DelegatingHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\DelegatingStream.cs">
+      <Link>ProductionCode\DelegatingStream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\FormUrlEncodedContent.cs">
+      <Link>ProductionCode\FormUrlEncodedContent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\AuthenticationHeaderValue.cs">
+      <Link>ProductionCode\AuthenticationHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\BaseHeaderParser.cs">
+      <Link>ProductionCode\BaseHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ByteArrayHeaderParser.cs">
+      <Link>ProductionCode\ByteArrayHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\CacheControlHeaderParser.cs">
+      <Link>ProductionCode\CacheControlHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\CacheControlHeaderValue.cs">
+      <Link>ProductionCode\CacheControlHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ContentDispositionHeaderValue.cs">
+      <Link>ProductionCode\ContentDispositionHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ContentRangeHeaderValue.cs">
+      <Link>ProductionCode\ContentRangeHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\DateHeaderParser.cs">
+      <Link>ProductionCode\DateHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\EntityTagHeaderValue.cs">
+      <Link>ProductionCode\EntityTagHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\GenericHeaderParser.cs">
+      <Link>ProductionCode\GenericHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HeaderUtilities.cs">
+      <Link>ProductionCode\HeaderUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpContentHeaders.cs">
+      <Link>ProductionCode\HttpContentHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpGeneralHeaders.cs">
+      <Link>ProductionCode\HttpGeneralHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpHeaderParser.cs">
+      <Link>ProductionCode\HttpHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpHeaders.cs">
+      <Link>ProductionCode\HttpHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpHeaderValueCollection.cs">
+      <Link>ProductionCode\HttpHeaderValueCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpRequestHeaders.cs">
+      <Link>ProductionCode\HttpRequestHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\HttpResponseHeaders.cs">
+      <Link>ProductionCode\HttpResponseHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\Int32NumberHeaderParser.cs">
+      <Link>ProductionCode\Int32NumberHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\Int64NumberHeaderParser.cs">
+      <Link>ProductionCode\Int64NumberHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\MediaTypeHeaderParser.cs">
+      <Link>ProductionCode\MediaTypeHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\MediaTypeHeaderValue.cs">
+      <Link>ProductionCode\MediaTypeHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\MediaTypeWithQualityHeaderValue.cs">
+      <Link>ProductionCode\MediaTypeWithQualityHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\NameValueHeaderValue.cs">
+      <Link>ProductionCode\NameValueHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\NameValueWithParametersHeaderValue.cs">
+      <Link>ProductionCode\NameValueWithParametersHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ObjectCollection.cs">
+      <Link>ProductionCode\ObjectCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ProductHeaderValue.cs">
+      <Link>ProductionCode\ProductHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ProductInfoHeaderParser.cs">
+      <Link>ProductionCode\ProductInfoHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ProductInfoHeaderValue.cs">
+      <Link>ProductionCode\ProductInfoHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\RangeConditionHeaderValue.cs">
+      <Link>ProductionCode\RangeConditionHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\RangeHeaderValue.cs">
+      <Link>ProductionCode\RangeHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\RangeItemHeaderValue.cs">
+      <Link>ProductionCode\RangeItemHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\RetryConditionHeaderValue.cs">
+      <Link>ProductionCode\RetryConditionHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\StringWithQualityHeaderValue.cs">
+      <Link>ProductionCode\StringWithQualityHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\TimeSpanHeaderParser.cs">
+      <Link>ProductionCode\TimeSpanHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\TransferCodingHeaderParser.cs">
+      <Link>ProductionCode\TransferCodingHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\TransferCodingHeaderValue.cs">
+      <Link>ProductionCode\TransferCodingHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\TransferCodingWithQualityHeaderValue.cs">
+      <Link>ProductionCode\TransferCodingWithQualityHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\UriHeaderParser.cs">
+      <Link>ProductionCode\UriHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\ViaHeaderValue.cs">
+      <Link>ProductionCode\ViaHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Headers\WarningHeaderValue.cs">
+      <Link>ProductionCode\WarningHeaderValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpClient.cs">
+      <Link>ProductionCode\HttpClient.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpCompletionOption.cs">
+      <Link>ProductionCode\HttpCompletionOption.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpContent.cs">
+      <Link>ProductionCode\HttpContent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpMessageHandler.cs">
+      <Link>ProductionCode\HttpMessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpMessageInvoker.cs">
+      <Link>ProductionCode\HttpMessageInvoker.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpMethod.cs">
+      <Link>ProductionCode\HttpMethod.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpParseResult.cs">
+      <Link>ProductionCode\HttpParseResult.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpRequestException.cs">
+      <Link>ProductionCode\HttpRequestException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpRequestMessage.cs">
+      <Link>ProductionCode\HttpRequestMessage.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpResponseMessage.cs">
+      <Link>ProductionCode\HttpResponseMessage.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpRuleParser.cs">
+      <Link>ProductionCode\HttpRuleParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\HttpUtilities.cs">
+      <Link>ProductionCode\HttpUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\MessageProcessingHandler.cs">
+      <Link>ProductionCode\MessageProcessingHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\MultipartContent.cs">
+      <Link>ProductionCode\MultipartContent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\MultipartFormDataContent.cs">
+      <Link>ProductionCode\MultipartFormDataContent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\StreamContent.cs">
+      <Link>ProductionCode\StreamContent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\StreamToStreamCopy.cs">
+      <Link>ProductionCode\StreamToStreamCopy.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\StringContent.cs">
+      <Link>ProductionCode\StringContent.cs</Link>
+    </Compile>
+    <Compile Include="Fakes\HttpClientHandler.cs" />
+    <Compile Include="Headers\AuthenticationHeaderValueTest.cs" />
+    <Compile Include="Headers\ByteArrayHeaderParserTest.cs" />
+    <Compile Include="Headers\CacheControlHeaderParserTest.cs" />
+    <Compile Include="Headers\CacheControlHeaderValueTest.cs" />
+    <Compile Include="Headers\ContentDispositionHeaderValueTest.cs" />
+    <Compile Include="Headers\ContentRangeHeaderValueTest.cs" />
+    <Compile Include="Headers\DateHeaderParserTest.cs" />
+    <Compile Include="Headers\EntityTagHeaderValueTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\AuthenticationParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\ContentRangeParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\EntityTagParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\HostParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\MailAddressParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\NameValueParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\NameValueWithParametersParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\ProductParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\RangeConditionParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\RangeParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\RetryConditionParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\StringWithQualityParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\TokenListParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\ViaParserTest.cs" />
+    <Compile Include="Headers\GenericHeaderParserTest\WarningParserTest.cs" />
+    <Compile Include="Headers\HeaderUtilitiesTest.cs" />
+    <Compile Include="Headers\HttpContentHeadersTest.cs" />
+    <Compile Include="Headers\HttpHeadersTest.cs" />
+    <Compile Include="Headers\HttpHeaderValueCollectionTest.cs" />
+    <Compile Include="Headers\HttpRequestHeadersTest.cs" />
+    <Compile Include="Headers\HttpResponseHeadersTest.cs" />
+    <Compile Include="Headers\Int32NumberHeaderParserTest.cs" />
+    <Compile Include="Headers\Int64NumberHeaderParserTest.cs" />
+    <Compile Include="Headers\MediaTypeHeaderParserTest.cs" />
+    <Compile Include="Headers\MediaTypeHeaderValueTest.cs" />
+    <Compile Include="Headers\MediaTypeWithQualityHeaderValueTest.cs" />
+    <Compile Include="Headers\NameValueHeaderValueTest.cs" />
+    <Compile Include="Headers\NameValueWithParametersHeaderValueTest.cs" />
+    <Compile Include="Headers\ObjectCollectionTest.cs" />
+    <Compile Include="Headers\ProductHeaderValueTest.cs" />
+    <Compile Include="Headers\ProductInfoHeaderParserTest.cs" />
+    <Compile Include="Headers\ProductInfoHeaderValueTest.cs" />
+    <Compile Include="Headers\RangeConditionHeaderValueTest.cs" />
+    <Compile Include="Headers\RangeHeaderValueTest.cs" />
+    <Compile Include="Headers\RangeItemHeaderValueTest.cs" />
+    <Compile Include="Headers\RetryConditionHeaderValueTest.cs" />
+    <Compile Include="Headers\StringWithQualityHeaderValueTest.cs" />
+    <Compile Include="Headers\TimeSpanHeaderParserTest.cs" />
+    <Compile Include="Headers\TransferCodingHeaderParserTest.cs" />
+    <Compile Include="Headers\TransferCodingHeaderValueTest.cs" />
+    <Compile Include="Headers\TransferCodingWithQualityHeaderValueTest.cs" />
+    <Compile Include="Headers\UriHeaderParserTest.cs" />
+    <Compile Include="Headers\ViaHeaderValueTest.cs" />
+    <Compile Include="Headers\WarningHeaderValueTest.cs" />
+    <Compile Include="HttpContentTest.cs" />
+    <Compile Include="HttpRuleParserTest.cs" />
+    <Compile Include="MockContent.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Contracts": "4.0.0-*",
+    "System.Diagnostics.Tools": "4.0.0-*",
+    "System.Linq": "4.0.0-*",
+    "System.Net.Primitives": "4.0.10-*",
+    "System.Reflection": "4.0.10-*",
+    "System.Reflection.TypeExtensions": "4.0.0-*",
+    "xunit": "2.0.0-beta5-build2785",
+    "xunit.abstractions.netcore": "1.0.0-prerelease",
+    "xunit.assert": "2.0.0-beta5-build2785",
+    "xunit.core.netcore": "1.0.1-prerelease"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}


### PR DESCRIPTION
This is a port of the existing System.Net.Http unit tests. There are over 790 tests.  The majority of these test the header parsers as well as some of the HttpClient base methods.

Similar to our other unit tests, the sources of System.Net.Http are built into the test assembly itself. This enables us to test internal members as well as public members.

The tests have been ported from MSTest-style to Xunit and additional formatting tools run so that the sources conform to the CoreFX coding style guidelines.