### PR TITLE
System.Linq.Parallel remove use of 'Shared' in enumerators

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RangeEnumerable.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RangeEnumerable.cs
@@ -76,7 +76,7 @@ namespace System.Linq.Parallel
             private readonly int _from; // The initial value.
             private readonly int _count; // How many values to yield.
             private readonly int _initialIndex; // The ordinal index of the first value in the range.
-            private Shared<int> _currentCount; // The 0-based index of the current value. [allocate in moveNext to avoid false-sharing]
+            private int _currentIndex = -1; // The 0-based index of the current value.
 
             //-----------------------------------------------------------------------------------
             // Creates a new enumerator.
@@ -96,16 +96,12 @@ namespace System.Linq.Parallel
 
             internal override bool MoveNext(ref int currentElement, ref int currentKey)
             {
-                if (_currentCount == null)
-                    _currentCount = new Shared<int>(-1);
-
                 // Calculate the next index and ensure it falls within our range.
-                int nextCount = _currentCount.Value + 1;
-                if (nextCount < _count)
+                if (_currentIndex + 1 < _count)
                 {
-                    _currentCount.Value = nextCount;
-                    currentElement = nextCount + _from;
-                    currentKey = nextCount + _initialIndex;
+                    _currentIndex++;
+                    currentElement = _currentIndex + _from;
+                    currentKey = _currentIndex + _initialIndex;
                     return true;
                 }
 
@@ -116,7 +112,7 @@ namespace System.Linq.Parallel
             {
                 // We set the current value such that the next addition of step
                 // results in the 1st real value in the range.
-                _currentCount = null;
+                _currentIndex = -1;
             }
         }
     }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RepeatEnumerable.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RepeatEnumerable.cs
@@ -81,7 +81,7 @@ namespace System.Linq.Parallel
             private readonly TResult _element; // The element to repeat.
             private readonly int _count; // The number of times to repeat it.
             private readonly int _indexOffset; // Our index offset.
-            private Shared<int> _currentIndex; // The number of times we have already repeated it. [allocate in moveNext to avoid false-sharing]
+            private int _currentCount = -1; // The number of times we have already repeated it.
 
             //-----------------------------------------------------------------------------------
             // Creates a new enumerator.
