### PR TITLE
Fix a couple issues discovered during unit test stress

### DIFF
--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -92,7 +92,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void AllowedSymbols()
         {
-            string dirName = Path.Combine(TestDirectory, "!@#$%^&");
+            string dirName = Path.Combine(TestDirectory, Path.GetRandomFileName() + "!@#$%^&");
             DirectoryInfo dir = new DirectoryInfo(dirName);
             dir.Create();
 

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory_str.cs
@@ -88,7 +88,7 @@ namespace System.IO.FileSystem.Tests
         [Fact]
         public void Symbols()
         {
-            string subdirName = "!@#$%^&";
+            string subdirName = "!@#$%^&" + Path.GetRandomFileName();
 
             DirectoryInfo dir = new DirectoryInfo(TestDirectory).CreateSubdirectory(subdirName);
 

--- a/src/System.IO.FileSystem/tests/FileInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create.cs
@@ -126,7 +126,7 @@ public class FileInfo_Create
             strLoc = "Loc_87yg7";
 
             iCountTestcases++;
-            fileName = Path.Combine(TestInfo.CurrentDirectory, "!@#$%^&");
+            fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName() + "!@#$%^&");
             file2 = new FileInfo(fileName);
             fs = file2.Create();
             fs.Dispose();

--- a/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Create_str.cs
@@ -154,7 +154,7 @@ public class FileInfo_Create_str
 
             strLoc = "Loc_87yg7";
 
-            fileName = Path.Combine(TestInfo.CurrentDirectory, "!@#$%^&");
+            fileName = Path.Combine(TestInfo.CurrentDirectory, Path.GetRandomFileName() + "!@#$%^&");
             iCountTestcases++;
             try
             {


### PR DESCRIPTION
Conflicting file/dir names with special symbols in the working directory.  Prepend a random path string.