### PR TITLE
Fix AV in MemoryMappedViewAccessor reading/writing

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -71,8 +71,9 @@ namespace System.IO.MemoryMappedFiles
             // VirtualQueryEx: http://msdn.microsoft.com/en-us/library/windows/desktop/aa366907(v=vs.85).aspx
             if (((viewInfo.State & Interop.mincore.MemOptions.MEM_RESERVE) != 0) || (viewSize < nativeSize))
             {
-                IntPtr tempHandle = Interop.mincore.VirtualAlloc(viewHandle, (UIntPtr)nativeSize, Interop.mincore.MemOptions.MEM_COMMIT,
-                                                        MemoryMappedFile.GetPageAccess(access));
+                IntPtr tempHandle = Interop.mincore.VirtualAlloc(
+                    viewHandle, (UIntPtr)(nativeSize != MemoryMappedFile.DefaultSize ? nativeSize : viewSize), 
+                    Interop.mincore.MemOptions.MEM_COMMIT, MemoryMappedFile.GetPageAccess(access));
                 int lastError = Marshal.GetLastWin32Error();
                 if (viewHandle.IsInvalid)
                 {


### PR DESCRIPTION
On Windows, when a MemoryMappedViewAccessor is created with DelayAllocatePages and a capacity of 0 (meaning to use the whole capacity of the map), VirtualAlloc is incorrectly being called with a size of 0 rather than the actual viewSize.  This leads to an AV when trying to read/write via the view accessor.