### PR TITLE
Fix handle recycling / double-close bug in System.IO.Pipes

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
@@ -98,6 +98,7 @@ namespace System.IO.Pipes
         public String GetClientHandleAsString()
         {
             _clientHandleExposed = true;
+            GC.SuppressFinalize(_clientHandle);
             return _clientHandle.DangerousGetHandle().ToString();
         }
 

--- a/src/System.IO.Pipes/tests/NamedPipesThrowsTests.cs
+++ b/src/System.IO.Pipes/tests/NamedPipesThrowsTests.cs
@@ -225,7 +225,7 @@ namespace System.IO.Pipes.Tests
                     safeHandle.DangerousAddRef(ref gotRef);
                     IntPtr handle = safeHandle.DangerousGetHandle();
 
-                    SafePipeHandle fakePipeHandle = new SafePipeHandle(handle, true);
+                    SafePipeHandle fakePipeHandle = new SafePipeHandle(handle, ownsHandle: false);
                     Assert.Throws<IOException>(() => new NamedPipeServerStream(PipeDirection.InOut, false, true, fakePipeHandle));
                 }
                 finally
@@ -326,7 +326,7 @@ namespace System.IO.Pipes.Tests
                     safeHandle.DangerousAddRef(ref gotRef);
                     IntPtr handle = safeHandle.DangerousGetHandle();
 
-                    SafePipeHandle fakePipeHandle = new SafePipeHandle(handle, true);
+                    SafePipeHandle fakePipeHandle = new SafePipeHandle(handle, ownsHandle: false);
                     Assert.Throws<IOException>(() => new NamedPipeClientStream(PipeDirection.InOut, false, true, fakePipeHandle));
                 }
                 finally


### PR DESCRIPTION
The design of AnonymousServerPipeStream calls for a developer to instantiate the server stream and then grab from it the client handle to use to instantiate an AnonymousClientPipeStream.  The handle can be grabbed in two ways, either via ClientSafePipeHandle (which returns the internal SafePipeHandle) or via GetClientHandleAsString (which returns the handle's value serialized as a string).  In either case, the server marks the client handle as being exposed, which means it won't call Dispose on the handle when the server stream is Disposed or finalized.

However, just because the stream doesn't call Dispose on it doesn't change the fact that the client SafePipeHandle has its own finalizer.  If the consuming code calls GetClientHandleAsString and passes that to an AnonymousClientPipeStream, that AnonymousClientPipeStream will construct a SafePipeHandle from it.  Since the AnonymousClientPipeStream could be in another process (it doesn't know where the string comes from), it marks the SafePipeHandle as ownsHandle=true, which means that disposing of the client stream or letting it or the handle get finalized will close the client handle.  And since the AnonymousServerPipeStream also has a SafePipeHandle that thinks it owns the same handle value in the same process, we now run the risk of double-disposal of the same handle value, and the resulting recycling concerns.

Given the existing design, there's no perfect solution here, but I think the best solution that maps to the expected usage pattern is to simply suppress the finalization of the client handle in the server stream's GetClientHandleAsString.  In the case where the string is passed to another process, the developer is expected to call DisposeLocalCopyOfClientHandle; that's always been the case, this change just makes it that much more important.

The commit also fixes two handle recylcling issues in the System.IO.Pipes tests.  A SafePipeHandle is being constructed around an arbitrary file handle, and since it's being constructed as ownsHandle=true, that SafePipeHandle will get finalized and will close a handle that's already been closed and potentially recycled.  The fix is simply to change ownsHandle to false.

(As an aside, I think this may address issue #1841, but I'm not positive.)