@@ -100,14 +100,11 @@ namespace System.Linq.Parallel
 
             internal override bool MoveNext(ref TResult currentElement, ref int currentKey)
             {
-                if (_currentIndex == null)
-                    _currentIndex = new Shared<int>(-1);
-
-                if (_currentIndex.Value < (_count - 1))
+                if (_currentCount + 1 < _count)
                 {
-                    ++_currentIndex.Value;
+                    ++_currentCount;
                     currentElement = _element;
-                    currentKey = _currentIndex.Value + _indexOffset;
+                    currentKey = _currentCount + _indexOffset;
                     return true;
                 }
 
@@ -116,7 +113,7 @@ namespace System.Linq.Parallel
 
             internal override void Reset()
             {
-                _currentIndex = null;
+                _currentCount = -1;
             }
         }
     }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ExceptQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ExceptQueryOperator.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Parallel
 {
     /// <summary>
     /// Operator that yields the elements from the first data source that aren't in the second.
-    /// This is known as the set relative complement, i.e. left - right. 
+    /// This is known as the set relative complement, i.e. left - right.
     /// </summary>
     /// <typeparam name="TInputOutput"></typeparam>
     internal sealed class ExceptQueryOperator<TInputOutput> :
@@ -39,7 +39,7 @@ namespace System.Linq.Parallel
         internal override QueryResults<TInputOutput> Open(
             QuerySettings settings, bool preferStriping)
         {
-            // We just open our child operators, left and then right.  Do not propagate the preferStriping value, but 
+            // We just open our child operators, left and then right.  Do not propagate the preferStriping value, but
             // instead explicitly set it to false. Regardless of whether the parent prefers striping or range
             // partitioning, the output will be hash-partitioned.
             QueryResults<TInputOutput> leftChildResults = LeftChild.Open(settings, false);
@@ -105,7 +105,6 @@ namespace System.Linq.Parallel
             outputRecipient.Receive(outputStream);
         }
 
-
         //---------------------------------------------------------------------------------------
         // Returns an enumerable that represents the query executing sequentially.
         //
@@ -140,7 +139,7 @@ namespace System.Linq.Parallel
             private IEqualityComparer<TInputOutput> _comparer; // A comparer used for equality checks/hash-coding.
             private Set<TInputOutput> _hashLookup; // The hash lookup, used to produce the distinct set.
             private CancellationToken _cancellationToken;
-            private Shared<int> _outputLoopCount;
+            private int _outputLoopCount = 0;
 
             //---------------------------------------------------------------------------------------
             // Instantiates a new except query operator enumerator.
@@ -174,8 +173,6 @@ namespace System.Linq.Parallel
 
                 if (_hashLookup == null)
                 {
-                    _outputLoopCount = new Shared<int>(0);
-
                     _hashLookup = new Set<TInputOutput>(_comparer);
 
                     Pair rightElement = new Pair(default(TInputOutput), default(NoKeyMemoizationRequired));
@@ -197,7 +194,7 @@ namespace System.Linq.Parallel
 
                 while (_leftSource.MoveNext(ref leftElement, ref leftKeyUnused))
                 {
-                    if ((_outputLoopCount.Value++ & CancellationState.POLL_INTERVAL) == 0)
+                    if ((_outputLoopCount++ & CancellationState.POLL_INTERVAL) == 0)
                         CancellationState.ThrowIfCanceled(_cancellationToken);
 
                     if (_hashLookup.Add((TInputOutput)leftElement.First))

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
@@ -14,7 +14,7 @@ using System.Threading;
 namespace System.Linq.Parallel
 {
     /// <summary>
-    /// Operator that yields the union of two data sources. 
+    /// Operator that yields the union of two data sources.
     /// </summary>
     /// <typeparam name="TInputOutput"></typeparam>
     internal sealed class UnionQueryOperator<TInputOutput> :
@@ -43,7 +43,7 @@ namespace System.Linq.Parallel
         internal override QueryResults<TInputOutput> Open(
             QuerySettings settings, bool preferStriping)
         {
-            // We just open our child operators, left and then right.  Do not propagate the preferStriping value, but 
+            // We just open our child operators, left and then right.  Do not propagate the preferStriping value, but
             // instead explicitly set it to false. Regardless of whether the parent prefers striping or range
             // partitioning, the output will be hash-partitioned.
             QueryResults<TInputOutput> leftChildResults = LeftChild.Open(settings, false);
@@ -151,7 +151,6 @@ namespace System.Linq.Parallel
             }
         }
 
-
         //---------------------------------------------------------------------------------------
         // Returns an enumerable that represents the query executing sequentially.
         //
@@ -186,7 +185,7 @@ namespace System.Linq.Parallel
             private readonly int _partitionIndex; // The current partition.
             private Set<TInputOutput> _hashLookup; // The hash lookup, used to produce the union.
             private CancellationToken _cancellationToken;
-            private Shared<int> _outputLoopCount;
+            private int _outputLoopCount = 0;
             private readonly IEqualityComparer<TInputOutput> _comparer;
 
             //---------------------------------------------------------------------------------------
@@ -218,7 +217,6 @@ namespace System.Linq.Parallel
                 if (_hashLookup == null)
                 {
                     _hashLookup = new Set<TInputOutput>(_comparer);
-                    _outputLoopCount = new Shared<int>(0);
                 }
 
                 Debug.Assert(_hashLookup != null);
@@ -252,7 +250,6 @@ namespace System.Linq.Parallel
                     _leftSource = null;
                 }
 
-
                 if (_rightSource != null)
                 {
                     // Iterate over this set's elements until we find a unique element.
@@ -261,7 +258,7 @@ namespace System.Linq.Parallel
 
                     while (_rightSource.MoveNext(ref currentRightElement, ref keyUnused))
                     {
-                        if ((_outputLoopCount.Value++ & CancellationState.POLL_INTERVAL) == 0)
+                        if ((_outputLoopCount++ & CancellationState.POLL_INTERVAL) == 0)
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
                         // We ensure we never return duplicates by tracking them in our set.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/IndexedWhereQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/IndexedWhereQueryOperator.cs
@@ -66,7 +66,6 @@ namespace System.Linq.Parallel
             SetOrdinalIndexState(OrdinalIndexState.Increasing);
         }
 
-
         //---------------------------------------------------------------------------------------
         // Just opens the current operator, including opening the child and wrapping it with
         // partitions as needed.
@@ -109,7 +108,6 @@ namespace System.Linq.Parallel
             recipient.Receive(outputStream);
         }
 
-
         //---------------------------------------------------------------------------------------
         // Returns an enumerable that represents the query executing sequentially.
         //
@@ -119,7 +117,6 @@ namespace System.Linq.Parallel
             IEnumerable<TInputOutput> wrappedChild = CancellableEnumerable.Wrap(Child.AsSequentialQuery(token), token);
             return wrappedChild.Where(_predicate);
         }
-
 
         //---------------------------------------------------------------------------------------
         // Whether this operator performs a premature merge that would not be performed in
@@ -140,7 +137,7 @@ namespace System.Linq.Parallel
             private readonly QueryOperatorEnumerator<TInputOutput, int> _source; // The data source to enumerate.
             private readonly Func<TInputOutput, int, bool> _predicate; // The predicate used for filtering.
             private CancellationToken _cancellationToken;
-            private Shared<int> _outputLoopCount;
+            private int _outputLoopCount = 0;
             //-----------------------------------------------------------------------------------
             // Instantiates a new enumerator.
             //
@@ -166,12 +163,9 @@ namespace System.Linq.Parallel
                 // Iterate through the input until we reach the end of the sequence or find
                 // an element matching the predicate.
 
-                if (_outputLoopCount == null)
-                    _outputLoopCount = new Shared<int>(0);
-
                 while (_source.MoveNext(ref currentElement, ref currentKey))
                 {
-                    if ((_outputLoopCount.Value++ & CancellationState.POLL_INTERVAL) == 0)
+                    if ((_outputLoopCount++ & CancellationState.POLL_INTERVAL) == 0)
                         CancellationState.ThrowIfCanceled(_cancellationToken);
 
                     if (_predicate(currentElement, currentKey))

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
@@ -8,8 +8,8 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Collections.Generic;
-using System.Threading;
 using System.Diagnostics;
+using System.Threading;
 
 namespace System.Linq.Parallel
 {
@@ -157,7 +157,7 @@ namespace System.Linq.Parallel
             private readonly CancellationToken _cancellationToken; // Indicates that cancellation has occurred.
 
             private List<Pair> _buffer; // Our buffer.
-            private Shared<int> _bufferIndex; // Our current index within the buffer. [allocate in moveNext to avoid false-sharing]
+            private int _bufferIndex = -1; // Our current index within the buffer.
 
             //---------------------------------------------------------------------------------------
             // Instantiates a new select enumerator.
@@ -225,9 +225,8 @@ namespace System.Linq.Parallel
                     _sharedBarrier.Signal();
                     _sharedBarrier.Wait(_cancellationToken);
 
-                    // Publish the buffer and set the index to just before the 1st element.
+                    // Publish the buffer.
                     _buffer = buffer;
-                    _bufferIndex = new Shared<int>(-1);
                 }
 
                 // Now either enter (or continue) the yielding phase. As soon as we reach this, we know the
@@ -236,19 +235,19 @@ namespace System.Linq.Parallel
                 {
                     // In the case of a Take, we will yield each element from our buffer for which
                     // the element is lesser than the 'count'-th index found.
-                    if (_count == 0 || _bufferIndex.Value >= _buffer.Count - 1)
+                    if (_count == 0 || _bufferIndex >= _buffer.Count - 1)
                     {
                         return false;
                     }
 
                     // Increment the index, and remember the values.
-                    ++_bufferIndex.Value;
-                    currentElement = (TResult)_buffer[_bufferIndex.Value].First;
-                    currentKey = (TKey)_buffer[_bufferIndex.Value].Second;
+                    ++_bufferIndex;
+                    currentElement = (TResult)_buffer[_bufferIndex].First;
+                    currentKey = (TKey)_buffer[_bufferIndex].Second;
 
                     // Only yield the element if its index is less than or equal to the max index.
                     return _sharedIndices.Count == 0
-                        || _keyComparer.Compare((TKey)_buffer[_bufferIndex.Value].Second, _sharedIndices.MaxValue) <= 0;
+                        || _keyComparer.Compare((TKey)_buffer[_bufferIndex].Second, _sharedIndices.MaxValue) <= 0;
                 }
                 else
                 {
@@ -268,16 +267,16 @@ namespace System.Linq.Parallel
                         // In the case of a skip, we must skip over elements whose index is lesser than the
                         // 'count'-th index found. Once we've exhausted the buffer, we must go back and continue
                         // enumerating the data source until it is empty.
-                        if (_bufferIndex.Value < _buffer.Count - 1)
+                        if (_bufferIndex < _buffer.Count - 1)
                         {
-                            for (_bufferIndex.Value++; _bufferIndex.Value < _buffer.Count; _bufferIndex.Value++)
+                            for (_bufferIndex++; _bufferIndex < _buffer.Count; _bufferIndex++)
                             {
                                 // If the current buffered element's index is greater than the 'count'-th index,
                                 // we will yield it as a result.
-                                if (_keyComparer.Compare((TKey)_buffer[_bufferIndex.Value].Second, minKey) > 0)
+                                if (_keyComparer.Compare((TKey)_buffer[_bufferIndex].Second, minKey) > 0)
                                 {
-                                    currentElement = (TResult)_buffer[_bufferIndex.Value].First;
-                                    currentKey = (TKey)_buffer[_bufferIndex.Value].Second;
+                                    currentElement = (TResult)_buffer[_bufferIndex].First;
+                                    currentKey = (TKey)_buffer[_bufferIndex].Second;
                                     return true;
                                 }
                             }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/WhereQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/WhereQueryOperator.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Parallel
 {
     /// <summary>
     /// The operator type for Where statements. This operator filters out elements that
-    /// don't match a filter function (supplied at instantiation time). 
+    /// don't match a filter function (supplied at instantiation time).
     /// </summary>
     /// <typeparam name="TInputOutput"></typeparam>
     internal sealed class WhereQueryOperator<TInputOutput> : UnaryQueryOperator<TInputOutput, TInputOutput>
@@ -103,7 +103,7 @@ namespace System.Linq.Parallel
             private readonly QueryOperatorEnumerator<TInputOutput, TKey> _source; // The data source to enumerate.
             private readonly Func<TInputOutput, bool> _predicate; // The predicate used for filtering.
             private CancellationToken _cancellationToken;
-            private Shared<int> _outputLoopCount;
+            private int _outputLoopCount = 0;
 
             //-----------------------------------------------------------------------------------
             // Instantiates a new enumerator.
@@ -131,12 +131,9 @@ namespace System.Linq.Parallel
                 // Iterate through the input until we reach the end of the sequence or find
                 // an element matching the predicate.
 
-                if (_outputLoopCount == null)
-                    _outputLoopCount = new Shared<int>(0);
-
                 while (_source.MoveNext(ref currentElement, ref currentKey))
                 {
-                    if ((_outputLoopCount.Value++ & CancellationState.POLL_INTERVAL) == 0)
+                    if ((_outputLoopCount++ & CancellationState.POLL_INTERVAL) == 0)
                         CancellationState.ThrowIfCanceled(_cancellationToken);
 
                     if (_predicate(currentElement))


### PR DESCRIPTION
Several PLINQ classes use a wrapper type called `Shared` for maintaining the enumerator counts, even though this is never exported from the object (much less a thread, as the type purports to be for).  This removes that use in favor of a simple int.

All tests (both the original PLINQ ones, and my expanded ones) passing.

I'm not sure why it's being used in this instance.  `Shared` purports to be for 'sharing a value between threads', but seems to really be used as a substitute for passing a `ref` field.  However, this wasn't necessary for where it was used in the enumerators, and seems misleading besides:

 1. `Shared` itself isn't implemented in a threadsafe manner.
 2. None of the enumerators using it would have been safe if it was.
 3. There was no synchronization between `MoveNext` and `Current`, and doing so is ill-advised/difficult (easier for synchronization the next level up).

This change leaves the use as passing a `ref` field alone, as that's a trickier problem.

<hr /> 
Personally, I'd like to remove use of the type, especially, for the various early-exit `bool` flags; `Shared` doesn't use `volatile` with the wrapped field, so early-exit really becomes "if I eventually see it" (annoying and eats resources, but not fatal per-se).
Where important, PLINQ is using locking/`Interlocked` to deal with the update problem, but this begs the question of why a `ref` field wasn't used in the first place...